### PR TITLE
maint: add vendor_rust to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,8 +23,9 @@ debian/authd
 # Output of the go coverage tool, specifically when used with LiteIDE
 *.out
 
-# Dependency directories (remove the comment below to include it)
+# Dependency directories
 vendor/
+vendor_rust/
 
 # Go workspace file
 go.work


### PR DESCRIPTION
We don't ever plan to commit this directory, so ignore it.