### PR TITLE
PAM: Add support for more native pam features and initial support for gdm

### DIFF
--- a/.github/workflows/qa.yaml
+++ b/.github/workflows/qa.yaml
@@ -12,6 +12,11 @@ jobs:
     name: Code sanity
     runs-on: ubuntu-latest
     steps:
+      - name: Install dependencies
+        uses: awalsh128/cache-apt-pkgs-action@latest
+        with:
+          packages: libgdm-dev libpam0g-dev
+          version: 1.0
       - uses: actions/checkout@v3
       - name: Go code sanity check
         uses: canonical/desktop-engineering/gh-actions/go/code-sanity@main
@@ -23,6 +28,11 @@ jobs:
     name: Tests
     runs-on: ubuntu-latest
     steps:
+      - name: Install dependencies
+        uses: awalsh128/cache-apt-pkgs-action@latest
+        with:
+          packages: libgdm-dev libpam0g-dev
+          version: 1.0
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v4
         with:

--- a/go.mod
+++ b/go.mod
@@ -23,6 +23,7 @@ require (
 
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/elliotchance/orderedmap/v2 v2.2.0 // indirect
 	github.com/fsnotify/fsnotify v1.6.0 // indirect
 	github.com/golang/protobuf v1.5.3 // indirect
 	github.com/hashicorp/hcl v1.0.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -52,6 +52,8 @@ github.com/cpuguy83/go-md2man/v2 v2.0.2/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46t
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/elliotchance/orderedmap/v2 v2.2.0 h1:7/2iwO98kYT4XkOjA9mBEIwvi4KpGB4cyHeOFOnj4Vk=
+github.com/elliotchance/orderedmap/v2 v2.2.0/go.mod h1:85lZyVbpGaGvHvnKa7Qhx7zncAdBIBq6u56Hb1PRU5Q=
 github.com/envoyproxy/go-control-plane v0.9.0/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/go-control-plane v0.9.1-0.20191026205805-5f8ba28d4473/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/go-control-plane v0.9.4/go.mod h1:6rpuAdCZL397s3pYoYcLgu1mIlRU8Am5FuJP05cCM98=

--- a/pam/pam-utils.c
+++ b/pam/pam-utils.c
@@ -1,0 +1,56 @@
+#include "pam-utils.h"
+
+#include <security/pam_appl.h>
+
+char *
+argv_string_get (const char **argv, unsigned i)
+{
+  return strdup (argv[i]);
+}
+
+char *
+get_user (pam_handle_t *pamh, const char *prompt)
+{
+  if (!pamh)
+    return NULL;
+  int pam_err = 0;
+  const char *user;
+
+  if ((pam_err = pam_get_user (pamh, &user, prompt)) != PAM_SUCCESS)
+    return NULL;
+  return strdup (user);
+}
+
+const char *
+get_module_name (pam_handle_t *pamh)
+{
+  const char *module_name;
+
+  if (pam_get_item (pamh, PAM_SERVICE, (const void **) &module_name) != PAM_SUCCESS)
+    return NULL;
+
+  return module_name;
+}
+
+struct pam_response *
+send_msg (pam_handle_t *pamh, const char *msg, int style)
+{
+  const struct pam_message pam_msg = {
+    .msg_style = style,
+    .msg = msg,
+  };
+  const struct pam_conv *pc;
+  struct pam_response *resp;
+
+  if (pam_get_item (pamh, PAM_CONV, (const void **) &pc) != PAM_SUCCESS)
+    return NULL;
+
+  if (!pc || !pc->conv)
+    return NULL;
+
+  if (pc->conv (1, (const struct pam_message *[]){ &pam_msg }, &resp,
+                pc->appdata_ptr) != PAM_SUCCESS)
+    return NULL;
+
+  return resp;
+}

--- a/pam/pam-utils.c
+++ b/pam/pam-utils.c
@@ -1,6 +1,7 @@
 #include "pam-utils.h"
 
 #include <security/pam_appl.h>
+#include <assert.h>
 
 char *
 argv_string_get (const char **argv, unsigned i)
@@ -32,13 +33,9 @@ get_module_name (pam_handle_t *pamh)
   return module_name;
 }
 
-struct pam_response *
-send_msg (pam_handle_t *pamh, const char *msg, int style)
+static struct pam_response *
+send_msg_generic (pam_handle_t *pamh, const struct pam_message *pam_msg)
 {
-  const struct pam_message pam_msg = {
-    .msg_style = style,
-    .msg = msg,
-  };
   const struct pam_conv *pc;
   struct pam_response *resp;
 
@@ -48,9 +45,77 @@ send_msg (pam_handle_t *pamh, const char *msg, int style)
   if (!pc || !pc->conv)
     return NULL;
 
-  if (pc->conv (1, (const struct pam_message *[]){ &pam_msg }, &resp,
+  if (pc->conv (1, (const struct pam_message *[]){ pam_msg }, &resp,
                 pc->appdata_ptr) != PAM_SUCCESS)
     return NULL;
 
   return resp;
+}
+
+struct pam_response *
+send_msg (pam_handle_t *pamh, const char *msg, int style)
+{
+  const struct pam_message pam_msg = {
+    .msg_style = style,
+    .msg = msg,
+  };
+
+  return send_msg_generic (pamh, &pam_msg);
+}
+
+GdmPamExtensionChoiceListRequest *
+gdm_choices_request_create (const char *title,
+                            size_t      num)
+{
+  GdmPamExtensionChoiceListRequest *request;
+
+  request = calloc (1, GDM_PAM_EXTENSION_CHOICE_LIST_REQUEST_SIZE (num));
+  GDM_PAM_EXTENSION_CHOICE_LIST_REQUEST_INIT (request, (char *) title, num);
+
+  return request;
+}
+
+void
+gdm_choices_request_set (GdmPamExtensionChoiceListRequest *request, size_t i,
+                         const char *key, const char *text)
+{
+  assert (request != NULL && i < request->list.number_of_items);
+
+  request->list.items[i].key = strdup (key);
+  request->list.items[i].text = strdup (text);
+}
+
+void
+gdm_choices_request_free (GdmPamExtensionChoiceListRequest *request)
+{
+  assert (request != NULL);
+
+  for (size_t i = 0; i < request->list.number_of_items; ++i)
+    {
+      free ((char *) request->list.items[i].key);
+      free ((char *) request->list.items[i].text);
+    }
+
+  free (request);
+}
+
+char *
+gdm_choices_request_ask (pam_handle_t *pamh, GdmPamExtensionChoiceListRequest *request)
+{
+  GdmPamExtensionChoiceListResponse *response;
+  struct pam_message prompt_message;
+  struct pam_response *reply;
+  char *ret_key;
+
+  GDM_PAM_EXTENSION_MESSAGE_TO_BINARY_PROMPT_MESSAGE (request, &prompt_message);
+  reply = send_msg_generic (pamh, &prompt_message);
+
+  if (!reply)
+    return NULL;
+
+  response = GDM_PAM_EXTENSION_REPLY_TO_CHOICE_LIST_RESPONSE (reply);
+  ret_key = strdup (response->key);
+  free (response);
+
+  return ret_key;
 }

--- a/pam/pam-utils.h
+++ b/pam/pam-utils.h
@@ -1,0 +1,16 @@
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+#include <security/pam_modules.h>
+
+char *argv_string_get (const char **argv,
+                       unsigned     i);
+
+char *get_user (pam_handle_t *pamh,
+                const char   *prompt);
+
+const char *get_module_name (pam_handle_t *pamh);
+
+struct pam_response *send_msg (pam_handle_t *pamh,
+                               const char   *msg,
+                               int           style);

--- a/pam/pam-utils.h
+++ b/pam/pam-utils.h
@@ -1,6 +1,8 @@
 #include <stdlib.h>
 #include <string.h>
+#include <stdbool.h>
 #include <unistd.h>
+#include <gdm/gdm-pam-extensions.h>
 #include <security/pam_modules.h>
 
 char *argv_string_get (const char **argv,
@@ -14,3 +16,22 @@ const char *get_module_name (pam_handle_t *pamh);
 struct pam_response *send_msg (pam_handle_t *pamh,
                                const char   *msg,
                                int           style);
+
+inline bool
+gdm_choices_list_supported (void)
+{
+  return GDM_PAM_EXTENSION_SUPPORTED (GDM_PAM_EXTENSION_CHOICE_LIST);
+}
+
+GdmPamExtensionChoiceListRequest *gdm_choices_request_create (const char *,
+                                                              size_t);
+
+void gdm_choices_request_set (GdmPamExtensionChoiceListRequest *,
+                              size_t      i,
+                              const char *key,
+                              const char *value);
+
+char * gdm_choices_request_ask (pam_handle_t *pamh,
+                                GdmPamExtensionChoiceListRequest *);
+
+void gdm_choices_request_free (GdmPamExtensionChoiceListRequest *);

--- a/pam/pam.go
+++ b/pam/pam.go
@@ -197,7 +197,7 @@ func pam_sm_authenticate(pamh *C.pam_handle_t, flags, argc C.int, argv **C.char)
 		UserName: &user,
 	})
 	if err != nil {
-		log.Debugf(context.TODO(), "Could not get current available brokers: %v", err)
+		sendAndLogError(pamh, "Could not get current available brokers: %v", err)
 		return C.PAM_AUTHINFO_UNAVAIL
 	}
 

--- a/pam/pam.go
+++ b/pam/pam.go
@@ -68,7 +68,7 @@ func pam_sm_authenticate(pamh *C.pam_handle_t, flags, argc C.int, argv **C.char)
 	client, close, err := newClient(argc, argv)
 	if err != nil {
 		log.Debugf(context.TODO(), "%s", err)
-		return C.PAM_IGNORE
+		return C.PAM_AUTHINFO_UNAVAIL
 	}
 	defer close()
 
@@ -84,7 +84,7 @@ func pam_sm_authenticate(pamh *C.pam_handle_t, flags, argc C.int, argv **C.char)
 	})
 	if err != nil {
 		log.Debugf(context.TODO(), "Could not get current available brokers: %v", err)
-		return C.PAM_IGNORE
+		return C.PAM_AUTHINFO_UNAVAIL
 	}
 
 	type Stage int

--- a/pam/pam.go
+++ b/pam/pam.go
@@ -4,10 +4,7 @@ package main
 #cgo LDFLAGS: -lpam -fPIC
 #include <security/pam_appl.h>
 #include <security/pam_ext.h>
-#include <stdlib.h>
-#include <string.h>
 
-char *string_from_argv(int i, char **argv);
 */
 import "C"
 

--- a/pam/utils_c.go
+++ b/pam/utils_c.go
@@ -1,60 +1,7 @@
 package main
 
 /*
-#include <security/pam_appl.h>
-#include <security/pam_modules.h>
-#include <stdlib.h>
-#include <string.h>
-#include <unistd.h>
-
-char *string_from_argv(int i, char **argv) {
-  return strdup(argv[i]);
-}
-
-char *get_user(pam_handle_t *pamh, const char *prompt) {
-  if (!pamh)
-    return NULL;
-  int pam_err = 0;
-  const char *user;
-  if ((pam_err = pam_get_user(pamh, &user, prompt)) != PAM_SUCCESS)
-    return NULL;
-  return strdup(user);
-}
-
-const char *
-get_module_name (pam_handle_t *pamh)
-{
-  const char *module_name;
-
-  if (pam_get_item(pamh, PAM_SERVICE, (const void **) &module_name) != PAM_SUCCESS)
-    return NULL;
-
-  return module_name;
-}
-
-static struct pam_response *
-send_msg (pam_handle_t *pamh, const char *msg, int style)
-{
-  const struct pam_message pam_msg = {
-    .msg_style = style,
-    .msg = msg,
-  };
-  const struct pam_conv *pc;
-  struct pam_response *resp;
-
-  if (pam_get_item (pamh, PAM_CONV, (const void **) &pc) != PAM_SUCCESS)
-    return NULL;
-
-  if (!pc || !pc->conv)
-    return NULL;
-
-  if (pc->conv (1, (const struct pam_message *[]){ &pam_msg }, &resp,
-                pc->appdata_ptr) != PAM_SUCCESS)
-    return NULL;
-
-  return resp;
-}
-
+#include "pam-utils.h"
 */
 import "C"
 
@@ -80,7 +27,7 @@ const (
 func sliceFromArgv(argc C.int, argv **C.char) []string {
 	r := make([]string, 0, argc)
 	for i := 0; i < int(argc); i++ {
-		s := C.string_from_argv(C.int(i), argv)
+		s := C.argv_string_get(argv, C.uint(i))
 		defer C.free(unsafe.Pointer(s))
 		r = append(r, C.GoString(s))
 	}

--- a/pam/utils_c.go
+++ b/pam/utils_c.go
@@ -20,6 +20,41 @@ char *get_user(pam_handle_t *pamh, const char *prompt) {
     return NULL;
   return strdup(user);
 }
+
+const char *
+get_module_name (pam_handle_t *pamh)
+{
+  const char *module_name;
+
+  if (pam_get_item(pamh, PAM_SERVICE, (const void **) &module_name) != PAM_SUCCESS)
+    return NULL;
+
+  return module_name;
+}
+
+static struct pam_response *
+send_msg (pam_handle_t *pamh, const char *msg, int style)
+{
+  const struct pam_message pam_msg = {
+    .msg_style = style,
+    .msg = msg,
+  };
+  const struct pam_conv *pc;
+  struct pam_response *resp;
+
+  if (pam_get_item (pamh, PAM_CONV, (const void **) &pc) != PAM_SUCCESS)
+    return NULL;
+
+  if (!pc || !pc->conv)
+    return NULL;
+
+  if (pc->conv (1, (const struct pam_message *[]){ &pam_msg }, &resp,
+                pc->appdata_ptr) != PAM_SUCCESS)
+    return NULL;
+
+  return resp;
+}
+
 */
 import "C"
 
@@ -30,6 +65,17 @@ import (
 
 // pamHandle allows to pass C.pam_handle_t to this package.
 type pamHandle = *C.pam_handle_t
+
+type PamPrompt int
+
+const (
+	PamPromptEchoOff PamPrompt = 1
+	PamPromptEchoOn  PamPrompt = 2
+	PamPromptError   PamPrompt = 3
+	PamPromptInfo    PamPrompt = 4
+	PamPromptRadio   PamPrompt = 5
+	PamPromptBinary  PamPrompt = 7
+)
 
 func sliceFromArgv(argc C.int, argv **C.char) []string {
 	r := make([]string, 0, argc)
@@ -61,4 +107,49 @@ func getPassword(prompt string) (string, error) {
 	}
 	defer C.free(unsafe.Pointer(cPasswd))
 	return C.GoString(cPasswd), nil
+}
+
+func getModuleName(pamh pamHandle) (string, error) {
+	cModuleName := C.get_module_name(pamh)
+	if cModuleName == nil {
+		return "", fmt.Errorf("no module name found")
+	}
+	return C.GoString(cModuleName), nil
+}
+
+func pamConv(pamh pamHandle, prompt string, kind PamPrompt) (string, error) {
+	cPrompt := C.CString(prompt)
+	defer C.free(unsafe.Pointer(cPrompt))
+	cResponse := C.send_msg(pamh, cPrompt, C.int(kind))
+	if cResponse == nil {
+		return "", fmt.Errorf("conversation with PAM application failed")
+	}
+	defer C.free(unsafe.Pointer(cResponse))
+	return C.GoString(cResponse.resp), nil
+}
+
+func sendInfo(pamh pamHandle, prompt string) error {
+	_, err := pamConv(pamh, "INFO: "+prompt, PamPromptInfo)
+	return err
+}
+
+func sendInfof(pamh pamHandle, format string, args ...interface{}) error {
+	return sendInfo(pamh, fmt.Sprintf(format, args...))
+}
+
+func sendError(pamh pamHandle, prompt string) error {
+	_, err := pamConv(pamh, "ERROR: "+prompt, PamPromptError)
+	return err
+}
+
+func sendErrorf(pamh pamHandle, format string, args ...interface{}) error {
+	return sendInfo(pamh, fmt.Sprintf(format, args...))
+}
+
+func requestInput(pamh pamHandle, prompt string) (string, error) {
+	return pamConv(pamh, prompt+": ", PamPromptEchoOn)
+}
+
+func requestSecret(pamh pamHandle, prompt string) (string, error) {
+	return pamConv(pamh, prompt+": ", PamPromptEchoOff)
 }


### PR DESCRIPTION
Various changes while learning this on the _go_... In particular:
 - Added more pam native features so that we can do proper PAM conversation and show messages
 - Refactor the code so that the module can behave differently depending on the client capabilities
 - Add initial support (potentially done, but we have connection issues with the daemon) for standard PAM clients as SSH clients
 - Implement support for the GDM private protocol for choice lists to allow user selection of actions to do

Some shell interaction can be tested with hacks like:

<details>

```diff
diff --git a/js/gdm/util.js b/js/gdm/util.js
index 78c45cbbaa..58e9f93c12 100644
--- a/js/gdm/util.js
+++ b/js/gdm/util.js
@@ -46,6 +46,9 @@ var DISABLE_USER_LIST_KEY = 'disable-user-list';
 var USER_READ_TIME = 48;
 const FINGERPRINT_ERROR_TIMEOUT_WAIT = 15;
 
+// const SHELL_TEST_MODULE = 'gdm-shell-test';
+const SHELL_TEST_MODULE = 'gdm-authd';
+
 var MessageType = {
     // Keep messages in order by priority
     NONE: 0,
@@ -465,6 +468,7 @@ var ShellUserVerifier = class extends Signals.EventEmitter {
             return;
         }
 
+        print('GDM: Client using choice list?', this._client.get_user_verifier_choice_list);
         if (this._client.get_user_verifier_choice_list)
             this._userVerifierChoiceList = this._client.get_user_verifier_choice_list();
         else
@@ -510,6 +514,9 @@ var ShellUserVerifier = class extends Signals.EventEmitter {
             'service-unavailable', this._onServiceUnavailable.bind(this),
             'reset', this._onReset.bind(this),
             'verification-complete', this._onVerificationComplete.bind(this),
+            'conversation-started', (v, service) => {
+                print('GDM: Conversation started with',service)
+            },
             this);
 
         if (this._userVerifierChoiceList) {
@@ -602,10 +609,15 @@ var ShellUserVerifier = class extends Signals.EventEmitter {
             this._fingerprintReaderType !== FingerprintReaderType.NONE &&
             !this.serviceIsForeground(FINGERPRINT_SERVICE_NAME))
             this._startService(FINGERPRINT_SERVICE_NAME);
+
+        print('GDM: Starting service', SHELL_TEST_MODULE)
+        this._startService(SHELL_TEST_MODULE);
     }
 
     _onChoiceListQuery(client, serviceName, promptMessage, list) {
-        if (!this.serviceIsForeground(serviceName))
+        log('GDM: Choice list query got from', serviceName, 'msg', promptMessage,
+            'list', list.deepUnpack());
+        if (!this.serviceIsForeground(serviceName) && serviceName !== SHELL_TEST_MODULE)
             return;
 
         this.emit('show-choice-list', serviceName, promptMessage, list.deepUnpack());
@@ -629,13 +641,19 @@ var ShellUserVerifier = class extends Signals.EventEmitter {
                 this._queueMessage(serviceName, _('(or place finger on reader)'),
                     MessageType.HINT);
             }
+        } else if (serviceName === SHELL_TEST_MODULE) {
+            print('GDM: got message from',serviceName, info)
+            this._queueMessage(serviceName, info, MessageType.INFO);
         }
     }
 
     _onProblem(client, serviceName, problem) {
         const isFingerprint = this.serviceIsFingerprint(serviceName);
 
-        if (!this.serviceIsForeground(serviceName) && !isFingerprint)
+        print('GDM: Got probelem on',serviceName, ':', problem);
+
+        if (!this.serviceIsForeground(serviceName) && !isFingerprint &&
+            serviceName !== SHELL_TEST_MODULE)
             return;
 
         this._queuePriorityMessage(serviceName, problem, MessageType.ERROR);
@@ -669,14 +687,14 @@ var ShellUserVerifier = class extends Signals.EventEmitter {
     }
 
     _onInfoQuery(client, serviceName, question) {
-        if (!this.serviceIsForeground(serviceName))
+        if (!this.serviceIsForeground(serviceName) && serviceName !== SHELL_TEST_MODULE)
             return;
 
         this.emit('ask-question', serviceName, question, false);
     }
 
     _onSecretInfoQuery(client, serviceName, secretQuestion) {
-        if (!this.serviceIsForeground(serviceName))
+        if (!this.serviceIsForeground(serviceName) && serviceName !== SHELL_TEST_MODULE)
             return;
 
         let token = null;
@@ -768,15 +786,18 @@ var ShellUserVerifier = class extends Signals.EventEmitter {
 
     _onServiceUnavailable(_client, serviceName, errorMessage) {
         this._unavailableServices.add(serviceName);
+        print('GDM: Service unavailable', serviceName, errorMessage)
 
         if (!errorMessage)
             return;
 
-        if (this.serviceIsForeground(serviceName) || this.serviceIsFingerprint(serviceName))
+        if (this.serviceIsForeground(serviceName) || this.serviceIsFingerprint(serviceName) ||
+            serviceName === SHELL_TEST_MODULE)
             this._queueMessage(serviceName, errorMessage, MessageType.ERROR);
     }
 
     _onConversationStopped(client, serviceName) {
+        print('GDM: Conversation stopped with',serviceName)
         // If the login failed with the preauthenticated oVirt credentials
         // then discard the credentials and revert to default authentication
         // mechanism.

```

</details>