### PR TITLE
Update validateUILayouts logic

### DIFF
--- a/internal/brokers/export_test.go
+++ b/internal/brokers/export_test.go
@@ -2,6 +2,8 @@ package brokers
 
 import (
 	"context"
+	"fmt"
+	"sort"
 
 	"github.com/godbus/dbus/v5"
 )
@@ -25,4 +27,40 @@ func (m *Manager) SetBrokerForSession(b *Broker, sessionID string) {
 	m.transactionsToBrokerMu.Lock()
 	m.transactionsToBroker[sessionID] = b
 	m.transactionsToBrokerMu.Unlock()
+}
+
+// GenerateLayoutValidators generates the layout validators and assign them to the specified broker.
+func GenerateLayoutValidators(b *Broker, sessionID string, supportedUILayouts []map[string]string) {
+	b.layoutValidators = generateValidators(context.Background(), sessionID, supportedUILayouts)
+}
+
+// LayoutValidatorsString returns a string representation of the layout validators.
+func (b *Broker) LayoutValidatorsString() string {
+	// Gets the map keys and sort them
+	var keys []string
+	for k := range b.layoutValidators {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+
+	var s string
+	for _, k := range keys {
+		layoutStr := fmt.Sprintf("\t%s:\n", k)
+
+		validator := b.layoutValidators[k]
+
+		// Same thing for sorting the keys of the validator map
+		var vKeys []string
+		for v := range validator {
+			vKeys = append(vKeys, v)
+		}
+		sort.Strings(vKeys)
+
+		for _, v := range vKeys {
+			layoutStr += fmt.Sprintf("\t\t%s: { required: %v, supportedValues: %v }\n", v, validator[v].required, validator[v].supportedValues)
+		}
+
+		s += layoutStr
+	}
+	return s
 }

--- a/internal/brokers/testdata/TestGetAuthenticationModes/golden/get_authentication_modes_and_generate_validator_ignoring_whitespaces_in_supported_values
+++ b/internal/brokers/testdata/TestGetAuthenticationModes/golden/get_authentication_modes_and_generate_validator_ignoring_whitespaces_in_supported_values
@@ -1,6 +1,6 @@
 MODES:
-[]
+[{"id":"mode1","label":"Mode 1"}]
 
 VALIDATORS:
-	required-value:
+	layout-with-spaces:
 		value: { required: true, supportedValues: [value_type other_value_type] }

--- a/internal/brokers/testdata/TestGetAuthenticationModes/golden/get_authentication_modes_and_generate_validators
+++ b/internal/brokers/testdata/TestGetAuthenticationModes/golden/get_authentication_modes_and_generate_validators
@@ -1,0 +1,8 @@
+MODES:
+[{"id":"mode1","label":"Mode 1"}]
+
+VALIDATORS:
+	optional-value:
+		value: { required: false, supportedValues: [value_type other_value_type] }
+	required-value:
+		value: { required: true, supportedValues: [value_type other_value_type] }

--- a/internal/brokers/testdata/TestGetAuthenticationModes/golden/get_authentication_modes_and_ignores_invalid_ui_layout
+++ b/internal/brokers/testdata/TestGetAuthenticationModes/golden/get_authentication_modes_and_ignores_invalid_ui_layout
@@ -1,5 +1,5 @@
 MODES:
-[]
+[{"id":"mode1","label":"Mode 1"}]
 
 VALIDATORS:
 	required-value:

--- a/internal/brokers/testdata/TestGetAuthenticationModes/golden/get_multiple_authentication_modes_and_generate_validators
+++ b/internal/brokers/testdata/TestGetAuthenticationModes/golden/get_multiple_authentication_modes_and_generate_validators
@@ -1,0 +1,8 @@
+MODES:
+[{"id":"mode1","label":"Mode 1"},{"id":"mode2","label":"Mode 2"}]
+
+VALIDATORS:
+	optional-value:
+		value: { required: false, supportedValues: [value_type other_value_type] }
+	required-value:
+		value: { required: true, supportedValues: [value_type other_value_type] }

--- a/internal/brokers/testdata/TestGetAuthenticationModes/golden/successfully_get_authentication_modes
+++ b/internal/brokers/testdata/TestGetAuthenticationModes/golden/successfully_get_authentication_modes
@@ -1,2 +1,0 @@
-- id: mode1
-  label: Mode 1

--- a/internal/brokers/testdata/TestSelectAuthenticationMode/golden/successfully_select_form_authentication_mode
+++ b/internal/brokers/testdata/TestSelectAuthenticationMode/golden/successfully_select_form_authentication_mode
@@ -1,5 +1,0 @@
-button: ""
-entry: chars_password
-label: Success form
-type: form
-wait: ""

--- a/internal/brokers/testdata/TestSelectAuthenticationMode/golden/successfully_select_mode_with_missing_optional_value
+++ b/internal/brokers/testdata/TestSelectAuthenticationMode/golden/successfully_select_mode_with_missing_optional_value
@@ -1,0 +1,1 @@
+type: optional-value

--- a/internal/brokers/testdata/TestSelectAuthenticationMode/golden/successfully_select_mode_with_optional_value
+++ b/internal/brokers/testdata/TestSelectAuthenticationMode/golden/successfully_select_mode_with_optional_value
@@ -1,0 +1,2 @@
+type: optional-value
+value: value_type

--- a/internal/brokers/testdata/TestSelectAuthenticationMode/golden/successfully_select_mode_with_required_value
+++ b/internal/brokers/testdata/TestSelectAuthenticationMode/golden/successfully_select_mode_with_required_value
@@ -1,0 +1,2 @@
+type: required-value
+value: value_type

--- a/internal/brokers/testdata/TestSelectAuthenticationMode/golden/successfully_select_newpassword_authentication_mode
+++ b/internal/brokers/testdata/TestSelectAuthenticationMode/golden/successfully_select_newpassword_authentication_mode
@@ -1,4 +1,0 @@
-button: ""
-entry: chars_password
-label: Success newpassword
-type: newpassword

--- a/internal/brokers/testdata/TestSelectAuthenticationMode/golden/successfully_select_qrcode_authentication_mode
+++ b/internal/brokers/testdata/TestSelectAuthenticationMode/golden/successfully_select_qrcode_authentication_mode
@@ -1,6 +1,0 @@
-button: ""
-content: Success QRCode
-entry: ""
-label: ""
-type: qrcode
-wait: "true"

--- a/internal/testutils/broker.go
+++ b/internal/testutils/broker.go
@@ -119,94 +119,66 @@ func (b *BrokerBusMock) GetAuthenticationModes(sessionID string, supportedUILayo
 		return []map[string]string{
 			{"invalid": "invalid"},
 		}, nil
-
 	case "GAM_empty":
 		return nil, nil
-
 	case "GAM_error":
 		return nil, dbus.MakeFailedError(fmt.Errorf("Broker %q: GetAuthenticationModes errored out", b.name))
+	case "GAM_multiple_modes":
+		return []map[string]string{
+			{"id": "mode1", "label": "Mode 1"},
+			{"id": "mode2", "label": "Mode 2"},
+		}, nil
+	default:
+		return []map[string]string{
+			{"id": "mode1", "label": "Mode 1"},
+		}, nil
 	}
-
-	return []map[string]string{
-		{"id": "mode1", "label": "Mode 1"},
-	}, nil
 }
 
 // SelectAuthenticationMode returns default values to be used in tests or an error if requested.
 func (b *BrokerBusMock) SelectAuthenticationMode(sessionID, authenticationModeName string) (uiLayoutInfo map[string]string, dbusErr *dbus.Error) {
 	switch sessionID {
+	case "SAM_success_required_value":
+		return map[string]string{
+			"type":  "required-value",
+			"value": "value_type",
+		}, nil
+	case "SAM_success_optional_value":
+		return map[string]string{
+			"type":  "optional-value",
+			"value": "value_type",
+		}, nil
+	case "SAM_missing_optional_value":
+		return map[string]string{
+			"type": "optional-value",
+		}, nil
 	case "SAM_invalid_layout_type":
 		return map[string]string{
 			"invalid": "invalid",
 		}, nil
-	case "SAM_no_layout":
-		return nil, nil
+	case "SAM_missing_required_value":
+		return map[string]string{
+			"type": "required-value",
+		}, nil
+	case "SAM_invalid_required_value":
+		return map[string]string{
+			"type":  "required-value",
+			"value": "invalid value",
+		}, nil
+	case "SAM_invalid_optional_value":
+		return map[string]string{
+			"type":  "optional-value",
+			"value": "invalid value",
+		}, nil
 	case "SAM_error":
 		return nil, dbus.MakeFailedError(fmt.Errorf("Broker %q: SelectAuthenticationMode errored out", b.name))
-
-	case "SAM_form_no_label":
-		return map[string]string{
-			"type":  "form",
-			"label": "",
-			"entry": "chars_password",
-		}, nil
-	case "SAM_form_invalid_entry":
-		return map[string]string{
-			"type":  "form",
-			"label": "Invalid Entry",
-			"entry": "invalid",
-		}, nil
-	case "SAM_form_invalid_wait":
-		return map[string]string{
-			"type":  "form",
-			"label": "Invalid Wait",
-			"entry": "chars_password",
-			"wait":  "invalid",
-		}, nil
-	case "SAM_form_success":
-		return map[string]string{
-			"type":  "form",
-			"label": "Success form",
-			"entry": "chars_password",
-		}, nil
-	case "SAM_qrcode_no_content":
-		return map[string]string{
-			"type":    "qrcode",
-			"content": "",
-		}, nil
-	case "SAM_qrcode_invalid_wait":
-		return map[string]string{
-			"type":    "qrcode",
-			"content": "Invalid Wait",
-			"wait":    "invalid",
-		}, nil
-	case "SAM_qrcode_success":
-		return map[string]string{
-			"type":    "qrcode",
-			"content": "Success QRCode",
-			"wait":    "true",
-		}, nil
-	case "SAM_newpassword_no_label":
-		return map[string]string{
-			"type":  "newpassword",
-			"label": "",
-			"entry": "chars_password",
-		}, nil
-	case "SAM_newpassword_invalid_entry":
-		return map[string]string{
-			"type":  "newpassword",
-			"label": "Invalid Entry",
-			"entry": "invalid",
-		}, nil
-	case "SAM_newpassword_success":
-		return map[string]string{
-			"type":  "newpassword",
-			"label": "Success newpassword",
-			"entry": "chars_password",
-		}, nil
-	default:
+	case "SAM_no_layout":
+		return nil, nil
+	case "SAM_empty_layout":
 		return map[string]string{}, nil
 	}
+	// Should never get here
+	return map[string]string{}, nil
 }
 
 // IsAuthorized returns default values to be used in tests or an error if requested.


### PR DESCRIPTION
We used to have a static verification for the UI layouts returned by the broker, but those are subject to change according to what the system can currently handle. This means that it's up to PAM to provide which layouts are supported, which fields of those layouts are required and what values those fields support.

This replaces the previous static implementation of validateUILayouts with a dynamic one that takes into consideration what was specified by PAM.

UDENG-1166