### PR TITLE
Initial implementation for the ExampleBroker bus and the dbus communication with the daemon

### DIFF
--- a/cmd/authd/main.go
+++ b/cmd/authd/main.go
@@ -9,6 +9,7 @@ import (
 	"syscall"
 
 	"github.com/ubuntu/authd/cmd/authd/daemon"
+	"github.com/ubuntu/authd/internal/brokers/examplebroker"
 	"github.com/ubuntu/authd/internal/log"
 )
 
@@ -18,6 +19,13 @@ import (
 
 func main() {
 	//i18n.InitI18nDomain(common.TEXTDOMAIN)
+	go func() {
+		err := examplebroker.StartBus()
+		if err != nil {
+			log.Error(context.Background(), err)
+			os.Exit(1)
+		}
+	}()
 	a := daemon.New()
 	os.Exit(run(a))
 }

--- a/internal/brokers/broker.go
+++ b/internal/brokers/broker.go
@@ -56,8 +56,6 @@ func NewBroker(ctx context.Context, name, configFile string, bus *dbus.Conn) (b 
 		if err != nil {
 			return Broker{}, err
 		}
-	} else if name != localBrokerName {
-		broker, fullName, brandIcon = newExampleBroker(name)
 	}
 
 	return Broker{

--- a/internal/brokers/dbusbroker.go
+++ b/internal/brokers/dbusbroker.go
@@ -57,21 +57,84 @@ func newDbusBroker(ctx context.Context, bus *dbus.Conn, configFile string) (b db
 	}, fullNameVal.String(), brandIconVal.String(), nil
 }
 
-// To be implemented.
+// NewSession calls the corresponding method on the broker bus and returns the session ID and encryption key.
 func (b dbusBroker) NewSession(ctx context.Context, username, lang string) (sessionID, encryptionKey string, err error) {
-	return "", "", nil
+	dbusMethod := b.interfaceName + ".NewSession"
+
+	call := b.dbusObject.CallWithContext(ctx, dbusMethod, 0, username, lang)
+	if err = call.Err; err != nil {
+		return "", "", err
+	}
+	if err = call.Store(&sessionID, &encryptionKey); err != nil {
+		return "", "", err
+	}
+
+	return sessionID, encryptionKey, nil
 }
+
+// GetAuthenticationModes calls the corresponding method on the broker bus and returns the authentication modes supported by it.
 func (b dbusBroker) GetAuthenticationModes(ctx context.Context, sessionID string, supportedUILayouts []map[string]string) (authenticationModes []map[string]string, err error) {
-	return nil, nil
+	dbusMethod := b.interfaceName + ".GetAuthenticationModes"
+
+	call := b.dbusObject.CallWithContext(ctx, dbusMethod, 0, sessionID, supportedUILayouts)
+	if err = call.Err; err != nil {
+		return nil, err
+	}
+	if err = call.Store(&authenticationModes); err != nil {
+		return nil, err
+	}
+
+	return authenticationModes, nil
 }
+
+// SelectAuthenticationMode calls the corresponding method on the broker bus and returns the UI layout for the selected mode.
 func (b dbusBroker) SelectAuthenticationMode(ctx context.Context, sessionID, authenticationModeName string) (uiLayoutInfo map[string]string, err error) {
-	return nil, nil
+	dbusMethod := b.interfaceName + ".SelectAuthenticationMode"
+
+	call := b.dbusObject.CallWithContext(ctx, dbusMethod, 0, sessionID, authenticationModeName)
+	if err = call.Err; err != nil {
+		return nil, err
+	}
+	if err = call.Store(&uiLayoutInfo); err != nil {
+		return nil, err
+	}
+
+	return uiLayoutInfo, nil
 }
+
+// IsAuthorized calls the corresponding method on the broker bus and returns the user information and access.
 func (b dbusBroker) IsAuthorized(ctx context.Context, sessionID, authenticationData string) (access, infoUser string, err error) {
-	return "", "", nil
+	dbusMethod := b.interfaceName + ".IsAuthorized"
+
+	call := b.dbusObject.CallWithContext(ctx, dbusMethod, 0, sessionID, authenticationData)
+	if err = call.Err; err != nil {
+		return "", "", err
+	}
+	if err = call.Store(&access, &infoUser); err != nil {
+		return "", "", err
+	}
+
+	return access, infoUser, nil
 }
+
+// EndSession calls the corresponding method on the broker bus.
 func (b dbusBroker) EndSession(ctx context.Context, sessionID string) (err error) {
+	dbusMethod := b.interfaceName + ".EndSession"
+
+	call := b.dbusObject.CallWithContext(ctx, dbusMethod, 0, sessionID)
+	if err = call.Err; err != nil {
+		return err
+	}
+
 	return nil
 }
+
+// CancelIsAuthorized calls the corresponding method on the broker bus.
 func (b dbusBroker) CancelIsAuthorized(ctx context.Context, sessionID string) {
+	dbusMethod := b.interfaceName + ".CancelIsAuthorized"
+
+	call := b.dbusObject.CallWithContext(ctx, dbusMethod, 0, sessionID)
+	if call.Err != nil {
+		log.Errorf(ctx, "could not cancel IsAuthorized call for session %q: %v", sessionID, call.Err)
+	}
 }

--- a/internal/brokers/examplebroker/ExampleBroker
+++ b/internal/brokers/examplebroker/ExampleBroker
@@ -1,0 +1,8 @@
+# Add this to /etc/authd/broker.d to configure the ExampleBroker
+name = ExampleBroker
+brand_icon = /usr/share/backgrounds/warty-final-ubuntu.png
+
+[dbus]
+name = com.ubuntu.auth.ExampleBroker
+object = /com/ubuntu/auth/ExampleBroker
+interface = com.ubuntu.auth.ExampleBroker

--- a/internal/brokers/examplebroker/com.ubuntu.auth.ExampleBroker.conf
+++ b/internal/brokers/examplebroker/com.ubuntu.auth.ExampleBroker.conf
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?> <!-- -*- XML -*- -->
+
+<!-- This file should be added to /usr/share/dbus-1/system.d/ to allow connection to the bus service. -->
+
+<!DOCTYPE busconfig PUBLIC
+ "-//freedesktop//DTD D-BUS Bus Configuration 1.0//EN"
+ "http://www.freedesktop.org/standards/dbus/1.0/busconfig.dtd">
+
+<busconfig>
+  <!-- Only root can own the service -->
+  <policy user="root">
+    <allow own="com.ubuntu.auth.ExampleBroker"/>
+  </policy>
+
+  <!-- Allow anyone to invoke methods -->
+  <policy context="default">
+    <allow send_destination="com.ubuntu.auth.ExampleBroker"
+           send_interface="com.ubuntu.auth.ExampleBroker"/>
+    <allow send_destination="com.ubuntu.auth.ExampleBroker"
+           send_interface="org.freedesktop.DBus.Introspectable"/>
+  </policy>
+</busconfig>

--- a/internal/brokers/examplebroker/com.ubuntu.auth.ExampleBroker.xml
+++ b/internal/brokers/examplebroker/com.ubuntu.auth.ExampleBroker.xml
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!-- This file should be added in /usr/share/dbus-1/interfaces/ to configure the ExampleBroker -->
+
+<!DOCTYPE node PUBLIC
+"-//freedesktop//DTD D-BUS Object Introspection 1.0//EN"
+"http://www.freedesktop.org/standards/dbus/1.0/introspect.dtd">
+
+<node>
+  <interface name="com.ubuntu.auth.ExampleBroker">
+    <method name="NewSession">
+      <arg type="s" direction="in" name="username"/>
+      <arg type="s" direction="in" name="lang"/>
+      <arg type="s" direction="out" name="sessionID"/>
+      <arg type="s" direction="out" name="encryptionKey"/>
+    </method>
+    <method name="GetAuthenticationModes">
+      <arg type="s" direction="in" name="sessionID"/>
+      <arg type="a{s}s" direction="in" name="supportedUILayouts"/>
+      <arg type="a{s}s" direction="out" name="authenticationModes"/>
+    </method>
+    <method name="SelectAuthenticationMode">
+        <arg type="s" direction="in" name="sessionID"/>
+        <arg type="s" direction="in" name="authenticationModeName"/>
+        <arg type="a{s}s" direction="out"  name="uiLayoutInfo"/>
+    </method>
+    <method name="IsAuthorized">
+        <arg type="s" direction="in" name="sessionID"/>
+        <arg type="s" direction="in" name="authenticationData"/>
+        <arg type="s" direction="out" name="access"/>
+        <arg type="s" direction="out" name="infoUser"/>
+    </method>
+    <method name="EndSession">
+        <arg type="s" direction="in" name="sessionID"/>
+    </method>
+    <method name="CancelIsAuthorized">
+        <arg type="s" direction="in" name="sessionID"/>
+    </method>
+  </interface>
+  <interface name="org.freedesktop.DBus.Introspectable">
+    <method name="Introspect">
+      <arg name="out" direction="out" type="s"/>
+    </method>
+  </interface>
+</node>

--- a/internal/brokers/examplebroker/configurebroker.sh
+++ b/internal/brokers/examplebroker/configurebroker.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+# This script needs sudo privileges
+
+set -eu
+
+# Copy the configuration file to /etc/authd/broker.d/ExampleBroker
+cp ./ExampleBroker /etc/authd/broker.d/ExampleBroker
+
+# Copy the interface definition to /usr/share/dbus-1/interfaces
+cp ./com.ubuntu.auth.ExampleBroker.xml /usr/share/dbus-1/interfaces/com.ubuntu.auth.ExampleBroker.xml
+
+# Copy the dbus configuration file to /usr/share/dbus-1/system.d/
+cp ./com.ubuntu.auth.ExampleBroker.conf /usr/share/dbus-1/system.d/com.ubuntu.auth.ExampleBroker.conf

--- a/internal/brokers/examplebroker/examplebrokerbus.go
+++ b/internal/brokers/examplebroker/examplebrokerbus.go
@@ -1,0 +1,116 @@
+package examplebroker
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/godbus/dbus/v5"
+	"github.com/godbus/dbus/v5/introspect"
+	"github.com/ubuntu/decorate"
+)
+
+const (
+	dbusObjectPath = "/com/ubuntu/auth/ExampleBroker"
+	dbusInterface  = "com.ubuntu.auth.ExampleBroker"
+)
+
+// Bus is the D-Bus object that will answer calls for the broker.
+type Bus struct {
+	broker *broker
+}
+
+// StartBus starts the D-Bus service and exports it on the system bus.
+func StartBus() (err error) {
+	defer decorate.OnError(&err, "could not start example broker bus")
+
+	conn, err := dbus.ConnectSystemBus()
+	if err != nil {
+		return err
+	}
+	defer conn.Close()
+
+	b, _, _ := newBroker("ExampleBroker")
+	obj := Bus{broker: b}
+	err = conn.Export(&obj, dbusObjectPath, dbusInterface)
+	if err != nil {
+		_ = conn.Close()
+		return err
+	}
+
+	if err = conn.Export(introspect.NewIntrospectable(&introspect.Node{
+		Name: dbusObjectPath,
+		Interfaces: []introspect.Interface{
+			introspect.IntrospectData,
+			{
+				Name:    dbusInterface,
+				Methods: introspect.Methods(&obj),
+			},
+		},
+	}), dbusObjectPath, introspect.IntrospectData.Name); err != nil {
+		_ = conn.Close()
+		return err
+	}
+
+	reply, err := conn.RequestName(dbusInterface, dbus.NameFlagDoNotQueue)
+	if err != nil {
+		_ = conn.Close()
+		return err
+	}
+	if reply != dbus.RequestNameReplyPrimaryOwner {
+		_ = conn.Close()
+		return fmt.Errorf("D-Bus name already taken")
+	}
+
+	select {}
+}
+
+// NewSession is the method through which the broker and the daemon will communicate once dbusInterface.NewSession is called.
+func (b *Bus) NewSession(username, lang string) (sessionID, encryptionKey string, dbusErr *dbus.Error) {
+	sessionID, encryptionKey, err := b.broker.NewSession(context.Background(), username, lang)
+	if err != nil {
+		return "", "", dbus.MakeFailedError(err)
+	}
+	return sessionID, encryptionKey, nil
+}
+
+// GetAuthenticationModes is the method through which the broker and the daemon will communicate once dbusInterface.GetAuthenticationModes is called.
+func (b *Bus) GetAuthenticationModes(sessionID string, supportedUILayouts []map[string]string) (authenticationModes []map[string]string, dbusErr *dbus.Error) {
+	authenticationModes, err := b.broker.GetAuthenticationModes(context.Background(), sessionID, supportedUILayouts)
+	if err != nil {
+		return nil, dbus.MakeFailedError(err)
+	}
+	return authenticationModes, nil
+}
+
+// SelectAuthenticationMode is the method through which the broker and the daemon will communicate once dbusInterface.SelectAuthenticationMode is called.
+func (b *Bus) SelectAuthenticationMode(sessionID, authenticationModeName string) (uiLayoutInfo map[string]string, dbusErr *dbus.Error) {
+	uiLayoutInfo, err := b.broker.SelectAuthenticationMode(context.Background(), sessionID, authenticationModeName)
+	if err != nil {
+		return nil, dbus.MakeFailedError(err)
+	}
+	return uiLayoutInfo, nil
+}
+
+// IsAuthorized is the method through which the broker and the daemon will communicate once dbusInterface.IsAuthorized is called.
+func (b *Bus) IsAuthorized(sessionID, authenticationData string) (access, infoUser string, dbusErr *dbus.Error) {
+	access, infoUser, err := b.broker.IsAuthorized(context.Background(), sessionID, authenticationData)
+	if err != nil {
+		return "", "", dbus.MakeFailedError(err)
+	}
+	return access, infoUser, nil
+}
+
+// EndSession is the method through which the broker and the daemon will communicate once dbusInterface.EndSession is called.
+func (b *Bus) EndSession(sessionID string) (dbusErr *dbus.Error) {
+	err := b.broker.EndSession(context.Background(), sessionID)
+	if err != nil {
+		return dbus.MakeFailedError(err)
+	}
+	return nil
+}
+
+// CancelIsAuthorized is the method through which the broker and the daemon will communicate once dbusInterface.CancelIsAuthorized is called.
+func (b *Bus) CancelIsAuthorized(sessionID string) (dbusErr *dbus.Error) {
+	b.broker.CancelIsAuthorized(context.Background(), sessionID)
+	return nil
+}


### PR DESCRIPTION
Up until now, we only had the example broker running locally since we didn't have the `dbus` integration with the daemon. This PR implements the `dbus` calls and the ExampleBroker bus that will handle them.

UDENG-1064