### PR TITLE
Restore cmd/authd behavior and rework examplebroker creation

### DIFF
--- a/cmd/authd/daemon/daemon.go
+++ b/cmd/authd/daemon/daemon.go
@@ -106,6 +106,7 @@ func (a *App) serve(config daemonConfig) error {
 		close(a.ready)
 		return err
 	}
+	defer m.Stop()
 
 	var daemonopts []daemon.Option
 	if config.SystemDirs.SocketPath != "" {

--- a/cmd/authd/main.go
+++ b/cmd/authd/main.go
@@ -3,17 +3,13 @@ package main
 
 import (
 	"context"
-	"fmt"
 	"os"
 	"os/signal"
 	"sync"
 	"syscall"
-	"time"
 
 	"github.com/ubuntu/authd/cmd/authd/daemon"
-	"github.com/ubuntu/authd/internal/brokers/examplebroker"
 	"github.com/ubuntu/authd/internal/log"
-	"github.com/ubuntu/authd/internal/testutils"
 )
 
 //FIXME go:generate go run ../generate_completion_documentation.go completion ../../generated
@@ -22,43 +18,8 @@ import (
 
 func main() {
 	//i18n.InitI18nDomain(common.TEXTDOMAIN)
-	busCleanup, err := testutils.StartSystemBusMock()
-	if err != nil {
-		os.Exit(1)
-	}
-	fmt.Printf("Mock system bus started on %s\n", os.Getenv("DBUS_SYSTEM_BUS_ADDRESS"))
-
-	// Create the directory for the broker configuration files.
-	if err = os.MkdirAll("/etc/authd/broker.d", 0750); err != nil {
-		busCleanup()
-		os.Exit(1)
-	}
-	cleanup := func() {
-		os.RemoveAll("/etc/authd/broker.d")
-		busCleanup()
-	}
-
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-	done := make(chan struct{})
-	go func() {
-		if err = examplebroker.StartBus(ctx); err != nil {
-			log.Error(context.Background(), err)
-			cleanup()
-			os.Exit(1)
-		}
-		close(done)
-	}()
-	// Give some time for the broker to start
-	time.Sleep(time.Second)
-
-	exitCode := run(daemon.New())
-	// After the daemon has exited, we can stop the broker as well.
-	cancel()
-	<-done
-	// We use os.Exit, so we need to call cleanup manually since defered functions won't be executed.
-	cleanup()
-	os.Exit(exitCode)
+	a := daemon.New()
+	os.Exit(run(a))
 }
 
 type app interface {

--- a/internal/brokers/broker.go
+++ b/internal/brokers/broker.go
@@ -6,11 +6,9 @@ import (
 	"errors"
 	"fmt"
 	"hash/fnv"
-	"os"
 	"strings"
 
 	"github.com/godbus/dbus/v5"
-	"github.com/ubuntu/authd/internal/brokers/examplebroker"
 	"github.com/ubuntu/authd/internal/log"
 	"github.com/ubuntu/authd/internal/responses"
 	"github.com/ubuntu/decorate"
@@ -65,9 +63,6 @@ func newBroker(ctx context.Context, name, configFile string, bus *dbus.Conn) (b 
 		if err != nil {
 			return Broker{}, err
 		}
-	} else if _, set := os.LookupEnv("AUTHD_USE_EXAMPLES"); set && name != localBrokerName {
-		// if the broker does not have a config file and the AUTHD_USE_EXAMPLES env var is set, use the example broker
-		broker, fullName, brandIcon = examplebroker.New(name)
 	}
 
 	return Broker{

--- a/internal/brokers/examplebroker/dbus.go
+++ b/internal/brokers/examplebroker/dbus.go
@@ -12,9 +12,8 @@ import (
 )
 
 const (
-	dbusObjectPath = "/com/ubuntu/auth/ExampleBroker"
-	dbusInterface  = "com.ubuntu.auth.ExampleBroker"
-	configDir      = "/etc/authd/broker.d/"
+	dbusObjectPath = "/com/ubuntu/authd/ExampleBroker"
+	dbusInterface  = "com.ubuntu.authd.ExampleBroker"
 )
 
 // Bus is the D-Bus object that will answer calls for the broker.
@@ -23,7 +22,7 @@ type Bus struct {
 }
 
 // StartBus starts the D-Bus service and exports it on the system bus.
-func StartBus(ctx context.Context) (err error) {
+func StartBus(ctx context.Context, cfgPath string) (err error) {
 	defer decorate.OnError(&err, "could not start example broker bus")
 
 	conn, err := dbus.ConnectSystemBus()
@@ -60,22 +59,22 @@ func StartBus(ctx context.Context) (err error) {
 		return fmt.Errorf("D-Bus name already taken")
 	}
 
-	if err = os.WriteFile(filepath.Join(configDir, "examplebroker.conf"),
-		[]byte(`
+	if err = os.WriteFile(filepath.Join(cfgPath, "examplebroker.conf"),
+		[]byte(fmt.Sprintf(`
 name = ExampleBroker
 brand_icon = /usr/share/backgrounds/warty-final-ubuntu.png
 
 [dbus]
-name = com.ubuntu.authd.ExampleBroker
-object = /com/ubuntu/authd/ExampleBroker
-interface = com.ubuntu.authd.ExampleBroker
-`),
+name = %s
+object = %s
+interface = %s
+`, dbusInterface, dbusObjectPath, dbusInterface)),
 		0600); err != nil {
 		return err
 	}
 
 	<-ctx.Done()
-	return os.Remove(filepath.Join(configDir, "examplebroker.conf"))
+	return nil
 }
 
 // NewSession is the method through which the broker and the daemon will communicate once dbusInterface.NewSession is called.

--- a/internal/brokers/withexamples.go
+++ b/internal/brokers/withexamples.go
@@ -1,0 +1,114 @@
+//go:build withexamplebroker
+
+package brokers
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"time"
+
+	"github.com/ubuntu/authd/internal/brokers/examplebroker"
+	"github.com/ubuntu/authd/internal/log"
+)
+
+// useExampleBrokers starts a mock system bus and exports the examplebroker in it.
+func useExampleBrokers() (string, func(), error) {
+	busCleanup, err := startSystemBusMock()
+	if err != nil {
+		return "", nil, err
+	}
+	log.Debugf(context.Background(), "Mock system bus started on %s\n", os.Getenv("DBUS_SYSTEM_BUS_ADDRESS"))
+
+	// Create the directory for the broker configuration files.
+	cfgPath, err := os.MkdirTemp(os.TempDir(), "examplebroker.d")
+	if err != nil {
+		busCleanup()
+		return "", nil, err
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		defer os.RemoveAll(cfgPath)
+		defer busCleanup()
+		if err = examplebroker.StartBus(ctx, cfgPath); err != nil {
+			log.Errorf(ctx, "Error starting examplebroker: %v", err)
+		}
+	}()
+
+	// Give some time for the broker to start
+	time.Sleep(time.Second)
+
+	return cfgPath, func() {
+		cancel()
+		<-done
+	}, nil
+}
+
+// startSystemBusMock starts a mock dbus daemon and returns a cancel function to stop it.
+func startSystemBusMock() (func(), error) {
+	busDir := filepath.Join(os.TempDir(), "authd-system-bus-mock")
+	if err := os.MkdirAll(busDir, 0750); err != nil {
+		return nil, err
+	}
+
+	cfgPath := filepath.Join(busDir, "bus.conf")
+	listenPath := filepath.Join(busDir, "bus.sock")
+
+	err := os.WriteFile(cfgPath, []byte(fmt.Sprintf(localSystemBusCfg, listenPath)), 0600)
+	if err != nil {
+		err = errors.Join(err, os.RemoveAll(busDir))
+		return nil, err
+	}
+
+	busCtx, busCancel := context.WithCancel(context.Background())
+	//#nosec:G204 // This is only for manual testing purposes and won't be in production code.
+	cmd := exec.CommandContext(busCtx, "dbus-daemon", "--config-file="+cfgPath)
+	if err := cmd.Start(); err != nil {
+		busCancel()
+		err = errors.Join(err, os.RemoveAll(busDir))
+		return nil, err
+	}
+	// Give some time for the daemon to start.
+	time.Sleep(5 * time.Millisecond)
+
+	prev, set := os.LookupEnv("DBUS_SYSTEM_BUS_ADDRESS")
+	os.Setenv("DBUS_SYSTEM_BUS_ADDRESS", "unix:path="+listenPath)
+
+	return func() {
+		busCancel()
+		_ = cmd.Wait()
+		_ = os.RemoveAll(busDir)
+
+		if !set {
+			os.Unsetenv("DBUS_SYSTEM_BUS_ADDRESS")
+		} else {
+			os.Setenv("DBUS_SYSTEM_BUS_ADDRESS", prev)
+		}
+	}, nil
+}
+
+// Stop calls the function responsible for cleaning up the examplebrokers.
+func (m *Manager) Stop() {
+	m.cleanup()
+}
+
+var localSystemBusCfg = `<!DOCTYPE busconfig PUBLIC "-//freedesktop//DTD D-Bus Bus Configuration 1.0//EN"
+ "http://www.freedesktop.org/standards/dbus/1.0/busconfig.dtd">
+<busconfig>
+  <type>system</type>
+  <keep_umask/>
+  <listen>unix:path=%s</listen>
+  <policy context="default">
+    <allow user="*"/>
+    <allow send_destination="*" eavesdrop="true"/>
+    <allow eavesdrop="true"/>
+    <allow own="*"/>
+  </policy>
+</busconfig>
+`

--- a/internal/brokers/withoutexamples.go
+++ b/internal/brokers/withoutexamples.go
@@ -1,0 +1,11 @@
+//go:build !withexamplebroker
+
+package brokers
+
+// useExampleBrokers is a no-op in production code.
+func useExampleBrokers() (string, func(), error) {
+	return "", nil, nil
+}
+
+// Stop is a no-op in production code.
+func (m *Manager) Stop() {}

--- a/internal/manager/withexamples.go
+++ b/internal/manager/withexamples.go
@@ -1,0 +1,8 @@
+//go:build withexamplebroker
+
+package manager
+
+// Stop calls the brokerManager function that stops and cleans the examplebroker files.
+func (m *Manager) Stop() {
+	m.brokerManager.Stop()
+}

--- a/internal/manager/withoutexamples.go
+++ b/internal/manager/withoutexamples.go
@@ -1,0 +1,6 @@
+//go:build !withexamplebroker
+
+package manager
+
+// Stop is a no-op in production code.
+func (m *Manager) Stop() {}


### PR DESCRIPTION
We want the ability to run `authd` with the `examplebroker` in order to run manual tests, but without affecting the cmd package. Since this will be shipped in production, we also needed to change the way the `examplebrokers` are created, since using environment variables would introduce a big security liability.
This PR restores the previous behavior of the cmd package and switches the `examplebrokers` creation to rely on build tags instead, which will not impact the production code.

UDENG-1259