### PR TITLE
fix(examplebroker): Update userLastSelectedMode and getPasswdModes logics to be more concise

### DIFF
--- a/internal/brokers/examplebroker/broker.go
+++ b/internal/brokers/examplebroker/broker.go
@@ -106,6 +106,9 @@ func (b *Broker) NewSession(ctx context.Context, username, lang string) (session
 	case "user-can-reset":
 		info.neededAuthSteps = 2
 		info.pwdChange = canReset
+	case "user-mfa-with-reset":
+		info.neededAuthSteps = 3
+		info.pwdChange = canReset
 	}
 
 	b.currentSessionsMu.Lock()

--- a/internal/brokers/examplebroker/broker.go
+++ b/internal/brokers/examplebroker/broker.go
@@ -124,7 +124,7 @@ func (b *Broker) GetAuthenticationModes(ctx context.Context, sessionID string, s
 	allModes := getSupportedModes(sessionInfo, supportedUILayouts)
 
 	// If the user needs mfa, we remove the last used mode from the list of available modes.
-	if sessionInfo.currentAuthStep > 1 && sessionInfo.currentAuthStep < sessionInfo.neededAuthSteps {
+	if sessionInfo.currentAuthStep > 1 && sessionInfo.currentAuthStep <= sessionInfo.neededAuthSteps {
 		allModes = getMfaModes(sessionInfo, sessionInfo.allModes)
 	}
 	// If the user needs or can reset the password, we only show those authentication modes.


### PR DESCRIPTION
This PR consists of two important fixes:
1) Fix the logic for updating the userLastSelectedMode: we were updating it every time IsAuthenticated was called, which is not ideal (the user could be "locked" on a failing state). Now, it only updates when access is `Granted`. For MFA cases, we store and use the first selected mode (as it would be the "main" authentication mode).

2) Fix the way we get the password reset modes. Before, they were being returned by the getSupportedModes function and they were being shown on the first list of modes returned by the broker (not ideal, since the user should only be able to reset the password AFTER authenticating). Now, they're parsed separately and an error is returned if the user needs to reset the password, but no mode is available.

UDENG-1494