### PR TITLE
tests(cache): Export db name

### DIFF
--- a/internal/cache/db.go
+++ b/internal/cache/db.go
@@ -18,10 +18,12 @@ import (
 	"go.etcd.io/bbolt"
 )
 
-const (
+var (
 	dbName          = "authd.db"
 	dirtyFlagDbName = dbName + ".dirty"
+)
 
+const (
 	userByNameBucketName   = "UserByName"
 	userByIDBucketName     = "UserByID"
 	groupByNameBucketName  = "GroupByName"

--- a/internal/cache/db_test.go
+++ b/internal/cache/db_test.go
@@ -49,7 +49,7 @@ func TestNew(t *testing.T) {
 			t.Parallel()
 
 			cacheDir := t.TempDir()
-			dbDestPath := filepath.Join(cacheDir, cache.DbName)
+			dbDestPath := filepath.Join(cacheDir, cachetests.DbName)
 
 			if tc.dbFile == "-" {
 				err := os.RemoveAll(cacheDir)
@@ -58,7 +58,7 @@ func TestNew(t *testing.T) {
 				createDBFile(t, filepath.Join("testdata", tc.dbFile+".db.yaml"), cacheDir)
 			}
 			if tc.dirtyFlag {
-				err := os.WriteFile(filepath.Join(cacheDir, cache.DirtyFlagDbName), nil, 0600)
+				err := os.WriteFile(filepath.Join(cacheDir, cachetests.DirtyFlagDbName), nil, 0600)
 				require.NoError(t, err, "Setup: could not create dirty flag file")
 			}
 			if tc.perm != nil {
@@ -67,7 +67,7 @@ func TestNew(t *testing.T) {
 			}
 
 			if tc.corruptedDbFile {
-				err := os.WriteFile(filepath.Join(cacheDir, cache.DbName), []byte("Corrupted db"), 0600)
+				err := os.WriteFile(filepath.Join(cacheDir, cachetests.DbName), []byte("Corrupted db"), 0600)
 				require.NoError(t, err, "Setup: Can't update the file with invalid db content")
 			}
 
@@ -441,7 +441,7 @@ func createDBFile(t *testing.T, src, destDir string) {
 func requireNoDirtyFileInDir(t *testing.T, cacheDir string) {
 	t.Helper()
 
-	_, err := os.Stat(filepath.Join(cacheDir, cache.DirtyFlagDbName))
+	_, err := os.Stat(filepath.Join(cacheDir, cachetests.DirtyFlagDbName))
 	require.ErrorIs(t, err, fs.ErrNotExist, "Dirty flag should have been removed")
 }
 

--- a/internal/cache/export_test.go
+++ b/internal/cache/export_test.go
@@ -1,12 +1,5 @@
 package cache
 
-const (
-	// DbName is dbName exported for tests.
-	DbName = dbName
-	// DirtyFlagDbName is dirtyFlagDbName exported for tests.
-	DirtyFlagDbName = dirtyFlagDbName
-)
-
 // RequestClearDatabase is used in tests for checking the behaviour of the database dynamic clear up.
 func RequestClearDatabase(c *Cache) {
 	c.requestClearDatabase()

--- a/internal/cache/tests/serialization.go
+++ b/internal/cache/tests/serialization.go
@@ -9,6 +9,15 @@ import (
 	"github.com/ubuntu/authd/internal/cache"
 )
 
+var (
+	// DbName is database name exported for tests
+	//go:linkname DbName github.com/ubuntu/authd/internal/cache.dbName
+	DbName string
+	// DirtyFlagDbName is the dirty flag exported for tests.
+	//go:linkname DirtyFlagDbName github.com/ubuntu/authd/internal/cache.dirtyFlagDbName
+	DirtyFlagDbName string
+)
+
 // DumpToYaml deserializes the cache database to a writer in a yaml format.
 //
 //go:linkname DumpToYaml github.com/ubuntu/authd/internal/cache.(*Cache).dumpToYaml


### PR DESCRIPTION
Export database name for cachetests to be reusable. We are now exporting the cache tests internal implementations for testing purposes with linking. This will be reused when working on making the service manager failing.

UDENG-1477
