### PR TITLE
CI: Build debian packages and run autopackage tests

### DIFF
--- a/.github/workflows/build-deb.yaml
+++ b/.github/workflows/build-deb.yaml
@@ -35,3 +35,41 @@ jobs:
           extra-source-build-script: |
             cargo install --locked --root=/usr cargo-vendor-filterer
             command -v cargo-vendor-filterer
+
+  run-autopkgtests:
+    name: Run autopkgtests
+    needs: build-deb-package
+    runs-on: ubuntu-latest
+
+    container:
+      image: ubuntu:${{ env.UBUNTU_VERSION }}
+
+    steps:
+    - name: Prepare container
+      run: |
+        set -eu
+
+        echo 'APT::Get::Assume-Yes "true";' > /etc/apt/apt.conf.d/90aptyes
+        apt update
+
+    - name: Download artifacts
+      uses: actions/download-artifact@v4
+      with:
+        run-id: ${{ needs.build-deb-package.outputs.run-id }}
+
+    - name: Install dependencies
+      run: |
+        apt install autopkgtest
+
+    - name: Create test user
+      run: |
+        apt install adduser
+        adduser --disabled-password --gecos "" tester
+
+    - name: Run autopkgtests
+      run: |
+        mv -v ./*-debian-source/* .
+        mv -v ./*-debian-packages/* .
+        autopkgtest --apt-pocket proposed --apt-upgrade --no-built-binaries --user=tester \
+          *_${{ needs.build-deb-package.outputs.pkg-version }}*.deb \
+          ${{ needs.build-deb-package.outputs.pkg-name }}_${{ needs.build-deb-package.outputs.pkg-version }}_source.changes -- null

--- a/.github/workflows/build-deb.yaml
+++ b/.github/workflows/build-deb.yaml
@@ -9,12 +9,26 @@ on:
   pull_request:
 
 env:
-  UBUNTU_VERSION: devel
+  UBUNTU_VERSIONS: |
+    ["noble", "devel"]
 
 jobs:
+  define-versions:
+    name: Define build versions
+    runs-on: ubuntu-latest
+    outputs:
+      ubuntu-versions: ${{ env.UBUNTU_VERSIONS }}
+    steps:
+      - run: 'true'
+
   build-deb-package:
     name: Build ubuntu package
     runs-on: ubuntu-latest
+    needs: define-versions
+    strategy:
+      fail-fast: false
+      matrix:
+        ubuntu-version: ${{ fromJSON(needs.define-versions.outputs.ubuntu-versions) }}
     outputs:
       run-id: ${{ github.run_id }}
       pkg-src-changes: ${{ env.PKG_SOURCE_CHANGES }}
@@ -26,7 +40,7 @@ jobs:
       - name: Build debian packages and sources
         uses: canonical/desktop-engineering/gh-actions/common/build-debian@main
         with:
-          docker-image: ubuntu:${{ env.UBUNTU_VERSION }}
+          docker-image: ubuntu:${{ matrix.ubuntu-version }}
           extra-source-build-deps: |
             ca-certificates
             git
@@ -37,8 +51,14 @@ jobs:
 
   run-autopkgtests:
     name: Run autopkgtests
-    needs: build-deb-package
     runs-on: ubuntu-latest
+    needs:
+      - define-versions
+      - build-deb-package
+    strategy:
+      fail-fast: false
+      matrix:
+        ubuntu-version: ${{ fromJSON(needs.define-versions.outputs.ubuntu-versions) }}
 
     steps:
     - name: Download artifacts
@@ -50,5 +70,5 @@ jobs:
     - name: Run autopkgtests
       uses: canonical/desktop-engineering/gh-actions/common/run-autopkgtest@main
       with:
-        lxd-image: ubuntu:${{ env.UBUNTU_VERSION }}
+        lxd-image: ubuntu:${{ matrix.ubuntu-version }}
         source-changes: ${{ needs.build-deb-package.outputs.pkg-src-changes }}

--- a/.github/workflows/build-deb.yaml
+++ b/.github/workflows/build-deb.yaml
@@ -1,0 +1,37 @@
+name: Build debian packages
+
+on:
+  push:
+    branches:
+      - main
+    tags:
+      - "*"
+  pull_request:
+
+env:
+  UBUNTU_VERSION: devel
+
+jobs:
+  build-deb-package:
+    name: Build ubuntu package
+    runs-on: ubuntu-latest
+    outputs:
+      run-id: ${{ github.run_id }}
+      pkg-name: ${{ env.PKG_NAME }}
+      pkg-version: ${{ env.PKG_VERSION }}
+
+    steps:
+      - name: Checkout authd code
+        uses: actions/checkout@v4
+
+      - name: Build debian packages and sources
+        uses: canonical/desktop-engineering/gh-actions/common/build-debian@main
+        with:
+          docker-image: ubuntu:${{ env.UBUNTU_VERSION }}
+          extra-source-build-deps: |
+            ca-certificates
+            git
+            libssl-dev
+          extra-source-build-script: |
+            cargo install --locked --root=/usr cargo-vendor-filterer
+            command -v cargo-vendor-filterer

--- a/.github/workflows/build-deb.yaml
+++ b/.github/workflows/build-deb.yaml
@@ -49,16 +49,66 @@ jobs:
             cargo install --locked --root=/usr cargo-vendor-filterer
             command -v cargo-vendor-filterer
 
+  check-modified-files:
+    name: Check modified files
+    runs-on: ubuntu-latest
+    needs:
+      - build-deb-package
+    outputs:
+      list: ${{ fromJSON(steps.git-diff.outputs.modified_files) }}
+
+    steps:
+      - name: Checkout authd code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 100
+
+      - id: git-diff
+        name: Check modified files
+        run: |
+          set -ue
+
+          base_ref=${{ github.event.pull_request.base.sha }}
+          if [ -z "${base_ref}" ]; then
+            base_ref=${{ github.event.before }}
+          fi
+          if [ -z "${base_ref}" ]; then
+            base_ref=$(git log --root --reverse -n1 --format=%H)
+          fi
+
+          # Build a JSON array of modified paths.
+          modified_files=$(git diff --name-only "${base_ref}" HEAD | \
+            while read line; do
+              jq -n --arg path "$line" '$path'
+            done | jq -n '. |= [inputs]')
+          echo "${modified_files}"
+
+          escaped_json=$(echo "${modified_files}" | jq '.| tostring')
+          echo "modified_files=${escaped_json}" >> "${GITHUB_OUTPUT}"
+
   run-autopkgtests:
     name: Run autopkgtests
     runs-on: ubuntu-latest
     needs:
       - define-versions
       - build-deb-package
+      - check-modified-files
     strategy:
       fail-fast: false
       matrix:
         ubuntu-version: ${{ fromJSON(needs.define-versions.outputs.ubuntu-versions) }}
+
+    # Run autopkgtests only on:
+    #  - Push events to main
+    #  - When a file in the debian subdir is modified
+    #  - When this file is modified
+    #  - On new tags
+    #  - On github release
+    if: ${{ (github.event_name == 'push' && github.ref == 'refs/heads/main') ||
+       contains(needs.check-modified-files.outputs.list, 'debian/') ||
+       contains(needs.check-modified-files.outputs.list, '.github/workflows/build-deb.yaml') ||
+       startsWith(github.ref, 'refs/tags/') ||
+       github.event_name == 'release' }}
 
     steps:
     - name: Download artifacts

--- a/.github/workflows/build-deb.yaml
+++ b/.github/workflows/build-deb.yaml
@@ -11,6 +11,7 @@ on:
 env:
   UBUNTU_VERSIONS: |
     ["noble", "devel"]
+  CARGO_VENDOR_FILTERER_VERSION: 0.5.16
 
 jobs:
   define-versions:
@@ -46,7 +47,8 @@ jobs:
             git
             libssl-dev
           extra-source-build-script: |
-            cargo install --locked --root=/usr cargo-vendor-filterer
+            cargo install --locked --root=/usr \
+              cargo-vendor-filterer@${{ env.CARGO_VENDOR_FILTERER_VERSION }}
             command -v cargo-vendor-filterer
 
   check-modified-files:

--- a/.github/workflows/build-deb.yaml
+++ b/.github/workflows/build-deb.yaml
@@ -17,8 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       run-id: ${{ github.run_id }}
-      pkg-name: ${{ env.PKG_NAME }}
-      pkg-version: ${{ env.PKG_VERSION }}
+      pkg-src-changes: ${{ env.PKG_SOURCE_CHANGES }}
 
     steps:
       - name: Checkout authd code
@@ -41,35 +40,15 @@ jobs:
     needs: build-deb-package
     runs-on: ubuntu-latest
 
-    container:
-      image: ubuntu:${{ env.UBUNTU_VERSION }}
-
     steps:
-    - name: Prepare container
-      run: |
-        set -eu
-
-        echo 'APT::Get::Assume-Yes "true";' > /etc/apt/apt.conf.d/90aptyes
-        apt update
-
     - name: Download artifacts
       uses: actions/download-artifact@v4
       with:
         run-id: ${{ needs.build-deb-package.outputs.run-id }}
-
-    - name: Install dependencies
-      run: |
-        apt install autopkgtest
-
-    - name: Create test user
-      run: |
-        apt install adduser
-        adduser --disabled-password --gecos "" tester
+        merge-multiple: true
 
     - name: Run autopkgtests
-      run: |
-        mv -v ./*-debian-source/* .
-        mv -v ./*-debian-packages/* .
-        autopkgtest --apt-pocket proposed --apt-upgrade --no-built-binaries --user=tester \
-          *_${{ needs.build-deb-package.outputs.pkg-version }}*.deb \
-          ${{ needs.build-deb-package.outputs.pkg-name }}_${{ needs.build-deb-package.outputs.pkg-version }}_source.changes -- null
+      uses: canonical/desktop-engineering/gh-actions/common/run-autopkgtest@main
+      with:
+        lxd-image: ubuntu:${{ env.UBUNTU_VERSION }}
+        source-changes: ${{ needs.build-deb-package.outputs.pkg-src-changes }}

--- a/debian/changelog
+++ b/debian/changelog
@@ -152,7 +152,7 @@ authd (0.2) noble; urgency=medium
       - libc
       - simple_logger
       - tokio
-  * Update tools and CI dependencies not related to package 
+  * Update tools and CI dependencies not related to package
     functionality
       - google.golang.org/protobuf
 

--- a/debian/copyright
+++ b/debian/copyright
@@ -80,10 +80,6 @@ Files: vendor/github.com/charmbracelet/*
 Copyright: 2019-2023 Charmbracelet, Inc
 License: MIT
 
-Files: vendor/github.com/containerd/console/*
-Copyright: The containerd Authors.
-License: Apache-2.0
-
 Files: vendor/github.com/coreos/*
 Copyright: 2015-2018 CoreOS, Inc. / 2014 Docker, Inc.
 License: Apache-2.0
@@ -99,10 +95,6 @@ License: BSD-3
 Files: vendor/github.com/godbus/*
 Copyright: 2013 Georg Reinke (<guelfey at gmail dot com>), Google
 License: BSD-2
-
-Files: vendor/github.com/golang/protobuf/*
-Copyright: Copyright: 2010 The Go Authors.
-License: BSD-3
 
 Files: vendor/github.com/google/uuid/*
 Copyright: 2009, 2014-2017, 2021 Google Inc.
@@ -244,12 +236,10 @@ Files: vendor_rust/anyhow/*
        vendor_rust/fastrand/*
        vendor_rust/fixedbitset/*
        vendor_rust/hermit-abi/*
-       vendor_rust/home/*
        vendor_rust/indexmap/*
        vendor_rust/itertools/*
        vendor_rust/itoa/*
        vendor_rust/linux-raw-sys/*
-       vendor_rust/num_cpus/*
        vendor_rust/once_cell/*
        vendor_rust/paste/*
        vendor_rust/petgraph/*
@@ -291,7 +281,6 @@ License: MIT
 Files: vendor_rust/backtrace/*
        vendor_rust/cc/*
        vendor_rust/cfg-if/*
-       vendor_rust/match_cfg/*
        vendor_rust/rustc-demangle/*
        vendor_rust/socket2/*
 Copyright: 2014 Alex Crichton
@@ -319,10 +308,6 @@ License: Apache-2.0
 
 Files: vendor_rust/errno/*
 Copyright: 2014 Chris Wong
-License: MIT
-
-Files: vendor_rust/error-chain/*
-Copyright: 2017 The Error-Chain Project Developers
 License: MIT
 
 Files: vendor_rust/fnv/*
@@ -449,10 +434,6 @@ Files: vendor_rust/tokio/*
 Copyright: 2019, 2023 Tokio Contributors
 License: MIT
 
-Files: vendor_rust/tokio-io-timeout/*
-Copyright: 2017 The tokio-io-timeout Developers
-License: MIT
-
 Files: vendor_rust/tonic/*
        vendor_rust/tonic-build/*
 Copyright: 2020 Lucio Franco
@@ -466,18 +447,6 @@ License: MIT
 
 Files: vendor_rust/try-lock/*
 Copyright: 2018 Sean McArthur / 2016 Alex Crichton
-License: MIT
-
-Files: vendor_rust/version_check/*
-Copyright: 2017-2018 Sergio Benitez
-License: MIT
-
-Files: vendor_rust/which/*
-Copyright: 2015 fangyuanziti
-License: MIT
-
-Files: vendor_rust/winapi*/*
-Copyright: 2015-2018 The winapi-rs Developers
 License: MIT
 
 Files: vendor_rust/windows*/*

--- a/debian/get-depends-go-bin-path.sh
+++ b/debian/get-depends-go-bin-path.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+
+set -eu
+
+debian_path=$(dirname "$0")
+backported_go_version=$(grep-dctrl -s Build-Depends -n - "${debian_path}"/control | \
+    sed -n "s,.*\bgolang-\([0-9.]\+\)\b.*,\1,p")
+
+if [ -n "${backported_go_version}" ]; then
+    echo "/usr/lib/go-${backported_go_version}/bin"
+fi

--- a/debian/rules
+++ b/debian/rules
@@ -50,8 +50,7 @@ export DH_GOLANG_BUILDPKG := $(AUTHD_GO_PACKAGE)/... \
 # We add the required backported version to the $PATH so that if it exists, then
 # we can use it. Otherwise we default to the go installed in original $PATH that
 # always matches with the latest available go version in the archive.
-AUTHD_BACKPORTED_GO_VERSION := $(shell grep-dctrl -s Build-Depends -n - ./debian/control | sed -n "s,.*\bgolang-\([0-9.]\+\)\b.*,\1,p")
-export PATH := $(shell printenv PATH):/usr/lib/go-$(AUTHD_BACKPORTED_GO_VERSION)/bin
+export PATH := $(shell printenv PATH):$(shell ./debian/get-depends-go-bin-path.sh)
 
 BUILDDIR := $(CURDIR)/obj-$(DEB_HOST_GNU_TYPE)
 

--- a/debian/tests/run-tests.sh
+++ b/debian/tests/run-tests.sh
@@ -6,4 +6,7 @@ export AUTHD_SKIP_EXTERNAL_DEPENDENT_TESTS=1
 export GOPROXY=off
 export GOTOOLCHAIN=local
 
+PATH=$PATH:$("$(dirname "$0")"/../get-depends-go-bin-path.sh)
+export PATH
+
 go test -v ./...


### PR DESCRIPTION
Add a workflow to build debian packages and run autopkgtests.

Requires: https://github.com/canonical/desktop-engineering/pull/58 

UDENG-2343