### PR TITLE
maint: linting and dead code removal

### DIFF
--- a/authd.proto
+++ b/authd.proto
@@ -3,7 +3,8 @@ package authd;
 
 option go_package = "github.com/ubuntu/authd";
 
-message Empty {}
+message Empty {
+}
 
 service PAM {
   rpc AvailableBrokers(Empty) returns (ABResponse);

--- a/pam/authentication.go
+++ b/pam/authentication.go
@@ -246,16 +246,3 @@ func dataToMsg(data string) string {
 	}
 	return r
 }
-
-// dataToUserInfo returns the user information from a given JSON string.
-//
-//nolint:unused // This is not used for now TODO
-func dataToUserInfo(data string) string {
-	/*v := make(map[string]string)
-	if err := json.Unmarshal([]byte(data), &v); err != nil {
-		log.Info(context.TODO(), "Invalid json data from provider: %v", data)
-		return ""
-	}*/
-
-	return "TODO"
-}


### PR DESCRIPTION
* Fix proto file syntax
* Remove dead code using userinfo which will never be passed to the PAM module, we only need them on the service side for the NSS cache.