### PR TITLE
fix: skip NSS lookups from dbus-daemon through systemd

### DIFF
--- a/nss/src/client/mod.rs
+++ b/nss/src/client/mod.rs
@@ -12,6 +12,16 @@ pub mod authd {
 
 /// new_client creates a new client connection to the gRPC server or returns an active one.
 pub async fn new_client() -> Result<NssClient<Channel>, Box<dyn Error>> {
+    // We need to skip NSS lookups performed by dbus through systemd, otherwise
+    // we could end up in a deadlock due to lookups happening while the authd
+    // daemon is starting up.
+    // This variable is set by systemd specifically for dbus.service to avoid a
+    // similar issue with nss-systemd - we can repurpose it for our case.
+    // ref: https://github.com/systemd/systemd/pull/22552
+    if std::env::var("SYSTEMD_NSS_DYNAMIC_BYPASS").is_ok() {
+        return Err("NSS lookup performed through systemd, skipping...".into());
+    }
+
     debug!("Connecting to authd on {}...", super::socket_path());
 
     // The URL must have a valid format, even though we don't use it.


### PR DESCRIPTION
While doing more tests that required frequent reboots I still encountered the boot hang issue described in UDENG-1862. I was able to trace it back to an issue in systemd where [something similar happened between nss-systemd and dbus](https://github.com/systemd/systemd/issues/15316).

Even with the strictest systemd unit dependency ordering we're still not able to rule out the deadlock completely, because while `dbus.service` may report that it's active, other services could still interact with it afterwards causing it to perform more _blocking_ NSS lookups, before the authd daemon has fully started.

To prevent this from happening, we can leverage the [systemd fix](https://github.com/systemd/systemd/pull/22552) which sets a specific environment variable when starting the dbus.service, telling itself (`nss-systemd`) to avoid using dbus for the lookup.

It's not really ideal to return an error here but it was the quickest way to do it without changing all the NSS entry points of the library.

Fixes UDENG-1862