### PR TITLE
Allow easy DB test helpers being exported

### DIFF
--- a/internal/cache/db_test.go
+++ b/internal/cache/db_test.go
@@ -2,7 +2,6 @@ package cache_test
 
 import (
 	"errors"
-	"io"
 	"io/fs"
 	"os"
 	"path/filepath"
@@ -12,6 +11,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 	"github.com/ubuntu/authd/internal/cache"
+	cachetests "github.com/ubuntu/authd/internal/cache/tests"
 	"github.com/ubuntu/authd/internal/testutils"
 )
 
@@ -86,7 +86,7 @@ func TestNew(t *testing.T) {
 				time.Sleep(time.Millisecond)
 			}
 
-			got, err := dumpToYaml(c)
+			got, err := cachetests.DumpToYaml(c)
 			require.NoError(t, err, "Created database should be valid yaml content")
 
 			want := testutils.LoadWithUpdateFromGolden(t, got)
@@ -254,7 +254,7 @@ func TestUpdateFromUserInfo(t *testing.T) {
 
 			requireNoDirtyFileInDir(t, cacheDir)
 
-			got, err := dumpToYaml(c)
+			got, err := cachetests.DumpToYaml(c)
 			require.NoError(t, err, "Created database should be valid yaml content")
 
 			want := testutils.LoadWithUpdateFromGolden(t, got)
@@ -434,7 +434,7 @@ func createDBFile(t *testing.T, src, destDir string) {
 	require.NoError(t, err, "Setup: should be able to read source file")
 	defer f.Close()
 
-	err = dbfromYAML(f, destDir)
+	err = cachetests.DbfromYAML(f, destDir)
 	require.NoError(t, err, "Setup: should be able to write database file")
 }
 
@@ -456,16 +456,10 @@ UserByName: {}
 UserToGroups: {}
 `
 
-	got, err := dumpToYaml(c)
+	got, err := cachetests.DumpToYaml(c)
 	require.NoError(t, err, "Created database should be valid yaml content")
 	require.Equal(t, want, got, "Database should only have empty buckets")
 }
-
-//go:linkname dumpToYaml github.com/ubuntu/authd/internal/cache.(*Cache).dumpToYaml
-func dumpToYaml(c *cache.Cache) (string, error)
-
-//go:linkname dbfromYAML github.com/ubuntu/authd/internal/cache.dbfromYAML
-func dbfromYAML(r io.Reader, destDir string) error
 
 func TestMain(m *testing.M) {
 	testutils.InstallUpdateFlag()

--- a/internal/cache/tests/serialization.go
+++ b/internal/cache/tests/serialization.go
@@ -1,0 +1,20 @@
+// Package tests export cache test functionalities used by other packages.
+package tests
+
+import (
+	"io"
+	//nolint:revive,nolintlint // needed for go:linkname, but only used in tests. nolinlint as false positive then.
+	_ "unsafe"
+
+	"github.com/ubuntu/authd/internal/cache"
+)
+
+// DumpToYaml deserializes the cache database to a writer in a yaml format.
+//
+//go:linkname DumpToYaml github.com/ubuntu/authd/internal/cache.(*Cache).dumpToYaml
+func DumpToYaml(c *cache.Cache) (string, error)
+
+// DbfromYAML loads a yaml formatted of the buckets and dump it into destDir, with its dbname.
+//
+//go:linkname DbfromYAML github.com/ubuntu/authd/internal/cache.dbfromYAML
+func DbfromYAML(r io.Reader, destDir string) error


### PR DESCRIPTION
Move those and link from a subpackage, to ensure we know exactly what we import in a package (not importing tests by accident). This will be reused in the PAM/NSS services tests to load and dump the database.