### PR TITLE
fix(daemon) Allow running without pre-created cache directory

### DIFF
--- a/cmd/authd/daemon/daemon.go
+++ b/cmd/authd/daemon/daemon.go
@@ -101,6 +101,11 @@ func New() *App {
 func (a *App) serve(config daemonConfig) error {
 	ctx := context.Background()
 
+	if err := ensureDirWithPerms(config.SystemDirs.CacheDir, 0700); err != nil {
+		close(a.ready)
+		return fmt.Errorf("error initializing cache directory at %q: %v", config.SystemDirs.CacheDir, err)
+	}
+
 	m, err := services.NewManager(ctx, config.SystemDirs.CacheDir, config.Brokers)
 	if err != nil {
 		close(a.ready)

--- a/cmd/authd/daemon/daemon_test.go
+++ b/cmd/authd/daemon/daemon_test.go
@@ -113,10 +113,15 @@ func TestAppRunFailsOnComponentsCreationAndQuit(t *testing.T) {
 	// Trigger the error with a cache directory that cannot be created over an
 	// existing file
 
+	const (
+		ok = iota
+		dirIsFile
+	)
+
 	testCases := map[string]struct {
-		unwritableSocketPath bool
+		socketPathBehavior int
 	}{
-		"Error on grpc daemon creation failure": {unwritableSocketPath: true},
+		"Error on grpc daemon creation failure": {socketPathBehavior: dirIsFile},
 	}
 
 	for name, tc := range testCases {
@@ -129,7 +134,8 @@ func TestAppRunFailsOnComponentsCreationAndQuit(t *testing.T) {
 			require.NoError(t, err, "Failed to write file")
 
 			var config daemon.DaemonConfig
-			if tc.unwritableSocketPath {
+			switch tc.socketPathBehavior {
+			case dirIsFile:
 				config.SystemDirs.SocketPath = filepath.Join(filePath, "mysocket")
 			}
 

--- a/cmd/authd/daemon/export_test.go
+++ b/cmd/authd/daemon/export_test.go
@@ -40,6 +40,9 @@ func GenerateTestConfig(t *testing.T, origConf *daemonConfig) string {
 	}
 	if conf.SystemDirs.CacheDir == "" {
 		conf.SystemDirs.CacheDir = t.TempDir()
+		//nolint: gosec // This is a directory owned only by the current user for tests.
+		err := os.Chmod(conf.SystemDirs.CacheDir, 0700)
+		require.NoError(t, err, "Setup: could not change permission on cache directory for tests")
 	}
 	if conf.SystemDirs.RunDir == "" {
 		conf.SystemDirs.RunDir = t.TempDir()

--- a/cmd/authd/daemon/export_test.go
+++ b/cmd/authd/daemon/export_test.go
@@ -11,6 +11,7 @@ import (
 
 type (
 	DaemonConfig = daemonConfig
+	SystemDirs   = systemDirs
 )
 
 func NewForTests(t *testing.T, conf *DaemonConfig, args ...string) *App {

--- a/cmd/authd/daemon/fs.go
+++ b/cmd/authd/daemon/fs.go
@@ -1,0 +1,25 @@
+package daemon
+
+import (
+	"fmt"
+	"io/fs"
+	"os"
+	"syscall"
+)
+
+// ensureDirWithPerms creates a directory at path if it doesn't exist yet with perm as permissions.
+// If the path exists, it will check if it’s a directory with those perms.
+func ensureDirWithPerms(path string, perm os.FileMode) error {
+	dir, err := os.Stat(path)
+	if err == nil {
+		if !dir.IsDir() {
+			return &os.PathError{Op: "mkdir", Path: path, Err: syscall.ENOTDIR}
+		}
+		if dir.Mode() != (perm | fs.ModeDir) {
+			return fmt.Errorf("permissions %v don't match what we desired: %v", dir.Mode(), perm|fs.ModeDir)
+		}
+
+		return nil
+	}
+	return os.Mkdir(path, perm)
+}


### PR DESCRIPTION
Ensure we can run without pre-existing cache directory. Check also its permission for safety measures.
Adapt and fix tests to cover those use cases and impossibilities to create manager.

UDENG-1477