### PR TITLE
fix(tests): increase wait time before exiting function

### DIFF
--- a/internal/cache/db.go
+++ b/internal/cache/db.go
@@ -378,6 +378,8 @@ func (c *Cache) Close() error {
 
 // requestClearDatabase ask for the clean goroutine to clear up the database.
 // If we already have a pending request, do not block on it.
+// TODO: improve behavior when cleanup is already running
+// (either remove the dangling dirty file or queue the cleanup request).
 func (c *Cache) requestClearDatabase() {
 	if err := os.WriteFile(c.dirtyFlagPath, nil, 0600); err != nil {
 		slog.Warn(fmt.Sprintf("Could not write dirty file flag to signal clearing up the database: %v", err))


### PR DESCRIPTION
This is causing flaky tests in error cases where the test DB is corrupt or has bad entries. I've tried to increase sleep times within the tests but it appears the issue is in the implementation itself.

The function exits if it's not able to send something on the `doClear` channel within 1 millisecond -- given that a cleanup might already be running this would exit without queueing any subsequent cleanup, which in turn left us with a dangling "dirty" DB file.

I think the ideal fix here would be to make this a buffered channel and be able to queue multiple cleanups while one is running, but for now I've increased the amount of time we wait before exiting.

Fixes UDENG-1847