### PR TITLE
Add button check to validateUILayout

### DIFF
--- a/internal/brokers/broker.go
+++ b/internal/brokers/broker.go
@@ -182,7 +182,7 @@ func validateUILayout(layout map[string]string) (r map[string]string, err error)
 	switch typ {
 	case "form":
 		if label == "" {
-			return nil, fmt.Errorf("'label' is required")
+			return nil, errors.New("'label' is required")
 		}
 		if !slices.Contains([]string{"chars", "digits", "chars_password", "digits_password", ""}, entry) {
 			return nil, fmt.Errorf("'entry' does not match allowed values for this type: %v", entry)
@@ -199,7 +199,7 @@ func validateUILayout(layout map[string]string) (r map[string]string, err error)
 		r["wait"] = wait
 	case "qrcode":
 		if content == "" {
-			return nil, fmt.Errorf("'content' is required")
+			return nil, errors.New("'content' is required")
 		}
 		if !slices.Contains([]string{"true", "false"}, wait) {
 			return nil, fmt.Errorf("'wait' is required and does not match allowed values for this type: %v", wait)

--- a/internal/brokers/broker.go
+++ b/internal/brokers/broker.go
@@ -190,6 +190,9 @@ func validateUILayout(layout map[string]string) (r map[string]string, err error)
 		if !slices.Contains([]string{"true", "false", ""}, wait) {
 			return nil, fmt.Errorf("'wait' does not match allowed values for this type: %v", wait)
 		}
+		if button != "" && wait != "true" {
+			return nil, errors.New("button is not allowed if wait is not true")
+		}
 		r["label"] = label
 		r["entry"] = entry
 		r["button"] = button

--- a/internal/brokers/examplebroker/examplebroker.go
+++ b/internal/brokers/examplebroker/examplebroker.go
@@ -160,6 +160,7 @@ func (b *Broker) GetAuthenticationModes(ctx context.Context, sessionID string, s
 							"label":  "Enter your one time credential",
 							"entry":  "chars",
 							"button": "Resend sms",
+							"wait":   "true",
 						}),
 					}
 				} else {


### PR DESCRIPTION
According to the specification, the broker can only specify a button for the layout if wait == true, otherwise the layout is invalid and an error should be returned.