### PR TITLE
fix(examplebroker): Mutliple fixes to example brokers

### DIFF
--- a/internal/brokers/examplebroker/broker.go
+++ b/internal/brokers/examplebroker/broker.go
@@ -295,14 +295,14 @@ func getSupportedModes(sessionInfo sessionInfo, supportedUILayouts []map[string]
 				}),
 			}
 
-			if layout["skip-button"] != "" {
+			if layout["button"] != "" {
 				allModes["optionalreset"] = map[string]string{
 					"selection_label": "Password reset",
 					"ui": mapToJSON(map[string]string{
-						"type":        "newpassword",
-						"label":       "Enter your new password",
-						"entry":       "chars_password",
-						"skip-button": "Skip",
+						"type":   "newpassword",
+						"label":  "Enter your new password",
+						"entry":  "chars_password",
+						"button": "Skip",
 					}),
 				}
 			}

--- a/internal/brokers/examplebroker/broker.go
+++ b/internal/brokers/examplebroker/broker.go
@@ -428,6 +428,7 @@ func (b *Broker) IsAuthenticated(ctx context.Context, sessionID, authenticationD
 			if sessionInfo.currentMfaStep < sessionInfo.neededMfa {
 				sessionInfo.currentMfaStep++
 				access = responses.AuthNext
+				data = ""
 			}
 		}
 	} else if access == responses.AuthRetry {

--- a/internal/brokers/examplebroker/broker.go
+++ b/internal/brokers/examplebroker/broker.go
@@ -287,7 +287,7 @@ func getSupportedModes(sessionInfo sessionInfo, supportedUILayouts []map[string]
 				break
 			}
 			allModes["mandatoryreset"] = map[string]string{
-				"selection_label": "Password reset (3 days until mandatory)",
+				"selection_label": "Password reset",
 				"ui": mapToJSON(map[string]string{
 					"type":  "newpassword",
 					"label": "Enter your new password",
@@ -300,7 +300,7 @@ func getSupportedModes(sessionInfo sessionInfo, supportedUILayouts []map[string]
 					"selection_label": "Password reset",
 					"ui": mapToJSON(map[string]string{
 						"type":   "newpassword",
-						"label":  "Enter your new password",
+						"label":  "Enter your new password (3 days until mandatory)",
 						"entry":  "chars_password",
 						"button": "Skip",
 					}),

--- a/internal/brokers/examplebroker/broker.go
+++ b/internal/brokers/examplebroker/broker.go
@@ -608,7 +608,7 @@ func (b *Broker) handleIsAuthenticated(ctx context.Context, sessionInfo sessionI
 		return responses.AuthDenied, `{"message": "user not found"}`, nil
 	}
 
-	return responses.AuthGranted, userInfoFromName(user.Name), nil
+	return responses.AuthGranted, fmt.Sprintf(`{"userinfo": %s}`, userInfoFromName(user.Name)), nil
 }
 
 // EndSession ends the requested session and triggers the necessary clean up steps, if any.

--- a/internal/brokers/examplebroker/broker.go
+++ b/internal/brokers/examplebroker/broker.go
@@ -59,76 +59,13 @@ type Broker struct {
 	isAuthenticatedCallsMu sync.Mutex
 }
 
-type exampleUser struct {
-	UID    string                       `json:"uid"`
-	Name   string                       `json:"name"`
-	Groups map[string]map[string]string `json:"groups"`
-}
-
-func (u exampleUser) String() string {
-	data, err := json.Marshal(u)
-	if err != nil {
-		panic(fmt.Sprintf("Invalid user data: %v", err))
-	}
-	return string(data)
-}
-
 var (
-	exampleUsers = map[string]exampleUser{
-		"user1": {
-			UID:  "4245874",
-			Name: "My user",
-			Groups: map[string]map[string]string{
-				"group1": {
-					"name": "Group 1",
-					"gid":  "3884",
-				},
-				"group2": {
-					"name": "Group 2",
-					"gid":  "4884",
-				},
-			},
-		},
-		"user2": {
-			UID:  "33333",
-			Name: "My secondary user",
-			Groups: map[string]map[string]string{
-				"group2": {
-					"name": "Group 2",
-					"gid":  "4884",
-				},
-			},
-		},
-		"user-mfa": {
-			UID:  "44444",
-			Name: "User that needs MFA",
-			Groups: map[string]map[string]string{
-				"group1": {
-					"name": "Group 1",
-					"gid":  "3884",
-				},
-			},
-		},
-		"user-needs-reset": {
-			UID:  "55555",
-			Name: "User that needs passwd reset",
-			Groups: map[string]map[string]string{
-				"group1": {
-					"name": "Group 1",
-					"gid":  "3884",
-				},
-			},
-		},
-		"user-can-reset": {
-			UID:  "66666",
-			Name: "User that can passwd reset",
-			Groups: map[string]map[string]string{
-				"group1": {
-					"name": "Group 1",
-					"gid":  "3884",
-				},
-			},
-		},
+	exampleUsers = map[string]string{
+		"user1":            "My user",
+		"user2":            "My secondary user",
+		"user-mfa":         "User that needs MFA",
+		"user-needs-reset": "User that needs passwd reset",
+		"user-can-reset":   "User that can passwd reset",
 	}
 )
 
@@ -603,12 +540,12 @@ func (b *Broker) handleIsAuthenticated(ctx context.Context, sessionInfo sessionI
 		}
 	}
 
-	user, exists := exampleUsers[sessionInfo.username]
+	name, exists := exampleUsers[sessionInfo.username]
 	if !exists {
 		return responses.AuthDenied, `{"message": "user not found"}`, nil
 	}
 
-	return responses.AuthGranted, fmt.Sprintf(`{"userinfo": %s}`, userInfoFromName(user.Name)), nil
+	return responses.AuthGranted, fmt.Sprintf(`{"userinfo": %s}`, userInfoFromName(name)), nil
 }
 
 // EndSession ends the requested session and triggers the necessary clean up steps, if any.

--- a/internal/brokers/examplebroker/dbus.go
+++ b/internal/brokers/examplebroker/dbus.go
@@ -8,13 +8,14 @@ import (
 
 	"github.com/godbus/dbus/v5"
 	"github.com/godbus/dbus/v5/introspect"
-	"github.com/ubuntu/authd/internal/brokers"
 	"github.com/ubuntu/decorate"
 )
 
 const (
 	dbusObjectPath = "/com/ubuntu/authd/ExampleBroker"
 	busName        = "com.ubuntu.authd.ExampleBroker"
+	// we need to redeclare the interface here to avoid include cycles.
+	dbusInterface = "com.ubuntu.authd.Broker"
 )
 
 // Bus is the D-Bus object that will answer calls for the broker.
@@ -34,7 +35,7 @@ func StartBus(ctx context.Context, cfgPath string) (err error) {
 
 	b, _, _ := New("ExampleBroker")
 	obj := Bus{broker: b}
-	err = conn.Export(&obj, dbusObjectPath, brokers.DbusInterface)
+	err = conn.Export(&obj, dbusObjectPath, dbusInterface)
 	if err != nil {
 		return err
 	}
@@ -44,7 +45,7 @@ func StartBus(ctx context.Context, cfgPath string) (err error) {
 		Interfaces: []introspect.Interface{
 			introspect.IntrospectData,
 			{
-				Name:    brokers.DbusInterface,
+				Name:    dbusInterface,
 				Methods: introspect.Methods(&obj),
 			},
 		},


### PR DESCRIPTION
Fix missing userinfo metadata when granting access. In the selection of userinfo, we missed the marker in the data json struct in the examplebroker. Readding it.
Fix multiple MFAs handling logic.
Removal of dead code.
Fixing cycling imports.
Labels changes.