### PR TITLE
fix(pam): Reset form field and do not restore state

### DIFF
--- a/pam/authentication.go
+++ b/pam/authentication.go
@@ -80,7 +80,8 @@ type authenticationModel struct {
 	errorMsg string
 }
 
-// startAuthentication signals that the authentication model can start wait:true authentication if supported.
+// startAuthentication signals that the authentication model can start
+// wait:true authentication and reset fields.
 type startAuthentication struct{}
 
 // newAuthenticationModel initializes a authenticationModel which needs to be Compose then.

--- a/pam/authentication.go
+++ b/pam/authentication.go
@@ -183,15 +183,7 @@ func (m *authenticationModel) Compose(brokerID, sessionID string, layout *authd.
 
 	switch layout.Type {
 	case "form":
-		var oldEntryValue string
-		// We need to port previous entry after a reselection (indicated by the fact that we didn’t clear the previous model)
-		if oldModel, ok := m.currentModel.(formModel); ok && layout.GetEntry() != "" {
-			oldEntryValue = oldModel.getEntryValue()
-		}
 		form := newFormModel(layout.GetLabel(), layout.GetEntry(), layout.GetButton(), layout.GetWait() == "true")
-		if oldEntryValue != "" {
-			form.setEntryValue(oldEntryValue)
-		}
 		m.currentModel = form
 
 	case "qrcode":

--- a/pam/formmodel.go
+++ b/pam/formmodel.go
@@ -54,6 +54,14 @@ func (m formModel) Init() tea.Cmd {
 func (m formModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	switch msg.(type) {
 	case startAuthentication:
+		// Reset the entry.
+		for _, fm := range m.focusableModels {
+			switch entry := fm.(type) {
+			case *textinputModel:
+				entry.SetValue("")
+			}
+		}
+
 		if !m.wait {
 			return m, nil
 		}

--- a/pam/formmodel.go
+++ b/pam/formmodel.go
@@ -144,27 +144,3 @@ func (m formModel) Blur() {
 	}
 	m.focusableModels[m.focusIndex].Blur()
 }
-
-// getEntryValue returns previous entry value, if any.
-func (m formModel) getEntryValue() string {
-	for _, entry := range m.focusableModels {
-		entry, ok := entry.(*textinputModel)
-		if !ok {
-			continue
-		}
-		return entry.Value()
-	}
-	return ""
-}
-
-// setEntryValue reset the entry (if present) to a given value.
-func (m *formModel) setEntryValue(value string) {
-	for _, entry := range m.focusableModels {
-		entry, ok := entry.(*textinputModel)
-		if !ok {
-			continue
-		}
-		entry.SetValue(value)
-		return
-	}
-}


### PR DESCRIPTION
We need to reset the form fields on invalid password (especially with hidden characters) to ensure that the new password typed by the user is vanilla.
We should not restore the state when resending password for a similar reason.