### PR TITLE
perf: continue if active UID is not a real user

### DIFF
--- a/internal/cache/db.go
+++ b/internal/cache/db.go
@@ -359,7 +359,10 @@ func getActiveUsers(procDir string) (activeUsers map[string]struct{}, err error)
 
 		u, err := user.LookupId(strconv.Itoa(int(stats.Uid)))
 		if err != nil {
-			return nil, err
+			// Possibly a ghost/orphaned UID - no reason to error out,
+			// warn the user and continue.
+			slog.Warn(fmt.Sprintf("Could not map active user ID to an actual user: %v", err))
+			continue
 		}
 
 		activeUsers[u.Name] = struct{}{}


### PR DESCRIPTION
In chroot environments where `/proc` is mounted it's common to have processes owned by UIDs that do not exist within the chroot.

I think getting the active users list should be a best effort approach where we don't fail hard if we cannot do this mapping for an user, mainly because it's highly likely for that user to not be in the DB we want to clean up anyway.

I haven't added a test for this because we don't currently mock `/proc`, and based on Denis' feedback this will be refactored in the near future.