### PR TITLE
fix(ci): Remove dependency from auto-updates job

### DIFF
--- a/.github/workflows/auto-updates.yaml
+++ b/.github/workflows/auto-updates.yaml
@@ -7,10 +7,11 @@ on:
       - debian/control
 concurrency: auto-update
 
+# Jobs in this action must not run concurrently, as they modify the repository.
+# When adding more jobs, make sure to use the "needs:" atribute to make sure they run sequentially.
 jobs:
   update-rust-packaging:
     name: Update packaging related Rust files
-    needs: update-po
     runs-on: ubuntu-latest
     # Right now, ubuntu 22.04 does not have the dh-cargo-vendored-sources script that is needed to
     # run this job, so we need to run it inside a rolling container to get the latest version possible.


### PR DESCRIPTION
We had this to prevent auto-update jobs from running concurrently, thus modifying the repo at the same time. Since now only have one job (at least for now), the job does not have any dependency.