### PR TITLE
Updating broker tests to cover some implicit cases

### DIFF
--- a/internal/brokers/broker_test.go
+++ b/internal/brokers/broker_test.go
@@ -115,7 +115,7 @@ func TestGetAuthenticationModes(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
-			b := newBrokerForTests(t, "")
+			b := newBrokerForTests(t, "", "")
 
 			if tc.supportedUILayouts == nil {
 				tc.supportedUILayouts = []string{"required-entry"}
@@ -173,7 +173,7 @@ func TestSelectAuthenticationMode(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
-			b := newBrokerForTests(t, "")
+			b := newBrokerForTests(t, "", "")
 
 			if tc.supportedUILayouts == nil {
 				tc.supportedUILayouts = []string{"required-entry"}
@@ -226,7 +226,7 @@ func TestIsAuthenticated(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
-			b := newBrokerForTests(t, "")
+			b := newBrokerForTests(t, "", "")
 
 			// Stores the combined output of both calls to IsAuthenticated
 			var firstCallReturn, secondCallReturn string
@@ -277,7 +277,7 @@ func TestCancelIsAuthenticated(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
-			b := newBrokerForTests(t, "")
+			b := newBrokerForTests(t, "", "")
 
 			var access string
 			ctx, cancel := context.WithCancel(context.Background())
@@ -299,14 +299,17 @@ func TestCancelIsAuthenticated(t *testing.T) {
 	}
 }
 
-func newBrokerForTests(t *testing.T, cfgDir string) (b brokers.Broker) {
+func newBrokerForTests(t *testing.T, cfgDir, brokerName string) (b brokers.Broker) {
 	t.Helper()
 
 	if cfgDir == "" {
 		cfgDir = t.TempDir()
 	}
+	if brokerName == "" {
+		brokerName = strings.ReplaceAll(t.Name(), "/", "_")
+	}
 
-	cfgPath, cleanup, err := testutils.StartBusBrokerMock(cfgDir, strings.ReplaceAll(t.Name(), "/", "_"))
+	cfgPath, cleanup, err := testutils.StartBusBrokerMock(cfgDir, brokerName)
 	require.NoError(t, err, "Setup: could not start bus broker mock")
 	t.Cleanup(cleanup)
 
@@ -314,7 +317,7 @@ func newBrokerForTests(t *testing.T, cfgDir string) (b brokers.Broker) {
 	require.NoError(t, err, "Setup: could not connect to system bus")
 	t.Cleanup(func() { require.NoError(t, conn.Close(), "Teardown: Failed to close the connection") })
 
-	b, err = brokers.NewBroker(context.Background(), strings.ReplaceAll(t.Name(), "/", "_"), cfgPath, conn)
+	b, err = brokers.NewBroker(context.Background(), brokerName, cfgPath, conn)
 	require.NoError(t, err, "Setup: could not create broker")
 
 	return b

--- a/internal/brokers/broker_test.go
+++ b/internal/brokers/broker_test.go
@@ -93,6 +93,8 @@ func TestNewBroker(t *testing.T) {
 func TestGetAuthenticationModes(t *testing.T) {
 	t.Parallel()
 
+	b := newBrokerForTests(t, "", "")
+
 	tests := map[string]struct {
 		sessionID          string
 		supportedUILayouts []string
@@ -115,8 +117,6 @@ func TestGetAuthenticationModes(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
-			b := newBrokerForTests(t, "", "")
-
 			if tc.supportedUILayouts == nil {
 				tc.supportedUILayouts = []string{"required-entry"}
 			}
@@ -126,7 +126,7 @@ func TestGetAuthenticationModes(t *testing.T) {
 				supportedUILayouts = append(supportedUILayouts, supportedLayouts[layout])
 			}
 
-			gotModes, err := b.GetAuthenticationModes(context.Background(), tc.sessionID, supportedUILayouts)
+			gotModes, err := b.GetAuthenticationModes(context.Background(), prefixID(t, tc.sessionID), supportedUILayouts)
 			if tc.wantErr {
 				require.Error(t, err, "GetAuthenticationModes should return an error, but did not")
 				return
@@ -136,7 +136,7 @@ func TestGetAuthenticationModes(t *testing.T) {
 			modesStr, err := json.Marshal(gotModes)
 			require.NoError(t, err, "Post: error when marshaling result")
 
-			got := "MODES:\n" + string(modesStr) + "\n\nVALIDATORS:\n" + b.LayoutValidatorsString(tc.sessionID)
+			got := "MODES:\n" + string(modesStr) + "\n\nVALIDATORS:\n" + b.LayoutValidatorsString(prefixID(t, tc.sessionID))
 			want := testutils.LoadWithUpdateFromGolden(t, got)
 			require.Equal(t, want, got, "GetAuthenticationModes should return the expected modes, but did not")
 		})
@@ -145,6 +145,8 @@ func TestGetAuthenticationModes(t *testing.T) {
 
 func TestSelectAuthenticationMode(t *testing.T) {
 	t.Parallel()
+
+	b := newBrokerForTests(t, "", "")
 
 	tests := map[string]struct {
 		sessionID          string
@@ -173,8 +175,6 @@ func TestSelectAuthenticationMode(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
-			b := newBrokerForTests(t, "", "")
-
 			if tc.supportedUILayouts == nil {
 				tc.supportedUILayouts = []string{"required-entry"}
 			}
@@ -184,9 +184,9 @@ func TestSelectAuthenticationMode(t *testing.T) {
 				supportedUILayouts = append(supportedUILayouts, supportedLayouts[layout])
 			}
 			// This is normally done in the broker's GetAuthenticationModes method, but we need to do it here to test the SelectAuthenticationMode method.
-			brokers.GenerateLayoutValidators(&b, tc.sessionID, supportedUILayouts)
+			brokers.GenerateLayoutValidators(&b, prefixID(t, tc.sessionID), supportedUILayouts)
 
-			gotUI, err := b.SelectAuthenticationMode(context.Background(), tc.sessionID, "mode1")
+			gotUI, err := b.SelectAuthenticationMode(context.Background(), prefixID(t, tc.sessionID), "mode1")
 			if tc.wantErr {
 				require.Error(t, err, "SelectAuthenticationMode should return an error, but did not")
 				return
@@ -201,6 +201,8 @@ func TestSelectAuthenticationMode(t *testing.T) {
 
 func TestIsAuthenticated(t *testing.T) {
 	t.Parallel()
+
+	b := newBrokerForTests(t, "", "")
 
 	tests := map[string]struct {
 		sessionID  string
@@ -226,8 +228,6 @@ func TestIsAuthenticated(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
-			b := newBrokerForTests(t, "", "")
-
 			// Stores the combined output of both calls to IsAuthenticated
 			var firstCallReturn, secondCallReturn string
 
@@ -237,8 +237,8 @@ func TestIsAuthenticated(t *testing.T) {
 			done := make(chan struct{})
 			go func() {
 				defer close(done)
-				access, gotData, err := b.IsAuthenticated(ctx, tc.sessionID, "password")
-				firstCallReturn = fmt.Sprintf("FIRST CALL:\n\taccess: %s\n\tdata: %+v\n\terr: %v\n", access, gotData, err)
+				access, gotData, err := b.IsAuthenticated(ctx, prefixID(t, tc.sessionID), "password")
+				firstCallReturn = fmt.Sprintf("FIRST CALL:\n\taccess: %s\n\tdata: %s\n\terr: %v\n", access, gotData, err)
 			}()
 
 			// Give some time for the first call to block
@@ -249,8 +249,8 @@ func TestIsAuthenticated(t *testing.T) {
 					cancel()
 					<-done
 				}
-				access, gotData, err := b.IsAuthenticated(context.Background(), tc.sessionID, "password")
-				secondCallReturn = fmt.Sprintf("SECOND CALL:\n\taccess: %s\n\tdata: %+v\n\terr: %v\n", access, gotData, err)
+				access, gotData, err := b.IsAuthenticated(context.Background(), prefixID(t, tc.sessionID), "password")
+				secondCallReturn = fmt.Sprintf("SECOND CALL:\n\taccess: %s\n\tdata: %s\n\terr: %v\n", access, gotData, err)
 			}
 
 			<-done
@@ -263,6 +263,8 @@ func TestIsAuthenticated(t *testing.T) {
 
 func TestCancelIsAuthenticated(t *testing.T) {
 	t.Parallel()
+
+	b := newBrokerForTests(t, "", "")
 
 	tests := map[string]struct {
 		sessionID string
@@ -277,13 +279,11 @@ func TestCancelIsAuthenticated(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
-			b := newBrokerForTests(t, "", "")
-
 			var access string
 			ctx, cancel := context.WithCancel(context.Background())
 			done := make(chan struct{})
 			go func() {
-				access, _, _ = b.IsAuthenticated(ctx, tc.sessionID, "password")
+				access, _, _ = b.IsAuthenticated(ctx, prefixID(t, tc.sessionID), "password")
 				close(done)
 			}()
 			defer cancel()
@@ -321,4 +321,10 @@ func newBrokerForTests(t *testing.T, cfgDir, brokerName string) (b brokers.Broke
 	require.NoError(t, err, "Setup: could not create broker")
 
 	return b
+}
+
+// prefixID is a helper function that prefixes the given ID with the test name to avoid conflicts.
+func prefixID(t *testing.T, id string) string {
+	t.Helper()
+	return t.Name() + testutils.IDSeparator + id
 }

--- a/internal/brokers/manager_test.go
+++ b/internal/brokers/manager_test.go
@@ -136,7 +136,7 @@ func TestBrokerFromSessionID(t *testing.T) {
 			t.Parallel()
 
 			cfgDir := t.TempDir()
-			b := newBrokerForTests(t, cfgDir)
+			b := newBrokerForTests(t, cfgDir, "")
 			m, err := brokers.NewManager(context.Background(), nil, brokers.WithCfgDir(cfgDir))
 			require.NoError(t, err, "Setup: could not create manager")
 

--- a/internal/brokers/testdata/TestIsAuthenticated/golden/error_when_authenticating
+++ b/internal/brokers/testdata/TestIsAuthenticated/golden/error_when_authenticating
@@ -1,4 +1,4 @@
 FIRST CALL:
 	access: 
 	data: 
-	err: Broker "TestIsAuthenticated_Error_when_authenticating": IsAuthenticated errored out
+	err: Broker "TestIsAuthenticated": IsAuthenticated errored out

--- a/internal/brokers/testdata/TestIsAuthenticated/golden/error_when_calling_isauthenticated_a_second_time_without_cancelling
+++ b/internal/brokers/testdata/TestIsAuthenticated/golden/error_when_calling_isauthenticated_a_second_time_without_cancelling
@@ -5,4 +5,4 @@ FIRST CALL:
 SECOND CALL:
 	access: 
 	data: 
-	err: Broker "TestIsAuthenticated_Error_when_calling_IsAuthenticated_a_second_time_without_cancelling": IsAuthenticated already running for session "IA_second_call"
+	err: Broker "TestIsAuthenticated": IsAuthenticated already running for session "TestIsAuthenticated/Error_when_calling_IsAuthenticated_a_second_time_without_cancelling_separator_IA_second_call"

--- a/internal/brokers/testdata/TestNewManager/golden/creates_without_autodiscovery_when_configuredbrokers_is_set
+++ b/internal/brokers/testdata/TestNewManager/golden/creates_without_autodiscovery_when_configuredbrokers_is_set
@@ -1,0 +1,2 @@
+- local
+- Broker2

--- a/internal/brokers/testdata/TestNewSession/golden/successfully_start_a_new_session
+++ b/internal/brokers/testdata/TestNewSession/golden/successfully_start_a_new_session
@@ -1,2 +1,2 @@
 ID: BROKER_ID-success-session_id
-Encryption Key: TestNewSession_Successfully_start_a_new_session_key
+Encryption Key: TestNewSession_Successfully_start_a_new_session-key

--- a/internal/brokers/testdata/TestNewSession/golden/successfully_start_a_new_session_with_the_correct_broker
+++ b/internal/brokers/testdata/TestNewSession/golden/successfully_start_a_new_session_with_the_correct_broker
@@ -1,2 +1,2 @@
 ID: BROKER_ID-success-session_id
-Encryption Key: TestNewSession_Broker1_key
+Encryption Key: TestNewSession_Broker1-key

--- a/internal/brokers/testdata/TestNewSession/golden/successfully_start_a_new_session_with_the_correct_broker
+++ b/internal/brokers/testdata/TestNewSession/golden/successfully_start_a_new_session_with_the_correct_broker
@@ -1,0 +1,2 @@
+ID: BROKER_ID-success-session_id
+Encryption Key: TestNewSession_Broker1_key

--- a/internal/services/pam/testdata/TestSelectBroker/golden/successfully_select_a_broker_and_creates_the_session
+++ b/internal/services/pam/testdata/TestSelectBroker/golden/successfully_select_a_broker_and_creates_the_session
@@ -1,2 +1,2 @@
 ID: BROKER_ID-TestSelectBroker/Successfully_select_a_broker_and_creates_the_session_separator_success-session_id
-Encryption Key: BrokerMock_key
+Encryption Key: BrokerMock-key

--- a/internal/testutils/broker.go
+++ b/internal/testutils/broker.go
@@ -118,7 +118,7 @@ func (b *BrokerBusMock) NewSession(username, lang string) (sessionID, encryption
 	if parsedUsername == "NS_no_id" {
 		return "", username + "_key", nil
 	}
-	return fmt.Sprintf("%s-session_id", username), b.name + "_key", nil
+	return GenerateSessionID(username), GenerateEncryptionKey(b.name), nil
 }
 
 // GetAuthenticationModes returns default values to be used in tests or an error if requested.
@@ -317,4 +317,14 @@ func userInfoFromName(name string) string {
 	}`)).Execute(&buf, user)
 
 	return buf.String()
+}
+
+// GenerateSessionID returns a sessionID that can be used in tests.
+func GenerateSessionID(username string) string {
+	return fmt.Sprintf("%s-session_id", username)
+}
+
+// GenerateEncryptionKey returns an encryption key that can be used in tests.
+func GenerateEncryptionKey(brokerName string) string {
+	return fmt.Sprintf("%s-key", brokerName)
 }


### PR DESCRIPTION
The `brokers.Manager` has to manage multiple sessions and brokers at once and we were not testing that. This PR adds a couple of test cases to cover those scenarios, mainly:
- Starting a session on the correct broker;
- Ending a session on the correct broker;
- Creating a new manager without autodiscovery if []configuredBrokers was set;

This also updates the broker tests to use a MockBroker per test family rather than creating a MockBroker per test case. This saves memory and speed whilst also providing a more "realistic" environment in which a Broker attends multiple calls. 

UDENG-1329