### PR TITLE
feat(authd): rework brokers config file

### DIFF
--- a/internal/brokers/dbusbroker.go
+++ b/internal/brokers/dbusbroker.go
@@ -28,22 +28,22 @@ func newDbusBroker(ctx context.Context, bus *dbus.Conn, configFile string) (b db
 		return b, "", "", fmt.Errorf("could not read ini configuration for broker %v", err)
 	}
 
-	fullNameVal, err := cfg.Section("").GetKey("name")
+	fullNameVal, err := cfg.Section("authd").GetKey("name")
 	if err != nil {
 		return b, "", "", fmt.Errorf("missing field for broker: %v", err)
 	}
 
-	brandIconVal, err := cfg.Section("").GetKey("brand_icon")
+	brandIconVal, err := cfg.Section("authd").GetKey("brand_icon")
 	if err != nil {
 		return b, "", "", fmt.Errorf("missing field for broker: %v", err)
 	}
 
-	dbusName, err := cfg.Section("dbus").GetKey("name")
+	dbusName, err := cfg.Section("authd").GetKey("dbus_name")
 	if err != nil {
 		return b, "", "", fmt.Errorf("missing field for broker: %v", err)
 	}
 
-	objectName, err := cfg.Section("dbus").GetKey("object")
+	objectName, err := cfg.Section("authd").GetKey("dbus_object")
 	if err != nil {
 		return b, "", "", fmt.Errorf("missing field for broker: %v", err)
 	}

--- a/internal/brokers/examplebroker/ExampleBroker
+++ b/internal/brokers/examplebroker/ExampleBroker
@@ -1,7 +1,6 @@
 # Add this to /etc/authd/broker.d to configure the ExampleBroker
+[authd]
 name = ExampleBroker
 brand_icon = /usr/share/backgrounds/warty-final-ubuntu.png
-
-[dbus]
-name = com.ubuntu.authd.ExampleBroker
-object = /com/ubuntu/authd/ExampleBroker
+dbus_name = com.ubuntu.authd.ExampleBroker
+dbus_object = /com/ubuntu/authd/ExampleBroker

--- a/internal/brokers/examplebroker/dbus.go
+++ b/internal/brokers/examplebroker/dbus.go
@@ -62,13 +62,11 @@ func StartBus(ctx context.Context, cfgPath string) (err error) {
 	}
 
 	if err = os.WriteFile(filepath.Join(cfgPath, "examplebroker.conf"),
-		[]byte(fmt.Sprintf(`
+		[]byte(fmt.Sprintf(`[authd]
 name = ExampleBroker
 brand_icon = /usr/share/backgrounds/warty-final-ubuntu.png
-
-[dbus]
-name = %s
-object = %s
+dbus_name = %s
+dbus_object = %s
 `, busName, dbusObjectPath)),
 		0600); err != nil {
 		return err

--- a/internal/brokers/manager_test.go
+++ b/internal/brokers/manager_test.go
@@ -35,6 +35,8 @@ func TestNewManager(t *testing.T) {
 		"Creates only local broker when config dir does not exist":                   {brokerConfigDir: "does/not/exist"},
 		"Creates manager even if broker is not exported on dbus":                     {brokerConfigDir: "not_on_bus"},
 
+		"Ignores any unknown sections and fields": {brokerConfigDir: "extra_fields"},
+
 		"Error when can't connect to system bus": {brokerConfigDir: "valid_brokers", noBus: true, wantErr: true},
 		"Error when broker config dir is a file": {brokerConfigDir: "file_config_dir", wantErr: true},
 	}

--- a/internal/brokers/testdata/TestNewManager/golden/ignores_any_unknown_sections_and_fields
+++ b/internal/brokers/testdata/TestNewManager/golden/ignores_any_unknown_sections_and_fields
@@ -1,0 +1,2 @@
+- local
+- Broker

--- a/internal/brokers/testdata/broker.d/extra_fields/extra_fields
+++ b/internal/brokers/testdata/broker.d/extra_fields/extra_fields
@@ -1,0 +1,11 @@
+ignore_field = ignored_global
+
+[authd]
+name = Broker
+brand_icon = some_icon.png
+dbus_name = com.ubuntu.authd.Broker
+dbus_object = /com/ubuntu/authd/Broker
+ignore_field = ignored_field_in_authd
+
+[ignored_section]
+ignore_field = ignored_field_in_ignored_section

--- a/internal/brokers/testdata/broker.d/invalid_brokers/no_brand_icon
+++ b/internal/brokers/testdata/broker.d/invalid_brokers/no_brand_icon
@@ -1,5 +1,4 @@
+[authd]
 name = Broker
-
-[dbus]
-name = com.ubuntu.authd.Broker
-object = /com/ubuntu/authd/Broker
+dbus_name = com.ubuntu.authd.Broker
+dbus_object = /com/ubuntu/authd/Broker

--- a/internal/brokers/testdata/broker.d/invalid_brokers/no_dbus_name
+++ b/internal/brokers/testdata/broker.d/invalid_brokers/no_dbus_name
@@ -1,5 +1,4 @@
+[authd]
 name = Broker
 brand_icon = some_icon.png
-
-[dbus]
-object = /com/ubuntu/authd/Broker
+dbus_object = /com/ubuntu/authd/Broker

--- a/internal/brokers/testdata/broker.d/invalid_brokers/no_dbus_object
+++ b/internal/brokers/testdata/broker.d/invalid_brokers/no_dbus_object
@@ -1,5 +1,4 @@
+[authd]
 name = Broker
 brand_icon = some_icon.png
-
-[dbus]
-name = com.ubuntu.authd.Broker
+dbus_name = com.ubuntu.authd.Broker

--- a/internal/brokers/testdata/broker.d/invalid_brokers/no_name
+++ b/internal/brokers/testdata/broker.d/invalid_brokers/no_name
@@ -1,5 +1,4 @@
+[authd]
 brand_icon = some_icon.png
-
-[dbus]
-name = com.ubuntu.authd.Broker
-object = /com/ubuntu/authd/Broker
+dbus_name = com.ubuntu.authd.Broker
+dbus_object = /com/ubuntu/authd/Broker

--- a/internal/brokers/testdata/broker.d/mixed_brokers/valid
+++ b/internal/brokers/testdata/broker.d/mixed_brokers/valid
@@ -1,6 +1,5 @@
+[authd]
 name = Broker
 brand_icon = some_icon.png
-
-[dbus]
-name = com.ubuntu.authd.Broker
-object = /com/ubuntu/authd/Broker
+dbus_name = com.ubuntu.authd.Broker
+dbus_object = /com/ubuntu/authd/Broker

--- a/internal/brokers/testdata/broker.d/not_on_bus/not_on_bus
+++ b/internal/brokers/testdata/broker.d/not_on_bus/not_on_bus
@@ -1,6 +1,5 @@
+[authd]
 name = OfflineBroker
 brand_icon = some_icon.png
-
-[dbus]
-name = not.exported.onbus.OfflineBroker
-object = /not/exported/onbus/Broker
+dbus_name = not.exported.onbus.OfflineBroker
+dbus_object = /not/exported/onbus/Broker

--- a/internal/brokers/testdata/broker.d/valid_brokers/valid
+++ b/internal/brokers/testdata/broker.d/valid_brokers/valid
@@ -1,6 +1,5 @@
+[authd]
 name = Broker
 brand_icon = some_icon.png
-
-[dbus]
-name = com.ubuntu.authd.Broker
-object = /com/ubuntu/authd/Broker
+dbus_name = com.ubuntu.authd.Broker
+dbus_object = /com/ubuntu/authd/Broker

--- a/internal/brokers/testdata/broker.d/valid_brokers/valid_2
+++ b/internal/brokers/testdata/broker.d/valid_brokers/valid_2
@@ -1,6 +1,5 @@
+[authd]
 name = Broker2
 brand_icon = some_icon.png
-
-[dbus]
-name = com.ubuntu.authd.Broker2
-object = /com/ubuntu/authd/Broker2
+dbus_name = com.ubuntu.authd.Broker2
+dbus_object = /com/ubuntu/authd/Broker2

--- a/internal/testutils/broker/broker.go
+++ b/internal/testutils/broker/broker.go
@@ -27,12 +27,11 @@ const (
 	IDSeparator = "_separator_"
 )
 
-var brokerConfigTemplate = `name = %s
+var brokerConfigTemplate = `[authd]
+name = %s
 brand_icon = mock_icon.png
-
-[dbus]
-name = com.ubuntu.authd.%s
-object = /com/ubuntu/authd/%s
+dbus_name = com.ubuntu.authd.%s
+dbus_object = /com/ubuntu/authd/%s
 `
 
 type isAuthenticatedCtx struct {


### PR DESCRIPTION
Move all key name under authd section. This way, we delimit the section mandatory for authd from others, the rest is available for the broker to reuse.
Adapt existing and add additional tests for it.

UDEENG-2007.