### PR TITLE
Default broker selection

### DIFF
--- a/pam/authorization.go
+++ b/pam/authorization.go
@@ -74,6 +74,7 @@ type authorizationModel struct {
 
 	currentModel       authorizationComponent
 	currentSessionID   string
+	currentBrokerID    string
 	cancelIsAuthorized func()
 
 	errorMsg string
@@ -112,7 +113,7 @@ func (m *authorizationModel) Update(msg tea.Msg) (authorizationModel, tea.Cmd) {
 		log.Infof(context.TODO(), "isAuthorizedResultReceived: %v", msg.access)
 		switch msg.access {
 		case responses.AuthAllowed:
-			return *m, sendEvent(pamSuccess{})
+			return *m, sendEvent(pamSuccess{brokerID: m.currentBrokerID})
 
 		case responses.AuthRetry:
 			m.errorMsg = dataToMsg(msg.data)
@@ -174,7 +175,8 @@ func (m *authorizationModel) Blur() {
 }
 
 // Compose creates and attaches the sub layout models based on UILayout.
-func (m *authorizationModel) Compose(sessionID string, layout *authd.UILayout) tea.Cmd {
+func (m *authorizationModel) Compose(brokerID, sessionID string, layout *authd.UILayout) tea.Cmd {
+	m.currentBrokerID = brokerID
 	m.currentSessionID = sessionID
 	m.cancelIsAuthorized = func() {}
 
@@ -222,6 +224,7 @@ func (m *authorizationModel) Reset() {
 	m.cancelIsAuthorized = func() {}
 	m.currentModel = nil
 	m.currentSessionID = ""
+	m.currentBrokerID = ""
 }
 
 // dataToMsg returns the data message from a given JSON message.

--- a/pam/brokerselection.go
+++ b/pam/brokerselection.go
@@ -169,10 +169,6 @@ func (m *brokerSelectionModel) AutoSelectForUser(username string) tea.Cmd {
 			return nil
 		}
 		brokerID := r.GetPreviousBroker()
-		// TODO: REMOVE, for testing
-		if username == "user1" {
-			brokerID = "494968244"
-		}
 		if brokerID == "" {
 			return nil
 		}

--- a/pam/commands.go
+++ b/pam/commands.go
@@ -57,6 +57,7 @@ func startBrokerSession(client authd.PAMClient, brokerID, username string) tea.C
 		}
 
 		return SessionStarted{
+			brokerID:      brokerID,
 			sessionID:     sessionID,
 			encryptionKey: encryptionKey,
 		}

--- a/pam/commands.go
+++ b/pam/commands.go
@@ -22,7 +22,7 @@ func sendEvent(msg tea.Msg) tea.Cmd {
 func startBrokerSession(client authd.PAMClient, brokerID, username string) tea.Cmd {
 	return func() tea.Msg {
 		if brokerID == "local" {
-			return pamIgnore{}
+			return pamIgnore{localBrokerID: brokerID}
 		}
 
 		// Start a transaction for this user with the broker.

--- a/pam/model.go
+++ b/pam/model.go
@@ -28,6 +28,7 @@ const (
 
 // sessionInfo contains the global broker session information.
 type sessionInfo struct {
+	brokerID      string
 	sessionID     string
 	encryptionKey string
 }
@@ -63,6 +64,7 @@ type BrokerSelected struct {
 
 // SessionStarted signals that we started a session with a given broker.
 type SessionStarted struct {
+	brokerID      string
 	sessionID     string
 	encryptionKey string
 }
@@ -170,6 +172,7 @@ func (m *model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 	case SessionStarted:
 		m.currentSession = &sessionInfo{
+			brokerID:      msg.brokerID,
 			sessionID:     msg.sessionID,
 			encryptionKey: msg.encryptionKey,
 		}
@@ -195,7 +198,7 @@ func (m *model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		log.Info(context.TODO(), "UILayoutReceived")
 
 		return m, tea.Sequence(
-			m.authorizationModel.Compose(m.currentSession.sessionID, msg.layout),
+			m.authorizationModel.Compose(m.currentSession.brokerID, m.currentSession.sessionID, msg.layout),
 			m.changeStage(stageChallenge))
 
 	case SessionEnded:

--- a/pam/pam.go
+++ b/pam/pam.go
@@ -46,19 +46,6 @@ func pam_sm_authenticate(pamh *C.pam_handle_t, flags, argc C.int, argv **C.char)
 
 	// Attach logger and info handler.
 	// TODO
-	log.SetLevel(log.DebugLevel)
-	f, err := os.OpenFile("/tmp/logdebug", os.O_CREATE|os.O_APPEND|os.O_RDWR, 0644)
-	if err != nil {
-		panic(err)
-	}
-	defer f.Close()
-	logrus.SetOutput(f)
-
-	// Check if we are in an interactive terminal to see if we can do something
-	/*if !term.IsTerminal(int(os.Stdin.Fd())) {
-		log.Info(context.TODO(), "Not in an interactive terminal and not an authd compatible application. Exiting")
-		return C.PAM_IGNORE
-	}*/
 
 	interactiveTerminal := term.IsTerminal(int(os.Stdin.Fd()))
 
@@ -189,6 +176,20 @@ func pam_sm_setcred(pamh *C.pam_handle_t, flags, argc C.int, argv **C.char) C.in
 	return C.PAM_IGNORE
 }
 
+// Simulating pam on the CLI for manual testing
 func main() {
-	fmt.Println("RETURN: ", pam_sm_authenticate(nil, 0, 0, nil))
+	log.SetLevel(log.DebugLevel)
+	f, err := os.OpenFile("/tmp/logdebug", os.O_CREATE|os.O_APPEND|os.O_RDWR, 0644)
+	if err != nil {
+		panic(err)
+	}
+	defer f.Close()
+	logrus.SetOutput(f)
+
+	authResult := pam_sm_authenticate(nil, 0, 0, nil)
+	fmt.Println("Auth return:", authResult)
+
+	// Simulate setting auth broker as default.
+	accMgmtResult := pam_sm_acct_mgmt(nil, 0, 0, nil)
+	fmt.Println("Acct mgmt return:", accMgmtResult)
 }

--- a/pam/pam.go
+++ b/pam/pam.go
@@ -95,6 +95,8 @@ func pam_sm_authenticate(pamh *C.pam_handle_t, flags, argc C.int, argv **C.char)
 		brokerIDUsedToAuthenticate = exitMsg.brokerID
 		return C.PAM_SUCCESS
 	case pamIgnore:
+		// localBrokerID is only set on pamIgnore if the user has chosen local broker.
+		brokerIDUsedToAuthenticate = exitMsg.localBrokerID
 		if exitMsg.String() != "" {
 			log.Debugf(context.TODO(), "Ignoring authd authentication: %s", exitMsg)
 		}

--- a/pam/pam.go
+++ b/pam/pam.go
@@ -126,30 +126,37 @@ func pam_sm_authenticate(pamh *C.pam_handle_t, flags, argc C.int, argv **C.char)
 	return errCode
 }
 
+// pam_sm_acct_mgmt sets any used brokerID as default for the user.
+//
 //export pam_sm_acct_mgmt
 func pam_sm_acct_mgmt(pamh *C.pam_handle_t, flags, argc C.int, argv **C.char) C.int {
-	/*client, closeConn, err := newClient(argc, argv)
+	// Only set the brokerID as default if we stored one after authentication.
+	if brokerIDUsedToAuthenticate == "" {
+		return C.PAM_IGNORE
+	}
+
+	// Get current user for broker
+	user := getPAMUser(pamh)
+	if user == "" {
+		log.Infof(context.TODO(), "can't get user from PAM")
+		return C.PAM_IGNORE
+	}
+
+	client, closeConn, err := newClient(argc, argv)
 	if err != nil {
 		log.Debugf(context.TODO(), "%s", err)
 		return C.PAM_IGNORE
 	}
 	defer closeConn()
 
-	// Get current user for broker.
-	user, err := getUser(pamh, "")
-	if err != nil {
-		log.Infof(context.TODO(), "Can't get user: %v", err)
-		return C.PAM_IGNORE
-	}
-
 	req := authd.SDBFURequest{
-		SessionId: sessionID,
-		Username:  user,
+		BrokerId: brokerIDUsedToAuthenticate,
+		Username: user,
 	}
 	if _, err := client.SetDefaultBrokerForUser(context.TODO(), &req); err != nil {
-		log.Infof(context.TODO(), "Can't set default broker for %q on session %q: %v", user, sessionID, err)
+		log.Infof(context.TODO(), "Can't set default broker  (%q) for %q: %v", brokerIDUsedToAuthenticate, user, err)
 		return C.PAM_IGNORE
-	}*/
+	}
 
 	return C.PAM_SUCCESS
 }

--- a/pam/return.go
+++ b/pam/return.go
@@ -14,7 +14,8 @@ func (err pamSuccess) String() string {
 
 // pamIgnore signals PAM module to return PAM_IGNORE and Quit tea.Model.
 type pamIgnore struct {
-	msg string
+	localBrokerID string // Only set for local broker to store it globally.
+	msg           string
 }
 
 // String returns the string of pamIgnore message.

--- a/pam/return.go
+++ b/pam/return.go
@@ -4,6 +4,7 @@ package main
 
 // pamSuccess signals PAM module to return PAM_SUCCESS and Quit tea.Model.
 type pamSuccess struct {
+	brokerID string
 }
 
 // String returns the string of pamSuccess.

--- a/pam/userselection.go
+++ b/pam/userselection.go
@@ -40,8 +40,7 @@ func newUserSelectionModel(pamh pamHandle) userSelectionModel {
 
 // Init initializes userSelectionModel, by getting it from PAM if prefilled.
 func (m *userSelectionModel) Init() tea.Cmd {
-	pamUser := "user1" // TODO: remove once on pam
-	//pamUser := getPAMUser(m.pamh)
+	pamUser := getPAMUser(m.pamh)
 	if pamUser != "" {
 		return sendUserSelected(pamUser)
 	}

--- a/pam/utils_c.go
+++ b/pam/utils_c.go
@@ -50,8 +50,14 @@ func sliceFromArgv(argc C.int, argv **C.char) []string {
 	return r
 }
 
+// mockPamUser mocks the PAM user item in absence of pamh for manual testing.
+var mockPamUser = "user1" // TODO: remove assignement once ok with debugging
+
 // getPAMUser returns the user from PAM.
 func getPAMUser(pamh *C.pam_handle_t) string {
+	if pamh == nil {
+		return mockPamUser
+	}
 	cUsername := C.get_user(pamh)
 	if cUsername == nil {
 		return ""
@@ -62,6 +68,10 @@ func getPAMUser(pamh *C.pam_handle_t) string {
 
 // setPAMUser set current user to PAM.
 func setPAMUser(pamh *C.pam_handle_t, username string) {
+	if pamh == nil {
+		mockPamUser = username
+		return
+	}
 	cUsername := C.CString(username)
 	defer C.free(unsafe.Pointer(cUsername))
 


### PR DESCRIPTION
Reenable default broker selection, even with manual testing.

This allows to store remote or local provider selection upon successful authentication.
When manually testing with the binary instead of the PAM stack, consider local selection as always successful.

To reset the default broker selected for a give user, we can restart the authd process as we don’t store the default broker yet in persistent memory.

UDENG-1177