### PR TITLE
Allow dynamic request of the UI layout

### DIFF
--- a/pam/model.go
+++ b/pam/model.go
@@ -179,8 +179,12 @@ func (m *model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m, sendEvent(GetAuthenticationModesRequested{})
 
 	case GetAuthenticationModesRequested:
+		if m.currentSession == nil || !m.authModeSelectionModel.IsReady() {
+			return m, nil
+		}
+
 		return m, tea.Sequence(
-			getAuthenticationModes(m.client, m.currentSession.sessionID),
+			getAuthenticationModes(m.client, m.currentSession.sessionID, m.authModeSelectionModel.SupportedUILayouts()),
 			m.changeStage(stageAuthModeSelection),
 		)
 


### PR DESCRIPTION
Right now, the UI layout is hardcoded in the pam module and just requested in time.

Requests those rather at the start of the transaction, asynchronously, so that then, we can query third parties like GDM.

UDENG-1300