### PR TITLE
Make cache/brokers/socket directories configurable

### DIFF
--- a/cmd/authd/daemon/daemon.go
+++ b/cmd/authd/daemon/daemon.go
@@ -59,7 +59,7 @@ func New() *App {
 			a.config = daemonConfig{
 				SystemDirs: systemDirs{
 					CacheDir:   consts.DefaultCacheDir,
-					SocketPath: consts.DefaultSocketPath, // FIXME bogus: this forces this socket path without activation.
+					SocketPath: "",
 				},
 			}
 

--- a/cmd/authd/daemon/daemon.go
+++ b/cmd/authd/daemon/daemon.go
@@ -33,7 +33,6 @@ type App struct {
 type systemDirs struct {
 	CacheDir   string
 	SocketPath string
-	RunDir     string
 }
 
 // daemonConfig defines configuration parameters of the daemon.
@@ -61,7 +60,6 @@ func New() *App {
 				SystemDirs: systemDirs{
 					CacheDir:   consts.DefaultCacheDir,
 					SocketPath: consts.DefaultSocketPath, // FIXME bogus: this forces this socket path without activation.
-					RunDir:     consts.DefaultRunDir,
 				},
 			}
 

--- a/cmd/authd/daemon/daemon.go
+++ b/cmd/authd/daemon/daemon.go
@@ -31,8 +31,9 @@ type App struct {
 
 // only overriable for tests.
 type systemDirs struct {
-	CacheDir   string
-	SocketPath string
+	BrokersConfPath string
+	CacheDir        string
+	SocketPath      string
 }
 
 // daemonConfig defines configuration parameters of the daemon.
@@ -58,8 +59,9 @@ func New() *App {
 			// Set config defaults
 			a.config = daemonConfig{
 				SystemDirs: systemDirs{
-					CacheDir:   consts.DefaultCacheDir,
-					SocketPath: "",
+					BrokersConfPath: consts.DefaultBrokersConfPath,
+					CacheDir:        consts.DefaultCacheDir,
+					SocketPath:      "",
 				},
 			}
 
@@ -105,7 +107,7 @@ func (a *App) serve(config daemonConfig) error {
 		return fmt.Errorf("error initializing cache directory at %q: %v", cacheDir, err)
 	}
 
-	m, err := services.NewManager(ctx, cacheDir, config.Brokers)
+	m, err := services.NewManager(ctx, cacheDir, config.SystemDirs.BrokersConfPath, config.Brokers)
 	if err != nil {
 		close(a.ready)
 		return err

--- a/cmd/authd/daemon/daemon_test.go
+++ b/cmd/authd/daemon/daemon_test.go
@@ -317,6 +317,7 @@ func TestNoConfigSetDefaults(t *testing.T) {
 	require.NoError(t, err, "Run should not return an error")
 
 	require.Equal(t, 0, a.Config().Verbosity, "Default Verbosity")
+	require.Equal(t, consts.DefaultBrokersConfPath, a.Config().SystemDirs.BrokersConfPath, "Default brokers configuration path")
 	require.Equal(t, consts.DefaultCacheDir, a.Config().SystemDirs.CacheDir, "Default cache directory")
 	require.Equal(t, "", a.Config().SystemDirs.SocketPath, "No socket address as default")
 }

--- a/cmd/authd/daemon/daemon_test.go
+++ b/cmd/authd/daemon/daemon_test.go
@@ -318,7 +318,7 @@ func TestNoConfigSetDefaults(t *testing.T) {
 
 	require.Equal(t, 0, a.Config().Verbosity, "Default Verbosity")
 	require.Equal(t, consts.DefaultCacheDir, a.Config().SystemDirs.CacheDir, "Default cache directory")
-	require.Equal(t, consts.DefaultSocketPath, a.Config().SystemDirs.SocketPath, "Default socket address")
+	require.Equal(t, "", a.Config().SystemDirs.SocketPath, "No socket address as default")
 }
 
 func TestBadConfigReturnsError(t *testing.T) {

--- a/cmd/authd/daemon/daemon_test.go
+++ b/cmd/authd/daemon/daemon_test.go
@@ -157,25 +157,25 @@ func TestAppRunFailsOnComponentsCreationAndQuit(t *testing.T) {
 			var config daemon.DaemonConfig
 			switch tc.cachePathBehavior {
 			case dirIsFile:
-				config.SystemDirs.CacheDir = filePath
+				config.Paths.Cache = filePath
 			case hasWrongPermission:
-				config.SystemDirs.CacheDir = worldAccessDir
+				config.Paths.Cache = worldAccessDir
 			case parentDirDoesNotExists:
-				config.SystemDirs.CacheDir = filepath.Join(shortTmp, "not-exists", "cache")
+				config.Paths.Cache = filepath.Join(shortTmp, "not-exists", "cache")
 			}
 			switch tc.socketPathBehavior {
 			case dirIsFile:
-				config.SystemDirs.SocketPath = filepath.Join(filePath, "mysocket")
+				config.Paths.Socket = filepath.Join(filePath, "mysocket")
 			default:
-				config.SystemDirs.SocketPath = filepath.Join(shortTmp, "mysocket")
+				config.Paths.Socket = filepath.Join(shortTmp, "mysocket")
 			}
 			switch tc.cacheDBBehavior {
 			case hasWrongPermission:
-				config.SystemDirs.CacheDir = filepath.Join(shortTmp, "cache")
-				err := os.MkdirAll(config.SystemDirs.CacheDir, 0700)
+				config.Paths.Cache = filepath.Join(shortTmp, "cache")
+				err := os.MkdirAll(config.Paths.Cache, 0700)
 				require.NoError(t, err, "Setup: could not create cache directory")
 				//nolint: gosec // This is a file with invalid permission for tests.
-				err = os.WriteFile(filepath.Join(config.SystemDirs.CacheDir, cachetests.DbName), nil, 0644)
+				err = os.WriteFile(filepath.Join(config.Paths.Cache, cachetests.DbName), nil, 0644)
 				require.NoError(t, err, "Setup: could not create database with invalid permissions")
 			}
 
@@ -264,7 +264,7 @@ func TestConfigLoad(t *testing.T) {
 	customizedSocketPath := filepath.Join(t.TempDir(), "mysocket")
 	var config daemon.DaemonConfig
 	config.Verbosity = 1
-	config.SystemDirs.SocketPath = customizedSocketPath
+	config.Paths.Socket = customizedSocketPath
 
 	a, wait := startDaemon(t, &config)
 	defer wait()
@@ -279,7 +279,7 @@ func TestAutoDetectConfig(t *testing.T) {
 	customizedSocketPath := filepath.Join(t.TempDir(), "mysocket")
 	var config daemon.DaemonConfig
 	config.Verbosity = 1
-	config.SystemDirs.SocketPath = customizedSocketPath
+	config.Paths.Socket = customizedSocketPath
 
 	configPath := daemon.GenerateTestConfig(t, &config)
 	configNextToBinaryPath := filepath.Join(filepath.Dir(os.Args[0]), "authd.yaml")
@@ -317,9 +317,9 @@ func TestNoConfigSetDefaults(t *testing.T) {
 	require.NoError(t, err, "Run should not return an error")
 
 	require.Equal(t, 0, a.Config().Verbosity, "Default Verbosity")
-	require.Equal(t, consts.DefaultBrokersConfPath, a.Config().SystemDirs.BrokersConfPath, "Default brokers configuration path")
-	require.Equal(t, consts.DefaultCacheDir, a.Config().SystemDirs.CacheDir, "Default cache directory")
-	require.Equal(t, "", a.Config().SystemDirs.SocketPath, "No socket address as default")
+	require.Equal(t, consts.DefaultBrokersConfPath, a.Config().Paths.BrokersConf, "Default brokers configuration path")
+	require.Equal(t, consts.DefaultCacheDir, a.Config().Paths.Cache, "Default cache directory")
+	require.Equal(t, "", a.Config().Paths.Socket, "No socket address as default")
 }
 
 func TestBadConfigReturnsError(t *testing.T) {

--- a/cmd/authd/daemon/export_test.go
+++ b/cmd/authd/daemon/export_test.go
@@ -11,7 +11,7 @@ import (
 
 type (
 	DaemonConfig = daemonConfig
-	SystemDirs   = systemDirs
+	SystemPaths  = systemPaths
 )
 
 func NewForTests(t *testing.T, conf *DaemonConfig, args ...string) *App {
@@ -38,14 +38,14 @@ func GenerateTestConfig(t *testing.T, origConf *daemonConfig) string {
 	if conf.Verbosity == 0 {
 		conf.Verbosity = 2
 	}
-	if conf.SystemDirs.CacheDir == "" {
-		conf.SystemDirs.CacheDir = t.TempDir()
+	if conf.Paths.Cache == "" {
+		conf.Paths.Cache = t.TempDir()
 		//nolint: gosec // This is a directory owned only by the current user for tests.
-		err := os.Chmod(conf.SystemDirs.CacheDir, 0700)
+		err := os.Chmod(conf.Paths.Cache, 0700)
 		require.NoError(t, err, "Setup: could not change permission on cache directory for tests")
 	}
-	if conf.SystemDirs.SocketPath == "" {
-		conf.SystemDirs.SocketPath = filepath.Join(t.TempDir(), "authd.socket")
+	if conf.Paths.Socket == "" {
+		conf.Paths.Socket = filepath.Join(t.TempDir(), "authd.socket")
 	}
 	d, err := yaml.Marshal(conf)
 	require.NoError(t, err, "Setup: could not marshal configuration for tests")

--- a/cmd/authd/daemon/export_test.go
+++ b/cmd/authd/daemon/export_test.go
@@ -44,9 +44,6 @@ func GenerateTestConfig(t *testing.T, origConf *daemonConfig) string {
 		err := os.Chmod(conf.SystemDirs.CacheDir, 0700)
 		require.NoError(t, err, "Setup: could not change permission on cache directory for tests")
 	}
-	if conf.SystemDirs.RunDir == "" {
-		conf.SystemDirs.RunDir = t.TempDir()
-	}
 	if conf.SystemDirs.SocketPath == "" {
 		conf.SystemDirs.SocketPath = filepath.Join(t.TempDir(), "authd.socket")
 	}

--- a/internal/brokers/broker_test.go
+++ b/internal/brokers/broker_test.go
@@ -66,9 +66,9 @@ func TestNewBroker(t *testing.T) {
 			conn, err := testutils.GetSystemBusConnection(t)
 			require.NoError(t, err, "Setup: could not connect to system bus")
 
-			configDir := filepath.Join(brokerCfgs, "valid_brokers")
+			configDir := filepath.Join(brokerConfFixtures, "valid_brokers")
 			if tc.wantErr {
-				configDir = filepath.Join(brokerCfgs, "invalid_brokers")
+				configDir = filepath.Join(brokerConfFixtures, "invalid_brokers")
 			}
 			if tc.configFile != "" {
 				tc.configFile = filepath.Join(configDir, tc.configFile)

--- a/internal/brokers/export_test.go
+++ b/internal/brokers/export_test.go
@@ -13,13 +13,6 @@ func NewBroker(ctx context.Context, name, configFile string, bus *dbus.Conn) (Br
 	return newBroker(ctx, name, configFile, bus)
 }
 
-// WithCfgDir uses a dedicated path for the broker config dir.
-func WithCfgDir(p string) func(o *options) {
-	return func(o *options) {
-		o.brokerCfgDir = p
-	}
-}
-
 // SetBrokerForSession sets the broker for a given session.
 //
 // This is to be used only in tests.

--- a/internal/brokers/manager.go
+++ b/internal/brokers/manager.go
@@ -30,38 +30,11 @@ type Manager struct {
 	cleanup func()
 }
 
-// Option is the function signature used to tweak the daemon creation.
-type Option func(*options)
-
-type options struct {
-	rootDir      string
-	brokerCfgDir string
-}
-
-// WithRootDir uses a dedicated path for our root.
-func WithRootDir(p string) func(o *options) {
-	return func(o *options) {
-		o.rootDir = p
-	}
-}
-
 // NewManager creates a new broker manager object.
-func NewManager(ctx context.Context, configuredBrokers []string, args ...Option) (m *Manager, err error) {
+func NewManager(ctx context.Context, brokersConfPath string, configuredBrokers []string) (m *Manager, err error) {
 	defer decorate.OnError(&err /*i18n.G(*/, "can't create brokers detection object") //)
 
 	log.Debug(ctx, "Building broker detection")
-
-	// Set default options.
-	opts := options{
-		rootDir:      "/",
-		brokerCfgDir: "etc/authd/broker.d",
-	}
-	// Apply given args.
-	for _, f := range args {
-		f(&opts)
-	}
-
-	brokersConfPath := filepath.Join(opts.rootDir, opts.brokerCfgDir)
 
 	brokersConfPathWithExample, cleanup, err := useExampleBrokers()
 	if err != nil {

--- a/internal/consts/consts.go
+++ b/internal/consts/consts.go
@@ -18,6 +18,9 @@ const (
 	// DefaultSocketPath is the default socket path.
 	DefaultSocketPath = "/run/authd.sock"
 
+	// DefaultBrokersConfPath is the default configuration directory for the brokers.
+	DefaultBrokersConfPath = "/etc/authd/brokers.d/"
+
 	// DefaultCacheDir is the default directory for the cache.
 	DefaultCacheDir = "/var/cache/authd/"
 )

--- a/internal/consts/consts.go
+++ b/internal/consts/consts.go
@@ -20,7 +20,4 @@ const (
 
 	// DefaultCacheDir is the default directory for the cache.
 	DefaultCacheDir = "/var/cache/authd/"
-
-	// DefaultRunDir is the default run directory.
-	DefaultRunDir = "/run/authd/"
 )

--- a/internal/services/manager.go
+++ b/internal/services/manager.go
@@ -24,12 +24,12 @@ type Manager struct {
 }
 
 // NewManager returns a new manager after creating all necessary items for our business logic.
-func NewManager(ctx context.Context, cacheDir string, configuredBrokers []string) (m Manager, err error) {
+func NewManager(ctx context.Context, cacheDir, brokersConfPath string, configuredBrokers []string) (m Manager, err error) {
 	defer decorate.OnError(&err /*i18n.G(*/, "can't create authd object") //)
 
 	log.Debug(ctx, "Building authd object")
 
-	brokerManager, err := brokers.NewManager(ctx, configuredBrokers)
+	brokerManager, err := brokers.NewManager(ctx, brokersConfPath, configuredBrokers)
 	if err != nil {
 		return m, err
 	}

--- a/internal/services/manager_test.go
+++ b/internal/services/manager_test.go
@@ -36,7 +36,7 @@ func TestNewManager(t *testing.T) {
 				t.Setenv("DBUS_SYSTEM_BUS_ADDRESS", tc.systemBusSocket)
 			}
 
-			m, err := services.NewManager(context.Background(), tc.cacheDir, nil)
+			m, err := services.NewManager(context.Background(), tc.cacheDir, t.TempDir(), nil)
 			if tc.wantErr {
 				require.Error(t, err, "NewManager should have returned an error, but did not")
 				return
@@ -51,7 +51,7 @@ func TestNewManager(t *testing.T) {
 func TestRegisterGRPCServices(t *testing.T) {
 	t.Parallel()
 
-	m, err := services.NewManager(context.Background(), t.TempDir(), nil)
+	m, err := services.NewManager(context.Background(), t.TempDir(), t.TempDir(), nil)
 	require.NoError(t, err, "Setup: could not create manager for the test")
 	defer require.NoError(t, m.Stop(), "Teardown: Stop should not have returned an error, but did")
 

--- a/internal/services/pam/pam_test.go
+++ b/internal/services/pam/pam_test.go
@@ -531,18 +531,18 @@ func initBrokers() (brokerConfigPath string, cleanup func(), err error) {
 		return "", nil, err
 	}
 
-	brokerDir := filepath.Join(tmpDir, "etc", "authd", "broker.d")
-	if err = os.MkdirAll(brokerDir, 0750); err != nil {
+	brokersConfPath := filepath.Join(tmpDir, "etc", "authd", "broker.d")
+	if err = os.MkdirAll(brokersConfPath, 0750); err != nil {
 		_ = os.RemoveAll(tmpDir)
 		return "", nil, err
 	}
-	_, brokerCleanup, err := testutils.StartBusBrokerMock(brokerDir, "BrokerMock")
+	_, brokerCleanup, err := testutils.StartBusBrokerMock(brokersConfPath, "BrokerMock")
 	if err != nil {
 		_ = os.RemoveAll(tmpDir)
 		return "", nil, err
 	}
 
-	return tmpDir, func() {
+	return brokersConfPath, func() {
 		brokerCleanup()
 		_ = os.RemoveAll(tmpDir)
 	}, nil
@@ -628,7 +628,7 @@ func TestMain(m *testing.M) {
 	defer busCleanup()
 
 	// Start brokers mock over dbus.
-	brokersConfigPath, cleanup, err := initBrokers()
+	brokersConfPath, cleanup, err := initBrokers()
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "%v\n", err)
 		os.Exit(1)
@@ -636,7 +636,7 @@ func TestMain(m *testing.M) {
 	defer cleanup()
 
 	// Get manager shared across grpc services.
-	brokerManager, err = brokers.NewManager(context.Background(), nil, brokers.WithRootDir(brokersConfigPath))
+	brokerManager, err = brokers.NewManager(context.Background(), brokersConfPath, nil)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "%v\n", err)
 		os.Exit(1)


### PR DESCRIPTION
* Allow exporting them as environment variable or via a configuration file (using a subdomain, to ensure it’s not exposed at the root level).
* Don’t export them as flags: this is niche-case enough to be as configuration rather than flags.
* Ensure we minimize the usage of `With*()` by only having it for really optional parameter. For the others, it means that this directory should be explicit passed and the const default is initiliazed at the start of the program, just before loading overidden configuration.
* Align the naming around those variables.

UDENG-1392