### PR TITLE
deps(go): bump go to 1.21.4

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/ubuntu/authd
 
-go 1.21.1
+go 1.21.4
 
 require (
 	github.com/charmbracelet/bubbles v0.16.1


### PR DESCRIPTION
`govulncheck` was updated and now some CI tests are failing due to security vulnerabilities in some standard library packages. This can be fixed by bumping the required go version to 1.21.4, which is done in this PR. 