### PR TITLE
ci: give explicit PR permissions to GitHub token

### DIFF
--- a/.github/workflows/auto-updates.yaml
+++ b/.github/workflows/auto-updates.yaml
@@ -7,6 +7,10 @@ on:
       - debian/control
 concurrency: auto-update
 
+permissions:
+  pull-requests: write
+  contents: write
+
 # Jobs in this action must not run concurrently, as they modify the repository.
 # When adding more jobs, make sure to use the "needs:" atribute to make sure they run sequentially.
 jobs:


### PR DESCRIPTION
When dependabot triggers a PR the `GITHUB_TOKEN` is read-only and [must explicitly be given write permissions](https://github.com/peter-evans/create-pull-request/issues/1873). This is a side effect of upgrading to the v5 create-pull-request-action.

Explicitly set these in the workflow to avoid it failing on commits by dependabot, but also to more clearly define the workflow's expected permissions.