### PR TITLE
tests(services): Add tests to services.Manager

### DIFF
--- a/internal/services/manager_test.go
+++ b/internal/services/manager_test.go
@@ -1,0 +1,94 @@
+package services_test
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/ubuntu/authd/internal/services"
+	"github.com/ubuntu/authd/internal/testutils"
+	"google.golang.org/grpc"
+)
+
+func TestNewManager(t *testing.T) {
+	tests := map[string]struct {
+		cacheDir string
+
+		systemBusSocket string
+
+		wantErr bool
+	}{
+		"Successfully create the manager": {},
+
+		"Error when can not create cache":          {cacheDir: "doesnotexist", wantErr: true},
+		"Error when can not create broker manager": {systemBusSocket: "doesnotexist", wantErr: true},
+	}
+	for name, tc := range tests {
+		tc := tc
+		t.Run(name, func(t *testing.T) {
+			if tc.cacheDir == "" {
+				tc.cacheDir = t.TempDir()
+			}
+			if tc.systemBusSocket != "" {
+				t.Setenv("DBUS_SYSTEM_BUS_ADDRESS", tc.systemBusSocket)
+			}
+
+			m, err := services.NewManager(context.Background(), tc.cacheDir, nil)
+			if tc.wantErr {
+				require.Error(t, err, "NewManager should have returned an error, but did not")
+				return
+			}
+			defer require.NoError(t, m.Stop(), "Teardown: Stop should not have returned an error, but did")
+
+			require.NoError(t, err, "NewManager should not have returned an error, but did")
+		})
+	}
+}
+
+func TestRegisterGRPCServices(t *testing.T) {
+	t.Parallel()
+
+	m, err := services.NewManager(context.Background(), t.TempDir(), nil)
+	require.NoError(t, err, "Setup: could not create manager for the test")
+	defer require.NoError(t, m.Stop(), "Teardown: Stop should not have returned an error, but did")
+
+	got := m.RegisterGRPCServices(context.Background()).GetServiceInfo()
+	want := testutils.LoadWithUpdateFromGoldenYAML(t, got)
+	requireEqualServices(t, want, got)
+}
+
+// requireEqualServices asserts that the grpc services were registered as expected.
+//
+// This is needed because the order of the methods and the services is not guaranteed.
+func requireEqualServices(t *testing.T, want, got map[string]grpc.ServiceInfo) {
+	t.Helper()
+
+	for name, wantInfo := range want {
+		gotInfo, ok := got[name]
+		if !ok {
+			t.Error("Expected services to match, but didn't")
+			return
+		}
+		require.ElementsMatch(t, wantInfo.Methods, gotInfo.Methods, "Expected methods to match, but didn't")
+		delete(got, name)
+	}
+	require.Empty(t, got, "Expected no extra services, but got %v", got)
+}
+
+func TestMain(m *testing.M) {
+	testutils.InstallUpdateFlag()
+	flag.Parse()
+
+	// Start system bus mock.
+	cleanup, err := testutils.StartSystemBusMock()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "%v\n", err)
+		os.Exit(1)
+	}
+	defer cleanup()
+
+	m.Run()
+}

--- a/internal/services/testdata/TestRegisterGRPCServices/golden
+++ b/internal/services/testdata/TestRegisterGRPCServices/golden
@@ -1,0 +1,54 @@
+authd.NSS:
+    methods:
+        - name: GetPasswdByUID
+          isclientstream: false
+          isserverstream: false
+        - name: GetPasswdEntries
+          isclientstream: false
+          isserverstream: false
+        - name: GetGroupByName
+          isclientstream: false
+          isserverstream: false
+        - name: GetGroupByGID
+          isclientstream: false
+          isserverstream: false
+        - name: GetGroupEntries
+          isclientstream: false
+          isserverstream: false
+        - name: GetShadowByName
+          isclientstream: false
+          isserverstream: false
+        - name: GetShadowEntries
+          isclientstream: false
+          isserverstream: false
+        - name: GetPasswdByName
+          isclientstream: false
+          isserverstream: false
+    metadata: authd.proto
+authd.PAM:
+    methods:
+        - name: SelectAuthenticationMode
+          isclientstream: false
+          isserverstream: false
+        - name: IsAuthenticated
+          isclientstream: false
+          isserverstream: false
+        - name: EndSession
+          isclientstream: false
+          isserverstream: false
+        - name: SetDefaultBrokerForUser
+          isclientstream: false
+          isserverstream: false
+        - name: AvailableBrokers
+          isclientstream: false
+          isserverstream: false
+        - name: GetPreviousBroker
+          isclientstream: false
+          isserverstream: false
+        - name: SelectBroker
+          isclientstream: false
+          isserverstream: false
+        - name: GetAuthenticationModes
+          isclientstream: false
+          isserverstream: false
+    metadata: authd.proto


### PR DESCRIPTION
The `services.Manager` didn't have tests yet, this PR fixes that. 

UDENG-1419