### PR TITLE
Rename allowed to granted as access accepted

### DIFF
--- a/internal/brokers/examplebroker/broker.go
+++ b/internal/brokers/examplebroker/broker.go
@@ -479,7 +479,7 @@ func (b *Broker) IsAuthenticated(ctx context.Context, sessionID, authenticationD
 	}()
 
 	access, data, err = b.handleIsAuthenticated(b.isAuthenticatedCalls[sessionID].ctx, sessionInfo, authData)
-	if access == responses.AuthAllowed {
+	if access == responses.AuthGranted {
 		switch sessionInfo.username {
 		case "user-needs-reset":
 			fallthrough
@@ -605,7 +605,7 @@ func (b *Broker) handleIsAuthenticated(ctx context.Context, sessionInfo sessionI
 		return responses.AuthDenied, "", nil
 	}
 
-	return responses.AuthAllowed, user.String(), nil
+	return responses.AuthGranted, user.String(), nil
 }
 
 // EndSession ends the requested session and triggers the necessary clean up steps, if any.

--- a/internal/brokers/responses/responses.go
+++ b/internal/brokers/responses/responses.go
@@ -2,8 +2,8 @@
 package responses
 
 const (
-	// AuthAllowed is the response when the authentication is allowed.
-	AuthAllowed = "allowed"
+	// AuthGranted is the response when the authentication is granted.
+	AuthGranted = "granted"
 	// AuthDenied is the response when the authentication is denied.
 	AuthDenied = "denied"
 	// AuthCancelled is the response when the authentication is cancelled.
@@ -15,4 +15,4 @@ const (
 )
 
 // AuthReplies is the list of all possible authentication replies.
-var AuthReplies = []string{AuthAllowed, AuthDenied, AuthCancelled, AuthRetry, AuthNext}
+var AuthReplies = []string{AuthGranted, AuthDenied, AuthCancelled, AuthRetry, AuthNext}

--- a/internal/brokers/testdata/TestIsAuthenticated/golden/empty_data_gets_json_formatted
+++ b/internal/brokers/testdata/TestIsAuthenticated/golden/empty_data_gets_json_formatted
@@ -1,4 +1,4 @@
 FIRST CALL:
-	access: allowed
+	access: granted
 	data: {}
 	err: <nil>

--- a/internal/brokers/testdata/TestIsAuthenticated/golden/error_when_calling_isauthenticated_a_second_time_without_cancelling
+++ b/internal/brokers/testdata/TestIsAuthenticated/golden/error_when_calling_isauthenticated_a_second_time_without_cancelling
@@ -1,6 +1,6 @@
 FIRST CALL:
-	access: allowed
-	data: {"mock_answer": "authentication allowed by timeout"}
+	access: granted
+	data: {"mock_answer": "authentication granted by timeout"}
 	err: <nil>
 SECOND CALL:
 	access: 

--- a/internal/brokers/testdata/TestIsAuthenticated/golden/successfully_authenticate
+++ b/internal/brokers/testdata/TestIsAuthenticated/golden/successfully_authenticate
@@ -1,4 +1,4 @@
 FIRST CALL:
-	access: allowed
-	data: {"mock_answer": "authentication allowed by default"}
+	access: granted
+	data: {"mock_answer": "authentication granted by default"}
 	err: <nil>

--- a/internal/brokers/testdata/TestIsAuthenticated/golden/successfully_authenticate_after_cancelling_first_call
+++ b/internal/brokers/testdata/TestIsAuthenticated/golden/successfully_authenticate_after_cancelling_first_call
@@ -3,6 +3,6 @@ FIRST CALL:
 	data: {"mock_answer": "cancelled by user"}
 	err: <nil>
 SECOND CALL:
-	access: allowed
-	data: {"mock_answer": "authentication allowed by timeout"}
+	access: granted
+	data: {"mock_answer": "authentication granted by timeout"}
 	err: <nil>

--- a/internal/services/pam/testdata/TestIsAuthenticated/golden/empty_data_gets_json_formatted
+++ b/internal/services/pam/testdata/TestIsAuthenticated/golden/empty_data_gets_json_formatted
@@ -1,4 +1,4 @@
 FIRST CALL:
-	access: allowed
+	access: granted
 	data: {}
 	err: <nil>

--- a/internal/services/pam/testdata/TestIsAuthenticated/golden/error_when_calling_second_time_without_cancelling
+++ b/internal/services/pam/testdata/TestIsAuthenticated/golden/error_when_calling_second_time_without_cancelling
@@ -1,6 +1,6 @@
 FIRST CALL:
-	access: allowed
-	data: {"mock_answer": "authentication allowed by timeout"}
+	access: granted
+	data: {"mock_answer": "authentication granted by timeout"}
 	err: <nil>
 SECOND CALL:
 	access: 

--- a/internal/services/pam/testdata/TestIsAuthenticated/golden/successfully_authenticate
+++ b/internal/services/pam/testdata/TestIsAuthenticated/golden/successfully_authenticate
@@ -1,4 +1,4 @@
 FIRST CALL:
-	access: allowed
-	data: {"mock_answer": "authentication allowed by default"}
+	access: granted
+	data: {"mock_answer": "authentication granted by default"}
 	err: <nil>

--- a/internal/services/pam/testdata/TestIsAuthenticated/golden/successfully_authenticate_if_first_call_is_canceled
+++ b/internal/services/pam/testdata/TestIsAuthenticated/golden/successfully_authenticate_if_first_call_is_canceled
@@ -3,6 +3,6 @@ FIRST CALL:
 	data: 
 	err: rpc error: code = Canceled desc = context canceled
 SECOND CALL:
-	access: allowed
-	data: {"mock_answer": "authentication allowed by timeout"}
+	access: granted
+	data: {"mock_answer": "authentication granted by timeout"}
 	err: <nil>

--- a/internal/testutils/broker.go
+++ b/internal/testutils/broker.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/godbus/dbus/v5"
 	"github.com/godbus/dbus/v5/introspect"
+	"github.com/ubuntu/authd/internal/brokers/responses"
 )
 
 const (
@@ -219,8 +220,8 @@ func (b *BrokerBusMock) IsAuthenticated(sessionID, authenticationData string) (a
 		b.isAuthenticatedCallsMu.Unlock()
 	}()
 
-	access = "allowed"
-	data = `{"mock_answer": "authentication allowed by default"}`
+	access = responses.AuthGranted
+	data = `{"mock_answer": "authentication granted by default"}`
 	if parsedID == "IA_invalid" {
 		access = "invalid"
 	}
@@ -242,8 +243,8 @@ func (b *BrokerBusMock) IsAuthenticated(sessionID, authenticationData string) (a
 				access = "cancelled"
 				data = `{"mock_answer": "cancelled by user"}`
 			case <-time.After(2 * time.Second):
-				access = "allowed"
-				data = `{"mock_answer": "authentication allowed by timeout"}`
+				access = responses.AuthGranted
+				data = `{"mock_answer": "authentication granted by timeout"}`
 			}
 		}
 		//TODO: Add cases for the new access types

--- a/pam/authentication.go
+++ b/pam/authentication.go
@@ -112,7 +112,7 @@ func (m *authenticationModel) Update(msg tea.Msg) (authenticationModel, tea.Cmd)
 	case isAuthenticatedResultReceived:
 		log.Infof(context.TODO(), "isAuthenticatedResultReceived: %v", msg.access)
 		switch msg.access {
-		case responses.AuthAllowed:
+		case responses.AuthGranted:
 			return *m, sendEvent(pamSuccess{brokerID: m.currentBrokerID})
 
 		case responses.AuthRetry:


### PR DESCRIPTION
Now that the semantic is around authentication, use granted as a keyword instead of allowed.
Remove a couple of hardcoded data.