### PR TITLE
fix(cache): Ignore info() err on getActiveUsers if it is ErrNotExist

### DIFF
--- a/internal/cache/db.go
+++ b/internal/cache/db.go
@@ -342,6 +342,10 @@ func getActiveUsers(procDir string) (activeUsers map[string]struct{}, err error)
 
 		info, err := dirEntry.Info()
 		if err != nil {
+			// If the file doesn't exist, it means the process is not running anymore so we can ignore it.
+			if errors.Is(err, fs.ErrNotExist) {
+				continue
+			}
 			return nil, err
 		}
 


### PR DESCRIPTION
If dirEntry.info() returns an ErrNotExist error, it means that the file is no longer available, which means that the process doesn't exist anymore, so we can ignore it.

Closes #79
UDENG-1521