### PR TITLE
feat(users/services): Local groups cleanup

### DIFF
--- a/internal/services/pam/pam_test.go
+++ b/internal/services/pam/pam_test.go
@@ -376,7 +376,7 @@ func TestIsAuthenticated(t *testing.T) {
 					fmt.Sprintf("GO_WANT_HELPER_PROCESS_DEST=%s", destCmdsFile),
 					fmt.Sprintf("GO_WANT_HELPER_PROCESS_GROUPFILE=%s", groupFilePath),
 					os.Args[0], "-test.run=TestMockgpasswd", "--"}
-				usertests.OverrideDefaultOptions(t, groupFilePath, gpasswd)
+				usertests.OverrideDefaultOptions(t, groupFilePath, gpasswd, nil)
 			}
 
 			cacheDir := t.TempDir()
@@ -477,7 +477,7 @@ func TestIsAuthenticated(t *testing.T) {
 				return
 			}
 
-			gotGPasswd := usertests.IdemnpotentOutputFromGPasswd(t, destCmdsFile)
+			gotGPasswd := usertests.IdempotentGPasswdOutput(t, destCmdsFile)
 			wantGPasswd := testutils.LoadWithUpdateFromGolden(t, gotGPasswd, testutils.WithGoldenPath(goldenGpasswdPath))
 			require.Equal(t, wantGPasswd, gotGPasswd, "IsAuthenticated should return the expected combined data, but did not")
 		})

--- a/internal/users/export_test.go
+++ b/internal/users/export_test.go
@@ -13,3 +13,10 @@ func WithGpasswdCmd(cmds []string) Option {
 		o.gpasswdCmd = cmds
 	}
 }
+
+// WithGetUsersFunc overrides the getusers func with a custom one for tests.
+func WithGetUsersFunc(getUsersFunc func() []string) Option {
+	return func(o *options) {
+		o.getUsersFunc = getUsersFunc
+	}
+}

--- a/internal/users/getpwent_c.go
+++ b/internal/users/getpwent_c.go
@@ -1,0 +1,23 @@
+package users
+
+// #include <stdlib.h>
+// #include <pwd.h>
+import "C"
+
+// getPasswdUsernames gets the list of users using `getpwent` and returns their usernames.
+func getPasswdUsernames() []string {
+	C.setpwent()
+	defer C.endpwent()
+
+	var entries []string
+	for {
+		cPasswd := C.getpwent()
+		if cPasswd == nil {
+			break
+		}
+
+		entries = append(entries, C.GoString(cPasswd.pw_name))
+	}
+
+	return entries
+}

--- a/internal/users/getpwent_test.go
+++ b/internal/users/getpwent_test.go
@@ -1,0 +1,15 @@
+package users
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetPasswdUsernames(t *testing.T) {
+	t.Parallel()
+
+	got := getPasswdUsernames()
+	require.NotEmpty(t, got, "GetPasswdUsernames should never return an empty list")
+	require.Contains(t, got, "root", "GetPasswdUsernames should always return root")
+}

--- a/internal/users/testdata/TestCleanLocalGroups/golden/cleans_up_multiple_users_from_group
+++ b/internal/users/testdata/TestCleanLocalGroups/golden/cleans_up_multiple_users_from_group
@@ -1,0 +1,3 @@
+--delete inactiveuser localgroup1
+--delete inactiveuser2 localgroup1
+--delete inactiveuser3 localgroup1

--- a/internal/users/testdata/TestCleanLocalGroups/golden/cleans_up_multiple_users_from_multiple_groups
+++ b/internal/users/testdata/TestCleanLocalGroups/golden/cleans_up_multiple_users_from_multiple_groups
@@ -1,0 +1,6 @@
+--delete inactiveuser localgroup2
+--delete inactiveuser localgroup3
+--delete inactiveuser2 localgroup1
+--delete inactiveuser2 localgroup3
+--delete inactiveuser3 localgroup1
+--delete inactiveuser3 localgroup2

--- a/internal/users/testdata/TestCleanLocalGroups/golden/cleans_up_user_from_group
+++ b/internal/users/testdata/TestCleanLocalGroups/golden/cleans_up_user_from_group
@@ -1,0 +1,1 @@
+--delete inactiveuser localgroup1

--- a/internal/users/testdata/TestCleanLocalGroups/golden/cleans_up_user_from_multiple_groups
+++ b/internal/users/testdata/TestCleanLocalGroups/golden/cleans_up_user_from_multiple_groups
@@ -1,0 +1,3 @@
+--delete inactiveuser localgroup1
+--delete inactiveuser localgroup3
+--delete inactiveuser localgroup4

--- a/internal/users/testdata/TestCleanLocalGroups/golden/error_on_any_unignored_delete_gpasswd_error
+++ b/internal/users/testdata/TestCleanLocalGroups/golden/error_on_any_unignored_delete_gpasswd_error
@@ -1,0 +1,5 @@
+--delete  cloudgroup1
+--delete  cloudgroup2
+--delete  localgroup1
+--delete  localgroup3
+--delete  localgroup4

--- a/internal/users/testdata/TestCleanUserFromLocalGroups/golden/cleans_up_user_from_group
+++ b/internal/users/testdata/TestCleanUserFromLocalGroups/golden/cleans_up_user_from_group
@@ -1,0 +1,1 @@
+--delete myuser localgroup1

--- a/internal/users/testdata/TestCleanUserFromLocalGroups/golden/cleans_up_user_from_multiple_groups
+++ b/internal/users/testdata/TestCleanUserFromLocalGroups/golden/cleans_up_user_from_multiple_groups
@@ -1,0 +1,2 @@
+--delete myuser localgroup1
+--delete myuser localgroup2

--- a/internal/users/testdata/inactive_user_in_many_groups.group
+++ b/internal/users/testdata/inactive_user_in_many_groups.group
@@ -1,0 +1,6 @@
+localgroup1:x:41:otheruser,myuser,inactiveuser
+localgroup2:x:42:myuser
+localgroup3:x:43:inactiveuser
+localgroup4:x:44:inactiveuser
+cloudgroup1:x:9998:otheruser3
+cloudgroup2:x:9999:otheruser4

--- a/internal/users/testdata/inactive_user_in_one_group.group
+++ b/internal/users/testdata/inactive_user_in_one_group.group
@@ -1,0 +1,5 @@
+localgroup1:x:41:myuser,inactiveuser
+localgroup2:x:42:otheruser
+localgroup4:x:44:otheruser2
+cloudgroup1:x:9998:otheruser3
+cloudgroup2:x:9999:otheruser4

--- a/internal/users/testdata/inactive_users_in_many_groups.group
+++ b/internal/users/testdata/inactive_users_in_many_groups.group
@@ -1,0 +1,6 @@
+localgroup1:x:41:inactiveuser2,inactiveuser3
+localgroup2:x:42:inactiveuser,inactiveuser3
+localgroup3:x:43:inactiveuser,inactiveuser2
+localgroup4:x:44:otheruser2
+cloudgroup1:x:9998:otheruser3
+cloudgroup2:x:9999:otheruser4

--- a/internal/users/testdata/inactive_users_in_one_group.group
+++ b/internal/users/testdata/inactive_users_in_one_group.group
@@ -1,0 +1,5 @@
+localgroup1:x:41:inactiveuser,inactiveuser2,inactiveuser3
+localgroup2:x:42:otheruser
+localgroup4:x:44:otheruser2
+cloudgroup1:x:9998:otheruser3
+cloudgroup2:x:9999:otheruser4

--- a/internal/users/tests/tests.go
+++ b/internal/users/tests/tests.go
@@ -34,8 +34,8 @@ func OverrideDefaultOptions(t *testing.T, groupPath string, gpasswdCmd []string)
 	defaultOptions.gpasswdCmd = gpasswdCmd
 }
 
-// IdemnpotentOutputFromGPasswd sort and trim spaces around mock gpasswd output.
-func IdemnpotentOutputFromGPasswd(t *testing.T, cmdsFilePath string) string {
+// IdempotentGPasswdOutput sort and trim spaces around mock gpasswd output.
+func IdempotentGPasswdOutput(t *testing.T, cmdsFilePath string) string {
 	t.Helper()
 
 	d, err := os.ReadFile(cmdsFilePath)
@@ -54,7 +54,6 @@ func Mockgpasswd(_ *testing.T) {
 	if os.Getenv("GO_WANT_HELPER_PROCESS_DEST") == "" {
 		return
 	}
-	defer os.Exit(0)
 
 	args := os.Args
 	for len(args) > 0 {
@@ -95,6 +94,7 @@ func Mockgpasswd(_ *testing.T) {
 
 	if _, err := f.Write([]byte(strings.Join(args, " ") + "\n")); err != nil {
 		fmt.Fprintf(os.Stderr, "Mock: error while writing in file: %v", err)
+		f.Close()
 		os.Exit(1)
 	}
 }

--- a/internal/users/users.go
+++ b/internal/users/users.go
@@ -96,6 +96,7 @@ func existingLocalGroups(user, groupPath string) (groups []string, err error) {
 	if err != nil {
 		return nil, err
 	}
+	defer f.Close()
 
 	// Format of a line composing the group file is:
 	// group_name:password:group_id:user1,…,usern
@@ -107,7 +108,7 @@ func existingLocalGroups(user, groupPath string) (groups []string, err error) {
 		}
 		elems := strings.Split(t, ":")
 		if len(elems) != 4 {
-			return nil, fmt.Errorf("unexpected number of elements in group file on line (should have 4 separators): %q", t)
+			return nil, fmt.Errorf("malformed entry in group file (should have 4 separators): %q", t)
 		}
 
 		n := elems[0]

--- a/internal/users/users_test.go
+++ b/internal/users/users_test.go
@@ -121,7 +121,7 @@ func TestUpdateLocalGroups(t *testing.T) {
 				return
 			}
 
-			got := usertests.IdemnpotentOutputFromGPasswd(t, destCmdsFile)
+			got := usertests.IdempotentGPasswdOutput(t, destCmdsFile)
 			want := testutils.LoadWithUpdateFromGolden(t, got)
 			require.Equal(t, want, got, "UpdateLocalGroups should do the expected gpasswd operation, but did not")
 		})

--- a/internal/users/users_test.go
+++ b/internal/users/users_test.go
@@ -128,6 +128,157 @@ func TestUpdateLocalGroups(t *testing.T) {
 	}
 }
 
+func TestCleanLocalGroups(t *testing.T) {
+	t.Parallel()
+
+	tests := map[string]struct {
+		groupFilePath string
+
+		getUsersReturn []string
+
+		wantErr bool
+	}{
+		"No-op when there are no inactive users":        {groupFilePath: "user_in_many_groups.group"},
+		"Cleans up user from group":                     {groupFilePath: "inactive_user_in_one_group.group"},
+		"Cleans up user from multiple groups":           {groupFilePath: "inactive_user_in_many_groups.group"},
+		"Cleans up multiple users from group":           {groupFilePath: "inactive_users_in_one_group.group"},
+		"Cleans up multiple users from multiple groups": {groupFilePath: "inactive_users_in_many_groups.group"},
+
+		"Error if there's no active user":             {groupFilePath: "user_in_many_groups.group", getUsersReturn: []string{}, wantErr: true},
+		"Error on missing groups file":                {groupFilePath: "does_not_exists.group", wantErr: true},
+		"Error when groups file is malformed":         {groupFilePath: "malformed_file.group", wantErr: true},
+		"Error on any unignored delete gpasswd error": {groupFilePath: "gpasswdfail_in_deleted_group.group", wantErr: true},
+	}
+	for name, tc := range tests {
+		tc := tc
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			destCmdsFile := filepath.Join(t.TempDir(), "gpasswd.output")
+			groupFilePath := filepath.Join("testdata", tc.groupFilePath)
+			gpasswdCmd := []string{"env", "GO_WANT_HELPER_PROCESS=1",
+				fmt.Sprintf("GO_WANT_HELPER_PROCESS_DEST=%s", destCmdsFile),
+				fmt.Sprintf("GO_WANT_HELPER_PROCESS_GROUPFILE=%s", groupFilePath),
+				os.Args[0], "-test.run=TestMockgpasswd", "--",
+			}
+
+			if tc.getUsersReturn == nil {
+				tc.getUsersReturn = []string{"myuser", "otheruser", "otheruser2", "otheruser3", "otheruser4"}
+			}
+
+			cleanupOptions := []users.Option{
+				users.WithGpasswdCmd(gpasswdCmd),
+				users.WithGroupPath(groupFilePath),
+				users.WithGetUsersFunc(func() []string { return tc.getUsersReturn }),
+			}
+			err := users.CleanLocalGroups(cleanupOptions...)
+			if tc.wantErr {
+				require.Error(t, err, "CleanupLocalGroups should have failed")
+			} else {
+				require.NoError(t, err, "CleanupLocalGroups should not have failed")
+			}
+
+			// Always check the golden files missing for no-op too on error
+			referenceFilePath := testutils.GoldenPath(t)
+			if testutils.Update() {
+				// The file may already not exists.
+				_ = os.Remove(testutils.GoldenPath(t))
+				referenceFilePath = destCmdsFile
+			}
+
+			var shouldExists bool
+			if _, err := os.Stat(referenceFilePath); err == nil {
+				shouldExists = true
+			}
+			if !shouldExists {
+				require.NoFileExists(t, destCmdsFile, "UpdateLocalGroups should not call gpasswd by did")
+				return
+			}
+
+			got := usertests.IdempotentGPasswdOutput(t, destCmdsFile)
+			want := testutils.LoadWithUpdateFromGolden(t, got)
+			require.Equal(t, want, got, "Clean up should do the expected gpasswd operation, but did not")
+		})
+	}
+}
+
+func TestCleanUserFromLocalGroups(t *testing.T) {
+	t.Parallel()
+
+	tests := map[string]struct {
+		username string
+
+		groupFilePath   string
+		wantMockFailure bool
+
+		wantErr bool
+	}{
+		"Cleans up user from group":                   {},
+		"Cleans up user from multiple groups":         {groupFilePath: "user_in_many_groups.group"},
+		"No op if user does not belong to any groups": {username: "groupless"},
+
+		"Error on missing groups file":                {groupFilePath: "does_not_exists.group", wantErr: true},
+		"Error when groups file is malformed":         {groupFilePath: "malformed_file.group", wantErr: true},
+		"Error on any unignored delete gpasswd error": {wantMockFailure: true, wantErr: true},
+	}
+	for name, tc := range tests {
+		tc := tc
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			if tc.username == "" {
+				tc.username = "myuser"
+			}
+			if tc.groupFilePath == "" {
+				tc.groupFilePath = "user_in_one_group.group"
+			}
+
+			destCmdsFile := filepath.Join(t.TempDir(), "gpasswd.output")
+			groupFilePath := filepath.Join("testdata", tc.groupFilePath)
+			gpasswdCmd := []string{"env", "GO_WANT_HELPER_PROCESS=1",
+				fmt.Sprintf("GO_WANT_HELPER_PROCESS_DEST=%s", destCmdsFile),
+				fmt.Sprintf("GO_WANT_HELPER_PROCESS_GROUPFILE=%s", groupFilePath),
+				os.Args[0], "-test.run=TestMockgpasswd", "--",
+			}
+			if tc.wantMockFailure {
+				gpasswdCmd = append(gpasswdCmd, "gpasswdfail")
+			}
+
+			cleanupOptions := []users.Option{
+				users.WithGpasswdCmd(gpasswdCmd),
+				users.WithGroupPath(groupFilePath),
+			}
+			err := users.CleanUserFromLocalGroups(tc.username, cleanupOptions...)
+			if tc.wantErr {
+				require.Error(t, err, "CleanUserFromLocalGroups should have failed")
+			} else {
+				require.NoError(t, err, "CleanUserFromLocalGroups should not have failed")
+			}
+
+			// Always check the golden files missing for no-op too on error
+			referenceFilePath := testutils.GoldenPath(t)
+			if testutils.Update() {
+				// The file may already not exists.
+				_ = os.Remove(testutils.GoldenPath(t))
+				referenceFilePath = destCmdsFile
+			}
+
+			var shouldExists bool
+			if _, err := os.Stat(referenceFilePath); err == nil {
+				shouldExists = true
+			}
+			if !shouldExists {
+				require.NoFileExists(t, destCmdsFile, "UpdateLocalGroups should not call gpasswd by did")
+				return
+			}
+
+			got := usertests.IdempotentGPasswdOutput(t, destCmdsFile)
+			want := testutils.LoadWithUpdateFromGolden(t, got)
+			require.Equal(t, want, got, "Clean up should do the expected gpasswd operation, but did not")
+		})
+	}
+}
+
 func TestMockgpasswd(t *testing.T) {
 	usertests.Mockgpasswd(t)
 }


### PR DESCRIPTION
Due to limitations with our `cache`, we can't know exactly which users were deleted when the database was corrupted and it got cleared up and rebuilt, so we need to have a routine that periodically cleans the local groups from any unexistent users.

This is a complex task that could potentially spawn a lot of subprocesses (in the form of `gpasswd --delete` calls) to clean the local groups. However, the dominant factor of complexity in the code is the number of groups (and the number of users that belong to those groups) rather than the number of existent users. Since we query directly `/etc/groups` to look for the groups, we are only dealing with local groups here and, as such, we should be fine with performance.

UDENG-1864