### PR TITLE
Move service manager at the root of services

### DIFF
--- a/cmd/authd/daemon/daemon.go
+++ b/cmd/authd/daemon/daemon.go
@@ -11,7 +11,7 @@ import (
 	"github.com/ubuntu/authd/internal/consts"
 	"github.com/ubuntu/authd/internal/daemon"
 	"github.com/ubuntu/authd/internal/log"
-	"github.com/ubuntu/authd/internal/manager"
+	"github.com/ubuntu/authd/internal/services"
 	"github.com/ubuntu/decorate"
 )
 
@@ -101,7 +101,7 @@ func New() *App {
 func (a *App) serve(config daemonConfig) error {
 	ctx := context.Background()
 
-	m, err := manager.New(ctx, config.Brokers)
+	m, err := services.NewManager(ctx, config.Brokers)
 	if err != nil {
 		close(a.ready)
 		return err

--- a/internal/services/manager.go
+++ b/internal/services/manager.go
@@ -1,5 +1,5 @@
-// Package manager mediates all the business logic of the application.
-package manager
+// Package services mediates all the business logic of the application via a manager.
+package services
 
 import (
 	"context"
@@ -20,8 +20,8 @@ type Manager struct {
 	pamService    pam.Service
 }
 
-// New returns a new manager after creating all necessary items for our business logic.
-func New(ctx context.Context, configuredBrokers []string) (m Manager, err error) {
+// NewManager returns a new manager after creating all necessary items for our business logic.
+func NewManager(ctx context.Context, configuredBrokers []string) (m Manager, err error) {
 	defer decorate.OnError(&err /*i18n.G(*/, "can't create authd object") //)
 
 	log.Debug(ctx, "Building authd object")

--- a/internal/services/withexamples.go
+++ b/internal/services/withexamples.go
@@ -1,6 +1,6 @@
 //go:build withexamplebroker
 
-package manager
+package services
 
 // Stop calls the brokerManager function that stops and cleans the examplebroker files.
 func (m *Manager) Stop() {

--- a/internal/services/withoutexamples.go
+++ b/internal/services/withoutexamples.go
@@ -1,6 +1,6 @@
 //go:build !withexamplebroker
 
-package manager
+package services
 
 // Stop is a no-op in production code.
 func (m *Manager) Stop() {}


### PR DESCRIPTION
As this relies heavily on the services, it’s more logical to have it in the same directory, to coordinate any child services.