### PR TITLE
tests: Switch to gpasswd mock helper functions

### DIFF
--- a/internal/users/localgroups/tests/tests.go
+++ b/internal/users/localgroups/tests/tests.go
@@ -112,28 +112,26 @@ func Mockgpasswd(_ *testing.T) {
 // SetupGPasswdMock setup the gpasswd mock and return the path to the file where the commands will be written.
 //
 // Tests that require this can not be run in parallel.
-func SetupGPasswdMock(t *testing.T, localGroupsFile string) string {
+func SetupGPasswdMock(t *testing.T, localGroupsFilepath string) string {
 	t.Helper()
 
 	destCmdsFile := filepath.Join(t.TempDir(), "gpasswd.output")
-	groupFilePath := filepath.Join("testdata", "groups", localGroupsFile)
 
 	gpasswd := []string{"env", "GO_WANT_HELPER_PROCESS=1",
 		fmt.Sprintf("GO_WANT_HELPER_PROCESS_DEST=%s", destCmdsFile),
-		fmt.Sprintf("GO_WANT_HELPER_PROCESS_GROUPFILE=%s", groupFilePath),
+		fmt.Sprintf("GO_WANT_HELPER_PROCESS_GROUPFILE=%s", localGroupsFilepath),
 		os.Args[0], "-test.run=TestMockgpasswd", "--"}
 
-	OverrideDefaultOptions(t, groupFilePath, gpasswd, nil)
+	OverrideDefaultOptions(t, localGroupsFilepath, gpasswd, nil)
 
 	return destCmdsFile
 }
 
 // RequireGPasswdOutput compare the output of gpasswd with the golden file.
-func RequireGPasswdOutput(t *testing.T, destCmdsFile string) {
+func RequireGPasswdOutput(t *testing.T, destCmdsFile, goldenGpasswdPath string) {
 	t.Helper()
 
 	// TODO: this should be extracted in testutils, but still allow post-treatement of file like sorting.
-	goldenGpasswdPath := filepath.Join(testutils.GoldenPath(t) + ".gpasswd.output")
 	referenceFilePath := goldenGpasswdPath
 	if testutils.Update() {
 		// The file may already not exists.

--- a/internal/users/manager_test.go
+++ b/internal/users/manager_test.go
@@ -58,7 +58,7 @@ func TestNewManager(t *testing.T) {
 			if tc.localGroupsFile == "" {
 				tc.localGroupsFile = "users_in_groups.group"
 			}
-			destCmdsFile := grouptests.SetupGPasswdMock(t, tc.localGroupsFile)
+			destCmdsFile := grouptests.SetupGPasswdMock(t, filepath.Join("testdata", "groups", tc.localGroupsFile))
 
 			cacheDir := t.TempDir()
 			if tc.dbFile == "" {
@@ -121,13 +121,13 @@ func TestNewManager(t *testing.T) {
 				requireClearedDatabase(t, usertests.GetManagerCache(m))
 			}
 
-			grouptests.RequireGPasswdOutput(t, destCmdsFile)
+			grouptests.RequireGPasswdOutput(t, destCmdsFile, testutils.GoldenPath(t)+".gpasswd.output")
 		})
 	}
 }
 
 func TestStop(t *testing.T) {
-	destCmdsFile := grouptests.SetupGPasswdMock(t, "users_in_groups.group")
+	destCmdsFile := grouptests.SetupGPasswdMock(t, filepath.Join("testdata", "groups", "users_in_groups.group"))
 
 	cacheDir := t.TempDir()
 	err := os.WriteFile(filepath.Join(cacheDir, cachetests.DbName), []byte("Corrupted db"), 0600)
@@ -141,7 +141,7 @@ func TestStop(t *testing.T) {
 	require.ErrorIs(t, err, bbolt.ErrDatabaseNotOpen, "AllUsers should return an error, but did not")
 
 	// Ensure that the manager only stopped after the routine was done.
-	grouptests.RequireGPasswdOutput(t, destCmdsFile)
+	grouptests.RequireGPasswdOutput(t, destCmdsFile, testutils.GoldenPath(t)+".gpasswd.output")
 }
 
 func TestUpdateUser(t *testing.T) {
@@ -231,7 +231,7 @@ func TestUpdateUser(t *testing.T) {
 
 			var destCmdsFile string
 			if tc.localGroupsFile != "" {
-				destCmdsFile = grouptests.SetupGPasswdMock(t, tc.localGroupsFile)
+				destCmdsFile = grouptests.SetupGPasswdMock(t, filepath.Join("testdata", "groups", tc.localGroupsFile))
 			}
 
 			if tc.userCase == "" {
@@ -264,7 +264,7 @@ func TestUpdateUser(t *testing.T) {
 			want := testutils.LoadWithUpdateFromGoldenYAML(t, got)
 			require.Equal(t, want, got, "Did not get expected database content")
 
-			grouptests.RequireGPasswdOutput(t, destCmdsFile)
+			grouptests.RequireGPasswdOutput(t, destCmdsFile, testutils.GoldenPath(t)+".gpasswd.output")
 		})
 	}
 }


### PR DESCRIPTION
We had some duplicated code in our tests, but after #185 we now have the `gpasswd` mock setup wrapped in new helpers that allow us to deduplicate some code.