### PR TITLE
ci: Update dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,6 +11,9 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+    commit-message:
+      include: "scope"
+      prefix: "deps(ci)"
 
   # Codebase
   ## Go dependencies
@@ -18,14 +21,23 @@ updates:
     directory: "/" # Location of package manifests
     schedule:
       interval: "daily"
+    commit-message:
+      include: "scope"
+      prefix: "deps(go)"
 
   - package-ecosystem: "gomod"
     directory: "/tools"
     schedule:
       interval: "daily"
+    commit-message:
+      include: "scope"
+      prefix: "deps(go-tools)"
 
   ## Rust dependencies
   - package-ecosystem: "cargo"
     directory: "/"
     schedule:
       interval: "daily"
+    commit-message:
+      include: "scope"
+      prefix: "deps(rust)"


### PR DESCRIPTION
Doing some improvements on the dependabot config file to prefix the bump commits with our new pull request naming standards.