### PR TITLE
fix(CI/coverage): Cover all packages by default

### DIFF
--- a/.github/workflows/qa.yaml
+++ b/.github/workflows/qa.yaml
@@ -134,7 +134,7 @@ jobs:
           # Overriding the default coverage directory is not an exported flag of go test (yet), so
           # we need to override it using the test.gocoverdir flag instead.
           #TODO: Update when https://go-review.googlesource.com/c/go/+/456595 is merged.
-          go test -cover -covermode=set ./... -shuffle=on -args -test.gocoverdir="${raw_cov_dir}"
+          go test -cover -covermode=set ./... -coverpkg=./... -shuffle=on -args -test.gocoverdir="${raw_cov_dir}"
 
           # Convert the raw coverage data into textfmt so we can merge the Rust one into it
           go tool covdata textfmt -i="${raw_cov_dir}" -o="/tmp/coverage.out"

--- a/gotestcov
+++ b/gotestcov
@@ -40,7 +40,7 @@ mkdir -p "${raw_cov_dir}"
 # Overriding the default coverage directory is currently not an exported flag of go test
 # We need to override it using the test.gocoverdir flag instead.
 #TODO: Update when https://go-review.googlesource.com/c/go/+/456595 is merged.
-go test -cover -covermode=set $@ -shuffle=on -args -test.gocoverdir="${raw_cov_dir}"
+go test -cover -covermode=set -coverpkg=./... $@  -shuffle=on -args -test.gocoverdir="${raw_cov_dir}"
 
 # Convert the raw coverage data into textfmt so we can merge the Rust one into it
 go tool covdata textfmt -i="${raw_cov_dir}" -o="${cov_dir}/coverage.out"


### PR DESCRIPTION
By default, Go only calculates coverage of the package being tested. While this is good to see how effective our unit tests are, we also miss the coverage on more complex tests that test more than one package at a time.

By adding the `-coverpkg=./...` flag, Go now calculates the test coverage on the current package + all of the sub-packages.