### PR TITLE
Fix(config): clean unused value

### DIFF
--- a/internal/brokers/testdata/broker.d/invalid_brokers/no_brand_icon
+++ b/internal/brokers/testdata/broker.d/invalid_brokers/no_brand_icon
@@ -3,4 +3,3 @@ name = Broker
 [dbus]
 name = com.ubuntu.authd.Broker
 object = /com/ubuntu/authd/Broker
-interface = com.ubuntu.authd.Broker

--- a/internal/brokers/testdata/broker.d/invalid_brokers/no_dbus_name
+++ b/internal/brokers/testdata/broker.d/invalid_brokers/no_dbus_name
@@ -3,4 +3,3 @@ brand_icon = some_icon.png
 
 [dbus]
 object = /com/ubuntu/authd/Broker
-interface = com.ubuntu.authd.Broker

--- a/internal/brokers/testdata/broker.d/invalid_brokers/no_dbus_object
+++ b/internal/brokers/testdata/broker.d/invalid_brokers/no_dbus_object
@@ -3,4 +3,3 @@ brand_icon = some_icon.png
 
 [dbus]
 name = com.ubuntu.authd.Broker
-interface = com.ubuntu.authd.Broker

--- a/internal/brokers/testdata/broker.d/invalid_brokers/no_name
+++ b/internal/brokers/testdata/broker.d/invalid_brokers/no_name
@@ -3,4 +3,3 @@ brand_icon = some_icon.png
 [dbus]
 name = com.ubuntu.authd.Broker
 object = /com/ubuntu/authd/Broker
-interface = com.ubuntu.authd.Broker

--- a/internal/brokers/testdata/broker.d/mixed_brokers/valid
+++ b/internal/brokers/testdata/broker.d/mixed_brokers/valid
@@ -4,4 +4,3 @@ brand_icon = some_icon.png
 [dbus]
 name = com.ubuntu.authd.Broker
 object = /com/ubuntu/authd/Broker
-interface = com.ubuntu.authd.Broker

--- a/internal/brokers/testdata/broker.d/not_on_bus/not_on_bus
+++ b/internal/brokers/testdata/broker.d/not_on_bus/not_on_bus
@@ -4,4 +4,3 @@ brand_icon = some_icon.png
 [dbus]
 name = not.exported.onbus.OfflineBroker
 object = /not/exported/onbus/Broker
-interface = not.exported.onbus.OfflineBroker

--- a/internal/brokers/testdata/broker.d/valid_brokers/valid
+++ b/internal/brokers/testdata/broker.d/valid_brokers/valid
@@ -4,4 +4,3 @@ brand_icon = some_icon.png
 [dbus]
 name = com.ubuntu.authd.Broker
 object = /com/ubuntu/authd/Broker
-interface = com.ubuntu.authd.Broker

--- a/internal/brokers/testdata/broker.d/valid_brokers/valid_2
+++ b/internal/brokers/testdata/broker.d/valid_brokers/valid_2
@@ -4,4 +4,3 @@ brand_icon = some_icon.png
 [dbus]
 name = com.ubuntu.authd.Broker2
 object = /com/ubuntu/authd/Broker2
-interface = com.ubuntu.authd.Broker2


### PR DESCRIPTION
It's been quite a while we don’t need the interface entry anymore as we define the interface in authd.
Remove it from the example fixtures.