### PR TITLE
refactor(brokers): bus interface no longer overridable through broker config

### DIFF
--- a/internal/brokers/broker_test.go
+++ b/internal/brokers/broker_test.go
@@ -53,11 +53,10 @@ func TestNewBroker(t *testing.T) {
 		"Error when config file does not exist": {configFile: "do not exist", wantErr: true},
 
 		// Missing field errors
-		"Error when config does not have name field":           {configFile: "no_name", wantErr: true},
-		"Error when config does not have brand_icon field":     {configFile: "no_brand_icon", wantErr: true},
-		"Error when config does not have dbus.name field":      {configFile: "no_dbus_name", wantErr: true},
-		"Error when config does not have dbus.object field":    {configFile: "no_dbus_object", wantErr: true},
-		"Error when config does not have dbus.interface field": {configFile: "no_dbus_interface", wantErr: true},
+		"Error when config does not have name field":        {configFile: "no_name", wantErr: true},
+		"Error when config does not have brand_icon field":  {configFile: "no_brand_icon", wantErr: true},
+		"Error when config does not have dbus.name field":   {configFile: "no_dbus_name", wantErr: true},
+		"Error when config does not have dbus.object field": {configFile: "no_dbus_object", wantErr: true},
 	}
 	for name, tc := range tests {
 		tc := tc

--- a/internal/brokers/examplebroker/ExampleBroker
+++ b/internal/brokers/examplebroker/ExampleBroker
@@ -3,6 +3,5 @@ name = ExampleBroker
 brand_icon = /usr/share/backgrounds/warty-final-ubuntu.png
 
 [dbus]
-name = com.ubuntu.auth.ExampleBroker
-object = /com/ubuntu/auth/ExampleBroker
-interface = com.ubuntu.auth.ExampleBroker
+name = com.ubuntu.authd.ExampleBroker
+object = /com/ubuntu/authd/ExampleBroker

--- a/internal/brokers/examplebroker/com.ubuntu.auth.ExampleBroker.conf
+++ b/internal/brokers/examplebroker/com.ubuntu.auth.ExampleBroker.conf
@@ -9,14 +9,14 @@
 <busconfig>
   <!-- Only root can own the service -->
   <policy user="root">
-    <allow own="com.ubuntu.auth.ExampleBroker"/>
+    <allow own="com.ubuntu.authd.ExampleBroker"/>
   </policy>
 
   <!-- Allow anyone to invoke methods -->
   <policy context="default">
-    <allow send_destination="com.ubuntu.auth.ExampleBroker"
-           send_interface="com.ubuntu.auth.ExampleBroker"/>
-    <allow send_destination="com.ubuntu.auth.ExampleBroker"
+    <allow send_destination="com.ubuntu.authd.ExampleBroker"
+           send_interface="com.ubuntu.authd.Broker"/>
+    <allow send_destination="com.ubuntu.authd.ExampleBroker"
            send_interface="org.freedesktop.DBus.Introspectable"/>
   </policy>
 </busconfig>

--- a/internal/brokers/examplebroker/com.ubuntu.auth.ExampleBroker.xml
+++ b/internal/brokers/examplebroker/com.ubuntu.auth.ExampleBroker.xml
@@ -7,7 +7,7 @@
 "http://www.freedesktop.org/standards/dbus/1.0/introspect.dtd">
 
 <node>
-  <interface name="com.ubuntu.auth.ExampleBroker">
+  <interface name="com.ubuntu.authd.Broker">
     <method name="NewSession">
       <arg type="s" direction="in" name="username"/>
       <arg type="s" direction="in" name="lang"/>

--- a/internal/brokers/examplebroker/dbus.go
+++ b/internal/brokers/examplebroker/dbus.go
@@ -8,12 +8,13 @@ import (
 
 	"github.com/godbus/dbus/v5"
 	"github.com/godbus/dbus/v5/introspect"
+	"github.com/ubuntu/authd/internal/brokers"
 	"github.com/ubuntu/decorate"
 )
 
 const (
 	dbusObjectPath = "/com/ubuntu/authd/ExampleBroker"
-	dbusInterface  = "com.ubuntu.authd.ExampleBroker"
+	busName        = "com.ubuntu.authd.ExampleBroker"
 )
 
 // Bus is the D-Bus object that will answer calls for the broker.
@@ -33,7 +34,7 @@ func StartBus(ctx context.Context, cfgPath string) (err error) {
 
 	b, _, _ := New("ExampleBroker")
 	obj := Bus{broker: b}
-	err = conn.Export(&obj, dbusObjectPath, dbusInterface)
+	err = conn.Export(&obj, dbusObjectPath, brokers.DbusInterface)
 	if err != nil {
 		return err
 	}
@@ -43,7 +44,7 @@ func StartBus(ctx context.Context, cfgPath string) (err error) {
 		Interfaces: []introspect.Interface{
 			introspect.IntrospectData,
 			{
-				Name:    dbusInterface,
+				Name:    brokers.DbusInterface,
 				Methods: introspect.Methods(&obj),
 			},
 		},
@@ -51,7 +52,7 @@ func StartBus(ctx context.Context, cfgPath string) (err error) {
 		return err
 	}
 
-	reply, err := conn.RequestName(dbusInterface, dbus.NameFlagDoNotQueue)
+	reply, err := conn.RequestName(busName, dbus.NameFlagDoNotQueue)
 	if err != nil {
 		return err
 	}
@@ -67,8 +68,7 @@ brand_icon = /usr/share/backgrounds/warty-final-ubuntu.png
 [dbus]
 name = %s
 object = %s
-interface = %s
-`, dbusInterface, dbusObjectPath, dbusInterface)),
+`, busName, dbusObjectPath)),
 		0600); err != nil {
 		return err
 	}

--- a/internal/brokers/testdata/broker.d/invalid_brokers/no_dbus_interface
+++ b/internal/brokers/testdata/broker.d/invalid_brokers/no_dbus_interface
@@ -1,6 +1,0 @@
-name = Broker
-brand_icon = some_icon.png
-
-[dbus]
-name = com.ubuntu.authd.Broker
-object = /com/ubuntu/authd/Broker


### PR DESCRIPTION
As correctly pointed out by Marco, the bus interface should be a specific value as it's supposed to define an expected way of communication with the bus object rather than a custom value that is configurable.

UDENG-1409