### PR TITLE
fix(pam): avoid restoring previous session in user selection mode

### DIFF
--- a/pam/model.go
+++ b/pam/model.go
@@ -274,7 +274,9 @@ func (m *model) changeStage(s stage) tea.Cmd {
 		m.authModeSelectionModel.Blur()
 		m.authenticationModel.Blur()
 
-		return m.userSelectionModel.Focus()
+		// The session should be ended when going back to previous state, but we don’t quit the stage immediately
+		// and so, we should always ensure we cancel previous session.
+		return tea.Sequence(endSession(m.client, m.currentSession), m.userSelectionModel.Focus())
 
 	case stageBrokerSelection:
 		m.userSelectionModel.Blur()


### PR DESCRIPTION
There was an event race if after broker selection, the supported UI layouts took time to get back.
You then go back to user selection without really leaving the BrokerSelection page, which leaded to then reselecting the authentication layout from the previous session.

This fix will help in our next UI without any "stage" paths, when we don’t necessarily go back to broker selection to change users.