### PR TITLE
fix(examplebroker): Increase wait time for the mock start + update some return values of the broker

### DIFF
--- a/internal/brokers/examplebroker/broker.go
+++ b/internal/brokers/examplebroker/broker.go
@@ -672,7 +672,7 @@ func userInfoFromName(name string) string {
 		"uuid": "uuid-{{.Name}}",
 		"gecos": "gecos for {{.Name}}",
 		"dir": "/home/{{.Name}}",
-		"shell": "/bin/sh/{{.Name}}",
+		"shell": "/usr/bin/bash",
 		"avatar": "avatar for {{.Name}}",
 		"groups": [ {"name": "group-{{.Name}}", "ugid": "group-{{.Name}}"} ]
 	}`)).Execute(&buf, user)

--- a/internal/brokers/examplebroker/broker.go
+++ b/internal/brokers/examplebroker/broker.go
@@ -61,12 +61,12 @@ type Broker struct {
 }
 
 var (
-	exampleUsers = map[string]string{
-		"user1":            "My user",
-		"user2":            "My secondary user",
-		"user-mfa":         "User that needs MFA",
-		"user-needs-reset": "User that needs passwd reset",
-		"user-can-reset":   "User that can passwd reset",
+	exampleUsers = map[string]struct{}{
+		"user1":            {},
+		"user2":            {},
+		"user-mfa":         {},
+		"user-needs-reset": {},
+		"user-can-reset":   {},
 	}
 )
 
@@ -540,12 +540,10 @@ func (b *Broker) handleIsAuthenticated(ctx context.Context, sessionInfo sessionI
 		}
 	}
 
-	name, exists := exampleUsers[sessionInfo.username]
-	if !exists {
+	if _, exists := exampleUsers[sessionInfo.username]; !exists {
 		return responses.AuthDenied, `{"message": "user not found"}`, nil
 	}
-
-	return responses.AuthGranted, fmt.Sprintf(`{"userinfo": %s}`, userInfoFromName(name)), nil
+	return responses.AuthGranted, fmt.Sprintf(`{"userinfo": %s}`, userInfoFromName(sessionInfo.username)), nil
 }
 
 // EndSession ends the requested session and triggers the necessary clean up steps, if any.

--- a/internal/brokers/withexamples.go
+++ b/internal/brokers/withexamples.go
@@ -75,7 +75,7 @@ func startSystemBusMock() (func(), error) {
 		return nil, err
 	}
 	// Give some time for the daemon to start.
-	time.Sleep(5 * time.Millisecond)
+	time.Sleep(500 * time.Millisecond)
 
 	prev, set := os.LookupEnv("DBUS_SYSTEM_BUS_ADDRESS")
 	os.Setenv("DBUS_SYSTEM_BUS_ADDRESS", "unix:path="+listenPath)


### PR DESCRIPTION
We were using 5 milliseconds as a wait time for the dbus mock to start, despite already knowing that it wasn't enough (see [this commit](https://github.com/ubuntu/authd/commit/485a7b0343dc287f91062f99c5cb2234c0ea38d7)). This increases the wait time to 500 milliseconds.

Also, some of the returned values of the examplebroker represented mock values that were invalid in a real environment, so they had to be updated as well.

UDENG-1491