### PR TITLE
ci: Add step to build cmd/authd with withexamplebroker tag to QA job

### DIFF
--- a/.github/workflows/qa.yaml
+++ b/.github/workflows/qa.yaml
@@ -31,6 +31,10 @@ jobs:
         with:
           golangci-lint-configfile: ".golangci.yaml"
           tools-directory: "tools"
+      - name: Build cmd/authd with withexamplebroker tag
+        run: |
+          set -eu
+          go build -tags withexamplebroker ./cmd/authd
 
   rust-sanity:
     name: "Rust: Code sanity"


### PR DESCRIPTION
Adding a step to check if the daemon still builds with the `withexamplebroker` build tag to the sanity check job.

UDENG-1452