### PR TITLE
feat(cache/pam): Save user's last used broker to the cache

### DIFF
--- a/internal/cache/db.go
+++ b/internal/cache/db.go
@@ -32,6 +32,7 @@ const (
 	groupByIDBucketName    = "GroupByID"
 	userToGroupsBucketName = "UserToGroups"
 	groupToUsersBucketName = "GroupToUsers"
+	userToBrokerBucketName = "UserToBroker"
 
 	// defaultEntryExpiration is the amount of time the user is allowed on the cache without authenticating.
 	// It's equivalent to 6 months.
@@ -45,7 +46,9 @@ var (
 	allBuckets = [][]byte{
 		[]byte(userByNameBucketName), []byte(userByIDBucketName),
 		[]byte(groupByNameBucketName), []byte(groupByIDBucketName),
-		[]byte(userToGroupsBucketName), []byte(groupToUsersBucketName)}
+		[]byte(userToGroupsBucketName), []byte(groupToUsersBucketName),
+		[]byte(userToBrokerBucketName),
+	}
 )
 
 // Cache is our database API.
@@ -257,7 +260,7 @@ func openAndInitDB(path, dirtyFlagPath string) (*bbolt.DB, error) {
 
 		// Clear up any unknown buckets
 		var bucketNamesToDelete [][]byte
-		err = tx.ForEach(func(name []byte, b *bbolt.Bucket) error {
+		err = tx.ForEach(func(name []byte, _ *bbolt.Bucket) error {
 			if slices.Contains(allBucketsNames, string(name)) {
 				return nil
 			}

--- a/internal/cache/db_test.go
+++ b/internal/cache/db_test.go
@@ -492,6 +492,7 @@ GroupByName: {}
 GroupToUsers: {}
 UserByID: {}
 UserByName: {}
+UserToBroker: {}
 UserToGroups: {}
 `
 

--- a/internal/cache/delete.go
+++ b/internal/cache/delete.go
@@ -75,5 +75,8 @@ func deleteUser(buckets map[string]bucketWithName, uid int) (err error) {
 	if err = buckets[userByNameBucketName].Delete([]byte(u.Name)); err != nil {
 		panic(fmt.Sprintf("programming error: delete is not allowed in a RO transaction: %v", err))
 	}
+	if err = buckets[userToBrokerBucketName].Delete([]byte(strconv.Itoa(u.UID))); err != nil {
+		panic(fmt.Sprintf("programming error: delete is not allowed in a RO transaction: %v", err))
+	}
 	return nil
 }

--- a/internal/cache/getbroker.go
+++ b/internal/cache/getbroker.go
@@ -1,0 +1,36 @@
+package cache
+
+import (
+	"go.etcd.io/bbolt"
+)
+
+// BrokerForUser returns the broker ID assigned to the given username or an error if no entry was found.
+func (c *Cache) BrokerForUser(username string) (brokerID string, err error) {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+
+	u, err := c.UserByName(username)
+	if err != nil {
+		return "", err
+	}
+
+	err = c.db.View(func(tx *bbolt.Tx) error {
+		bucket, err := getBucket(tx, userToBrokerBucketName)
+		if err != nil {
+			c.requestClearDatabase()
+			return err
+		}
+
+		brokerID, err = getFromBucket[string](bucket, u.UID)
+		// The UserToBroker bucket is a string to string mapping, so there's no issues with marshalling.
+		if err != nil {
+			return err
+		}
+		return nil
+	})
+
+	if err != nil {
+		return "", err
+	}
+	return brokerID, nil
+}

--- a/internal/cache/testdata/TestBrokerForUser/golden
+++ b/internal/cache/testdata/TestBrokerForUser/golden
@@ -1,0 +1,1 @@
+ExampleBrokerID

--- a/internal/cache/testdata/TestNew/golden/clean_up_all_users
+++ b/internal/cache/testdata/TestNew/golden/clean_up_all_users
@@ -3,4 +3,5 @@ GroupByName: {}
 GroupToUsers: {}
 UserByID: {}
 UserByName: {}
+UserToBroker: {}
 UserToGroups: {}

--- a/internal/cache/testdata/TestNew/golden/clean_up_also_cleans_last_selected_broker_for_user
+++ b/internal/cache/testdata/TestNew/golden/clean_up_also_cleans_last_selected_broker_for_user
@@ -1,0 +1,17 @@
+GroupByID:
+    "33333": '{"Name":"group3","GID":33333}'
+    "99999": '{"Name":"commongroup","GID":99999}'
+GroupByName:
+    commongroup: '{"Name":"commongroup","GID":99999}'
+    group3: '{"Name":"group3","GID":33333}'
+GroupToUsers:
+    "33333": '{"GID":33333,"UIDs":[3333]}'
+    "99999": '{"GID":99999,"UIDs":[3333]}'
+UserByID:
+    "3333": '{"Name":"user3","UID":3333,"GID":33333,"Gecos":"User3","Dir":"/home/user3","Shell":"/bin/zsh","LastPwdChange":-1,"MaxPwdAge":-1,"PwdWarnPeriod":-1,"PwdInactivity":-1,"MinPwdAge":-1,"ExpirationDate":-1,"LastLogin":"ABCDETIME"}'
+UserByName:
+    user3: '{"Name":"user3","UID":3333,"GID":33333,"Gecos":"User3","Dir":"/home/user3","Shell":"/bin/zsh","LastPwdChange":-1,"MaxPwdAge":-1,"PwdWarnPeriod":-1,"PwdInactivity":-1,"MinPwdAge":-1,"ExpirationDate":-1,"LastLogin":"ABCDETIME"}'
+UserToBroker:
+    "3333": '"ExampleBrokerID"'
+UserToGroups:
+    "3333": '{"UID":3333,"GIDs":[33333,99999]}'

--- a/internal/cache/testdata/TestNew/golden/clean_up_as_much_as_possible_if_db_has_invalid_entries
+++ b/internal/cache/testdata/TestNew/golden/clean_up_as_much_as_possible_if_db_has_invalid_entries
@@ -16,6 +16,7 @@ UserByID:
 UserByName:
     user2: '"not-a-valid-json"'
     user3: '"not-a-valid-json"'
+UserToBroker: {}
 UserToGroups:
     "2222": '"not-a-valid-json"'
     "3333": '"not-a-valid-json"'

--- a/internal/cache/testdata/TestNew/golden/clean_up_on_interval
+++ b/internal/cache/testdata/TestNew/golden/clean_up_on_interval
@@ -11,5 +11,6 @@ UserByID:
     "3333": '{"Name":"user3","UID":3333,"GID":33333,"Gecos":"User3","Dir":"/home/user3","Shell":"/bin/zsh","LastPwdChange":-1,"MaxPwdAge":-1,"PwdWarnPeriod":-1,"PwdInactivity":-1,"MinPwdAge":-1,"ExpirationDate":-1,"LastLogin":"ABCDETIME"}'
 UserByName:
     user3: '{"Name":"user3","UID":3333,"GID":33333,"Gecos":"User3","Dir":"/home/user3","Shell":"/bin/zsh","LastPwdChange":-1,"MaxPwdAge":-1,"PwdWarnPeriod":-1,"PwdInactivity":-1,"MinPwdAge":-1,"ExpirationDate":-1,"LastLogin":"ABCDETIME"}'
+UserToBroker: {}
 UserToGroups:
     "3333": '{"UID":3333,"GIDs":[33333,99999]}'

--- a/internal/cache/testdata/TestNew/golden/clean_up_some_users
+++ b/internal/cache/testdata/TestNew/golden/clean_up_some_users
@@ -11,5 +11,6 @@ UserByID:
     "3333": '{"Name":"user3","UID":3333,"GID":33333,"Gecos":"User3","Dir":"/home/user3","Shell":"/bin/zsh","LastPwdChange":-1,"MaxPwdAge":-1,"PwdWarnPeriod":-1,"PwdInactivity":-1,"MinPwdAge":-1,"ExpirationDate":-1,"LastLogin":"ABCDETIME"}'
 UserByName:
     user3: '{"Name":"user3","UID":3333,"GID":33333,"Gecos":"User3","Dir":"/home/user3","Shell":"/bin/zsh","LastPwdChange":-1,"MaxPwdAge":-1,"PwdWarnPeriod":-1,"PwdInactivity":-1,"MinPwdAge":-1,"ExpirationDate":-1,"LastLogin":"ABCDETIME"}'
+UserToBroker: {}
 UserToGroups:
     "3333": '{"UID":3333,"GIDs":[33333,99999]}'

--- a/internal/cache/testdata/TestNew/golden/clean_up_user_even_if_it_is_not_listed_on_the_group
+++ b/internal/cache/testdata/TestNew/golden/clean_up_user_even_if_it_is_not_listed_on_the_group
@@ -8,5 +8,6 @@ UserByID:
     "2222": '{"Name":"user2","UID":2222,"GID":11111,"Gecos":"user2 gecos\nOn multiple lines","Dir":"/home/user2","Shell":"/bin/bash","LastPwdChange":-1,"MaxPwdAge":-1,"PwdWarnPeriod":-1,"PwdInactivity":-1,"MinPwdAge":-1,"ExpirationDate":-1,"LastLogin":"ABCDETIME"}'
 UserByName:
     user2: '{"Name":"user2","UID":2222,"GID":11111,"Gecos":"user2 gecos\nOn multiple lines","Dir":"/home/user2","Shell":"/bin/bash","LastPwdChange":-1,"MaxPwdAge":-1,"PwdWarnPeriod":-1,"PwdInactivity":-1,"MinPwdAge":-1,"ExpirationDate":-1,"LastLogin":"ABCDETIME"}'
+UserToBroker: {}
 UserToGroups:
     "2222": '{"UID":2222,"GIDs":[11111]}'

--- a/internal/cache/testdata/TestNew/golden/corrupted_database_when_opening_is_cleared_up
+++ b/internal/cache/testdata/TestNew/golden/corrupted_database_when_opening_is_cleared_up
@@ -3,4 +3,5 @@ GroupByName: {}
 GroupToUsers: {}
 UserByID: {}
 UserByName: {}
+UserToBroker: {}
 UserToGroups: {}

--- a/internal/cache/testdata/TestNew/golden/database_flagged_as_dirty_is_cleared_up
+++ b/internal/cache/testdata/TestNew/golden/database_flagged_as_dirty_is_cleared_up
@@ -3,4 +3,5 @@ GroupByName: {}
 GroupToUsers: {}
 UserByID: {}
 UserByName: {}
+UserToBroker: {}
 UserToGroups: {}

--- a/internal/cache/testdata/TestNew/golden/do_not_clean_active_user
+++ b/internal/cache/testdata/TestNew/golden/do_not_clean_active_user
@@ -8,5 +8,6 @@ UserByID:
     "1111": '{"Name":"ACTIVE_USER","UID":1111,"GID":11111,"Gecos":"ACTIVE_USER gecos\nOn multiple lines","Dir":"/home/ACTIVE_USER","Shell":"/bin/bash","LastPwdChange":-1,"MaxPwdAge":-1,"PwdWarnPeriod":-1,"PwdInactivity":-1,"MinPwdAge":-1,"ExpirationDate":-1,"LastLogin":"AAAAATIME"}'
 UserByName:
     ACTIVE_USER: '{"Name":"ACTIVE_USER","UID":1111,"GID":11111,"Gecos":"ACTIVE_USER gecos\nOn multiple lines","Dir":"/home/ACTIVE_USER","Shell":"/bin/bash","LastPwdChange":-1,"MaxPwdAge":-1,"PwdWarnPeriod":-1,"PwdInactivity":-1,"MinPwdAge":-1,"ExpirationDate":-1,"LastLogin":"AAAAATIME"}'
+UserToBroker: {}
 UserToGroups:
     "1111": '{"UID":1111,"GIDs":[11111]}'

--- a/internal/cache/testdata/TestNew/golden/do_not_clean_any_user
+++ b/internal/cache/testdata/TestNew/golden/do_not_clean_any_user
@@ -21,6 +21,7 @@ UserByName:
     user1: '{"Name":"user1","UID":1111,"GID":11111,"Gecos":"User1 gecos\nOn multiple lines","Dir":"/home/user1","Shell":"/bin/bash","LastPwdChange":-1,"MaxPwdAge":-1,"PwdWarnPeriod":-1,"PwdInactivity":-1,"MinPwdAge":-1,"ExpirationDate":-1,"LastLogin":"AAAAATIME"}'
     user2: '{"Name":"user2","UID":2222,"GID":22222,"Gecos":"User2","Dir":"/home/user2","Shell":"/bin/dash","LastPwdChange":-1,"MaxPwdAge":-1,"PwdWarnPeriod":-1,"PwdInactivity":-1,"MinPwdAge":-1,"ExpirationDate":-1,"LastLogin":"BBBBBTIME"}'
     user3: '{"Name":"user3","UID":3333,"GID":33333,"Gecos":"User3","Dir":"/home/user3","Shell":"/bin/zsh","LastPwdChange":-1,"MaxPwdAge":-1,"PwdWarnPeriod":-1,"PwdInactivity":-1,"MinPwdAge":-1,"ExpirationDate":-1,"LastLogin":"ABCDETIME"}'
+UserToBroker: {}
 UserToGroups:
     "1111": '{"UID":1111,"GIDs":[11111]}'
     "2222": '{"UID":2222,"GIDs":[22222,99999]}'

--- a/internal/cache/testdata/TestNew/golden/do_not_clean_user_if_can_not_delete_user_from_group
+++ b/internal/cache/testdata/TestNew/golden/do_not_clean_user_if_can_not_delete_user_from_group
@@ -8,5 +8,6 @@ UserByID:
     "1111": '{"Name":"user1","UID":1111,"GID":11111,"Gecos":"User1 gecos\nOn multiple lines","Dir":"/home/user1","Shell":"/bin/bash","LastPwdChange":-1,"MaxPwdAge":-1,"PwdWarnPeriod":-1,"PwdInactivity":-1,"MinPwdAge":-1,"ExpirationDate":-1,"LastLogin":"AAAAATIME"}'
 UserByName:
     user1: '{"Name":"user1","UID":1111,"GID":11111,"Gecos":"User1 gecos\nOn multiple lines","Dir":"/home/user1","Shell":"/bin/bash","LastPwdChange":-1,"MaxPwdAge":-1,"PwdWarnPeriod":-1,"PwdInactivity":-1,"MinPwdAge":-1,"ExpirationDate":-1,"LastLogin":"AAAAATIME"}'
+UserToBroker: {}
 UserToGroups:
     "1111": '{"UID":1111,"GIDs":[11111]}'

--- a/internal/cache/testdata/TestNew/golden/do_not_clean_user_if_can_not_get_groups
+++ b/internal/cache/testdata/TestNew/golden/do_not_clean_user_if_can_not_get_groups
@@ -8,5 +8,6 @@ UserByID:
     "1111": '{"Name":"user1","UID":1111,"GID":11111,"Gecos":"User1 gecos\nOn multiple lines","Dir":"/home/user1","Shell":"/bin/bash","LastPwdChange":-1,"MaxPwdAge":-1,"PwdWarnPeriod":-1,"PwdInactivity":-1,"MinPwdAge":-1,"ExpirationDate":-1,"LastLogin":"AAAAATIME"}'
 UserByName:
     user1: '{"Name":"user1","UID":1111,"GID":11111,"Gecos":"User1 gecos\nOn multiple lines","Dir":"/home/user1","Shell":"/bin/bash","LastPwdChange":-1,"MaxPwdAge":-1,"PwdWarnPeriod":-1,"PwdInactivity":-1,"MinPwdAge":-1,"ExpirationDate":-1,"LastLogin":"AAAAATIME"}'
+UserToBroker: {}
 UserToGroups:
     "1111": '"not-a-valid-json"'

--- a/internal/cache/testdata/TestNew/golden/do_not_prevent_cache_creation_if_cleanup_fails
+++ b/internal/cache/testdata/TestNew/golden/do_not_prevent_cache_creation_if_cleanup_fails
@@ -21,6 +21,7 @@ UserByName:
     user1: '{"Name":"user1","UID":1111,"GID":11111,"Gecos":"User1 gecos\nOn multiple lines","Dir":"/home/user1","Shell":"/bin/bash","LastPwdChange":-1,"MaxPwdAge":-1,"PwdWarnPeriod":-1,"PwdInactivity":-1,"MinPwdAge":-1,"ExpirationDate":-1,"LastLogin":"AAAAATIME"}'
     user2: '{"Name":"user2","UID":2222,"GID":22222,"Gecos":"User2","Dir":"/home/user2","Shell":"/bin/dash","LastPwdChange":-1,"MaxPwdAge":-1,"PwdWarnPeriod":-1,"PwdInactivity":-1,"MinPwdAge":-1,"ExpirationDate":-1,"LastLogin":"BBBBBTIME"}'
     user3: '{"Name":"user3","UID":3333,"GID":33333,"Gecos":"User3","Dir":"/home/user3","Shell":"/bin/zsh","LastPwdChange":-1,"MaxPwdAge":-1,"PwdWarnPeriod":-1,"PwdInactivity":-1,"MinPwdAge":-1,"ExpirationDate":-1,"LastLogin":"ABCDETIME"}'
+UserToBroker: {}
 UserToGroups:
     "1111": '{"UID":1111,"GIDs":[11111]}'
     "2222": '{"UID":2222,"GIDs":[22222,99999]}'

--- a/internal/cache/testdata/TestNew/golden/do_not_stop_cache_if_cleanup_routine_fails
+++ b/internal/cache/testdata/TestNew/golden/do_not_stop_cache_if_cleanup_routine_fails
@@ -21,6 +21,7 @@ UserByName:
     user1: '{"Name":"user1","UID":1111,"GID":11111,"Gecos":"User1 gecos\nOn multiple lines","Dir":"/home/user1","Shell":"/bin/bash","LastPwdChange":-1,"MaxPwdAge":-1,"PwdWarnPeriod":-1,"PwdInactivity":-1,"MinPwdAge":-1,"ExpirationDate":-1,"LastLogin":"AAAAATIME"}'
     user2: '{"Name":"user2","UID":2222,"GID":22222,"Gecos":"User2","Dir":"/home/user2","Shell":"/bin/dash","LastPwdChange":-1,"MaxPwdAge":-1,"PwdWarnPeriod":-1,"PwdInactivity":-1,"MinPwdAge":-1,"ExpirationDate":-1,"LastLogin":"BBBBBTIME"}'
     user3: '{"Name":"user3","UID":3333,"GID":33333,"Gecos":"User3","Dir":"/home/user3","Shell":"/bin/zsh","LastPwdChange":-1,"MaxPwdAge":-1,"PwdWarnPeriod":-1,"PwdInactivity":-1,"MinPwdAge":-1,"ExpirationDate":-1,"LastLogin":"ABCDETIME"}'
+UserToBroker: {}
 UserToGroups:
     "1111": '{"UID":1111,"GIDs":[11111]}'
     "2222": '{"UID":2222,"GIDs":[22222,99999]}'

--- a/internal/cache/testdata/TestNew/golden/dynamically_mark_database_as_corrupted_is_cleared_up
+++ b/internal/cache/testdata/TestNew/golden/dynamically_mark_database_as_corrupted_is_cleared_up
@@ -3,4 +3,5 @@ GroupByName: {}
 GroupToUsers: {}
 UserByID: {}
 UserByName: {}
+UserToBroker: {}
 UserToGroups: {}

--- a/internal/cache/testdata/TestNew/golden/new_recreates_any_missing_buckets_and_delete_unknowns
+++ b/internal/cache/testdata/TestNew/golden/new_recreates_any_missing_buckets_and_delete_unknowns
@@ -4,4 +4,5 @@ GroupToUsers: {}
 UserByID:
     "1111": '{"Name":"user1","UID":1111,"GID":11111,"Gecos":"User1 gecos\nOn multiple lines","Dir":"/home/user1","Shell":"/bin/bash","LastPwdChange":-1,"MaxPwdAge":-1,"PwdWarnPeriod":-1,"PwdInactivity":-1,"MinPwdAge":-1,"ExpirationDate":-1,"LastLogin":"AAAAATIME"}'
 UserByName: {}
+UserToBroker: {}
 UserToGroups: {}

--- a/internal/cache/testdata/TestNew/golden/new_with_already_existing_database
+++ b/internal/cache/testdata/TestNew/golden/new_with_already_existing_database
@@ -21,6 +21,7 @@ UserByName:
     user1: '{"Name":"user1","UID":1111,"GID":11111,"Gecos":"User1 gecos\nOn multiple lines","Dir":"/home/user1","Shell":"/bin/bash","LastPwdChange":-1,"MaxPwdAge":-1,"PwdWarnPeriod":-1,"PwdInactivity":-1,"MinPwdAge":-1,"ExpirationDate":-1,"LastLogin":"AAAAATIME"}'
     user2: '{"Name":"user2","UID":2222,"GID":22222,"Gecos":"User2","Dir":"/home/user2","Shell":"/bin/dash","LastPwdChange":-1,"MaxPwdAge":-1,"PwdWarnPeriod":-1,"PwdInactivity":-1,"MinPwdAge":-1,"ExpirationDate":-1,"LastLogin":"BBBBBTIME"}'
     user3: '{"Name":"user3","UID":3333,"GID":33333,"Gecos":"User3","Dir":"/home/user3","Shell":"/bin/zsh","LastPwdChange":-1,"MaxPwdAge":-1,"PwdWarnPeriod":-1,"PwdInactivity":-1,"MinPwdAge":-1,"ExpirationDate":-1,"LastLogin":"ABCDETIME"}'
+UserToBroker: {}
 UserToGroups:
     "1111": '{"UID":1111,"GIDs":[11111]}'
     "2222": '{"UID":2222,"GIDs":[22222,99999]}'

--- a/internal/cache/testdata/TestNew/golden/new_without_any_initialized_database
+++ b/internal/cache/testdata/TestNew/golden/new_without_any_initialized_database
@@ -3,4 +3,5 @@ GroupByName: {}
 GroupToUsers: {}
 UserByID: {}
 UserByName: {}
+UserToBroker: {}
 UserToGroups: {}

--- a/internal/cache/testdata/TestUpdateFromUserInfo/golden/add_user_to_group_from_another_user
+++ b/internal/cache/testdata/TestUpdateFromUserInfo/golden/add_user_to_group_from_another_user
@@ -21,6 +21,7 @@ UserByName:
     user1: '{"Name":"user1","UID":1111,"GID":11111,"Gecos":"User1 gecos\nOn multiple lines","Dir":"/home/user1","Shell":"/bin/bash","LastPwdChange":-1,"MaxPwdAge":-1,"PwdWarnPeriod":-1,"PwdInactivity":-1,"MinPwdAge":-1,"ExpirationDate":-1,"LastLogin":"ABCDETIME"}'
     user2: '{"Name":"user2","UID":2222,"GID":22222,"Gecos":"User2","Dir":"/home/user2","Shell":"/bin/dash","LastPwdChange":-1,"MaxPwdAge":-1,"PwdWarnPeriod":-1,"PwdInactivity":-1,"MinPwdAge":-1,"ExpirationDate":-1,"LastLogin":"BBBBBTIME"}'
     user3: '{"Name":"user3","UID":3333,"GID":33333,"Gecos":"User3","Dir":"/home/user3","Shell":"/bin/zsh","LastPwdChange":-1,"MaxPwdAge":-1,"PwdWarnPeriod":-1,"PwdInactivity":-1,"MinPwdAge":-1,"ExpirationDate":-1,"LastLogin":"ABCDETIME"}'
+UserToBroker: {}
 UserToGroups:
     "1111": '{"UID":1111,"GIDs":[11111,22222]}'
     "2222": '{"UID":2222,"GIDs":[22222,99999]}'

--- a/internal/cache/testdata/TestUpdateFromUserInfo/golden/insert_new_user
+++ b/internal/cache/testdata/TestUpdateFromUserInfo/golden/insert_new_user
@@ -8,5 +8,6 @@ UserByID:
     "1111": '{"Name":"user1","UID":1111,"GID":11111,"Gecos":"User1 gecos\nOn multiple lines","Dir":"/home/user1","Shell":"/bin/bash","LastPwdChange":-1,"MaxPwdAge":-1,"PwdWarnPeriod":-1,"PwdInactivity":-1,"MinPwdAge":-1,"ExpirationDate":-1,"LastLogin":"ABCDETIME"}'
 UserByName:
     user1: '{"Name":"user1","UID":1111,"GID":11111,"Gecos":"User1 gecos\nOn multiple lines","Dir":"/home/user1","Shell":"/bin/bash","LastPwdChange":-1,"MaxPwdAge":-1,"PwdWarnPeriod":-1,"PwdInactivity":-1,"MinPwdAge":-1,"ExpirationDate":-1,"LastLogin":"ABCDETIME"}'
+UserToBroker: {}
 UserToGroups:
     "1111": '{"UID":1111,"GIDs":[11111]}'

--- a/internal/cache/testdata/TestUpdateFromUserInfo/golden/invalid_value_entries_in_other_user_and_groups_don't_impact_current_request
+++ b/internal/cache/testdata/TestUpdateFromUserInfo/golden/invalid_value_entries_in_other_user_and_groups_don't_impact_current_request
@@ -21,6 +21,7 @@ UserByName:
     user1: '{"Name":"user1","UID":1111,"GID":11111,"Gecos":"User1 gecos\nOn multiple lines","Dir":"/home/user1","Shell":"/bin/bash","LastPwdChange":-1,"MaxPwdAge":-1,"PwdWarnPeriod":-1,"PwdInactivity":-1,"MinPwdAge":-1,"ExpirationDate":-1,"LastLogin":"ABCDETIME"}'
     user2: '"not-a-valid-json"'
     user3: '"not-a-valid-json"'
+UserToBroker: {}
 UserToGroups:
     "1111": '{"UID":1111,"GIDs":[11111]}'
     "2222": '"not-a-valid-json"'

--- a/internal/cache/testdata/TestUpdateFromUserInfo/golden/invalid_value_entry_in_groupbyid_but_user_restating_group_recreates_entries
+++ b/internal/cache/testdata/TestUpdateFromUserInfo/golden/invalid_value_entry_in_groupbyid_but_user_restating_group_recreates_entries
@@ -8,5 +8,6 @@ UserByID:
     "1111": '{"Name":"user1","UID":1111,"GID":11111,"Gecos":"User1 gecos\nOn multiple lines","Dir":"/home/user1","Shell":"/bin/bash","LastPwdChange":-1,"MaxPwdAge":-1,"PwdWarnPeriod":-1,"PwdInactivity":-1,"MinPwdAge":-1,"ExpirationDate":-1,"LastLogin":"ABCDETIME"}'
 UserByName:
     user1: '{"Name":"user1","UID":1111,"GID":11111,"Gecos":"User1 gecos\nOn multiple lines","Dir":"/home/user1","Shell":"/bin/bash","LastPwdChange":-1,"MaxPwdAge":-1,"PwdWarnPeriod":-1,"PwdInactivity":-1,"MinPwdAge":-1,"ExpirationDate":-1,"LastLogin":"ABCDETIME"}'
+UserToBroker: {}
 UserToGroups:
     "1111": '{"UID":1111,"GIDs":[11111]}'

--- a/internal/cache/testdata/TestUpdateFromUserInfo/golden/invalid_value_entry_in_groupbyname_recreates_entries
+++ b/internal/cache/testdata/TestUpdateFromUserInfo/golden/invalid_value_entry_in_groupbyname_recreates_entries
@@ -8,5 +8,6 @@ UserByID:
     "1111": '{"Name":"user1","UID":1111,"GID":11111,"Gecos":"User1 gecos\nOn multiple lines","Dir":"/home/user1","Shell":"/bin/bash","LastPwdChange":-1,"MaxPwdAge":-1,"PwdWarnPeriod":-1,"PwdInactivity":-1,"MinPwdAge":-1,"ExpirationDate":-1,"LastLogin":"ABCDETIME"}'
 UserByName:
     user1: '{"Name":"user1","UID":1111,"GID":11111,"Gecos":"User1 gecos\nOn multiple lines","Dir":"/home/user1","Shell":"/bin/bash","LastPwdChange":-1,"MaxPwdAge":-1,"PwdWarnPeriod":-1,"PwdInactivity":-1,"MinPwdAge":-1,"ExpirationDate":-1,"LastLogin":"ABCDETIME"}'
+UserToBroker: {}
 UserToGroups:
     "1111": '{"UID":1111,"GIDs":[11111]}'

--- a/internal/cache/testdata/TestUpdateFromUserInfo/golden/invalid_value_entry_in_groupbyname_recreates_entries_even_without_restating_group
+++ b/internal/cache/testdata/TestUpdateFromUserInfo/golden/invalid_value_entry_in_groupbyname_recreates_entries_even_without_restating_group
@@ -8,5 +8,6 @@ UserByID:
     "1111": '{"Name":"user1","UID":1111,"GID":11111,"Gecos":"User1 gecos\nOn multiple lines","Dir":"/home/user1","Shell":"/bin/bash","LastPwdChange":-1,"MaxPwdAge":-1,"PwdWarnPeriod":-1,"PwdInactivity":-1,"MinPwdAge":-1,"ExpirationDate":-1,"LastLogin":"ABCDETIME"}'
 UserByName:
     user1: '{"Name":"user1","UID":1111,"GID":11111,"Gecos":"User1 gecos\nOn multiple lines","Dir":"/home/user1","Shell":"/bin/bash","LastPwdChange":-1,"MaxPwdAge":-1,"PwdWarnPeriod":-1,"PwdInactivity":-1,"MinPwdAge":-1,"ExpirationDate":-1,"LastLogin":"ABCDETIME"}'
+UserToBroker: {}
 UserToGroups:
     "1111": '{"UID":1111,"GIDs":[11111]}'

--- a/internal/cache/testdata/TestUpdateFromUserInfo/golden/invalid_value_entry_in_userbyid_recreates_entries
+++ b/internal/cache/testdata/TestUpdateFromUserInfo/golden/invalid_value_entry_in_userbyid_recreates_entries
@@ -8,5 +8,6 @@ UserByID:
     "1111": '{"Name":"user1","UID":1111,"GID":11111,"Gecos":"User1 gecos\nOn multiple lines","Dir":"/home/user1","Shell":"/bin/bash","LastPwdChange":-1,"MaxPwdAge":-1,"PwdWarnPeriod":-1,"PwdInactivity":-1,"MinPwdAge":-1,"ExpirationDate":-1,"LastLogin":"ABCDETIME"}'
 UserByName:
     user1: '{"Name":"user1","UID":1111,"GID":11111,"Gecos":"User1 gecos\nOn multiple lines","Dir":"/home/user1","Shell":"/bin/bash","LastPwdChange":-1,"MaxPwdAge":-1,"PwdWarnPeriod":-1,"PwdInactivity":-1,"MinPwdAge":-1,"ExpirationDate":-1,"LastLogin":"ABCDETIME"}'
+UserToBroker: {}
 UserToGroups:
     "1111": '{"UID":1111,"GIDs":[11111]}'

--- a/internal/cache/testdata/TestUpdateFromUserInfo/golden/invalid_value_entry_in_userbyname_recreates_entries
+++ b/internal/cache/testdata/TestUpdateFromUserInfo/golden/invalid_value_entry_in_userbyname_recreates_entries
@@ -8,5 +8,6 @@ UserByID:
     "1111": '{"Name":"user1","UID":1111,"GID":11111,"Gecos":"User1 gecos\nOn multiple lines","Dir":"/home/user1","Shell":"/bin/bash","LastPwdChange":-1,"MaxPwdAge":-1,"PwdWarnPeriod":-1,"PwdInactivity":-1,"MinPwdAge":-1,"ExpirationDate":-1,"LastLogin":"ABCDETIME"}'
 UserByName:
     user1: '{"Name":"user1","UID":1111,"GID":11111,"Gecos":"User1 gecos\nOn multiple lines","Dir":"/home/user1","Shell":"/bin/bash","LastPwdChange":-1,"MaxPwdAge":-1,"PwdWarnPeriod":-1,"PwdInactivity":-1,"MinPwdAge":-1,"ExpirationDate":-1,"LastLogin":"ABCDETIME"}'
+UserToBroker: {}
 UserToGroups:
     "1111": '{"UID":1111,"GIDs":[11111]}'

--- a/internal/cache/testdata/TestUpdateFromUserInfo/golden/remove_group_from_user
+++ b/internal/cache/testdata/TestUpdateFromUserInfo/golden/remove_group_from_user
@@ -8,5 +8,6 @@ UserByID:
     "1111": '{"Name":"user1","UID":1111,"GID":22222,"Gecos":"User1 gecos\nOn multiple lines","Dir":"/home/user1","Shell":"/bin/bash","LastPwdChange":-1,"MaxPwdAge":-1,"PwdWarnPeriod":-1,"PwdInactivity":-1,"MinPwdAge":-1,"ExpirationDate":-1,"LastLogin":"ABCDETIME"}'
 UserByName:
     user1: '{"Name":"user1","UID":1111,"GID":22222,"Gecos":"User1 gecos\nOn multiple lines","Dir":"/home/user1","Shell":"/bin/bash","LastPwdChange":-1,"MaxPwdAge":-1,"PwdWarnPeriod":-1,"PwdInactivity":-1,"MinPwdAge":-1,"ExpirationDate":-1,"LastLogin":"ABCDETIME"}'
+UserToBroker: {}
 UserToGroups:
     "1111": '{"UID":1111,"GIDs":[22222]}'

--- a/internal/cache/testdata/TestUpdateFromUserInfo/golden/remove_user_from_a_group_still_part_from_another_user
+++ b/internal/cache/testdata/TestUpdateFromUserInfo/golden/remove_user_from_a_group_still_part_from_another_user
@@ -21,6 +21,7 @@ UserByName:
     user1: '{"Name":"user1","UID":1111,"GID":11111,"Gecos":"User1 gecos\nOn multiple lines","Dir":"/home/user1","Shell":"/bin/bash","LastPwdChange":-1,"MaxPwdAge":-1,"PwdWarnPeriod":-1,"PwdInactivity":-1,"MinPwdAge":-1,"ExpirationDate":-1,"LastLogin":"AAAAATIME"}'
     user2: '{"Name":"user2","UID":2222,"GID":22222,"Gecos":"User2","Dir":"/home/user2","Shell":"/bin/dash","LastPwdChange":-1,"MaxPwdAge":-1,"PwdWarnPeriod":-1,"PwdInactivity":-1,"MinPwdAge":-1,"ExpirationDate":-1,"LastLogin":"BBBBBTIME"}'
     user3: '{"Name":"user3","UID":3333,"GID":33333,"Gecos":"User3 gecos","Dir":"/home/user3","Shell":"/bin/zsh","LastPwdChange":-1,"MaxPwdAge":-1,"PwdWarnPeriod":-1,"PwdInactivity":-1,"MinPwdAge":-1,"ExpirationDate":-1,"LastLogin":"ABCDETIME"}'
+UserToBroker: {}
 UserToGroups:
     "1111": '{"UID":1111,"GIDs":[11111]}'
     "2222": '{"UID":2222,"GIDs":[22222,99999]}'

--- a/internal/cache/testdata/TestUpdateFromUserInfo/golden/update_group_by_changing_attributes
+++ b/internal/cache/testdata/TestUpdateFromUserInfo/golden/update_group_by_changing_attributes
@@ -8,5 +8,6 @@ UserByID:
     "1111": '{"Name":"user1","UID":1111,"GID":11111,"Gecos":"User1 gecos\nOn multiple lines","Dir":"/home/user1","Shell":"/bin/bash","LastPwdChange":-1,"MaxPwdAge":-1,"PwdWarnPeriod":-1,"PwdInactivity":-1,"MinPwdAge":-1,"ExpirationDate":-1,"LastLogin":"ABCDETIME"}'
 UserByName:
     user1: '{"Name":"user1","UID":1111,"GID":11111,"Gecos":"User1 gecos\nOn multiple lines","Dir":"/home/user1","Shell":"/bin/bash","LastPwdChange":-1,"MaxPwdAge":-1,"PwdWarnPeriod":-1,"PwdInactivity":-1,"MinPwdAge":-1,"ExpirationDate":-1,"LastLogin":"ABCDETIME"}'
+UserToBroker: {}
 UserToGroups:
     "1111": '{"UID":1111,"GIDs":[11111]}'

--- a/internal/cache/testdata/TestUpdateFromUserInfo/golden/update_last_login_time_for_user
+++ b/internal/cache/testdata/TestUpdateFromUserInfo/golden/update_last_login_time_for_user
@@ -8,5 +8,6 @@ UserByID:
     "1111": '{"Name":"user1","UID":1111,"GID":11111,"Gecos":"User1 gecos\nOn multiple lines","Dir":"/home/user1","Shell":"/bin/bash","LastPwdChange":-1,"MaxPwdAge":-1,"PwdWarnPeriod":-1,"PwdInactivity":-1,"MinPwdAge":-1,"ExpirationDate":-1,"LastLogin":"ABCDETIME"}'
 UserByName:
     user1: '{"Name":"user1","UID":1111,"GID":11111,"Gecos":"User1 gecos\nOn multiple lines","Dir":"/home/user1","Shell":"/bin/bash","LastPwdChange":-1,"MaxPwdAge":-1,"PwdWarnPeriod":-1,"PwdInactivity":-1,"MinPwdAge":-1,"ExpirationDate":-1,"LastLogin":"ABCDETIME"}'
+UserToBroker: {}
 UserToGroups:
     "1111": '{"UID":1111,"GIDs":[11111]}'

--- a/internal/cache/testdata/TestUpdateFromUserInfo/golden/update_only_user_even_if_we_have_multiple_of_them
+++ b/internal/cache/testdata/TestUpdateFromUserInfo/golden/update_only_user_even_if_we_have_multiple_of_them
@@ -21,6 +21,7 @@ UserByName:
     user1: '{"Name":"user1","UID":1111,"GID":11111,"Gecos":"User1 gecos\nOn multiple lines","Dir":"/home/user1","Shell":"/bin/bash","LastPwdChange":-1,"MaxPwdAge":-1,"PwdWarnPeriod":-1,"PwdInactivity":-1,"MinPwdAge":-1,"ExpirationDate":-1,"LastLogin":"ABCDETIME"}'
     user2: '{"Name":"user2","UID":2222,"GID":22222,"Gecos":"User2","Dir":"/home/user2","Shell":"/bin/dash","LastPwdChange":-1,"MaxPwdAge":-1,"PwdWarnPeriod":-1,"PwdInactivity":-1,"MinPwdAge":-1,"ExpirationDate":-1,"LastLogin":"BBBBBTIME"}'
     user3: '{"Name":"user3","UID":3333,"GID":33333,"Gecos":"User3","Dir":"/home/user3","Shell":"/bin/zsh","LastPwdChange":-1,"MaxPwdAge":-1,"PwdWarnPeriod":-1,"PwdInactivity":-1,"MinPwdAge":-1,"ExpirationDate":-1,"LastLogin":"ABCDETIME"}'
+UserToBroker: {}
 UserToGroups:
     "1111": '{"UID":1111,"GIDs":[11111]}'
     "2222": '{"UID":2222,"GIDs":[22222,99999]}'

--- a/internal/cache/testdata/TestUpdateFromUserInfo/golden/update_user_and_keep_existing_groups_without_specifying_them
+++ b/internal/cache/testdata/TestUpdateFromUserInfo/golden/update_user_and_keep_existing_groups_without_specifying_them
@@ -8,5 +8,6 @@ UserByID:
     "1111": '{"Name":"user1","UID":1111,"GID":11111,"Gecos":"User1 gecos\nOn multiple lines","Dir":"/home/user1","Shell":"/bin/bash","LastPwdChange":-1,"MaxPwdAge":-1,"PwdWarnPeriod":-1,"PwdInactivity":-1,"MinPwdAge":-1,"ExpirationDate":-1,"LastLogin":"ABCDETIME"}'
 UserByName:
     user1: '{"Name":"user1","UID":1111,"GID":11111,"Gecos":"User1 gecos\nOn multiple lines","Dir":"/home/user1","Shell":"/bin/bash","LastPwdChange":-1,"MaxPwdAge":-1,"PwdWarnPeriod":-1,"PwdInactivity":-1,"MinPwdAge":-1,"ExpirationDate":-1,"LastLogin":"ABCDETIME"}'
+UserToBroker: {}
 UserToGroups:
     "1111": '{"UID":1111,"GIDs":[11111]}'

--- a/internal/cache/testdata/TestUpdateFromUserInfo/golden/update_user_by_adding_a_new_default_group
+++ b/internal/cache/testdata/TestUpdateFromUserInfo/golden/update_user_by_adding_a_new_default_group
@@ -11,5 +11,6 @@ UserByID:
     "1111": '{"Name":"user1","UID":1111,"GID":22222,"Gecos":"User1 gecos\nOn multiple lines","Dir":"/home/user1","Shell":"/bin/bash","LastPwdChange":-1,"MaxPwdAge":-1,"PwdWarnPeriod":-1,"PwdInactivity":-1,"MinPwdAge":-1,"ExpirationDate":-1,"LastLogin":"ABCDETIME"}'
 UserByName:
     user1: '{"Name":"user1","UID":1111,"GID":22222,"Gecos":"User1 gecos\nOn multiple lines","Dir":"/home/user1","Shell":"/bin/bash","LastPwdChange":-1,"MaxPwdAge":-1,"PwdWarnPeriod":-1,"PwdInactivity":-1,"MinPwdAge":-1,"ExpirationDate":-1,"LastLogin":"ABCDETIME"}'
+UserToBroker: {}
 UserToGroups:
     "1111": '{"UID":1111,"GIDs":[22222,11111]}'

--- a/internal/cache/testdata/TestUpdateFromUserInfo/golden/update_user_by_adding_a_new_group
+++ b/internal/cache/testdata/TestUpdateFromUserInfo/golden/update_user_by_adding_a_new_group
@@ -11,5 +11,6 @@ UserByID:
     "1111": '{"Name":"user1","UID":1111,"GID":11111,"Gecos":"User1 gecos\nOn multiple lines","Dir":"/home/user1","Shell":"/bin/bash","LastPwdChange":-1,"MaxPwdAge":-1,"PwdWarnPeriod":-1,"PwdInactivity":-1,"MinPwdAge":-1,"ExpirationDate":-1,"LastLogin":"ABCDETIME"}'
 UserByName:
     user1: '{"Name":"user1","UID":1111,"GID":11111,"Gecos":"User1 gecos\nOn multiple lines","Dir":"/home/user1","Shell":"/bin/bash","LastPwdChange":-1,"MaxPwdAge":-1,"PwdWarnPeriod":-1,"PwdInactivity":-1,"MinPwdAge":-1,"ExpirationDate":-1,"LastLogin":"ABCDETIME"}'
+UserToBroker: {}
 UserToGroups:
     "1111": '{"UID":1111,"GIDs":[11111,22222]}'

--- a/internal/cache/testdata/TestUpdateFromUserInfo/golden/update_user_by_changing_attributes
+++ b/internal/cache/testdata/TestUpdateFromUserInfo/golden/update_user_by_changing_attributes
@@ -8,5 +8,6 @@ UserByID:
     "1111": '{"Name":"newuser1","UID":1111,"GID":11111,"Gecos":"New user1 gecos","Dir":"/home/newuser1","Shell":"/bin/dash","LastPwdChange":-1,"MaxPwdAge":-1,"PwdWarnPeriod":-1,"PwdInactivity":-1,"MinPwdAge":-1,"ExpirationDate":-1,"LastLogin":"ABCDETIME"}'
 UserByName:
     newuser1: '{"Name":"newuser1","UID":1111,"GID":11111,"Gecos":"New user1 gecos","Dir":"/home/newuser1","Shell":"/bin/dash","LastPwdChange":-1,"MaxPwdAge":-1,"PwdWarnPeriod":-1,"PwdInactivity":-1,"MinPwdAge":-1,"ExpirationDate":-1,"LastLogin":"ABCDETIME"}'
+UserToBroker: {}
 UserToGroups:
     "1111": '{"UID":1111,"GIDs":[11111]}'

--- a/internal/cache/testdata/multiple_users_and_groups_with_brokers.db.yaml
+++ b/internal/cache/testdata/multiple_users_and_groups_with_brokers.db.yaml
@@ -1,0 +1,31 @@
+GroupByID:
+  "11111": '{"Name":"group1","GID":11111}'
+  "22222": '{"Name":"group2","GID":22222}'
+  "33333": '{"Name":"group3","GID":33333}'
+  "99999": '{"Name":"commongroup","GID":99999}'
+GroupByName:
+  commongroup: '{"Name":"commongroup","GID":99999}'
+  group1: '{"Name":"group1","GID":11111}'
+  group2: '{"Name":"group2","GID":22222}'
+  group3: '{"Name":"group3","GID":33333}'
+GroupToUsers:
+  "11111": '{"GID":11111,"UIDs":[1111]}'
+  "22222": '{"GID":22222,"UIDs":[2222]}'
+  "33333": '{"GID":33333,"UIDs":[3333]}'
+  "99999": '{"GID":99999,"UIDs":[2222,3333]}'
+UserByID:
+  "1111": '{"Name":"user1","UID":1111,"GID":11111,"Gecos":"User1 gecos\nOn multiple lines","Dir":"/home/user1","Shell":"/bin/bash","LastPwdChange":-1,"MaxPwdAge":-1,"PwdWarnPeriod":-1,"PwdInactivity":-1,"MinPwdAge":-1,"ExpirationDate":-1,"LastLogin":"AAAAATIME"}'
+  "2222": '{"Name":"user2","UID":2222,"GID":22222,"Gecos":"User2","Dir":"/home/user2","Shell":"/bin/dash","LastPwdChange":-1,"MaxPwdAge":-1,"PwdWarnPeriod":-1,"PwdInactivity":-1,"MinPwdAge":-1,"ExpirationDate":-1,"LastLogin":"BBBBBTIME"}'
+  "3333": '{"Name":"user3","UID":3333,"GID":33333,"Gecos":"User3","Dir":"/home/user3","Shell":"/bin/zsh","LastPwdChange":-1,"MaxPwdAge":-1,"PwdWarnPeriod":-1,"PwdInactivity":-1,"MinPwdAge":-1,"ExpirationDate":-1,"LastLogin":"ABCDETIME"}'
+UserByName:
+  user1: '{"Name":"user1","UID":1111,"GID":11111,"Gecos":"User1 gecos\nOn multiple lines","Dir":"/home/user1","Shell":"/bin/bash","LastPwdChange":-1,"MaxPwdAge":-1,"PwdWarnPeriod":-1,"PwdInactivity":-1,"MinPwdAge":-1,"ExpirationDate":-1,"LastLogin":"AAAAATIME"}'
+  user2: '{"Name":"user2","UID":2222,"GID":22222,"Gecos":"User2","Dir":"/home/user2","Shell":"/bin/dash","LastPwdChange":-1,"MaxPwdAge":-1,"PwdWarnPeriod":-1,"PwdInactivity":-1,"MinPwdAge":-1,"ExpirationDate":-1,"LastLogin":"BBBBBTIME"}'
+  user3: '{"Name":"user3","UID":3333,"GID":33333,"Gecos":"User3","Dir":"/home/user3","Shell":"/bin/zsh","LastPwdChange":-1,"MaxPwdAge":-1,"PwdWarnPeriod":-1,"PwdInactivity":-1,"MinPwdAge":-1,"ExpirationDate":-1,"LastLogin":"ABCDETIME"}'
+UserToGroups:
+  "1111": '{"UID":1111,"GIDs":[11111]}'
+  "2222": '{"UID":2222,"GIDs":[22222,99999]}'
+  "3333": '{"UID":3333,"GIDs":[33333,99999]}'
+UserToBroker:
+  "1111": '"ExampleBrokerID"'
+  "2222": '"ExampleBrokerID"'
+  "3333": '"ExampleBrokerID"'

--- a/internal/services/pam/testdata/TestGetPreviousBroker/get-previous-broker.db
+++ b/internal/services/pam/testdata/TestGetPreviousBroker/get-previous-broker.db
@@ -1,0 +1,30 @@
+GroupByID:
+  "11111": '{"Name":"group1","GID":11111}'
+  "22222": '{"Name":"group2","GID":22222}'
+  "33333": '{"Name":"group3","GID":33333}'
+  "99999": '{"Name":"commongroup","GID":99999}'
+GroupByName:
+  commongroup: '{"Name":"commongroup","GID":99999}'
+  group1: '{"Name":"group1","GID":11111}'
+  group2: '{"Name":"group2","GID":22222}'
+  group3: '{"Name":"group3","GID":33333}'
+GroupToUsers:
+  "11111": '{"GID":11111,"UIDs":[1111]}'
+  "22222": '{"GID":22222,"UIDs":[2222]}'
+  "33333": '{"GID":33333,"UIDs":[3333]}'
+  "99999": '{"GID":99999,"UIDs":[2222,3333]}'
+UserByID:
+  "1111": '{"Name":"userwithbroker","UID":1111,"GID":11111,"Gecos":"userwithbroker gecos\nOn multiple lines","Dir":"/home/userwithbroker","Shell":"/bin/bash","LastPwdChange":-1,"MaxPwdAge":-1,"PwdWarnPeriod":-1,"PwdInactivity":-1,"MinPwdAge":-1,"ExpirationDate":-1,"LastLogin":"ABCDETIME"}'
+  "2222": '{"Name":"userwithinactivebroker","UID":2222,"GID":22222,"Gecos":"userwithinactivebroker","Dir":"/home/userwithinactivebroker","Shell":"/bin/dash","LastPwdChange":-1,"MaxPwdAge":-1,"PwdWarnPeriod":-1,"PwdInactivity":-1,"MinPwdAge":-1,"ExpirationDate":-1,"LastLogin":"ABCDETIME"}'
+  "3333": '{"Name":"userwithoutbroker","UID":3333,"GID":33333,"Gecos":"userwithoutbroker","Dir":"/home/userwithoutbroker","Shell":"/bin/zsh","LastPwdChange":-1,"MaxPwdAge":-1,"PwdWarnPeriod":-1,"PwdInactivity":-1,"MinPwdAge":-1,"ExpirationDate":-1,"LastLogin":"ABCDETIME"}'
+UserByName:
+  userwithbroker: '{"Name":"userwithbroker","UID":1111,"GID":11111,"Gecos":"userwithbroker gecos\nOn multiple lines","Dir":"/home/userwithbroker","Shell":"/bin/bash","LastPwdChange":-1,"MaxPwdAge":-1,"PwdWarnPeriod":-1,"PwdInactivity":-1,"MinPwdAge":-1,"ExpirationDate":-1,"LastLogin":"ABCDETIME"}'
+  userwithinactivebroker: '{"Name":"userwithinactivebroker","UID":2222,"GID":22222,"Gecos":"userwithinactivebroker","Dir":"/home/userwithinactivebroker","Shell":"/bin/dash","LastPwdChange":-1,"MaxPwdAge":-1,"PwdWarnPeriod":-1,"PwdInactivity":-1,"MinPwdAge":-1,"ExpirationDate":-1,"LastLogin":"ABCDETIME"}'
+  userwithoutbroker: '{"Name":"userwithoutbroker","UID":3333,"GID":33333,"Gecos":"userwithoutbroker","Dir":"/home/userwithoutbroker","Shell":"/bin/zsh","LastPwdChange":-1,"MaxPwdAge":-1,"PwdWarnPeriod":-1,"PwdInactivity":-1,"MinPwdAge":-1,"ExpirationDate":-1,"LastLogin":"ABCDETIME"}'
+UserToGroups:
+  "1111": '{"UID":1111,"GIDs":[11111]}'
+  "2222": '{"UID":2222,"GIDs":[22222,99999]}'
+  "3333": '{"UID":3333,"GIDs":[33333,99999]}'
+UserToBroker:
+  "1111": '"local"'
+  "2222": '"inactive-broker-id"'

--- a/internal/services/pam/testdata/TestIsAuthenticated/golden/denies_authentication_when_broker_times_out/cache.db
+++ b/internal/services/pam/testdata/TestIsAuthenticated/golden/denies_authentication_when_broker_times_out/cache.db
@@ -3,4 +3,5 @@ GroupByName: {}
 GroupToUsers: {}
 UserByID: {}
 UserByName: {}
+UserToBroker: {}
 UserToGroups: {}

--- a/internal/services/pam/testdata/TestIsAuthenticated/golden/error_on_empty_data_even_if_granted/cache.db
+++ b/internal/services/pam/testdata/TestIsAuthenticated/golden/error_on_empty_data_even_if_granted/cache.db
@@ -3,4 +3,5 @@ GroupByName: {}
 GroupToUsers: {}
 UserByID: {}
 UserByName: {}
+UserToBroker: {}
 UserToGroups: {}

--- a/internal/services/pam/testdata/TestIsAuthenticated/golden/error_when_authenticating/cache.db
+++ b/internal/services/pam/testdata/TestIsAuthenticated/golden/error_when_authenticating/cache.db
@@ -3,4 +3,5 @@ GroupByName: {}
 GroupToUsers: {}
 UserByID: {}
 UserByName: {}
+UserToBroker: {}
 UserToGroups: {}

--- a/internal/services/pam/testdata/TestIsAuthenticated/golden/error_when_broker_returns_invalid_access/cache.db
+++ b/internal/services/pam/testdata/TestIsAuthenticated/golden/error_when_broker_returns_invalid_access/cache.db
@@ -3,4 +3,5 @@ GroupByName: {}
 GroupToUsers: {}
 UserByID: {}
 UserByName: {}
+UserToBroker: {}
 UserToGroups: {}

--- a/internal/services/pam/testdata/TestIsAuthenticated/golden/error_when_broker_returns_invalid_data/cache.db
+++ b/internal/services/pam/testdata/TestIsAuthenticated/golden/error_when_broker_returns_invalid_data/cache.db
@@ -3,4 +3,5 @@ GroupByName: {}
 GroupToUsers: {}
 UserByID: {}
 UserByName: {}
+UserToBroker: {}
 UserToGroups: {}

--- a/internal/services/pam/testdata/TestIsAuthenticated/golden/error_when_broker_returns_invalid_userinfo/cache.db
+++ b/internal/services/pam/testdata/TestIsAuthenticated/golden/error_when_broker_returns_invalid_userinfo/cache.db
@@ -3,4 +3,5 @@ GroupByName: {}
 GroupToUsers: {}
 UserByID: {}
 UserByName: {}
+UserToBroker: {}
 UserToGroups: {}

--- a/internal/services/pam/testdata/TestIsAuthenticated/golden/error_when_calling_second_time_without_cancelling/cache.db
+++ b/internal/services/pam/testdata/TestIsAuthenticated/golden/error_when_calling_second_time_without_cancelling/cache.db
@@ -8,5 +8,6 @@ UserByID:
     "73793": '{"Name":"IA_second_call","UID":73793,"GID":73625,"Gecos":"gecos for IA_second_call","Dir":"/home/IA_second_call","Shell":"/bin/sh/IA_second_call","LastPwdChange":-1,"MaxPwdAge":-1,"PwdWarnPeriod":-1,"PwdInactivity":-1,"MinPwdAge":-1,"ExpirationDate":-1,"LastLogin":"ABCDETIME"}'
 UserByName:
     IA_second_call: '{"Name":"IA_second_call","UID":73793,"GID":73625,"Gecos":"gecos for IA_second_call","Dir":"/home/IA_second_call","Shell":"/bin/sh/IA_second_call","LastPwdChange":-1,"MaxPwdAge":-1,"PwdWarnPeriod":-1,"PwdInactivity":-1,"MinPwdAge":-1,"ExpirationDate":-1,"LastLogin":"ABCDETIME"}'
+UserToBroker: {}
 UserToGroups:
     "73793": '{"UID":73793,"GIDs":[73625]}'

--- a/internal/services/pam/testdata/TestIsAuthenticated/golden/error_when_sessionid_is_empty/cache.db
+++ b/internal/services/pam/testdata/TestIsAuthenticated/golden/error_when_sessionid_is_empty/cache.db
@@ -3,4 +3,5 @@ GroupByName: {}
 GroupToUsers: {}
 UserByID: {}
 UserByName: {}
+UserToBroker: {}
 UserToGroups: {}

--- a/internal/services/pam/testdata/TestIsAuthenticated/golden/error_when_there_is_no_broker/cache.db
+++ b/internal/services/pam/testdata/TestIsAuthenticated/golden/error_when_there_is_no_broker/cache.db
@@ -3,4 +3,5 @@ GroupByName: {}
 GroupToUsers: {}
 UserByID: {}
 UserByName: {}
+UserToBroker: {}
 UserToGroups: {}

--- a/internal/services/pam/testdata/TestIsAuthenticated/golden/successfully_authenticate/cache.db
+++ b/internal/services/pam/testdata/TestIsAuthenticated/golden/successfully_authenticate/cache.db
@@ -8,5 +8,6 @@ UserByID:
     "91525": '{"Name":"success","UID":91525,"GID":91357,"Gecos":"gecos for success","Dir":"/home/success","Shell":"/bin/sh/success","LastPwdChange":-1,"MaxPwdAge":-1,"PwdWarnPeriod":-1,"PwdInactivity":-1,"MinPwdAge":-1,"ExpirationDate":-1,"LastLogin":"ABCDETIME"}'
 UserByName:
     success: '{"Name":"success","UID":91525,"GID":91357,"Gecos":"gecos for success","Dir":"/home/success","Shell":"/bin/sh/success","LastPwdChange":-1,"MaxPwdAge":-1,"PwdWarnPeriod":-1,"PwdInactivity":-1,"MinPwdAge":-1,"ExpirationDate":-1,"LastLogin":"ABCDETIME"}'
+UserToBroker: {}
 UserToGroups:
     "91525": '{"UID":91525,"GIDs":[91357]}'

--- a/internal/services/pam/testdata/TestIsAuthenticated/golden/successfully_authenticate_if_first_call_is_canceled/cache.db
+++ b/internal/services/pam/testdata/TestIsAuthenticated/golden/successfully_authenticate_if_first_call_is_canceled/cache.db
@@ -8,5 +8,6 @@ UserByID:
     "73793": '{"Name":"IA_second_call","UID":73793,"GID":73625,"Gecos":"gecos for IA_second_call","Dir":"/home/IA_second_call","Shell":"/bin/sh/IA_second_call","LastPwdChange":-1,"MaxPwdAge":-1,"PwdWarnPeriod":-1,"PwdInactivity":-1,"MinPwdAge":-1,"ExpirationDate":-1,"LastLogin":"ABCDETIME"}'
 UserByName:
     IA_second_call: '{"Name":"IA_second_call","UID":73793,"GID":73625,"Gecos":"gecos for IA_second_call","Dir":"/home/IA_second_call","Shell":"/bin/sh/IA_second_call","LastPwdChange":-1,"MaxPwdAge":-1,"PwdWarnPeriod":-1,"PwdInactivity":-1,"MinPwdAge":-1,"ExpirationDate":-1,"LastLogin":"ABCDETIME"}'
+UserToBroker: {}
 UserToGroups:
     "73793": '{"UID":73793,"GIDs":[73625]}'

--- a/internal/services/pam/testdata/TestIsAuthenticated/golden/update_existing_db_on_success/cache.db
+++ b/internal/services/pam/testdata/TestIsAuthenticated/golden/update_existing_db_on_success/cache.db
@@ -12,6 +12,7 @@ UserByID:
 UserByName:
     otheruser: '{"Name":"otheruser","UID":77777,"GID":88888,"Gecos":"gecos for other user","Dir":"/home/otheruser","Shell":"/bin/sh/otheruser","LastPwdChange":-1,"MaxPwdAge":-1,"PwdWarnPeriod":-1,"PwdInactivity":-1,"MinPwdAge":-1,"ExpirationDate":-1,"LastLogin":"AAAAATIME"}'
     success: '{"Name":"success","UID":91525,"GID":91357,"Gecos":"gecos for success","Dir":"/home/success","Shell":"/bin/sh/success","LastPwdChange":-1,"MaxPwdAge":-1,"PwdWarnPeriod":-1,"PwdInactivity":-1,"MinPwdAge":-1,"ExpirationDate":-1,"LastLogin":"ABCDETIME"}'
+UserToBroker: {}
 UserToGroups:
     "77777": '{"UID":77777,"GIDs":[88888]}'
     "91525": '{"UID":91525,"GIDs":[91357]}'

--- a/internal/services/pam/testdata/TestSetDefaultBrokerForUser/golden/set_default_broker_for_existing_user/cache.db
+++ b/internal/services/pam/testdata/TestSetDefaultBrokerForUser/golden/set_default_broker_for_existing_user/cache.db
@@ -1,0 +1,31 @@
+GroupByID:
+    "11111": '{"Name":"group1","GID":11111}'
+    "22222": '{"Name":"group2","GID":22222}'
+    "33333": '{"Name":"group3","GID":33333}'
+    "99999": '{"Name":"commongroup","GID":99999}'
+GroupByName:
+    commongroup: '{"Name":"commongroup","GID":99999}'
+    group1: '{"Name":"group1","GID":11111}'
+    group2: '{"Name":"group2","GID":22222}'
+    group3: '{"Name":"group3","GID":33333}'
+GroupToUsers:
+    "11111": '{"GID":11111,"UIDs":[1111]}'
+    "22222": '{"GID":22222,"UIDs":[2222]}'
+    "33333": '{"GID":33333,"UIDs":[4444]}'
+    "99999": '{"GID":99999,"UIDs":[2222,4444]}'
+UserByID:
+    "1111": '{"Name":"userwithbroker","UID":1111,"GID":11111,"Gecos":"userwithbroker gecos\nOn multiple lines","Dir":"/home/userwithbroker","Shell":"/bin/bash","LastPwdChange":-1,"MaxPwdAge":-1,"PwdWarnPeriod":-1,"PwdInactivity":-1,"MinPwdAge":-1,"ExpirationDate":-1,"LastLogin":"ABCDETIME"}'
+    "2222": '{"Name":"userwithinactivebroker","UID":2222,"GID":22222,"Gecos":"userwithinactivebroker","Dir":"/home/userwithinactivebroker","Shell":"/bin/dash","LastPwdChange":-1,"MaxPwdAge":-1,"PwdWarnPeriod":-1,"PwdInactivity":-1,"MinPwdAge":-1,"ExpirationDate":-1,"LastLogin":"ABCDETIME"}'
+    "4444": '{"Name":"usersetbroker","UID":4444,"GID":33333,"Gecos":"usersetbroker","Dir":"/home/usersetbroker","Shell":"/bin/zsh","LastPwdChange":-1,"MaxPwdAge":-1,"PwdWarnPeriod":-1,"PwdInactivity":-1,"MinPwdAge":-1,"ExpirationDate":-1,"LastLogin":"ABCDETIME"}'
+UserByName:
+    usersetbroker: '{"Name":"usersetbroker","UID":4444,"GID":33333,"Gecos":"usersetbroker","Dir":"/home/usersetbroker","Shell":"/bin/zsh","LastPwdChange":-1,"MaxPwdAge":-1,"PwdWarnPeriod":-1,"PwdInactivity":-1,"MinPwdAge":-1,"ExpirationDate":-1,"LastLogin":"ABCDETIME"}'
+    userwithbroker: '{"Name":"userwithbroker","UID":1111,"GID":11111,"Gecos":"userwithbroker gecos\nOn multiple lines","Dir":"/home/userwithbroker","Shell":"/bin/bash","LastPwdChange":-1,"MaxPwdAge":-1,"PwdWarnPeriod":-1,"PwdInactivity":-1,"MinPwdAge":-1,"ExpirationDate":-1,"LastLogin":"ABCDETIME"}'
+    userwithinactivebroker: '{"Name":"userwithinactivebroker","UID":2222,"GID":22222,"Gecos":"userwithinactivebroker","Dir":"/home/userwithinactivebroker","Shell":"/bin/dash","LastPwdChange":-1,"MaxPwdAge":-1,"PwdWarnPeriod":-1,"PwdInactivity":-1,"MinPwdAge":-1,"ExpirationDate":-1,"LastLogin":"ABCDETIME"}'
+UserToBroker:
+    "1111": '"local"'
+    "2222": '"inactive-broker-id"'
+    "4444": '"1902181170"'
+UserToGroups:
+    "1111": '{"UID":1111,"GIDs":[11111]}'
+    "2222": '{"UID":2222,"GIDs":[22222,99999]}'
+    "4444": '{"UID":4444,"GIDs":[33333,99999]}'

--- a/internal/services/pam/testdata/TestSetDefaultBrokerForUser/set-default-broker.db
+++ b/internal/services/pam/testdata/TestSetDefaultBrokerForUser/set-default-broker.db
@@ -1,0 +1,30 @@
+GroupByID:
+  "11111": '{"Name":"group1","GID":11111}'
+  "22222": '{"Name":"group2","GID":22222}'
+  "33333": '{"Name":"group3","GID":33333}'
+  "99999": '{"Name":"commongroup","GID":99999}'
+GroupByName:
+  commongroup: '{"Name":"commongroup","GID":99999}'
+  group1: '{"Name":"group1","GID":11111}'
+  group2: '{"Name":"group2","GID":22222}'
+  group3: '{"Name":"group3","GID":33333}'
+GroupToUsers:
+  "11111": '{"GID":11111,"UIDs":[1111]}'
+  "22222": '{"GID":22222,"UIDs":[2222]}'
+  "33333": '{"GID":33333,"UIDs":[4444]}'
+  "99999": '{"GID":99999,"UIDs":[2222,4444]}'
+UserByID:
+  "1111": '{"Name":"userwithbroker","UID":1111,"GID":11111,"Gecos":"userwithbroker gecos\nOn multiple lines","Dir":"/home/userwithbroker","Shell":"/bin/bash","LastPwdChange":-1,"MaxPwdAge":-1,"PwdWarnPeriod":-1,"PwdInactivity":-1,"MinPwdAge":-1,"ExpirationDate":-1,"LastLogin":"ABCDETIME"}'
+  "2222": '{"Name":"userwithinactivebroker","UID":2222,"GID":22222,"Gecos":"userwithinactivebroker","Dir":"/home/userwithinactivebroker","Shell":"/bin/dash","LastPwdChange":-1,"MaxPwdAge":-1,"PwdWarnPeriod":-1,"PwdInactivity":-1,"MinPwdAge":-1,"ExpirationDate":-1,"LastLogin":"ABCDETIME"}'
+  "4444": '{"Name":"usersetbroker","UID":4444,"GID":33333,"Gecos":"usersetbroker","Dir":"/home/usersetbroker","Shell":"/bin/zsh","LastPwdChange":-1,"MaxPwdAge":-1,"PwdWarnPeriod":-1,"PwdInactivity":-1,"MinPwdAge":-1,"ExpirationDate":-1,"LastLogin":"ABCDETIME"}'
+UserByName:
+  userwithbroker: '{"Name":"userwithbroker","UID":1111,"GID":11111,"Gecos":"userwithbroker gecos\nOn multiple lines","Dir":"/home/userwithbroker","Shell":"/bin/bash","LastPwdChange":-1,"MaxPwdAge":-1,"PwdWarnPeriod":-1,"PwdInactivity":-1,"MinPwdAge":-1,"ExpirationDate":-1,"LastLogin":"ABCDETIME"}'
+  userwithinactivebroker: '{"Name":"userwithinactivebroker","UID":2222,"GID":22222,"Gecos":"userwithinactivebroker","Dir":"/home/userwithinactivebroker","Shell":"/bin/dash","LastPwdChange":-1,"MaxPwdAge":-1,"PwdWarnPeriod":-1,"PwdInactivity":-1,"MinPwdAge":-1,"ExpirationDate":-1,"LastLogin":"ABCDETIME"}'
+  usersetbroker: '{"Name":"usersetbroker","UID":4444,"GID":33333,"Gecos":"usersetbroker","Dir":"/home/usersetbroker","Shell":"/bin/zsh","LastPwdChange":-1,"MaxPwdAge":-1,"PwdWarnPeriod":-1,"PwdInactivity":-1,"MinPwdAge":-1,"ExpirationDate":-1,"LastLogin":"ABCDETIME"}'
+UserToGroups:
+  "1111": '{"UID":1111,"GIDs":[11111]}'
+  "2222": '{"UID":2222,"GIDs":[22222,99999]}'
+  "4444": '{"UID":4444,"GIDs":[33333,99999]}'
+UserToBroker:
+  "1111": '"local"'
+  "2222": '"inactive-broker-id"'


### PR DESCRIPTION
The default broker for the user used to be stored in memory only. This meant that, on each reboot, the user had to reselect the broker again. Now, the last broker used for authentication by the user is also stored in the database. This way, we can restore it every time.

UDENG-1649