### PR TITLE
feat(pam/adapter): Add Gdm model implementation

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -69,4 +69,4 @@ require (
 // FIXME: Use released version once we have one!
 // The branch below includes changes from this upstream PR:
 // - https://github.com/msteinert/pam/pull/13
-replace github.com/msteinert/pam/v2 => github.com/3v1n0/go-pam/v2 v2.0.0-20240119152522-79364f5b2eed
+replace github.com/msteinert/pam/v2 => github.com/3v1n0/go-pam/v2 v2.0.0-20240218173232-e182844e4e11

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,5 @@
-github.com/3v1n0/go-pam/v2 v2.0.0-20240119152522-79364f5b2eed h1:s7ioiXl7hgPDHp+dKPAeUDE7g0A7fzy7ikZ/IfJeah8=
-github.com/3v1n0/go-pam/v2 v2.0.0-20240119152522-79364f5b2eed/go.mod h1:KT28NNIcDFf3PcBmNI2mIGO4zZJ+9RSs/At2PB3IDVc=
+github.com/3v1n0/go-pam/v2 v2.0.0-20240218173232-e182844e4e11 h1:zGS1p61QyPZKDpk53NMEy50eNhLB3GILQQf6LnEWgr4=
+github.com/3v1n0/go-pam/v2 v2.0.0-20240218173232-e182844e4e11/go.mod h1:KT28NNIcDFf3PcBmNI2mIGO4zZJ+9RSs/At2PB3IDVc=
 github.com/atotto/clipboard v0.1.4 h1:EH0zSVneZPSuFR11BlR9YppQTVDbh5+16AmcJi4g1z4=
 github.com/atotto/clipboard v0.1.4/go.mod h1:ZY9tmq7sm5xIbd9bOK4onWV4S6X0u6GY7Vn0Yu86PYI=
 github.com/aymanbagabas/go-osc52/v2 v2.0.1 h1:HwpRHbFMcZLEVr42D4p7XBqjyuxQH5SMiErDT4WkJ2k=

--- a/pam/internal/adapter/authentication.go
+++ b/pam/internal/adapter/authentication.go
@@ -64,6 +64,9 @@ type isAuthenticatedResultReceived struct {
 	msg    string
 }
 
+// isAuthenticatedCancelled is the event to cancel the auth request.
+type isAuthenticatedCancelled struct{}
+
 // reselectAuthMode signals to restart auth mode selection with the same id (to resend sms or
 // reenable the broker).
 type reselectAuthMode struct{}
@@ -132,6 +135,10 @@ func (m *authenticationModel) Update(msg tea.Msg) (authenticationModel, tea.Cmd)
 			return *m, sendEvent(pamError{status: pam.ErrSystem, msg: fmt.Sprintf("could not encrypt challenge payload: %v", err)})
 		}
 		return *m, sendIsAuthenticated(ctx, m.client, m.currentSessionID, &authd.IARequest_AuthenticationData{Item: msg.item})
+
+	case isAuthenticatedCancelled:
+		m.cancelIsAuthenticated()
+		return *m, nil
 
 	case isAuthenticatedResultReceived:
 		log.Infof(context.TODO(), "isAuthenticatedResultReceived: %v", msg.access)

--- a/pam/internal/adapter/authentication.go
+++ b/pam/internal/adapter/authentication.go
@@ -146,7 +146,11 @@ func (m *authenticationModel) Update(msg tea.Msg) (authenticationModel, tea.Cmd)
 		log.Infof(context.TODO(), "isAuthenticatedResultReceived: %v", msg.access)
 		switch msg.access {
 		case brokers.AuthGranted:
-			return *m, sendEvent(PamSuccess{BrokerID: m.currentBrokerID})
+			infoMsg, err := dataToMsg(msg.msg)
+			if err != nil {
+				return *m, sendEvent(pamError{status: pam.ErrSystem, msg: err.Error()})
+			}
+			return *m, sendEvent(PamSuccess{BrokerID: m.currentBrokerID, msg: infoMsg})
 
 		case brokers.AuthRetry:
 			errorMsg, err := dataToMsg(msg.msg)

--- a/pam/internal/adapter/authentication.go
+++ b/pam/internal/adapter/authentication.go
@@ -65,7 +65,9 @@ type isAuthenticatedResultReceived struct {
 }
 
 // isAuthenticatedCancelled is the event to cancel the auth request.
-type isAuthenticatedCancelled struct{}
+type isAuthenticatedCancelled struct {
+	msg string
+}
 
 // reselectAuthMode signals to restart auth mode selection with the same id (to resend sms or
 // reenable the broker).

--- a/pam/internal/adapter/authmodeselection.go
+++ b/pam/internal/adapter/authmodeselection.go
@@ -80,8 +80,11 @@ func newAuthModeSelectionModel(clientType PamClientType) authModeSelectionModel 
 
 // Init initializes authModeSelectionModel.
 func (m *authModeSelectionModel) Init() tea.Cmd {
+	if m.clientType == Gdm {
+		// This is handled by the GDM model!
+		return nil
+	}
 	return func() tea.Msg {
-		// TODO: call to 3rd party like gdm, to support dynamic ui layouts
 		required, optional := "required", "optional"
 		supportedEntries := "optional:chars,chars_password"
 		requiredWithBooleans := "required:true,false"

--- a/pam/internal/adapter/brokerselection.go
+++ b/pam/internal/adapter/brokerselection.go
@@ -19,7 +19,8 @@ type brokerSelectionModel struct {
 	list.Model
 	focused bool
 
-	client authd.PAMClient
+	client     authd.PAMClient
+	clientType PamClientType
 
 	availableBrokers []*authd.ABResponse_BrokerInfo
 }
@@ -44,7 +45,7 @@ func selectBroker(brokerID string) tea.Cmd {
 }
 
 // newBrokerSelectionModel initializes an empty list with default options of brokerSelectionModel.
-func newBrokerSelectionModel(client authd.PAMClient) brokerSelectionModel {
+func newBrokerSelectionModel(client authd.PAMClient, clientType PamClientType) brokerSelectionModel {
 	l := list.New(nil, itemLayout{}, 80, 24)
 	l.Title = "Select your provider"
 	l.SetShowStatusBar(false)
@@ -56,8 +57,9 @@ func newBrokerSelectionModel(client authd.PAMClient) brokerSelectionModel {
 	l.Styles.HelpStyle = helpStyle*/
 
 	return brokerSelectionModel{
-		Model:  l,
-		client: client,
+		Model:      l,
+		client:     client,
+		clientType: clientType,
 	}
 }
 
@@ -103,6 +105,10 @@ func (m brokerSelectionModel) Update(msg tea.Msg) (brokerSelectionModel, tea.Cmd
 		return m, sendEvent(BrokerSelected{
 			BrokerID: broker.Id,
 		})
+	}
+
+	if m.clientType != InteractiveTerminal {
+		return m, nil
 	}
 
 	// interaction events

--- a/pam/internal/adapter/brokerselection.go
+++ b/pam/internal/adapter/brokerselection.go
@@ -72,6 +72,12 @@ func (m brokerSelectionModel) Init() tea.Cmd {
 func (m brokerSelectionModel) Update(msg tea.Msg) (brokerSelectionModel, tea.Cmd) {
 	switch msg := msg.(type) {
 	case brokersListReceived:
+		if len(msg.brokers) == 0 {
+			return m, sendEvent(pamError{
+				status: pam.ErrAuthinfoUnavail,
+				msg:    "No brokers available",
+			})
+		}
 		m.availableBrokers = msg.brokers
 
 		var allBrokers []list.Item

--- a/pam/internal/adapter/gdmmodel.go
+++ b/pam/internal/adapter/gdmmodel.go
@@ -1,0 +1,273 @@
+package adapter
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"time"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/msteinert/pam/v2"
+	"github.com/ubuntu/authd"
+	"github.com/ubuntu/authd/internal/brokers"
+	"github.com/ubuntu/authd/internal/log"
+	"github.com/ubuntu/authd/pam/internal/gdm"
+	"github.com/ubuntu/authd/pam/internal/proto"
+)
+
+const (
+	gdmPollFrequency time.Duration = time.Millisecond * 16
+)
+
+type gdmModel struct {
+	pamMTx pam.ModuleTransaction
+
+	waitingAuth bool
+}
+
+type gdmPollDone struct{}
+
+// Init initializes the main model orchestrator.
+func (m *gdmModel) Init() tea.Cmd {
+	return tea.Sequence(m.protoHello(),
+		requestUICapabilities(m.pamMTx),
+		m.pollGdm())
+}
+
+func (m *gdmModel) protoHello() tea.Cmd {
+	reply, err := gdm.SendData(m.pamMTx, &gdm.Data{Type: gdm.DataType_hello})
+	if err != nil {
+		return sendEvent(pamError{
+			status: pam.ErrCredUnavail,
+			msg:    fmt.Sprintf("GDM initialization failed: %v", err),
+		})
+	}
+	if reply.Type != gdm.DataType_hello || reply.Hello == nil ||
+		reply.Hello.Version != gdm.ProtoVersion {
+		version := -1
+		if reply.Hello != nil {
+			version = int(reply.Hello.Version)
+		}
+		return sendEvent(pamError{
+			status: pam.ErrCredUnavail,
+			msg: fmt.Sprintf("GDM protocol initialization failed, type %s, version %d",
+				reply.Type, version),
+		})
+	}
+	log.Debugf(context.TODO(), "Gdm Reply is %v", reply)
+	return nil
+}
+
+func requestUICapabilities(mTx pam.ModuleTransaction) tea.Cmd {
+	return func() tea.Msg {
+		res, err := gdm.SendRequestTyped[*gdm.ResponseData_UiLayoutCapabilities](mTx,
+			&gdm.RequestData_UiLayoutCapabilities{})
+		if err != nil {
+			return pamError{
+				status: pam.ErrSystem,
+				msg:    fmt.Sprintf("Sending GDM UI capabilities Request failed: %v", err),
+			}
+		}
+		if res == nil {
+			return supportedUILayoutsReceived{}
+		}
+		return supportedUILayoutsReceived{res.UiLayoutCapabilities.SupportedUiLayouts}
+	}
+}
+
+func (m *gdmModel) pollGdm() tea.Cmd {
+	gdmPollResults, err := gdm.SendPoll(m.pamMTx)
+	if err != nil {
+		return sendEvent(pamError{
+			status: pam.ErrSystem,
+			msg:    fmt.Sprintf("Sending GDM poll failed: %v", err),
+		})
+	}
+	log.Debugf(context.TODO(), "Gdm Poll response is %v", gdmPollResults)
+
+	commands := []tea.Cmd{sendEvent(gdmPollDone{})}
+
+	for _, result := range gdmPollResults {
+		switch res := result.Data.(type) {
+		case *gdm.EventData_UserSelected:
+			commands = append(commands, sendEvent(userSelected{
+				username: res.UserSelected.UserId,
+			}))
+
+		case *gdm.EventData_BrokerSelected:
+			if res.BrokerSelected == nil {
+				return sendEvent(pamError{status: pam.ErrSystem,
+					msg: "missing broker selected",
+				})
+			}
+			commands = append(commands, sendEvent(brokerSelected{
+				brokerID: res.BrokerSelected.BrokerId,
+			}))
+
+		case *gdm.EventData_AuthModeSelected:
+			if res.AuthModeSelected == nil {
+				return sendEvent(pamError{
+					status: pam.ErrSystem, msg: "missing auth mode id",
+				})
+			}
+			commands = append(commands, selectAuthMode(res.AuthModeSelected.AuthModeId))
+
+		case *gdm.EventData_IsAuthenticatedRequested:
+			if !m.waitingAuth {
+				log.Warningf(context.TODO(), "unexpected authentication received: %#v", res.IsAuthenticatedRequested)
+				break
+			}
+			m.waitingAuth = false
+			if res.IsAuthenticatedRequested == nil || res.IsAuthenticatedRequested.AuthenticationData == nil {
+				return sendEvent(pamError{
+					status: pam.ErrSystem, msg: "missing auth requested",
+				})
+			}
+			commands = append(commands, sendEvent(isAuthenticatedRequested{
+				item: res.IsAuthenticatedRequested.GetAuthenticationData().Item,
+			}))
+
+		case *gdm.EventData_ReselectAuthMode:
+			commands = append(commands, sendEvent(reselectAuthMode{}))
+
+		case *gdm.EventData_StageChanged:
+			if res.StageChanged == nil {
+				return sendEvent(pamError{
+					status: pam.ErrSystem, msg: "missing stage changed",
+				})
+			}
+			log.Infof(context.TODO(), "GDM Stage changed to %s", res.StageChanged.Stage)
+
+			if m.waitingAuth && res.StageChanged.Stage != proto.Stage_challenge {
+				// Maybe this can be sent only if we ever hit the challenge phase.
+				commands = append(commands, sendEvent(isAuthenticatedCancelled{}))
+			}
+			commands = append(commands, sendEvent(ChangeStage{res.StageChanged.Stage}))
+		}
+	}
+	return tea.Batch(commands...)
+}
+
+func (m *gdmModel) emitEvent(event gdm.Event) tea.Cmd {
+	return func() tea.Msg {
+		return m.emitEventSync(event)
+	}
+}
+
+func (m *gdmModel) emitEventSync(event gdm.Event) tea.Msg {
+	err := gdm.EmitEvent(m.pamMTx, event)
+	log.Debug(context.TODO(), "EventSend", event, "result", err)
+	if err != nil {
+		return pamError{
+			status: pam.ErrSystem,
+			msg:    fmt.Sprintf("Sending GDM event failed: %v", err),
+		}
+	}
+	return nil
+}
+
+func (m gdmModel) Update(msg tea.Msg) (gdmModel, tea.Cmd) {
+	switch msg := msg.(type) {
+	case gdmPollDone:
+		return m, tea.Sequence(
+			tea.Tick(gdmPollFrequency, func(time.Time) tea.Msg { return nil }),
+			m.pollGdm())
+
+	case userSelected:
+		return m, m.emitEvent(&gdm.EventData_UserSelected{
+			UserSelected: &gdm.Events_UserSelected{UserId: msg.username},
+		})
+
+	case brokersListReceived:
+		return m, m.emitEvent(&gdm.EventData_BrokersReceived{
+			BrokersReceived: &gdm.Events_BrokersReceived{BrokersInfos: msg.brokers},
+		})
+
+	case brokerSelected:
+		return m, m.emitEvent(&gdm.EventData_BrokerSelected{
+			BrokerSelected: &gdm.Events_BrokerSelected{BrokerId: msg.brokerID},
+		})
+
+	case authModesReceived:
+		return m, m.emitEvent(&gdm.EventData_AuthModesReceived{
+			AuthModesReceived: &gdm.Events_AuthModesReceived{AuthModes: msg.authModes},
+		})
+
+	case authModeSelected:
+		return m, m.emitEvent(&gdm.EventData_AuthModeSelected{
+			AuthModeSelected: &gdm.Events_AuthModeSelected{AuthModeId: msg.id},
+		})
+
+	case UILayoutReceived:
+		return m, sendEvent(m.emitEventSync(&gdm.EventData_UiLayoutReceived{
+			UiLayoutReceived: &gdm.Events_UiLayoutReceived{UiLayout: msg.layout},
+		}))
+
+	case startAuthentication:
+		if m.waitingAuth {
+			log.Warning(context.TODO(), "Ignored authentication start request while one is still going")
+			return m, nil
+		}
+		m.waitingAuth = true
+		return m, sendEvent(m.emitEventSync(&gdm.EventData_StartAuthentication{
+			StartAuthentication: &gdm.Events_StartAuthentication{},
+		}))
+
+	case isAuthenticatedResultReceived:
+		access := msg.access
+		authMsg, err := dataToMsg(msg.msg)
+		if err != nil {
+			return m, sendEvent(pamError{status: pam.ErrSystem, msg: err.Error()})
+		}
+
+		switch access {
+		case brokers.AuthGranted:
+		case brokers.AuthDenied:
+		case brokers.AuthCancelled:
+			return m, sendEvent(isAuthenticatedCancelled{})
+		case brokers.AuthRetry:
+		case brokers.AuthNext:
+		default:
+			accessJSON, _ := json.Marshal(fmt.Sprintf("Access %q is not valid", access))
+			return m, sendEvent(isAuthenticatedResultReceived{
+				access: brokers.AuthDenied,
+				msg:    fmt.Sprintf(`{"message": %s}`, accessJSON),
+			})
+		}
+
+		return m, sendEvent(m.emitEventSync(&gdm.EventData_AuthEvent{
+			AuthEvent: &gdm.Events_AuthEvent{Response: &authd.IAResponse{
+				Access: access,
+				Msg:    authMsg,
+			}},
+		}))
+
+	case isAuthenticatedCancelled:
+		m.waitingAuth = false
+
+		return m, sendEvent(m.emitEventSync(&gdm.EventData_AuthEvent{
+			AuthEvent: &gdm.Events_AuthEvent{Response: &authd.IAResponse{
+				Access: brokers.AuthCancelled,
+				Msg:    msg.msg,
+			}},
+		}))
+	}
+
+	return m, nil
+}
+
+func (m gdmModel) changeStage(s proto.Stage) tea.Cmd {
+	return func() tea.Msg {
+		_, err := gdm.SendRequest(m.pamMTx, &gdm.RequestData_ChangeStage{
+			ChangeStage: &gdm.Requests_ChangeStage{Stage: s},
+		})
+		if err != nil {
+			return pamError{
+				status: pam.ErrSystem,
+				msg:    fmt.Sprintf("Changing GDM stage failed: %v", err),
+			}
+		}
+		log.Debugf(context.TODO(), "Gdm stage change to %v sent", s)
+		return nil
+	}
+}

--- a/pam/internal/adapter/gdmmodel_convhandler_test.go
+++ b/pam/internal/adapter/gdmmodel_convhandler_test.go
@@ -1,0 +1,282 @@
+package adapter
+
+import (
+	"context"
+	"fmt"
+	"slices"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/msteinert/pam/v2"
+	"github.com/ubuntu/authd"
+	"github.com/ubuntu/authd/internal/log"
+	"github.com/ubuntu/authd/pam/internal/gdm"
+	"github.com/ubuntu/authd/pam/internal/proto"
+	pam_proto "github.com/ubuntu/authd/pam/internal/proto"
+)
+
+type gdmConvHandler struct {
+	mu *sync.Mutex
+	t  *testing.T
+
+	wantRequests        []gdm.RequestType
+	handledRequests     []gdm.RequestType
+	allRequestsReceived chan struct{}
+
+	receivedEvents    []*gdm.EventData
+	wantEvents        []gdm.EventType
+	allEventsReceived chan struct{}
+
+	pendingEvents        []*gdm.EventData
+	pendingEventsFlushed chan struct{}
+
+	supportedLayouts []*authd.UILayout
+	receivedBrokers  []*authd.ABResponse_BrokerInfo
+	selectedBrokerID string
+
+	currentStageChanged sync.Cond
+	currentStage        pam_proto.Stage
+	stageChanges        []pam_proto.Stage
+	lastNotifiedStage   *pam_proto.Stage
+
+	startAuthRequested chan struct{}
+	authEvents         []*authd.IAResponse
+}
+
+func (h *gdmConvHandler) checkAllEventsHaveBeenEmitted() bool {
+	receivedEventTypes := []gdm.EventType{}
+	for _, e := range h.receivedEvents {
+		receivedEventTypes = append(receivedEventTypes, e.Type)
+	}
+
+	return isSupersetOf(receivedEventTypes, h.wantEvents)
+}
+
+func (h *gdmConvHandler) checkAllRequestsHaveBeenHandled() bool {
+	return isSupersetOf(h.handledRequests, h.wantRequests)
+}
+
+func (h *gdmConvHandler) RespondPAM(style pam.Style, prompt string) (string, error) {
+	switch style {
+	case pam.TextInfo:
+		h.t.Logf("GDM PAM Info Message: %s", prompt)
+	case pam.ErrorMsg:
+		h.t.Logf("GDM PAM Error Message: %s", prompt)
+	default:
+		return "", fmt.Errorf("PAM style %d not implemented", style)
+	}
+	return "", nil
+}
+
+func (h *gdmConvHandler) RespondPAMBinary(ptr pam.BinaryPointer) (pam.BinaryPointer, error) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+
+	return gdm.DataConversationFunc(func(inData *gdm.Data) (*gdm.Data, error) {
+		outData, err := h.handleGdmData(inData)
+		if err != nil {
+			return nil, err
+		}
+		if inData.Type == gdm.DataType_poll && len(outData.PollResponse) == 0 {
+			return outData, err
+		}
+		json, err := inData.JSON()
+		if err != nil {
+			return nil, err
+		}
+		h.t.Log("->", string(json))
+		json, err = outData.JSON()
+		if err != nil {
+			return nil, err
+		}
+		h.t.Log("<-", string(json))
+		return outData, nil
+	}).RespondPAMBinary(ptr)
+}
+
+func (h *gdmConvHandler) handleGdmData(gdmData *gdm.Data) (*gdm.Data, error) {
+	log.Debugf(context.TODO(), "Handling authd protocol: %#v", gdmData)
+
+	switch gdmData.Type {
+	case gdm.DataType_hello:
+		return &gdm.Data{
+			Type:  gdm.DataType_hello,
+			Hello: &gdm.HelloData{Version: gdm.ProtoVersion},
+		}, nil
+
+	case gdm.DataType_request:
+		return h.handleAuthDRequest(gdmData)
+
+	case gdm.DataType_poll:
+		events := h.pendingEvents
+		h.pendingEvents = nil
+		if events != nil {
+			go func() {
+				// Ensure we mark the events as flushed only after we've returned.
+				time.Sleep(gdmPollFrequency * 2)
+				h.pendingEventsFlushed <- struct{}{}
+			}()
+		}
+		return &gdm.Data{
+			Type:         gdm.DataType_pollResponse,
+			PollResponse: events,
+		}, nil
+
+	case gdm.DataType_event:
+		if err := h.handleEvent(gdmData.Event); err != nil {
+			return nil, err
+		}
+		return &gdm.Data{
+			Type: gdm.DataType_eventAck,
+		}, nil
+	}
+
+	return nil, fmt.Errorf("unhandled protocol message %s",
+		gdmData.Type.String())
+}
+
+func (h *gdmConvHandler) handleAuthDRequest(gdmData *gdm.Data) (ret *gdm.Data, err error) {
+	defer func() {
+		h.handledRequests = append(h.handledRequests, gdmData.Request.Type)
+		if h.wantRequests == nil {
+			return
+		}
+		if !h.checkAllRequestsHaveBeenHandled() {
+			return
+		}
+
+		h.wantRequests = nil
+		go func() {
+			// Mark the events received after or while we're returning.
+			close(h.allRequestsReceived)
+		}()
+	}()
+
+	switch req := gdmData.Request.Data.(type) {
+	case *gdm.RequestData_UiLayoutCapabilities:
+		return &gdm.Data{
+			Type: gdm.DataType_response,
+			Response: &gdm.ResponseData{
+				Type: gdmData.Request.Type,
+				Data: &gdm.ResponseData_UiLayoutCapabilities{
+					UiLayoutCapabilities: &gdm.Responses_UiLayoutCapabilities{
+						SupportedUiLayouts: h.supportedLayouts,
+					},
+				},
+			},
+		}, nil
+
+	case *gdm.RequestData_ChangeStage:
+		h.t.Logf("Switching to stage %s", req.ChangeStage.Stage)
+		h.stageChanges = append(h.stageChanges, req.ChangeStage.Stage)
+
+		h.currentStage = req.ChangeStage.Stage
+		h.currentStageChanged.Broadcast()
+
+		return &gdm.Data{
+			Type: gdm.DataType_response,
+			Response: &gdm.ResponseData{
+				Type: gdmData.Request.Type,
+				Data: &gdm.ResponseData_Ack{},
+			},
+		}, nil
+
+	default:
+		return nil, fmt.Errorf("unknown request type")
+	}
+}
+
+func (h *gdmConvHandler) handleEvent(event *gdm.EventData) error {
+	defer func() {
+		h.receivedEvents = append(h.receivedEvents, event)
+
+		if h.wantEvents == nil {
+			return
+		}
+		if !h.checkAllEventsHaveBeenEmitted() {
+			return
+		}
+
+		h.wantEvents = nil
+		go func() {
+			// Mark the events received after or while we're returning.
+			close(h.allEventsReceived)
+		}()
+	}()
+
+	switch ev := event.Data.(type) {
+	case *gdm.EventData_BrokersReceived:
+		h.receivedBrokers = ev.BrokersReceived.BrokersInfos
+
+	case *gdm.EventData_BrokerSelected:
+		h.selectedBrokerID = ev.BrokerSelected.BrokerId
+
+	case *gdm.EventData_AuthModesReceived:
+		// TODO: Check the auth modes are matching.
+
+	case *gdm.EventData_UiLayoutReceived:
+		if !slices.ContainsFunc(h.supportedLayouts, func(layout *authd.UILayout) bool {
+			return layout.Type == ev.UiLayoutReceived.UiLayout.Type
+		}) {
+			return fmt.Errorf(`unknown layout type: "%s"`, ev.UiLayoutReceived.UiLayout.Type)
+		}
+
+	case *gdm.EventData_StartAuthentication:
+		go func() {
+			// Mark the events received after or while we're returning but not when locked.
+			h.startAuthRequested <- struct{}{}
+		}()
+
+	case *gdm.EventData_AuthEvent:
+		h.authEvents = append(h.authEvents, ev.AuthEvent.Response)
+	}
+
+	return nil
+}
+
+func (h *gdmConvHandler) waitForStageChange(stage proto.Stage) func() {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+
+	if h.currentStage == stage && (h.lastNotifiedStage == nil || *h.lastNotifiedStage != stage) {
+		h.lastNotifiedStage = &stage
+		return nil
+	}
+
+	return func() {
+		h.currentStageChanged.L.Lock()
+		defer h.currentStageChanged.L.Unlock()
+
+		for {
+			// We just got notified for a stage change but we should not notify all the waiting
+			// requests all together, each request to this function should be queued.
+			// So the goroutine that won the lock is the one that will be unblocked if the stage
+			// matches and if that's the first one noticing such change.
+			if h.currentStage == stage && (h.lastNotifiedStage == nil || *h.lastNotifiedStage != stage) {
+				h.lastNotifiedStage = &stage
+				return
+			}
+
+			h.currentStageChanged.Wait()
+		}
+	}
+}
+
+func (h *gdmConvHandler) waitForAuthenticationStarted() {
+	<-h.startAuthRequested
+}
+
+func (h *gdmConvHandler) consumeAuthenticationStartedEvents() {
+	select {
+	case <-h.startAuthRequested:
+	default:
+		return
+	}
+}
+
+func (h *gdmConvHandler) appendPollResultEvents(events ...*gdm.EventData) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	h.pendingEvents = append(h.pendingEvents, events...)
+}

--- a/pam/internal/adapter/gdmmodel_helpers_test.go
+++ b/pam/internal/adapter/gdmmodel_helpers_test.go
@@ -1,0 +1,24 @@
+package adapter
+
+import (
+	"golang.org/x/exp/constraints"
+)
+
+func isSupersetOf[T constraints.Integer](a []T, b []T) bool {
+	tracker := make(map[T]int)
+	for _, v := range a {
+		tracker[v]++
+	}
+
+	for _, value := range b {
+		n, found := tracker[value]
+		if !found {
+			return false
+		}
+		if n < 1 {
+			return false
+		}
+		tracker[value] = n - 1
+	}
+	return true
+}

--- a/pam/internal/adapter/gdmmodel_test.go
+++ b/pam/internal/adapter/gdmmodel_test.go
@@ -1670,6 +1670,33 @@ func TestGdmModel(t *testing.T) {
 				msg:    `Access "no way you get here!" is not valid`,
 			},
 		},
+		"Error on change stage using an unknown stage": {
+			gdmEvents: []*gdm.EventData{
+				gdm_test.ChangeStageEvent(gdmTestIgnoreStage),
+			},
+			wantGdmRequests: []gdm.RequestType{
+				gdm.RequestType_uiLayoutCapabilities,
+			},
+			wantNoGdmRequests: []gdm.RequestType{
+				gdm.RequestType_changeStage,
+			},
+			wantGdmEvents: []gdm.EventType{
+				gdm.EventType_brokersReceived,
+			},
+			wantNoGdmEvents: []gdm.EventType{
+				gdm.EventType_userSelected,
+				gdm.EventType_brokerSelected,
+				gdm.EventType_authModesReceived,
+				gdm.EventType_authModeSelected,
+				gdm.EventType_uiLayoutReceived,
+				gdm.EventType_authEvent,
+			},
+			wantStage: gdmTestIgnoreStage,
+			wantExitStatus: pamError{
+				status: pam.ErrSystem,
+				msg:    `unknown PAM stage: "-1"`,
+			},
+		},
 	}
 	for name, tc := range testCases {
 		tc := tc

--- a/pam/internal/adapter/gdmmodel_test.go
+++ b/pam/internal/adapter/gdmmodel_test.go
@@ -358,8 +358,7 @@ func TestGdmModel(t *testing.T) {
 			}},
 			wantExitStatus: PamSuccess{
 				BrokerID: firstBrokerInfo.Id,
-				// FIXME: Message is not sent in success case but it probably should!
-				// msg: "Hi GDM, it's a pleasure to get you in!",
+				msg:      "Hi GDM, it's a pleasure to get you in!",
 			},
 		},
 		"Authentication is ignored if not requested by model first": {

--- a/pam/internal/adapter/gdmmodel_test.go
+++ b/pam/internal/adapter/gdmmodel_test.go
@@ -1078,6 +1078,22 @@ func TestGdmModel(t *testing.T) {
 				msg:    "Sending GDM poll failed: Conversation error: poll response data member 0 invalid: missing event type",
 			},
 		},
+		"Error on no brokers": {
+			clientOptions: append(slices.Clone(singleBrokerClientOptions),
+				pam_test.WithAvailableBrokers(nil, nil),
+			),
+			wantGdmRequests: []gdm.RequestType{
+				gdm.RequestType_uiLayoutCapabilities,
+			},
+			wantNoGdmEvents: []gdm.EventType{
+				gdm.EventType_brokersReceived,
+				gdm.EventType_userSelected,
+			},
+			wantExitStatus: pamError{
+				status: pam.ErrAuthinfoUnavail,
+				msg:    "No brokers available",
+			},
+		},
 		"Error on invalid broker selection": {
 			clientOptions: append(slices.Clone(singleBrokerClientOptions),
 				pam_test.WithGetPreviousBrokerReturn(&firstBrokerInfo.Id, nil),

--- a/pam/internal/adapter/gdmmodel_test.go
+++ b/pam/internal/adapter/gdmmodel_test.go
@@ -1164,9 +1164,7 @@ func TestGdmModel(t *testing.T) {
 				}, nil),
 			),
 			messages: []tea.Msg{
-				tea.Sequence(tea.Tick(gdmPollFrequency, func(t time.Time) tea.Msg {
-					return userSelected{username: "daemon-selected-user-and-broker"}
-				}))(),
+				userSelected{username: "daemon-selected-user-and-broker"},
 			},
 			wantUsername:       "daemon-selected-user-and-broker",
 			wantSelectedBroker: firstBrokerInfo.Id,

--- a/pam/internal/adapter/gdmmodel_test.go
+++ b/pam/internal/adapter/gdmmodel_test.go
@@ -1,0 +1,1912 @@
+package adapter
+
+import (
+	"context"
+	"crypto/rand"
+	"crypto/rsa"
+	"encoding/base64"
+	"errors"
+	"fmt"
+	"os"
+	"slices"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/msteinert/pam/v2"
+	"github.com/stretchr/testify/require"
+	"github.com/ubuntu/authd"
+	"github.com/ubuntu/authd/internal/brokers"
+	"github.com/ubuntu/authd/pam/internal/gdm"
+	"github.com/ubuntu/authd/pam/internal/gdm_test"
+	"github.com/ubuntu/authd/pam/internal/pam_test"
+	"github.com/ubuntu/authd/pam/internal/proto"
+	pam_proto "github.com/ubuntu/authd/pam/internal/proto"
+)
+
+var gdmTestPrivateKey *rsa.PrivateKey
+var gdmTestSequentialMessages atomic.Int64
+
+const gdmTestIgnoredMessage string = "<ignored>"
+
+func TestGdmModel(t *testing.T) {
+	t.Parallel()
+
+	// This is not technically an error, as it means that during the tests
+	// we've stopped the program with a Quit request.
+	// However we do return a PAM error in such case because that's what we're
+	// going to return to the PAM stack in case authentication process has not
+	// been completed fully.
+	gdmTestEarlyStopExitStatus := pamError{
+		status: pam.ErrSystem,
+		msg:    "model did not return anything",
+	}
+
+	gdmTestIgnoreStage := pam_proto.Stage(-1)
+
+	firstBrokerInfo := &authd.ABResponse_BrokerInfo{
+		Id:        "testBroker",
+		Name:      "The best broker!",
+		BrandIcon: nil,
+	}
+	secondBrokerInfo := &authd.ABResponse_BrokerInfo{
+		Id:        "secondaryBroker",
+		Name:      "A broker that works too!",
+		BrandIcon: nil,
+	}
+
+	passwordUILayoutID := "Password"
+	singleBrokerClientOptions := []pam_test.DummyClientOptions{
+		// FIXME: Ideally we should use proper ID checks, but this can currently lead to
+		// races because the way our model is implemented and events can't be stopped and may
+		// arrive con delay.
+		pam_test.WithIgnoreSessionIDChecks(),
+		pam_test.WithAvailableBrokers([]*authd.ABResponse_BrokerInfo{
+			firstBrokerInfo,
+		}, nil),
+		pam_test.WithUILayout(passwordUILayoutID, "Password authentication", pam_test.FormUILayout()),
+	}
+	multiBrokerClientOptions := append(slices.Clone(singleBrokerClientOptions),
+		pam_test.WithAvailableBrokers([]*authd.ABResponse_BrokerInfo{
+			firstBrokerInfo, secondBrokerInfo,
+		}, nil),
+	)
+
+	testCases := map[string]struct {
+		client           authd.PAMClient
+		clientOptions    []pam_test.DummyClientOptions
+		supportedLayouts []*authd.UILayout
+		messages         []tea.Msg
+		commands         []tea.Cmd
+		gdmEvents        []*gdm.EventData
+		pamUser          string
+
+		wantExitStatus     PamReturnStatus
+		wantGdmRequests    []gdm.RequestType
+		wantGdmEvents      []gdm.EventType
+		wantGdmAuthRes     []*authd.IAResponse
+		wantNoGdmRequests  []gdm.RequestType
+		wantNoGdmEvents    []gdm.EventType
+		wantBrokers        []*authd.ABResponse_BrokerInfo
+		wantSelectedBroker string
+		wantStage          pam_proto.Stage
+		wantUsername       string
+		wantMessages       []tea.Msg
+	}{
+		"User selection stage": {
+			wantGdmRequests: []gdm.RequestType{gdm.RequestType_uiLayoutCapabilities},
+			wantStage:       pam_proto.Stage_userSelection,
+			wantGdmEvents: []gdm.EventType{
+				gdm.EventType_brokersReceived,
+			},
+			wantNoGdmRequests: []gdm.RequestType{
+				gdm.RequestType_changeStage, // -> broker Selection
+			},
+			wantNoGdmEvents: []gdm.EventType{
+				gdm.EventType_brokerSelected,
+				gdm.EventType_authModesReceived,
+				gdm.EventType_authModeSelected,
+				gdm.EventType_startAuthentication,
+				gdm.EventType_authEvent,
+			},
+			wantExitStatus: gdmTestEarlyStopExitStatus,
+		},
+		"Broker selection stage caused by server-side user selection": {
+			messages:     []tea.Msg{userSelected{username: "daemon-selected-user"}},
+			wantUsername: "daemon-selected-user",
+			wantGdmRequests: []gdm.RequestType{
+				gdm.RequestType_uiLayoutCapabilities,
+				gdm.RequestType_changeStage, // -> broker Selection
+			},
+			wantGdmEvents: []gdm.EventType{
+				gdm.EventType_userSelected,
+				gdm.EventType_brokersReceived,
+			},
+			wantNoGdmEvents: []gdm.EventType{
+				gdm.EventType_brokerSelected,
+				gdm.EventType_authModesReceived,
+				gdm.EventType_authModeSelected,
+				gdm.EventType_startAuthentication,
+				gdm.EventType_authEvent,
+			},
+			wantStage:      pam_proto.Stage_brokerSelection,
+			wantExitStatus: gdmTestEarlyStopExitStatus,
+		},
+		"Broker selection stage caused by server-side user selection after broker": {
+			messages: []tea.Msg{
+				gdmTestWaitForStage{
+					stage: pam_proto.Stage_userSelection,
+					commands: []tea.Cmd{
+						tea.Tick(50*time.Millisecond, func(t time.Time) tea.Msg {
+							return userSelected{username: "daemon-selected-user"}
+						}),
+						sendEvent(gdmTestWaitForStage{stage: pam_proto.Stage_brokerSelection}),
+					},
+				},
+			},
+			wantUsername: "daemon-selected-user",
+			wantGdmRequests: []gdm.RequestType{
+				gdm.RequestType_uiLayoutCapabilities,
+				gdm.RequestType_changeStage, // -> broker Selection
+			},
+			wantGdmEvents: []gdm.EventType{
+				gdm.EventType_userSelected,
+				gdm.EventType_brokersReceived,
+			},
+			wantNoGdmEvents: []gdm.EventType{
+				gdm.EventType_brokerSelected,
+				gdm.EventType_authModesReceived,
+				gdm.EventType_authModeSelected,
+				gdm.EventType_startAuthentication,
+				gdm.EventType_authEvent,
+			},
+			wantStage:      pam_proto.Stage_brokerSelection,
+			wantExitStatus: gdmTestEarlyStopExitStatus,
+		},
+		"Broker selection stage caused by client-side user selection": {
+			gdmEvents: []*gdm.EventData{
+				gdm_test.SelectUserEvent("gdm-selected-user"),
+			},
+			wantUsername: "gdm-selected-user",
+			wantGdmRequests: []gdm.RequestType{
+				gdm.RequestType_uiLayoutCapabilities,
+				gdm.RequestType_changeStage, // -> broker Selection
+			},
+			wantGdmEvents: []gdm.EventType{
+				gdm.EventType_userSelected,
+				gdm.EventType_brokersReceived,
+			},
+			wantNoGdmEvents: []gdm.EventType{
+				gdm.EventType_brokerSelected,
+				gdm.EventType_authModesReceived,
+				gdm.EventType_authModeSelected,
+				gdm.EventType_startAuthentication,
+				gdm.EventType_authEvent,
+			},
+			wantStage:      pam_proto.Stage_brokerSelection,
+			wantExitStatus: gdmTestEarlyStopExitStatus,
+		},
+		"Broker selection stage caused by module user selection": {
+			pamUser:      "gdm-pam-selected-user",
+			wantUsername: "gdm-pam-selected-user",
+			wantGdmRequests: []gdm.RequestType{
+				gdm.RequestType_uiLayoutCapabilities,
+				gdm.RequestType_changeStage, // -> broker Selection
+			},
+			wantGdmEvents: []gdm.EventType{
+				gdm.EventType_userSelected,
+				gdm.EventType_brokersReceived,
+			},
+			wantNoGdmEvents: []gdm.EventType{
+				gdm.EventType_authModesReceived,
+				gdm.EventType_authModeSelected,
+				gdm.EventType_startAuthentication,
+				gdm.EventType_authEvent,
+			},
+			wantStage:      pam_proto.Stage_brokerSelection,
+			wantExitStatus: gdmTestEarlyStopExitStatus,
+		},
+		"Challenge stage caused by server-side broker and authMode selection": {
+			clientOptions: append(slices.Clone(singleBrokerClientOptions),
+				pam_test.WithGetPreviousBrokerReturn(&firstBrokerInfo.Id, nil)),
+			messages: []tea.Msg{
+				tea.Sequence(tea.Tick(gdmPollFrequency, func(t time.Time) tea.Msg {
+					return userSelected{username: "daemon-selected-user-and-broker"}
+				}))(),
+				gdmTestWaitForStage{stage: pam_proto.Stage_challenge},
+			},
+			wantUsername:       "daemon-selected-user-and-broker",
+			wantSelectedBroker: firstBrokerInfo.Id,
+			wantGdmRequests: []gdm.RequestType{
+				gdm.RequestType_uiLayoutCapabilities,
+				gdm.RequestType_changeStage, // -> broker Selection
+				gdm.RequestType_changeStage, // -> authMode Selection
+				gdm.RequestType_changeStage, // -> challenge
+			},
+			wantGdmEvents: []gdm.EventType{
+				gdm.EventType_userSelected,
+				gdm.EventType_brokersReceived,
+				gdm.EventType_brokerSelected,
+				gdm.EventType_authModesReceived,
+				gdm.EventType_authModeSelected,
+				gdm.EventType_uiLayoutReceived,
+			},
+			wantNoGdmEvents: []gdm.EventType{
+				gdm.EventType_authEvent,
+			},
+			wantStage:      pam_proto.Stage_challenge,
+			wantExitStatus: gdmTestEarlyStopExitStatus,
+		},
+		"Challenge stage caused by client-side broker and authMode selection": {
+			gdmEvents: []*gdm.EventData{
+				gdm_test.SelectUserEvent("gdm-selected-user-and-broker"),
+			},
+			messages: []tea.Msg{
+				gdmTestWaitForStage{
+					stage: pam_proto.Stage_brokerSelection,
+					events: []*gdm.EventData{
+						gdm_test.SelectBrokerEvent(firstBrokerInfo.Id),
+					},
+				},
+				gdmTestWaitForStage{stage: pam_proto.Stage_challenge},
+			},
+			wantUsername:       "gdm-selected-user-and-broker",
+			wantSelectedBroker: firstBrokerInfo.Id,
+			wantGdmRequests: []gdm.RequestType{
+				gdm.RequestType_uiLayoutCapabilities,
+				gdm.RequestType_changeStage, // -> broker Selection
+				gdm.RequestType_changeStage, // -> authMode Selection
+				gdm.RequestType_changeStage, // -> challenge
+			},
+			wantGdmEvents: []gdm.EventType{
+				gdm.EventType_userSelected,
+				gdm.EventType_brokersReceived,
+				gdm.EventType_brokerSelected,
+				gdm.EventType_authModesReceived,
+				gdm.EventType_authModeSelected,
+				gdm.EventType_uiLayoutReceived,
+				gdm.EventType_startAuthentication,
+			},
+			wantNoGdmEvents: []gdm.EventType{
+				gdm.EventType_authEvent,
+			},
+			wantStage:      pam_proto.Stage_challenge,
+			wantExitStatus: gdmTestEarlyStopExitStatus,
+		},
+		"Authenticated after server-side user, broker and authMode selection": {
+			clientOptions: append(slices.Clone(singleBrokerClientOptions),
+				pam_test.WithGetPreviousBrokerReturn(&firstBrokerInfo.Id, nil),
+				pam_test.WithIsAuthenticatedWantChallenge("gdm-good-password")),
+			messages: []tea.Msg{
+				tea.Sequence(tea.Tick(gdmPollFrequency*2, func(t time.Time) tea.Msg {
+					return userSelected{username: "daemon-selected-user-and-broker"}
+				}))(),
+				gdmTestWaitForStage{
+					stage: pam_proto.Stage_challenge,
+					commands: []tea.Cmd{
+						sendEvent(gdmTestSendAuthDataWhenReady{&authd.IARequest_AuthenticationData_Challenge{
+							Challenge: "gdm-good-password",
+						}}),
+					},
+				},
+			},
+			wantUsername:       "daemon-selected-user-and-broker",
+			wantSelectedBroker: firstBrokerInfo.Id,
+			wantGdmRequests: []gdm.RequestType{
+				gdm.RequestType_uiLayoutCapabilities,
+				gdm.RequestType_changeStage, // -> broker Selection
+				gdm.RequestType_changeStage, // -> authMode Selection
+				gdm.RequestType_changeStage, // -> challenge
+			},
+			wantGdmEvents: []gdm.EventType{
+				gdm.EventType_userSelected,
+				gdm.EventType_brokersReceived,
+				gdm.EventType_brokerSelected,
+				gdm.EventType_authModeSelected,
+				gdm.EventType_uiLayoutReceived,
+				gdm.EventType_startAuthentication,
+				gdm.EventType_authEvent,
+			},
+			wantGdmAuthRes: []*authd.IAResponse{{Access: brokers.AuthGranted}},
+			wantStage:      pam_proto.Stage_challenge,
+			wantExitStatus: PamSuccess{BrokerID: firstBrokerInfo.Id},
+		},
+		"Authenticated with message after server-side user, broker and authMode selection": {
+			clientOptions: append(slices.Clone(multiBrokerClientOptions),
+				pam_test.WithGetPreviousBrokerReturn(&firstBrokerInfo.Id, nil),
+				pam_test.WithIsAuthenticatedReturn(&authd.IAResponse{
+					Access: brokers.AuthGranted,
+					Msg:    `{"message": "Hi GDM, it's a pleasure to get you in!"}`,
+				}, nil),
+			),
+			messages: []tea.Msg{
+				tea.Sequence(tea.Tick(gdmPollFrequency*2, func(t time.Time) tea.Msg {
+					return userSelected{username: "daemon-selected-user-and-broker"}
+				}))(),
+				gdmTestWaitForStage{
+					stage: pam_proto.Stage_challenge,
+					commands: []tea.Cmd{
+						sendEvent(gdmTestSendAuthDataWhenReady{&authd.IARequest_AuthenticationData_Challenge{
+							Challenge: "gdm-good-password",
+						}}),
+					},
+				},
+			},
+			wantUsername:       "daemon-selected-user-and-broker",
+			wantSelectedBroker: firstBrokerInfo.Id,
+			wantGdmRequests: []gdm.RequestType{
+				gdm.RequestType_uiLayoutCapabilities,
+				gdm.RequestType_changeStage, // -> broker Selection
+				gdm.RequestType_changeStage, // -> authMode Selection
+				gdm.RequestType_changeStage, // -> challenge
+			},
+			wantGdmEvents: []gdm.EventType{
+				gdm.EventType_userSelected,
+				gdm.EventType_brokersReceived,
+				gdm.EventType_brokerSelected,
+				gdm.EventType_authModeSelected,
+				gdm.EventType_uiLayoutReceived,
+				gdm.EventType_authEvent,
+				gdm.EventType_startAuthentication,
+			},
+			wantStage: pam_proto.Stage_challenge,
+			wantGdmAuthRes: []*authd.IAResponse{{
+				Access: brokers.AuthGranted,
+				Msg:    "Hi GDM, it's a pleasure to get you in!",
+			}},
+			wantExitStatus: PamSuccess{
+				BrokerID: firstBrokerInfo.Id,
+				// FIXME: Message is not sent in success case but it probably should!
+				// msg: "Hi GDM, it's a pleasure to get you in!",
+			},
+		},
+		"Authentication is ignored if not requested by model first": {
+			clientOptions: append(slices.Clone(singleBrokerClientOptions),
+				pam_test.WithIsAuthenticatedWantChallenge("gdm-good-password")),
+			gdmEvents: []*gdm.EventData{
+				gdm_test.IsAuthenticatedEvent(&authd.IARequest_AuthenticationData_Challenge{
+					Challenge: "gdm-good-password",
+				}),
+			},
+			wantGdmRequests: []gdm.RequestType{
+				gdm.RequestType_uiLayoutCapabilities,
+			},
+			wantNoGdmRequests: []gdm.RequestType{
+				gdm.RequestType_changeStage,
+			},
+			wantGdmEvents: []gdm.EventType{
+				gdm.EventType_brokersReceived,
+			},
+			wantNoGdmEvents: []gdm.EventType{
+				gdm.EventType_userSelected,
+				gdm.EventType_brokerSelected,
+				gdm.EventType_authModeSelected,
+				gdm.EventType_uiLayoutReceived,
+				gdm.EventType_startAuthentication,
+				gdm.EventType_authEvent,
+			},
+			wantStage:      pam_proto.Stage_userSelection,
+			wantExitStatus: gdmTestEarlyStopExitStatus,
+		},
+		"Cancelled after server-side user, broker and authMode selection": {
+			clientOptions: append(slices.Clone(multiBrokerClientOptions),
+				pam_test.WithGetPreviousBrokerReturn(&firstBrokerInfo.Id, nil),
+				pam_test.WithIsAuthenticatedReturn(&authd.IAResponse{
+					Access: brokers.AuthCancelled,
+				}, nil),
+			),
+			messages: []tea.Msg{
+				tea.Sequence(tea.Tick(gdmPollFrequency*2, func(t time.Time) tea.Msg {
+					return userSelected{username: "daemon-selected-user-and-broker"}
+				}))(),
+				gdmTestSendAuthDataWhenReady{&authd.IARequest_AuthenticationData_Challenge{
+					Challenge: "gdm-any-password",
+				}},
+			},
+			wantUsername:       "daemon-selected-user-and-broker",
+			wantSelectedBroker: firstBrokerInfo.Id,
+			wantGdmRequests: []gdm.RequestType{
+				gdm.RequestType_uiLayoutCapabilities,
+				gdm.RequestType_changeStage, // -> broker Selection
+				gdm.RequestType_changeStage, // -> authMode Selection
+				gdm.RequestType_changeStage, // -> challenge
+			},
+			wantGdmEvents: []gdm.EventType{
+				gdm.EventType_userSelected,
+				gdm.EventType_brokersReceived,
+				gdm.EventType_brokerSelected,
+				gdm.EventType_authModeSelected,
+				gdm.EventType_uiLayoutReceived,
+				gdm.EventType_startAuthentication,
+				gdm.EventType_authEvent,
+			},
+			wantStage:      pam_proto.Stage_challenge,
+			wantGdmAuthRes: []*authd.IAResponse{{Access: brokers.AuthCancelled}},
+			wantExitStatus: gdmTestEarlyStopExitStatus,
+		},
+		"Authenticated after server-side user, broker and authMode selection and after various retries": {
+			clientOptions: append(slices.Clone(singleBrokerClientOptions),
+				pam_test.WithGetPreviousBrokerReturn(&firstBrokerInfo.Id, nil),
+				pam_test.WithIsAuthenticatedWantChallenge("gdm-good-password"),
+				pam_test.WithIsAuthenticatedMaxRetries(1),
+			),
+			messages: []tea.Msg{
+				tea.Sequence(tea.Tick(gdmPollFrequency*2, func(t time.Time) tea.Msg {
+					return userSelected{username: "daemon-selected-user-and-broker"}
+				}))(),
+				gdmTestWaitForStage{
+					stage: pam_proto.Stage_challenge,
+					commands: []tea.Cmd{
+						sendEvent(gdmTestSendAuthDataWhenReady{&authd.IARequest_AuthenticationData_Challenge{
+							Challenge: "gdm-bad-password",
+						}}),
+						sendEvent(gdmTestSendAuthDataWhenReady{&authd.IARequest_AuthenticationData_Challenge{
+							Challenge: "gdm-good-password",
+						}}),
+					},
+				},
+			},
+			wantUsername:       "daemon-selected-user-and-broker",
+			wantSelectedBroker: firstBrokerInfo.Id,
+			wantGdmRequests: []gdm.RequestType{
+				gdm.RequestType_uiLayoutCapabilities,
+				gdm.RequestType_changeStage, // -> broker Selection
+				gdm.RequestType_changeStage, // -> authMode Selection
+				gdm.RequestType_changeStage, // -> challenge
+			},
+			wantGdmEvents: []gdm.EventType{
+				gdm.EventType_userSelected,
+				gdm.EventType_brokersReceived,
+				gdm.EventType_brokerSelected,
+				gdm.EventType_authModeSelected,
+				gdm.EventType_uiLayoutReceived,
+				gdm.EventType_startAuthentication,
+				gdm.EventType_authEvent, // retry
+				gdm.EventType_startAuthentication,
+				gdm.EventType_authEvent, // denied
+			},
+			wantMessages: []tea.Msg{
+				startAuthentication{},
+				startAuthentication{},
+			},
+			wantGdmAuthRes: []*authd.IAResponse{
+				{Access: brokers.AuthRetry},
+				{Access: brokers.AuthGranted},
+			},
+			wantStage:      pam_proto.Stage_challenge,
+			wantExitStatus: PamSuccess{BrokerID: firstBrokerInfo.Id},
+		},
+		"Authenticated after client-side user, broker and authMode selection": {
+			clientOptions: append(slices.Clone(multiBrokerClientOptions),
+				pam_test.WithIsAuthenticatedWantChallenge("gdm-good-password"),
+			),
+			gdmEvents: []*gdm.EventData{
+				gdm_test.SelectUserEvent("gdm-selected-user-broker-and-auth-mode"),
+			},
+			messages: []tea.Msg{
+				gdmTestWaitForStage{
+					stage: pam_proto.Stage_brokerSelection,
+					events: []*gdm.EventData{
+						gdm_test.SelectBrokerEvent(secondBrokerInfo.Id),
+					},
+					commands: []tea.Cmd{
+						sendEvent(gdmTestSendAuthDataWhenReady{&authd.IARequest_AuthenticationData_Challenge{
+							Challenge: "gdm-good-password",
+						}}),
+					},
+				},
+			},
+			wantUsername:       "gdm-selected-user-broker-and-auth-mode",
+			wantSelectedBroker: secondBrokerInfo.Id,
+			wantGdmRequests: []gdm.RequestType{
+				gdm.RequestType_uiLayoutCapabilities,
+				gdm.RequestType_changeStage, // -> broker Selection
+				gdm.RequestType_changeStage, // -> authMode Selection
+				gdm.RequestType_changeStage, // -> challenge
+			},
+			wantGdmEvents: []gdm.EventType{
+				gdm.EventType_userSelected,
+				gdm.EventType_brokersReceived,
+				gdm.EventType_brokerSelected,
+				gdm.EventType_authModeSelected,
+				gdm.EventType_uiLayoutReceived,
+				gdm.EventType_startAuthentication,
+				gdm.EventType_authEvent,
+			},
+			wantStage:      pam_proto.Stage_challenge,
+			wantGdmAuthRes: []*authd.IAResponse{{Access: brokers.AuthGranted}},
+			wantExitStatus: PamSuccess{BrokerID: secondBrokerInfo.Id},
+		},
+		"Authenticated after client-side user, broker and authMode selection and after various retries": {
+			clientOptions: append(slices.Clone(singleBrokerClientOptions),
+				pam_test.WithIsAuthenticatedWantChallenge("gdm-good-password"),
+				pam_test.WithIsAuthenticatedMaxRetries(1),
+			),
+			gdmEvents: []*gdm.EventData{
+				gdm_test.SelectUserEvent("gdm-selected-user-broker-and-auth-mode"),
+			},
+			messages: []tea.Msg{
+				gdmTestWaitForStage{
+					stage: pam_proto.Stage_brokerSelection,
+					events: []*gdm.EventData{
+						gdm_test.SelectBrokerEvent(firstBrokerInfo.Id),
+					},
+				},
+				gdmTestWaitForStage{
+					stage: pam_proto.Stage_challenge,
+					commands: []tea.Cmd{
+						sendEvent(gdmTestSendAuthDataWhenReady{&authd.IARequest_AuthenticationData_Challenge{
+							Challenge: "gdm-bad-password",
+						}}),
+						sendEvent(gdmTestSendAuthDataWhenReady{&authd.IARequest_AuthenticationData_Challenge{
+							Challenge: "gdm-good-password",
+						}}),
+					},
+				},
+			},
+			wantUsername:       "gdm-selected-user-broker-and-auth-mode",
+			wantSelectedBroker: firstBrokerInfo.Id,
+			wantGdmRequests: []gdm.RequestType{
+				gdm.RequestType_uiLayoutCapabilities,
+				gdm.RequestType_changeStage, // -> broker Selection
+				gdm.RequestType_changeStage, // -> authMode Selection
+				gdm.RequestType_changeStage, // -> challenge
+			},
+			wantGdmEvents: []gdm.EventType{
+				gdm.EventType_userSelected,
+				gdm.EventType_brokersReceived,
+				gdm.EventType_brokerSelected,
+				gdm.EventType_authModeSelected,
+				gdm.EventType_uiLayoutReceived,
+				gdm.EventType_startAuthentication,
+				gdm.EventType_authEvent,
+				gdm.EventType_startAuthentication,
+				gdm.EventType_authEvent,
+			},
+			wantMessages: []tea.Msg{
+				startAuthentication{},
+				startAuthentication{},
+			},
+			wantGdmAuthRes: []*authd.IAResponse{
+				{Access: brokers.AuthRetry},
+				{Access: brokers.AuthGranted},
+			},
+			wantStage:      pam_proto.Stage_challenge,
+			wantExitStatus: PamSuccess{BrokerID: firstBrokerInfo.Id},
+		},
+		"Cancelled auth after client-side user, broker and authMode selection": {
+			clientOptions: append(slices.Clone(singleBrokerClientOptions),
+				pam_test.WithIsAuthenticatedReturn(&authd.IAResponse{
+					Access: brokers.AuthCancelled,
+				}, nil),
+			),
+			gdmEvents: []*gdm.EventData{
+				gdm_test.SelectUserEvent("gdm-selected-user-broker-and-auth-mode"),
+			},
+			messages: []tea.Msg{
+				gdmTestWaitForStage{
+					stage: pam_proto.Stage_brokerSelection,
+					events: []*gdm.EventData{
+						gdm_test.SelectBrokerEvent(firstBrokerInfo.Id),
+					},
+				},
+				gdmTestSendAuthDataWhenReady{&authd.IARequest_AuthenticationData_Challenge{
+					Challenge: "gdm-some-password",
+				}},
+			},
+			wantUsername:       "gdm-selected-user-broker-and-auth-mode",
+			wantSelectedBroker: firstBrokerInfo.Id,
+			wantGdmRequests: []gdm.RequestType{
+				gdm.RequestType_uiLayoutCapabilities,
+				gdm.RequestType_changeStage, // -> broker Selection
+				gdm.RequestType_changeStage, // -> authMode Selection
+				gdm.RequestType_changeStage, // -> challenge
+			},
+			wantGdmEvents: []gdm.EventType{
+				gdm.EventType_userSelected,
+				gdm.EventType_brokersReceived,
+				gdm.EventType_brokerSelected,
+				gdm.EventType_authModeSelected,
+				gdm.EventType_uiLayoutReceived,
+				gdm.EventType_startAuthentication,
+				gdm.EventType_authEvent,
+			},
+			wantMessages: []tea.Msg{
+				startAuthentication{},
+			},
+			wantGdmAuthRes: []*authd.IAResponse{{Access: brokers.AuthCancelled}},
+			wantStage:      pam_proto.Stage_challenge,
+			wantExitStatus: gdmTestEarlyStopExitStatus,
+		},
+		"AuthMode selection stage from client after server-side broker and auth mode selection if there is only one auth mode": {
+			clientOptions: append(slices.Clone(singleBrokerClientOptions),
+				pam_test.WithGetPreviousBrokerReturn(&firstBrokerInfo.Id, nil),
+			),
+			messages: []tea.Msg{
+				tea.Sequence(tea.Tick(gdmPollFrequency, func(t time.Time) tea.Msg {
+					return userSelected{username: "daemon-selected-user-and-broker"}
+				}))(),
+				gdmTestWaitForStage{
+					stage: pam_proto.Stage_challenge,
+					events: []*gdm.EventData{
+						gdm_test.ChangeStageEvent(pam_proto.Stage_authModeSelection),
+					},
+					commands: []tea.Cmd{
+						sendEvent(gdmTestWaitForStage{stage: pam_proto.Stage_authModeSelection}),
+					},
+				},
+			},
+			wantUsername:       "daemon-selected-user-and-broker",
+			wantSelectedBroker: firstBrokerInfo.Id,
+			wantGdmRequests: []gdm.RequestType{
+				gdm.RequestType_uiLayoutCapabilities,
+				gdm.RequestType_changeStage, // -> broker Selection
+				gdm.RequestType_changeStage, // -> authMode Selection
+				gdm.RequestType_changeStage, // -> challenge
+				gdm.RequestType_changeStage, // -> authMode Selection
+			},
+			wantMessages: []tea.Msg{
+				startAuthentication{},
+			},
+			wantGdmEvents: []gdm.EventType{
+				gdm.EventType_userSelected,
+				gdm.EventType_brokersReceived,
+				gdm.EventType_brokerSelected,
+				gdm.EventType_authModeSelected,
+				gdm.EventType_authEvent,
+			},
+			wantNoGdmEvents: []gdm.EventType{
+				gdm.EventType_authEvent,
+			},
+			wantGdmAuthRes: []*authd.IAResponse{{Access: brokers.AuthCancelled}},
+			wantStage:      pam_proto.Stage_authModeSelection,
+			wantExitStatus: gdmTestEarlyStopExitStatus,
+		},
+		"AuthMode selection stage from client after server-side broker and auth mode selection with multiple auth modes": {
+			clientOptions: append(slices.Clone(singleBrokerClientOptions),
+				pam_test.WithGetPreviousBrokerReturn(&firstBrokerInfo.Id, nil),
+				pam_test.WithUILayout("pincode", "Pin Code", pam_test.FormUILayout()),
+			),
+			messages: []tea.Msg{
+				userSelected{username: "daemon-selected-user-and-broker"},
+				gdmTestWaitForStage{
+					stage: pam_proto.Stage_challenge,
+					events: []*gdm.EventData{
+						gdm_test.ChangeStageEvent(pam_proto.Stage_authModeSelection),
+					},
+					commands: []tea.Cmd{
+						sendEvent(gdmTestWaitForStage{stage: pam_proto.Stage_authModeSelection}),
+					},
+				},
+			},
+			wantUsername:       "daemon-selected-user-and-broker",
+			wantSelectedBroker: firstBrokerInfo.Id,
+			wantGdmRequests: []gdm.RequestType{
+				gdm.RequestType_uiLayoutCapabilities,
+				gdm.RequestType_changeStage, // -> broker Selection
+				gdm.RequestType_changeStage, // -> authMode Selection
+				gdm.RequestType_changeStage, // -> challenge
+				gdm.RequestType_changeStage, // -> authMode Selection
+			},
+			wantGdmEvents: []gdm.EventType{
+				gdm.EventType_userSelected,
+				gdm.EventType_brokersReceived,
+				gdm.EventType_brokerSelected,
+				gdm.EventType_authModesReceived,
+				gdm.EventType_authModeSelected,
+				gdm.EventType_uiLayoutReceived,
+				gdm.EventType_startAuthentication,
+				gdm.EventType_authEvent,
+			},
+			wantGdmAuthRes: []*authd.IAResponse{{Access: brokers.AuthCancelled}},
+			wantStage:      pam_proto.Stage_authModeSelection,
+			wantExitStatus: gdmTestEarlyStopExitStatus,
+		},
+		"AuthMode selection stage from client after client-side broker and auth mode selection if there is only one auth mode": {
+			gdmEvents: []*gdm.EventData{
+				gdm_test.SelectUserEvent("gdm-selected-user-broker-and-auth-mode"),
+			},
+			messages: []tea.Msg{
+				gdmTestWaitForStage{
+					stage: pam_proto.Stage_brokerSelection,
+					events: []*gdm.EventData{
+						gdm_test.SelectBrokerEvent(firstBrokerInfo.Id),
+					},
+				},
+				gdmTestWaitForStage{
+					stage: pam_proto.Stage_challenge,
+					events: []*gdm.EventData{
+						gdm_test.ChangeStageEvent(pam_proto.Stage_authModeSelection),
+					},
+					commands: []tea.Cmd{
+						sendEvent(gdmTestWaitForStage{stage: pam_proto.Stage_authModeSelection}),
+					},
+				},
+			},
+			wantUsername:       "gdm-selected-user-broker-and-auth-mode",
+			wantSelectedBroker: firstBrokerInfo.Id,
+			wantGdmRequests: []gdm.RequestType{
+				gdm.RequestType_uiLayoutCapabilities,
+				gdm.RequestType_changeStage, // -> broker Selection
+				gdm.RequestType_changeStage, // -> authMode Selection
+				gdm.RequestType_changeStage, // -> challenge
+				gdm.RequestType_changeStage, // -> authMode Selection
+			},
+			wantMessages: []tea.Msg{
+				startAuthentication{},
+			},
+			wantGdmEvents: []gdm.EventType{
+				gdm.EventType_userSelected,
+				gdm.EventType_brokersReceived,
+				gdm.EventType_brokerSelected,
+				gdm.EventType_authModeSelected,
+			},
+			wantNoGdmEvents: []gdm.EventType{
+				gdm.EventType_startAuthentication,
+				gdm.EventType_authEvent,
+			},
+			wantGdmAuthRes: []*authd.IAResponse{{Access: brokers.AuthCancelled}},
+			wantStage:      pam_proto.Stage_authModeSelection,
+			wantExitStatus: gdmTestEarlyStopExitStatus,
+		},
+		"Authenticated after auth selection stage from client after client-side broker and auth mode selection if there is only one auth mode": {
+			clientOptions: append(slices.Clone(singleBrokerClientOptions),
+				pam_test.WithIsAuthenticatedWantChallenge("gdm-good-password"),
+			),
+			gdmEvents: []*gdm.EventData{
+				gdm_test.SelectUserEvent("gdm-selected-user-broker-and-auth-mode"),
+			},
+			messages: []tea.Msg{
+				gdmTestWaitForStage{
+					stage: pam_proto.Stage_brokerSelection,
+					events: []*gdm.EventData{
+						gdm_test.SelectBrokerEvent(firstBrokerInfo.Id),
+					},
+				},
+				gdmTestWaitForStage{
+					stage: pam_proto.Stage_challenge,
+					events: []*gdm.EventData{
+						gdm_test.ChangeStageEvent(pam_proto.Stage_authModeSelection),
+					},
+					commands: []tea.Cmd{
+						sendEvent(gdmTestWaitForStage{
+							stage: pam_proto.Stage_authModeSelection,
+							events: []*gdm.EventData{
+								gdm_test.AuthModeSelectedEvent(passwordUILayoutID),
+							},
+							commands: []tea.Cmd{
+								sendEvent(gdmTestSendAuthDataWhenReady{&authd.IARequest_AuthenticationData_Challenge{
+									Challenge: "gdm-good-password",
+								}}),
+							},
+						}),
+					},
+				},
+			},
+			wantUsername:       "gdm-selected-user-broker-and-auth-mode",
+			wantSelectedBroker: firstBrokerInfo.Id,
+			wantGdmRequests: []gdm.RequestType{
+				gdm.RequestType_uiLayoutCapabilities,
+				gdm.RequestType_changeStage, // -> broker Selection
+				gdm.RequestType_changeStage, // -> authMode Selection
+				gdm.RequestType_changeStage, // -> challenge
+				gdm.RequestType_changeStage, // -> authMode Selection
+				gdm.RequestType_changeStage, // -> challenge
+			},
+			wantMessages: []tea.Msg{
+				startAuthentication{},
+				startAuthentication{},
+			},
+			wantGdmEvents: []gdm.EventType{
+				gdm.EventType_userSelected,
+				gdm.EventType_brokersReceived,
+				gdm.EventType_brokerSelected,
+				gdm.EventType_authModeSelected,
+				gdm.EventType_uiLayoutReceived,
+				gdm.EventType_startAuthentication,
+				gdm.EventType_authModeSelected,
+				gdm.EventType_uiLayoutReceived,
+				gdm.EventType_startAuthentication,
+				gdm.EventType_authEvent,
+			},
+			wantStage: pam_proto.Stage_challenge,
+			wantGdmAuthRes: []*authd.IAResponse{
+				{Access: brokers.AuthCancelled},
+				{Access: brokers.AuthGranted},
+			},
+			wantExitStatus: PamSuccess{BrokerID: firstBrokerInfo.Id},
+		},
+		"Authenticated after auth selection stage from client after client-side broker and auth mode selection with multiple auth modes": {
+			clientOptions: append(slices.Clone(singleBrokerClientOptions),
+				pam_test.WithUILayout("pincode", "Write the pin Code", pam_test.FormUILayout()),
+				pam_test.WithIsAuthenticatedWantChallenge("1234"),
+			),
+			gdmEvents: []*gdm.EventData{
+				gdm_test.SelectUserEvent("gdm-selected-user-broker-and-auth-mode"),
+			},
+			messages: []tea.Msg{
+				gdmTestWaitForStage{
+					stage: pam_proto.Stage_brokerSelection,
+					events: []*gdm.EventData{
+						gdm_test.SelectBrokerEvent(firstBrokerInfo.Id),
+					},
+				},
+				gdmTestWaitForStage{
+					stage: pam_proto.Stage_challenge,
+					events: []*gdm.EventData{
+						gdm_test.ChangeStageEvent(pam_proto.Stage_authModeSelection),
+					},
+					commands: []tea.Cmd{
+						sendEvent(gdmTestWaitForStage{
+							stage: pam_proto.Stage_authModeSelection,
+							events: []*gdm.EventData{
+								gdm_test.AuthModeSelectedEvent("pincode"),
+							},
+							commands: []tea.Cmd{
+								sendEvent(gdmTestSendAuthDataWhenReady{&authd.IARequest_AuthenticationData_Challenge{
+									Challenge: "1234",
+								}}),
+							},
+						}),
+					},
+				},
+			},
+			wantUsername:       "gdm-selected-user-broker-and-auth-mode",
+			wantSelectedBroker: firstBrokerInfo.Id,
+			wantGdmRequests: []gdm.RequestType{
+				gdm.RequestType_uiLayoutCapabilities,
+				gdm.RequestType_changeStage, // -> broker Selection
+				gdm.RequestType_changeStage, // -> authMode Selection
+				gdm.RequestType_changeStage, // -> challenge
+				gdm.RequestType_changeStage, // -> authMode Selection
+				gdm.RequestType_changeStage, // -> challenge
+			},
+			wantMessages: []tea.Msg{
+				startAuthentication{},
+				startAuthentication{},
+			},
+			wantGdmEvents: []gdm.EventType{
+				gdm.EventType_userSelected,
+				gdm.EventType_brokersReceived,
+				gdm.EventType_brokerSelected,
+				gdm.EventType_authModeSelected,
+				gdm.EventType_uiLayoutReceived,
+				gdm.EventType_startAuthentication,
+				gdm.EventType_authModeSelected,
+				gdm.EventType_uiLayoutReceived,
+				gdm.EventType_startAuthentication,
+				gdm.EventType_authEvent,
+			},
+			wantStage: pam_proto.Stage_challenge,
+			wantGdmAuthRes: []*authd.IAResponse{
+				{Access: brokers.AuthCancelled},
+				{Access: brokers.AuthGranted},
+			},
+			wantExitStatus: PamSuccess{BrokerID: firstBrokerInfo.Id},
+		},
+		"Broker selection stage from client after client-side broker and auth mode selection if there is only one auth mode": {
+			gdmEvents: []*gdm.EventData{
+				gdm_test.SelectUserEvent("gdm-selected-user-broker-and-auth-mode"),
+			},
+			messages: []tea.Msg{
+				gdmTestWaitForStage{
+					stage: pam_proto.Stage_brokerSelection,
+					events: []*gdm.EventData{
+						gdm_test.SelectBrokerEvent(firstBrokerInfo.Id),
+					},
+				},
+				gdmTestWaitForStage{
+					stage: pam_proto.Stage_challenge,
+					events: []*gdm.EventData{
+						gdm_test.ChangeStageEvent(pam_proto.Stage_authModeSelection),
+					},
+					commands: []tea.Cmd{
+						sendEvent(gdmTestWaitForStage{
+							stage: pam_proto.Stage_authModeSelection,
+							events: []*gdm.EventData{
+								gdm_test.ChangeStageEvent(pam_proto.Stage_brokerSelection),
+							},
+						}),
+					},
+				},
+			},
+			wantUsername:       "gdm-selected-user-broker-and-auth-mode",
+			wantSelectedBroker: firstBrokerInfo.Id,
+			wantGdmRequests: []gdm.RequestType{
+				gdm.RequestType_uiLayoutCapabilities,
+				gdm.RequestType_changeStage, // -> broker Selection
+				gdm.RequestType_changeStage, // -> authMode Selection
+				gdm.RequestType_changeStage, // -> challenge
+				gdm.RequestType_changeStage, // -> authMode Selection
+				gdm.RequestType_changeStage, // -> broker Selection
+			},
+			wantMessages: []tea.Msg{
+				startAuthentication{},
+			},
+			wantGdmEvents: []gdm.EventType{
+				gdm.EventType_userSelected,
+				gdm.EventType_brokersReceived,
+				gdm.EventType_brokerSelected,
+				gdm.EventType_authModeSelected,
+			},
+			wantNoGdmEvents: []gdm.EventType{
+				gdm.EventType_authEvent,
+			},
+			wantGdmAuthRes: []*authd.IAResponse{{Access: brokers.AuthCancelled}},
+			wantStage:      pam_proto.Stage_brokerSelection,
+			wantExitStatus: gdmTestEarlyStopExitStatus,
+		},
+		"User selection stage from client after client-side broker and auth mode selection if there is only one auth mode": {
+			gdmEvents: []*gdm.EventData{
+				gdm_test.SelectUserEvent("gdm-selected-user-broker-and-auth-mode"),
+			},
+			messages: []tea.Msg{
+				gdmTestWaitForStage{
+					stage: pam_proto.Stage_brokerSelection,
+					events: []*gdm.EventData{
+						gdm_test.SelectBrokerEvent(firstBrokerInfo.Id),
+					},
+				},
+				gdmTestWaitForStage{
+					stage: pam_proto.Stage_challenge,
+					events: []*gdm.EventData{
+						gdm_test.ChangeStageEvent(pam_proto.Stage_authModeSelection),
+					},
+					commands: []tea.Cmd{
+						sendEvent(gdmTestWaitForStage{
+							stage: pam_proto.Stage_authModeSelection,
+							events: []*gdm.EventData{
+								gdm_test.ChangeStageEvent(pam_proto.Stage_brokerSelection),
+							},
+							commands: []tea.Cmd{
+								sendEvent(gdmTestWaitForStage{
+									stage: pam_proto.Stage_brokerSelection,
+									events: []*gdm.EventData{
+										gdm_test.ChangeStageEvent(pam_proto.Stage_userSelection),
+									},
+									commands: []tea.Cmd{
+										sendEvent(gdmTestWaitForStage{stage: pam_proto.Stage_userSelection}),
+									},
+								}),
+							},
+						}),
+					},
+				},
+			},
+			wantUsername:       "gdm-selected-user-broker-and-auth-mode",
+			wantSelectedBroker: firstBrokerInfo.Id,
+			wantGdmRequests: []gdm.RequestType{
+				gdm.RequestType_uiLayoutCapabilities,
+				gdm.RequestType_changeStage, // -> broker Selection
+				gdm.RequestType_changeStage, // -> authMode Selection
+				gdm.RequestType_changeStage, // -> challenge
+				gdm.RequestType_changeStage, // -> authMode Selection
+				gdm.RequestType_changeStage, // -> broker Selection
+				gdm.RequestType_changeStage, // -> user Selection
+			},
+			wantMessages: []tea.Msg{
+				startAuthentication{},
+			},
+			wantGdmEvents: []gdm.EventType{
+				gdm.EventType_userSelected,
+				gdm.EventType_brokersReceived,
+				gdm.EventType_brokerSelected,
+				gdm.EventType_authModeSelected,
+			},
+			wantNoGdmEvents: []gdm.EventType{
+				gdm.EventType_authEvent,
+			},
+			wantGdmAuthRes: []*authd.IAResponse{{Access: brokers.AuthCancelled}},
+			wantStage:      pam_proto.Stage_userSelection,
+			wantExitStatus: gdmTestEarlyStopExitStatus,
+		},
+
+		// Error cases
+		"Error on no UI layouts": {
+			clientOptions: append(slices.Clone(singleBrokerClientOptions),
+				pam_test.WithUILayout(passwordUILayoutID, "", &authd.UILayout{}),
+			),
+			supportedLayouts: []*authd.UILayout{},
+			wantGdmRequests:  []gdm.RequestType{gdm.RequestType_uiLayoutCapabilities},
+			wantGdmEvents:    []gdm.EventType{gdm.EventType_brokersReceived},
+			wantNoGdmEvents: []gdm.EventType{
+				gdm.EventType_userSelected,
+			},
+			wantExitStatus: pamError{
+				status: pam.ErrCredUnavail,
+				msg:    "UI does not support any layouts",
+			},
+		},
+		"Error on brokers fetching error": {
+			clientOptions: append(slices.Clone(singleBrokerClientOptions),
+				pam_test.WithAvailableBrokers(nil, errors.New("brokers loading failed")),
+			),
+			wantGdmRequests: []gdm.RequestType{
+				gdm.RequestType_uiLayoutCapabilities,
+			},
+			wantNoGdmEvents: []gdm.EventType{
+				gdm.EventType_brokersReceived,
+				gdm.EventType_userSelected,
+			},
+			wantExitStatus: pamError{
+				status: pam.ErrSystem,
+				msg:    "could not get current available brokers: brokers loading failed",
+			},
+		},
+		"Error on forced quit": {
+			messages:       []tea.Msg{tea.Quit()},
+			wantExitStatus: gdmTestEarlyStopExitStatus,
+			wantNoGdmEvents: []gdm.EventType{
+				gdm.EventType_userSelected,
+			},
+		},
+		"Error on invalid poll data response for missing type": {
+			wantGdmRequests: []gdm.RequestType{
+				gdm.RequestType_uiLayoutCapabilities,
+			},
+			gdmEvents: []*gdm.EventData{
+				{
+					Type: gdm.EventType_userSelected,
+				},
+			},
+			wantGdmEvents: []gdm.EventType{
+				gdm.EventType_brokersReceived,
+			},
+			wantNoGdmEvents: []gdm.EventType{
+				gdm.EventType_userSelected,
+			},
+			wantExitStatus: pamError{
+				status: pam.ErrSystem,
+				msg:    "Sending GDM poll failed: Conversation error: poll response data member 0 invalid: missing event data",
+			},
+		},
+		"Error on invalid poll data response for missing data": {
+			wantGdmRequests: []gdm.RequestType{
+				gdm.RequestType_uiLayoutCapabilities,
+			},
+			gdmEvents: []*gdm.EventData{{}},
+			wantGdmEvents: []gdm.EventType{
+				gdm.EventType_brokersReceived,
+			},
+			wantNoGdmEvents: []gdm.EventType{
+				gdm.EventType_userSelected,
+			},
+			wantExitStatus: pamError{
+				status: pam.ErrSystem,
+				msg:    "Sending GDM poll failed: Conversation error: poll response data member 0 invalid: missing event type",
+			},
+		},
+		"Error on invalid broker selection": {
+			clientOptions: append(slices.Clone(singleBrokerClientOptions),
+				pam_test.WithGetPreviousBrokerReturn(&firstBrokerInfo.Id, nil),
+				pam_test.WithSelectBrokerReturn(nil, errors.New("error during broker selection")),
+			),
+			messages: []tea.Msg{
+				userSelected{username: "daemon-selected-user-and-broker"},
+				gdmTestWaitForStage{stage: proto.Stage_brokerSelection},
+			},
+			wantUsername:       "daemon-selected-user-and-broker",
+			wantSelectedBroker: firstBrokerInfo.Id,
+			wantGdmRequests: []gdm.RequestType{
+				gdm.RequestType_uiLayoutCapabilities,
+				gdm.RequestType_changeStage, // -> broker Selection
+			},
+			wantGdmEvents: []gdm.EventType{
+				gdm.EventType_userSelected,
+				gdm.EventType_brokersReceived,
+			},
+			wantStage: pam_proto.Stage_brokerSelection,
+			wantExitStatus: pamError{
+				status: pam.ErrSystem,
+				msg:    "can't select broker: error during broker selection",
+			},
+		},
+		"Error during broker selection if session ID is empty": {
+			clientOptions: append(slices.Clone(singleBrokerClientOptions),
+				pam_test.WithIgnoreSessionIDGeneration(),
+				pam_test.WithGetPreviousBrokerReturn(&firstBrokerInfo.Id, nil),
+				pam_test.WithSelectBrokerReturn(&authd.SBResponse{}, nil),
+			),
+			messages: []tea.Msg{
+				userSelected{username: "daemon-selected-user-and-broker"},
+			},
+			wantUsername:       "daemon-selected-user-and-broker",
+			wantSelectedBroker: firstBrokerInfo.Id,
+			wantGdmRequests: []gdm.RequestType{
+				gdm.RequestType_uiLayoutCapabilities,
+				gdm.RequestType_changeStage, // -> broker Selection
+			},
+			wantGdmEvents: []gdm.EventType{
+				gdm.EventType_userSelected,
+				gdm.EventType_brokersReceived,
+				gdm.EventType_brokerSelected,
+			},
+			wantStage: pam_proto.Stage_brokerSelection,
+			wantExitStatus: pamError{
+				status: pam.ErrSystem,
+				msg:    "no session ID returned by broker",
+			},
+		},
+		"Error during broker selection if encryption key is empty": {
+			client: pam_test.NewDummyClient(nil, append(slices.Clone(singleBrokerClientOptions),
+				pam_test.WithGetPreviousBrokerReturn(&firstBrokerInfo.Id, nil),
+				pam_test.WithSelectBrokerReturn(&authd.SBResponse{SessionId: "session-id"}, nil),
+			)...),
+			messages: []tea.Msg{
+				userSelected{username: "daemon-selected-user-and-broker"},
+				gdmTestWaitForStage{stage: pam_proto.Stage_brokerSelection},
+			},
+			wantUsername:       "daemon-selected-user-and-broker",
+			wantSelectedBroker: firstBrokerInfo.Id,
+			wantGdmRequests: []gdm.RequestType{
+				gdm.RequestType_uiLayoutCapabilities,
+				gdm.RequestType_changeStage, // -> broker Selection
+			},
+			wantGdmEvents: []gdm.EventType{
+				gdm.EventType_userSelected,
+				gdm.EventType_brokersReceived,
+				gdm.EventType_brokerSelected,
+			},
+			wantStage: pam_proto.Stage_brokerSelection,
+			wantExitStatus: pamError{
+				status: pam.ErrSystem,
+				msg:    "no encryption key returned by broker",
+			},
+		},
+		"Error during broker selection if encryption key is not valid base64": {
+			clientOptions: append(slices.Clone(singleBrokerClientOptions),
+				pam_test.WithGetPreviousBrokerReturn(&firstBrokerInfo.Id, nil),
+				pam_test.WithSelectBrokerReturn(&authd.SBResponse{
+					SessionId:     "session-id",
+					EncryptionKey: "no encryption key returned by broker",
+				}, nil),
+			),
+			messages: []tea.Msg{
+				tea.Sequence(tea.Tick(gdmPollFrequency, func(t time.Time) tea.Msg {
+					return userSelected{username: "daemon-selected-user-and-broker"}
+				}))(),
+			},
+			wantUsername:       "daemon-selected-user-and-broker",
+			wantSelectedBroker: firstBrokerInfo.Id,
+			wantGdmRequests: []gdm.RequestType{
+				gdm.RequestType_uiLayoutCapabilities,
+				gdm.RequestType_changeStage, // -> broker Selection
+			},
+			wantGdmEvents: []gdm.EventType{
+				gdm.EventType_userSelected,
+				gdm.EventType_brokersReceived,
+			},
+			wantStage: pam_proto.Stage_brokerSelection,
+			wantExitStatus: pamError{
+				status: pam.ErrSystem,
+				msg:    "encryption key sent by broker is not a valid base64 encoded string: illegal base64 data at input byte 2",
+			},
+		},
+		"Error during broker selection if encryption key is not valid key": {
+			clientOptions: append(slices.Clone(singleBrokerClientOptions),
+				pam_test.WithGetPreviousBrokerReturn(&firstBrokerInfo.Id, nil),
+				pam_test.WithSelectBrokerReturn(&authd.SBResponse{
+					SessionId: "session-id",
+					EncryptionKey: base64.StdEncoding.EncodeToString(
+						[]byte("not a valid encryption key!")),
+				}, nil),
+			),
+			messages: []tea.Msg{
+				userSelected{username: "daemon-selected-user-and-broker"},
+				gdmTestWaitForStage{stage: proto.Stage_brokerSelection},
+			},
+			wantUsername:       "daemon-selected-user-and-broker",
+			wantSelectedBroker: firstBrokerInfo.Id,
+			wantGdmRequests: []gdm.RequestType{
+				gdm.RequestType_uiLayoutCapabilities,
+				gdm.RequestType_changeStage, // -> broker Selection
+			},
+			wantGdmEvents: []gdm.EventType{
+				gdm.EventType_userSelected,
+				gdm.EventType_brokersReceived,
+			},
+			wantStage: pam_proto.Stage_brokerSelection,
+			wantExitStatus: pamError{
+				status: pam.ErrSystem,
+				msg:    gdmTestIgnoredMessage,
+			},
+		},
+		"Error during broker auth mode selection if UI is not valid": {
+			clientOptions: append(slices.Clone(singleBrokerClientOptions),
+				pam_test.WithUILayout(passwordUILayoutID, "", nil),
+			),
+			messages: []tea.Msg{
+				userSelected{username: "daemon-selected-user-for-client-selected-broker"},
+				gdmTestWaitForStage{
+					stage: pam_proto.Stage_brokerSelection,
+					events: []*gdm.EventData{
+						gdm_test.SelectBrokerEvent(firstBrokerInfo.Id),
+					},
+				},
+				gdmTestWaitForStage{stage: proto.Stage_authModeSelection},
+			},
+			wantUsername:       "daemon-selected-user-for-client-selected-broker",
+			wantSelectedBroker: firstBrokerInfo.Id,
+			wantGdmRequests: []gdm.RequestType{
+				gdm.RequestType_uiLayoutCapabilities,
+				gdm.RequestType_changeStage, // -> broker Selection
+				gdm.RequestType_changeStage, // -> authMode Selection
+			},
+			wantGdmEvents: []gdm.EventType{
+				gdm.EventType_userSelected,
+				gdm.EventType_brokersReceived,
+				gdm.EventType_brokerSelected,
+			},
+			wantStage: gdmTestIgnoreStage,
+			wantExitStatus: pamError{
+				status: pam.ErrSystem,
+				msg:    "invalid empty UI Layout information from broker",
+			},
+		},
+		"Error on missing authentication modes": {
+			clientOptions: append(slices.Clone(singleBrokerClientOptions),
+				pam_test.WithGetAuthenticationModesReturn([]*authd.GAMResponse_AuthenticationMode{}, nil),
+			),
+			messages: []tea.Msg{
+				userSelected{username: "daemon-selected-user-for-client-selected-broker"},
+				gdmTestWaitForStage{
+					stage: pam_proto.Stage_brokerSelection,
+					events: []*gdm.EventData{
+						gdm_test.SelectBrokerEvent(firstBrokerInfo.Id),
+					},
+				},
+				gdmTestWaitForStage{stage: proto.Stage_authModeSelection},
+			},
+			wantUsername:       "daemon-selected-user-for-client-selected-broker",
+			wantSelectedBroker: firstBrokerInfo.Id,
+			wantGdmRequests: []gdm.RequestType{
+				gdm.RequestType_uiLayoutCapabilities,
+				gdm.RequestType_changeStage, // -> broker Selection
+				gdm.RequestType_changeStage, // -> authMode Selection
+			},
+			wantGdmEvents: []gdm.EventType{
+				gdm.EventType_userSelected,
+				gdm.EventType_brokersReceived,
+				gdm.EventType_brokerSelected,
+			},
+			wantStage: gdmTestIgnoreStage,
+			wantExitStatus: pamError{
+				status: pam.ErrCredUnavail,
+				msg:    "no supported authentication mode available for this provider",
+			},
+		},
+		"Error on authentication mode selection": {
+			clientOptions: append(slices.Clone(singleBrokerClientOptions),
+				pam_test.WithSelectAuthenticationModeReturn(nil, errors.New("error selecting auth mode")),
+			),
+			messages: []tea.Msg{
+				userSelected{username: "daemon-selected-user-for-client-selected-broker"},
+				gdmTestWaitForStage{
+					stage: pam_proto.Stage_brokerSelection,
+					events: []*gdm.EventData{
+						gdm_test.SelectBrokerEvent(firstBrokerInfo.Id),
+					},
+				},
+				gdmTestWaitForStage{stage: proto.Stage_authModeSelection},
+			},
+			wantUsername:       "daemon-selected-user-for-client-selected-broker",
+			wantSelectedBroker: firstBrokerInfo.Id,
+			wantGdmRequests: []gdm.RequestType{
+				gdm.RequestType_uiLayoutCapabilities,
+				gdm.RequestType_changeStage, // -> broker Selection
+				gdm.RequestType_changeStage, // -> authMode Selection
+			},
+			wantGdmEvents: []gdm.EventType{
+				gdm.EventType_userSelected,
+				gdm.EventType_brokersReceived,
+			},
+			wantStage: gdmTestIgnoreStage,
+			wantExitStatus: pamError{
+				status: pam.ErrSystem,
+				msg:    "can't select authentication mode: error selecting auth mode",
+			},
+		},
+		"Error on invalid auth-mode layout type": {
+			clientOptions: append(slices.Clone(singleBrokerClientOptions),
+				pam_test.WithSelectAuthenticationModeReturn(&authd.UILayout{
+					Type: "invalid layout",
+				}, nil),
+			),
+			messages: []tea.Msg{
+				userSelected{username: "daemon-selected-user-with-client-selected-broker"},
+				gdmTestWaitForStage{
+					stage: pam_proto.Stage_brokerSelection,
+					events: []*gdm.EventData{
+						gdm_test.SelectBrokerEvent(firstBrokerInfo.Id),
+					},
+				},
+				gdmTestWaitForStage{stage: proto.Stage_challenge},
+			},
+			wantUsername:       "daemon-selected-user-with-client-selected-broker",
+			wantSelectedBroker: firstBrokerInfo.Id,
+			wantGdmRequests: []gdm.RequestType{
+				gdm.RequestType_uiLayoutCapabilities,
+				gdm.RequestType_changeStage, // -> broker Selection
+				gdm.RequestType_changeStage, // -> authMode Selection
+				gdm.RequestType_changeStage, // -> challenge
+			},
+			wantGdmEvents: []gdm.EventType{
+				gdm.EventType_userSelected,
+				gdm.EventType_brokersReceived,
+				gdm.EventType_brokerSelected,
+				gdm.EventType_authModesReceived,
+				gdm.EventType_authModeSelected,
+				gdm.EventType_uiLayoutReceived,
+			},
+			wantStage: gdmTestIgnoreStage,
+			wantExitStatus: pamError{
+				status: pam.ErrSystem,
+				msg:    `Sending GDM event failed: Conversation error: unknown layout type: "invalid layout"`,
+			},
+		},
+		"Error on authentication client failure": {
+			clientOptions: append(slices.Clone(singleBrokerClientOptions),
+				pam_test.WithIsAuthenticatedReturn(nil, errors.New("some authentication error")),
+			),
+			messages: []tea.Msg{
+				userSelected{username: "daemon-selected-user-for-client-selected-broker"},
+				gdmTestWaitForStage{
+					stage: pam_proto.Stage_brokerSelection,
+					events: []*gdm.EventData{
+						gdm_test.SelectBrokerEvent(firstBrokerInfo.Id),
+					},
+				},
+				gdmTestSendAuthDataWhenReady{&authd.IARequest_AuthenticationData_Challenge{
+					Challenge: "gdm-password",
+				}},
+			},
+			wantUsername:       "daemon-selected-user-for-client-selected-broker",
+			wantSelectedBroker: firstBrokerInfo.Id,
+			wantGdmRequests: []gdm.RequestType{
+				gdm.RequestType_uiLayoutCapabilities,
+				gdm.RequestType_changeStage, // -> broker Selection
+				gdm.RequestType_changeStage, // -> authMode Selection
+				gdm.RequestType_changeStage, // -> challenge
+			},
+			wantGdmEvents: []gdm.EventType{
+				gdm.EventType_userSelected,
+				gdm.EventType_brokersReceived,
+				gdm.EventType_brokerSelected,
+				gdm.EventType_authModesReceived,
+				gdm.EventType_authModeSelected,
+				gdm.EventType_uiLayoutReceived,
+			},
+			wantStage: pam_proto.Stage_challenge,
+			wantExitStatus: pamError{
+				status: pam.ErrSystem,
+				msg:    "authentication status failure: some authentication error",
+			},
+		},
+		"Error on authentication client invalid message": {
+			clientOptions: append(slices.Clone(singleBrokerClientOptions),
+				pam_test.WithGetPreviousBrokerReturn(&firstBrokerInfo.Id, nil),
+				pam_test.WithIsAuthenticatedReturn(&authd.IAResponse{
+					Access: brokers.AuthDenied,
+					Msg:    "invalid JSON",
+				}, nil),
+			),
+			messages: []tea.Msg{
+				userSelected{username: "daemon-selected-user-and-broker"},
+				gdmTestSendAuthDataWhenReady{&authd.IARequest_AuthenticationData_Challenge{
+					Challenge: "gdm-good-password",
+				}},
+			},
+			wantUsername:       "daemon-selected-user-and-broker",
+			wantSelectedBroker: firstBrokerInfo.Id,
+			wantGdmRequests: []gdm.RequestType{
+				gdm.RequestType_uiLayoutCapabilities,
+				gdm.RequestType_changeStage, // -> broker Selection
+				gdm.RequestType_changeStage, // -> authMode Selection
+				gdm.RequestType_changeStage, // -> challenge
+			},
+			wantGdmEvents: []gdm.EventType{
+				gdm.EventType_userSelected,
+				gdm.EventType_brokersReceived,
+				gdm.EventType_brokerSelected,
+				gdm.EventType_authModesReceived,
+				gdm.EventType_authModeSelected,
+				gdm.EventType_uiLayoutReceived,
+			},
+			wantStage: gdmTestIgnoreStage,
+			wantExitStatus: pamError{
+				status: pam.ErrSystem,
+				msg:    "invalid json data from provider: invalid character 'i' looking for beginning of value",
+			},
+		},
+		"Error on authentication client denied because of wrong password, with error message": {
+			clientOptions: append(slices.Clone(singleBrokerClientOptions),
+				pam_test.WithIsAuthenticatedWantChallenge("gdm-good-password"),
+				pam_test.WithIsAuthenticatedMessage("you're not allowed!"),
+			),
+			messages: []tea.Msg{
+				userSelected{username: "daemon-selected-user-for-client-selected-brokers-with-wrong-pass"},
+				gdmTestWaitForStage{
+					stage: pam_proto.Stage_brokerSelection,
+					events: []*gdm.EventData{
+						gdm_test.SelectBrokerEvent(firstBrokerInfo.Id),
+					},
+				},
+				gdmTestWaitForStage{
+					stage: pam_proto.Stage_authModeSelection,
+					commands: []tea.Cmd{
+						sendEvent(gdmTestSendAuthDataWhenReady{&authd.IARequest_AuthenticationData_Challenge{
+							Challenge: "gdm-wrong-password",
+						}}),
+					},
+				},
+			},
+			wantUsername:       "daemon-selected-user-for-client-selected-brokers-with-wrong-pass",
+			wantSelectedBroker: firstBrokerInfo.Id,
+			wantGdmRequests: []gdm.RequestType{
+				gdm.RequestType_uiLayoutCapabilities,
+				gdm.RequestType_changeStage, // -> broker Selection
+				gdm.RequestType_changeStage, // -> authMode Selection
+				gdm.RequestType_changeStage, // -> challenge
+			},
+			wantGdmEvents: []gdm.EventType{
+				gdm.EventType_userSelected,
+				gdm.EventType_brokersReceived,
+				gdm.EventType_brokerSelected,
+				gdm.EventType_authModesReceived,
+				gdm.EventType_authModeSelected,
+				gdm.EventType_uiLayoutReceived,
+				gdm.EventType_authEvent,
+			},
+			wantStage: gdmTestIgnoreStage,
+			wantGdmAuthRes: []*authd.IAResponse{{
+				Access: brokers.AuthDenied,
+				Msg:    "you're not allowed!",
+			}},
+			wantExitStatus: pamError{
+				status: pam.ErrAuth,
+				msg:    "you're not allowed!",
+			},
+		},
+		"Error on authentication client denied because of wrong password": {
+			clientOptions: append(slices.Clone(singleBrokerClientOptions),
+				pam_test.WithIsAuthenticatedWantChallenge("gdm-good-password"),
+			),
+			messages: []tea.Msg{
+				userSelected{username: "daemon-selected-user-and-client-selected-broker-with-wrong-pass"},
+				gdmTestWaitForStage{
+					stage: pam_proto.Stage_brokerSelection,
+					events: []*gdm.EventData{
+						gdm_test.SelectBrokerEvent(firstBrokerInfo.Id),
+					},
+				},
+				gdmTestWaitForStage{
+					stage: pam_proto.Stage_challenge,
+					commands: []tea.Cmd{
+						sendEvent(gdmTestSendAuthDataWhenReady{&authd.IARequest_AuthenticationData_Challenge{
+							Challenge: "gdm-wrong-password",
+						}}),
+					},
+				},
+			},
+			wantUsername:       "daemon-selected-user-and-client-selected-broker-with-wrong-pass",
+			wantSelectedBroker: firstBrokerInfo.Id,
+			wantGdmRequests: []gdm.RequestType{
+				gdm.RequestType_uiLayoutCapabilities,
+				gdm.RequestType_changeStage, // -> broker Selection
+				gdm.RequestType_changeStage, // -> authMode Selection
+				gdm.RequestType_changeStage, // -> challenge
+			},
+			wantGdmEvents: []gdm.EventType{
+				gdm.EventType_userSelected,
+				gdm.EventType_brokersReceived,
+				gdm.EventType_brokerSelected,
+				gdm.EventType_authModesReceived,
+				gdm.EventType_authModeSelected,
+				gdm.EventType_uiLayoutReceived,
+				gdm.EventType_authEvent,
+			},
+			wantStage:      gdmTestIgnoreStage,
+			wantGdmAuthRes: []*authd.IAResponse{{Access: brokers.AuthDenied}},
+			wantExitStatus: pamError{
+				status: pam.ErrAuth,
+				msg:    "Access denied",
+			},
+		},
+		"Error on authentication client denied because of wrong password after retry": {
+			clientOptions: append(slices.Clone(singleBrokerClientOptions),
+				pam_test.WithGetPreviousBrokerReturn(&firstBrokerInfo.Id, nil),
+				pam_test.WithIsAuthenticatedWantChallenge("gdm-good-password"),
+				pam_test.WithIsAuthenticatedMaxRetries(1),
+			),
+			messages: []tea.Msg{
+				tea.Sequence(tea.Tick(gdmPollFrequency*2, func(t time.Time) tea.Msg {
+					return userSelected{username: "daemon-selected-user-and-broker-with-wrong-pass"}
+				}))(),
+				gdmTestWaitForStage{
+					stage: pam_proto.Stage_challenge,
+					commands: []tea.Cmd{
+						sendEvent(gdmTestSendAuthDataWhenReady{&authd.IARequest_AuthenticationData_Challenge{
+							Challenge: "gdm-wrong-password",
+						}}),
+						sendEvent(gdmTestSendAuthDataWhenReady{&authd.IARequest_AuthenticationData_Challenge{
+							Challenge: "gdm-another-wrong-password",
+						}}),
+					},
+				},
+			},
+			wantUsername:       "daemon-selected-user-and-broker-with-wrong-pass",
+			wantSelectedBroker: firstBrokerInfo.Id,
+			wantGdmRequests: []gdm.RequestType{
+				gdm.RequestType_uiLayoutCapabilities,
+				gdm.RequestType_changeStage, // -> broker Selection
+				gdm.RequestType_changeStage, // -> authMode Selection
+				gdm.RequestType_changeStage, // -> challenge
+			},
+			wantGdmEvents: []gdm.EventType{
+				gdm.EventType_userSelected,
+				gdm.EventType_brokersReceived,
+				gdm.EventType_brokerSelected,
+				gdm.EventType_authModesReceived,
+				gdm.EventType_authModeSelected,
+				gdm.EventType_uiLayoutReceived,
+				gdm.EventType_authEvent, // retry
+				gdm.EventType_authEvent, // denied
+			},
+			wantStage: gdmTestIgnoreStage,
+			wantGdmAuthRes: []*authd.IAResponse{
+				{Access: brokers.AuthRetry},
+				{Access: brokers.AuthDenied},
+			},
+			wantExitStatus: pamError{
+				status: pam.ErrAuth,
+				msg:    "Access denied",
+			},
+		},
+		"Error on authentication client because of empty auth data access": {
+			clientOptions: append(slices.Clone(singleBrokerClientOptions),
+				pam_test.WithGetPreviousBrokerReturn(&firstBrokerInfo.Id, nil),
+				pam_test.WithIsAuthenticatedReturn(&authd.IAResponse{}, nil),
+			),
+			messages: []tea.Msg{
+				tea.Sequence(tea.Tick(gdmPollFrequency*2, func(t time.Time) tea.Msg {
+					return userSelected{username: "daemon-selected-user-and-broker-with-wrong-pass"}
+				}))(),
+				gdmTestWaitForStage{
+					stage: pam_proto.Stage_challenge,
+					commands: []tea.Cmd{
+						sendEvent(gdmTestSendAuthDataWhenReady{&authd.IARequest_AuthenticationData_Challenge{
+							Challenge: "gdm-some-password",
+						}}),
+					},
+				},
+			},
+			wantUsername:       "daemon-selected-user-and-broker-with-wrong-pass",
+			wantSelectedBroker: firstBrokerInfo.Id,
+			wantGdmRequests: []gdm.RequestType{
+				gdm.RequestType_uiLayoutCapabilities,
+				gdm.RequestType_changeStage, // -> broker Selection
+				gdm.RequestType_changeStage, // -> authMode Selection
+				gdm.RequestType_changeStage, // -> challenge
+			},
+			wantGdmEvents: []gdm.EventType{
+				gdm.EventType_userSelected,
+				gdm.EventType_brokersReceived,
+				gdm.EventType_brokerSelected,
+				gdm.EventType_authModesReceived,
+				gdm.EventType_authModeSelected,
+				gdm.EventType_uiLayoutReceived,
+				gdm.EventType_authEvent, // denied
+			},
+			wantStage: gdmTestIgnoreStage,
+			wantGdmAuthRes: []*authd.IAResponse{{
+				Access: brokers.AuthDenied,
+				Msg:    `Access "" is not valid`,
+			}},
+			wantExitStatus: pamError{
+				status: pam.ErrAuth,
+				msg:    `Access "" is not valid`,
+			},
+		},
+		"Error on authentication client because of invalid auth data access with message": {
+			clientOptions: append(slices.Clone(singleBrokerClientOptions),
+				pam_test.WithGetPreviousBrokerReturn(&firstBrokerInfo.Id, nil),
+				pam_test.WithIsAuthenticatedReturn(&authd.IAResponse{
+					Access: "no way you get here!",
+					Msg:    `{"message": "This is not a valid access"}`,
+				}, nil),
+			),
+			messages: []tea.Msg{
+				tea.Sequence(tea.Tick(gdmPollFrequency*2, func(t time.Time) tea.Msg {
+					return userSelected{username: "daemon-selected-user-and-broker-with-wrong-pass"}
+				}))(),
+				gdmTestWaitForStage{
+					stage: pam_proto.Stage_challenge,
+					commands: []tea.Cmd{
+						sendEvent(gdmTestSendAuthDataWhenReady{&authd.IARequest_AuthenticationData_Challenge{
+							Challenge: "gdm-some-password",
+						}}),
+					},
+				},
+			},
+			wantUsername:       "daemon-selected-user-and-broker-with-wrong-pass",
+			wantSelectedBroker: firstBrokerInfo.Id,
+			wantGdmRequests: []gdm.RequestType{
+				gdm.RequestType_uiLayoutCapabilities,
+				gdm.RequestType_changeStage, // -> broker Selection
+				gdm.RequestType_changeStage, // -> authMode Selection
+				gdm.RequestType_changeStage, // -> challenge
+			},
+			wantGdmEvents: []gdm.EventType{
+				gdm.EventType_userSelected,
+				gdm.EventType_brokersReceived,
+				gdm.EventType_brokerSelected,
+				gdm.EventType_authModesReceived,
+				gdm.EventType_authModeSelected,
+				gdm.EventType_uiLayoutReceived,
+				gdm.EventType_authEvent, // denied
+			},
+			wantStage: gdmTestIgnoreStage,
+			wantGdmAuthRes: []*authd.IAResponse{{
+				Access: brokers.AuthDenied,
+				Msg:    `Access "no way you get here!" is not valid`,
+			}},
+			wantExitStatus: pamError{
+				status: pam.ErrAuth,
+				msg:    `Access "no way you get here!" is not valid`,
+			},
+		},
+	}
+	for name, tc := range testCases {
+		tc := tc
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			if tc.clientOptions == nil {
+				tc.clientOptions = singleBrokerClientOptions
+			}
+			if tc.client == nil {
+				tc.client = pam_test.NewDummyClient(gdmTestPrivateKey, tc.clientOptions...)
+			}
+
+			messagesToSend := tc.messages
+			messagesToWait := append(tc.messages, tc.wantMessages...)
+
+			if tc.wantExitStatus != gdmTestEarlyStopExitStatus {
+				messagesToWait = append(messagesToWait, tc.wantExitStatus)
+			}
+
+			gdmMutex := sync.Mutex{}
+			gdmHandler := &gdmConvHandler{
+				t:                    t,
+				mu:                   &gdmMutex,
+				currentStageChanged:  *sync.NewCond(&gdmMutex),
+				pendingEventsFlushed: make(chan struct{}),
+				allRequestsReceived:  make(chan struct{}),
+				allEventsReceived:    make(chan struct{}),
+				startAuthRequested:   make(chan struct{}),
+				supportedLayouts:     tc.supportedLayouts,
+				pendingEvents:        tc.gdmEvents,
+				wantEvents:           tc.wantGdmEvents,
+				wantRequests:         tc.wantGdmRequests,
+			}
+			uiModel := UIModel{
+				PamMTx:     pam_test.NewModuleTransactionDummy(gdmHandler),
+				ClientType: Gdm,
+				Client:     tc.client,
+			}
+			appState := gdmTestUIModel{
+				UIModel:             uiModel,
+				gdmHandler:          gdmHandler,
+				wantMessages:        slices.Clone(messagesToWait),
+				wantMessagesHandled: make(chan struct{}),
+			}
+
+			if tc.supportedLayouts == nil {
+				gdmHandler.supportedLayouts = []*authd.UILayout{pam_test.FormUILayout()}
+			}
+
+			if tc.pamUser != "" {
+				require.NoError(t, uiModel.PamMTx.SetItem(pam.User, tc.pamUser))
+			}
+
+			devNull, err := os.OpenFile(os.DevNull, os.O_WRONLY|os.O_APPEND, 0600)
+			require.NoError(t, err)
+			teaOpts := []tea.ProgramOption{
+				tea.WithInput(nil),
+				tea.WithoutRenderer(),
+				tea.WithoutSignals(),
+				tea.WithoutSignalHandler(),
+				tea.WithFilter(appState.filterFunc),
+				tea.WithoutCatchPanics(),
+				// Explicitly set the output to something so that the program
+				// won't try to init some terminal fancy things that also appear
+				// to be racy...
+				// See: https://github.com/charmbracelet/bubbletea/issues/910
+				tea.WithOutput(devNull),
+			}
+			p := tea.NewProgram(&appState, teaOpts...)
+			appState.program = p
+
+			// testHadTimeout := false
+			controlDone := make(chan struct{})
+			go func() {
+				wg := sync.WaitGroup{}
+				if len(messagesToWait) > 0 {
+					for _, m := range messagesToSend {
+						t.Logf("Sent message %#v\n", m)
+						p.Send(m)
+					}
+					wg.Add(1)
+					go func() {
+						t.Log("Waiting for wantMessagesHandled", messagesToWait)
+						<-appState.wantMessagesHandled
+						t.Log("DONE waiting for wantMessagesHandled")
+						wg.Done()
+					}()
+				}
+				if len(tc.gdmEvents) > 0 {
+					wg.Add(1)
+					go func() {
+						t.Log("Waiting for pendingEventsFlushed")
+						<-gdmHandler.pendingEventsFlushed
+						t.Log("DONE waiting for pendingEventsFlushed")
+						wg.Done()
+					}()
+				}
+				if len(tc.wantGdmRequests) > 0 {
+					wg.Add(1)
+					go func() {
+						t.Log("Waiting for allRequestsReceived")
+						<-gdmHandler.allRequestsReceived
+						wg.Done()
+						t.Log("DONE waiting for allRequestsReceived")
+					}()
+				}
+				if len(tc.wantGdmEvents) > 0 {
+					wg.Add(1)
+					go func() {
+						t.Log("Waiting for allEventsReceived")
+						<-gdmHandler.allEventsReceived
+						wg.Done()
+						t.Log("DONE waiting for allEventsReceived")
+					}()
+				}
+
+				t.Log("Waiting for expected events")
+				waitChan := make(chan struct{})
+				go func() {
+					wg.Wait()
+					close(waitChan)
+				}()
+				select {
+				case <-time.After(5 * time.Second):
+				case <-waitChan:
+				}
+				t.Log("Waiting for events done...")
+
+				// Ensure we've nothing to send back...
+				select {
+				case <-time.After(gdmPollFrequency * 2):
+					// All good, it seems there's nothing coming.
+				case <-gdmHandler.pendingEventsFlushed:
+				}
+				t.Log("Waiting for flushing events done...")
+
+				defer close(controlDone)
+				t.Log("Time to quit!")
+				appState.programShouldQuit.Store(true)
+				p.Send(tea.Quit())
+			}()
+			_, err = p.Run()
+			require.NoError(t, err)
+
+			logStatus := func() {
+				appState.mu.Lock()
+				defer appState.mu.Unlock()
+				gdmHandler.mu.Lock()
+				defer gdmHandler.mu.Unlock()
+
+				receivedEventTypes := []gdm.EventType{}
+				for _, e := range gdmHandler.receivedEvents {
+					receivedEventTypes = append(receivedEventTypes, e.Type)
+				}
+
+				t.Log("----------------")
+				t.Logf("Remaining msgs: %#v\n", appState.wantMessages)
+				t.Log("----------------")
+				t.Logf("Received events: %#v\n", receivedEventTypes)
+				t.Logf("Wanted events: %#v\n", tc.wantGdmEvents)
+				t.Log("----------------")
+				t.Logf("Handled requests: %#v\n", gdmHandler.handledRequests)
+				t.Logf("Wanted requests: %#v\n", tc.wantGdmRequests)
+				t.Log("----------------")
+			}
+
+			select {
+			case <-time.After(5 * time.Second):
+				logStatus()
+				t.Fatalf("timeout waiting for test expected results")
+			case <-controlDone:
+			}
+
+			gdmHandler.mu.Lock()
+			defer gdmHandler.mu.Unlock()
+
+			appState.mu.Lock()
+			defer appState.mu.Unlock()
+
+			if tc.wantExitStatus.Message() == gdmTestIgnoredMessage {
+				switch wantRet := tc.wantExitStatus.(type) {
+				case PamReturnError:
+					exitErr, ok := appState.ExitStatus().(PamReturnError)
+					require.True(t, ok, "exit status should be an error")
+					require.Equal(t, wantRet.Status(), exitErr.Status())
+				case PamSuccess:
+					_, ok := appState.ExitStatus().(PamSuccess)
+					require.True(t, ok, "exit status should be a success")
+				default:
+					t.Fatalf("Unexpected exit status: %v", wantRet)
+				}
+			} else {
+				require.Equal(t, tc.wantExitStatus, appState.ExitStatus())
+			}
+
+			for _, req := range tc.wantNoGdmRequests {
+				require.NotContains(t, gdmHandler.handledRequests, req)
+			}
+
+			if tc.wantStage != gdmTestIgnoreStage {
+				require.Equal(t, tc.wantStage, gdmHandler.currentStage,
+					"GDM Stage does not match with expected one")
+			}
+
+			for _, req := range tc.wantGdmRequests {
+				// We don't do full equal check since we only care about having received
+				// the ones explicitly listed.
+				require.Contains(t, gdmHandler.handledRequests, req)
+			}
+
+			receivedEventTypes := []gdm.EventType{}
+			for _, e := range gdmHandler.receivedEvents {
+				receivedEventTypes = append(receivedEventTypes, e.Type)
+			}
+			require.True(t, isSupersetOf(receivedEventTypes, tc.wantGdmEvents),
+				"Required events have not been received: %#v vs %#v", tc.wantGdmEvents, receivedEventTypes)
+
+			require.Empty(t, appState.wantMessages, "Wanted messages have not all been processed")
+
+			username, err := appState.PamMTx.GetItem(pam.User)
+			require.NoError(t, err)
+			require.Equal(t, tc.wantUsername, username)
+			gdm_test.RequireEqualData(t, tc.wantGdmAuthRes, gdmHandler.authEvents)
+
+			if _, ok := tc.wantExitStatus.(PamReturnError); ok && tc.wantExitStatus != gdmTestEarlyStopExitStatus {
+				// If the model exited with error and that matches, we don't
+				// care much comparing all the expectations, since the final exit status
+				// is matching what we expect.
+				return
+			}
+
+			if tc.wantBrokers == nil {
+				availableBrokers, err := appState.Client.AvailableBrokers(context.TODO(), nil)
+				require.NoError(t, err)
+				tc.wantBrokers = availableBrokers.GetBrokersInfos()
+			}
+
+			require.Equal(t, tc.wantBrokers, gdmHandler.receivedBrokers)
+			require.Equal(t, tc.wantSelectedBroker, gdmHandler.selectedBrokerID)
+		})
+	}
+}
+
+func TestMain(m *testing.M) {
+	var err error
+	gdmTestPrivateKey, err = rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		panic(fmt.Sprintf("could not create an valid rsa key: %v", err))
+	}
+	defer pam_test.MaybeDoLeakCheck()
+	m.Run()
+}

--- a/pam/internal/adapter/gdmmodel_uimodel_test.go
+++ b/pam/internal/adapter/gdmmodel_uimodel_test.go
@@ -1,0 +1,174 @@
+package adapter
+
+import (
+	"context"
+	"reflect"
+	"slices"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/ubuntu/authd"
+	"github.com/ubuntu/authd/internal/log"
+	"github.com/ubuntu/authd/pam/internal/gdm"
+	"github.com/ubuntu/authd/pam/internal/gdm_test"
+	"github.com/ubuntu/authd/pam/internal/proto"
+)
+
+// gdmTestUIModel is an override of [UIModel] used for testing the module with gdm.
+type gdmTestUIModel struct {
+	UIModel
+
+	mu sync.Mutex
+
+	gdmHandler *gdmConvHandler
+
+	wantMessages        []tea.Msg
+	wantMessagesHandled chan struct{}
+
+	program           *tea.Program
+	programShouldQuit atomic.Bool
+}
+
+// Custom messages for testing the gdm model.
+
+type gdmTestAddPollResultEvent struct {
+	event *gdm.EventData
+}
+
+type gdmTestWaitForCommandsDone struct {
+	seq int64
+}
+
+type gdmTestWaitForStage struct {
+	stage    proto.Stage
+	events   []*gdm.EventData
+	commands []tea.Cmd
+}
+
+type gdmTestWaitForStageDone gdmTestWaitForStage
+
+type gdmTestSendAuthDataWhenReady struct {
+	item authd.IARequestAuthenticationDataItem
+}
+
+func (m *gdmTestUIModel) maybeHandleWantMessageUnlocked(msg tea.Msg) {
+	returnErrorMsg, isError := msg.(PamReturnError)
+
+	idx := slices.IndexFunc(m.wantMessages, func(wm tea.Msg) bool {
+		match := reflect.DeepEqual(wm, msg)
+		if match {
+			return true
+		}
+		if !isError {
+			return false
+		}
+		pamErr, ok := wm.(PamReturnError)
+		if !ok {
+			return false
+		}
+		if pamErr.Message() != gdmTestIgnoredMessage {
+			return false
+		}
+		return pamErr.Status() == returnErrorMsg.Status()
+	})
+
+	if idx < 0 {
+		return
+	}
+
+	m.wantMessages = slices.Delete(m.wantMessages, idx, idx+1)
+	if len(m.wantMessages) == 0 {
+		close(m.wantMessagesHandled)
+	}
+}
+
+func (m *gdmTestUIModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+	log.Debugf(context.TODO(), "%#v", msg)
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	commands := []tea.Cmd{}
+
+	_, cmd := m.UIModel.Update(msg)
+	commands = append(commands, cmd)
+
+	switch msg := msg.(type) {
+	case gdmTestAddPollResultEvent:
+		m.gdmHandler.appendPollResultEvents(msg.event)
+
+	case gdmTestWaitForStage:
+		doneMsg := (*gdmTestWaitForStageDone)(&msg)
+		if len(doneMsg.commands) > 0 {
+			seq := gdmTestSequentialMessages.Add(1)
+			doneCommandsMsg := gdmTestWaitForCommandsDone{seq: seq}
+			doneMsg.commands = append(doneMsg.commands, sendEvent(doneCommandsMsg))
+			m.wantMessages = append(m.wantMessages, doneCommandsMsg)
+		}
+
+		waitFunc := m.gdmHandler.waitForStageChange(msg.stage)
+		if waitFunc == nil {
+			commands = append(commands, sendEvent(doneMsg))
+			break
+		}
+
+		m.wantMessages = append(m.wantMessages, doneMsg)
+
+		go func() {
+			log.Debugf(context.TODO(), "Waiting for stage reached: %#v", doneMsg)
+			waitFunc()
+			log.Debugf(context.TODO(), "Stage reached: %#v", doneMsg)
+
+			m.program.Send(doneMsg)
+		}()
+
+	case *gdmTestWaitForStageDone:
+		msgCommands := tea.Sequence(msg.commands...)
+		if len(msg.events) > 0 {
+			m.gdmHandler.appendPollResultEvents(msg.events...)
+			// If we've events as poll results, let's wait for a polling cycle to complete
+			msgCommands = tea.Sequence(tea.Tick(gdmPollFrequency, func(t time.Time) tea.Msg {
+				return nil
+			}), msgCommands)
+		}
+		commands = append(commands, msgCommands)
+
+	case gdmTestSendAuthDataWhenReady:
+		doneMsg := gdmTestWaitForCommandsDone{seq: gdmTestSequentialMessages.Add(1)}
+		m.wantMessages = append(m.wantMessages, doneMsg)
+
+		go func() {
+			m.gdmHandler.waitForAuthenticationStarted()
+			m.gdmHandler.appendPollResultEvents(gdm_test.IsAuthenticatedEvent(msg.item))
+			m.program.Send(tea.Sequence(tea.Tick(gdmPollFrequency, func(t time.Time) tea.Msg {
+				return sendEvent(doneMsg)
+			}), sendEvent(doneMsg))())
+		}()
+
+	case gdmTestWaitForCommandsDone:
+		log.Debugf(context.TODO(), "Sequential messages done: %v", msg.seq)
+
+	case isAuthenticatedCancelled:
+		m.gdmHandler.consumeAuthenticationStartedEvents()
+	}
+
+	m.maybeHandleWantMessageUnlocked(msg)
+	return m, tea.Sequence(commands...)
+}
+
+func (m *gdmTestUIModel) filterFunc(model tea.Model, msg tea.Msg) tea.Msg {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	if _, ok := msg.(tea.QuitMsg); ok {
+		// Quit is never sent to the Update func so we handle it earlier.
+		m.maybeHandleWantMessageUnlocked(msg)
+		if !m.programShouldQuit.Load() {
+			return nil
+		}
+	}
+
+	return msg
+}

--- a/pam/internal/adapter/model.go
+++ b/pam/internal/adapter/model.go
@@ -92,6 +92,11 @@ type UILayoutReceived struct {
 // SessionEnded signals that the session is done and closed from the broker.
 type SessionEnded struct{}
 
+// ChangeStage signals that the model requires a stage change.
+type ChangeStage struct {
+	Stage pam_proto.Stage
+}
+
 // Init initializes the main model orchestrator.
 func (m *UIModel) Init() tea.Cmd {
 	m.exitStatus = pamError{status: pam.ErrSystem, msg: "model did not return anything"}
@@ -197,6 +202,9 @@ func (m *UIModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			encryptionKey: rsaPublicKey,
 		}
 		return m, sendEvent(GetAuthenticationModesRequested{})
+
+	case ChangeStage:
+		return m, m.changeStage(msg.Stage)
 
 	case GetAuthenticationModesRequested:
 		if m.currentSession == nil || !m.authModeSelectionModel.IsReady() {

--- a/pam/internal/adapter/model.go
+++ b/pam/internal/adapter/model.go
@@ -104,13 +104,13 @@ func (m *UIModel) Init() tea.Cmd {
 	var cmds []tea.Cmd
 	cmds = append(cmds, m.userSelectionModel.Init())
 
-	m.brokerSelectionModel = newBrokerSelectionModel(m.Client)
+	m.brokerSelectionModel = newBrokerSelectionModel(m.Client, m.ClientType)
 	cmds = append(cmds, m.brokerSelectionModel.Init())
 
-	m.authModeSelectionModel = newAuthModeSelectionModel()
+	m.authModeSelectionModel = newAuthModeSelectionModel(m.ClientType)
 	cmds = append(cmds, m.authModeSelectionModel.Init())
 
-	m.authenticationModel = newAuthenticationModel(m.Client)
+	m.authenticationModel = newAuthenticationModel(m.Client, m.ClientType)
 	cmds = append(cmds, m.authenticationModel.Init())
 
 	cmds = append(cmds, m.changeStage(pam_proto.Stage_userSelection))
@@ -257,6 +257,10 @@ func (m *UIModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 // View renders a text view of the whole UI.
 func (m *UIModel) View() string {
+	if m.ClientType != InteractiveTerminal {
+		return ""
+	}
+
 	var view strings.Builder
 
 	switch m.currentStage() {

--- a/pam/internal/adapter/model.go
+++ b/pam/internal/adapter/model.go
@@ -217,6 +217,9 @@ func (m *UIModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		)
 
 	case AuthModeSelected:
+		if m.currentSession == nil {
+			return m, nil
+		}
 		// Reselection/reset of current authentication mode requested (button clicked for instance)
 		if msg.ID == "" {
 			msg.ID = m.authModeSelectionModel.currentAuthModeSelectedID
@@ -231,6 +234,9 @@ func (m *UIModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 	case UILayoutReceived:
 		log.Info(context.TODO(), "UILayoutReceived")
+		if m.currentSession == nil {
+			return m, nil
+		}
 
 		return m, tea.Sequence(
 			m.authenticationModel.Compose(m.currentSession.brokerID, m.currentSession.sessionID, m.currentSession.encryptionKey, msg.layout),

--- a/pam/internal/adapter/model.go
+++ b/pam/internal/adapter/model.go
@@ -24,6 +24,8 @@ const (
 	Native PamClientType = iota
 	// InteractiveTerminal indicates an interactive terminal we can directly write our interface to.
 	InteractiveTerminal
+	// Gdm is a gnome-shell client via GDM display manager.
+	Gdm
 )
 
 var debug string
@@ -55,6 +57,7 @@ type UIModel struct {
 	brokerSelectionModel   brokerSelectionModel
 	authModeSelectionModel authModeSelectionModel
 	authenticationModel    authenticationModel
+	gdmModel               gdmModel
 
 	exitStatus PamReturnStatus
 }
@@ -99,8 +102,14 @@ type ChangeStage struct {
 
 // Init initializes the main model orchestrator.
 func (m *UIModel) Init() tea.Cmd {
-	m.userSelectionModel = newUserSelectionModel(m.PamMTx, m.ClientType)
 	var cmds []tea.Cmd
+
+	if m.ClientType == Gdm {
+		m.gdmModel = gdmModel{pamMTx: m.PamMTx}
+		cmds = append(cmds, m.gdmModel.Init())
+	}
+
+	m.userSelectionModel = newUserSelectionModel(m.PamMTx, m.ClientType)
 	cmds = append(cmds, m.userSelectionModel.Init())
 
 	m.brokerSelectionModel = newBrokerSelectionModel(m.Client, m.ClientType)
@@ -241,8 +250,14 @@ func (m *UIModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			return m, nil
 		}
 
+		var gdmCmd tea.Cmd
+		if m.ClientType == Gdm {
+			m.gdmModel, gdmCmd = m.gdmModel.Update(msg)
+		}
+
 		return m, tea.Sequence(
 			m.authenticationModel.Compose(m.currentSession.brokerID, m.currentSession.sessionID, m.currentSession.encryptionKey, msg.layout),
+			gdmCmd,
 			m.changeStage(pam_proto.Stage_challenge))
 
 	case SessionEnded:
@@ -260,6 +275,11 @@ func (m *UIModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	cmds = append(cmds, cmd)
 	m.authenticationModel, cmd = m.authenticationModel.Update(msg)
 	cmds = append(cmds, cmd)
+
+	if m.ClientType == Gdm {
+		m.gdmModel, cmd = m.gdmModel.Update(msg)
+		cmds = append(cmds, cmd)
+	}
 
 	return m, tea.Batch(cmds...)
 }
@@ -311,6 +331,7 @@ func (m *UIModel) currentStage() pam_proto.Stage {
 
 // changeStage returns a command acting to change the current stage and reset any previous views.
 func (m *UIModel) changeStage(s pam_proto.Stage) tea.Cmd {
+	var commands []tea.Cmd
 	if m.currentStage() != s {
 		switch m.currentStage() {
 		case pam_proto.Stage_userSelection:
@@ -322,29 +343,32 @@ func (m *UIModel) changeStage(s pam_proto.Stage) tea.Cmd {
 		case pam_proto.Stage_challenge:
 			m.authenticationModel.Blur()
 		}
+
+		if m.ClientType == Gdm {
+			commands = append(commands, m.gdmModel.changeStage(s))
+		}
 	}
 
 	switch s {
 	case pam_proto.Stage_userSelection:
 		// The session should be ended when going back to previous state, but we don’t quit the stage immediately
 		// and so, we should always ensure we cancel previous session.
-		return tea.Sequence(endSession(m.Client, m.currentSession), m.userSelectionModel.Focus())
+		commands = append(commands, endSession(m.Client, m.currentSession), m.userSelectionModel.Focus())
 
 	case pam_proto.Stage_brokerSelection:
 		m.authModeSelectionModel.Reset()
-		return tea.Sequence(endSession(m.Client, m.currentSession), m.brokerSelectionModel.Focus())
+		commands = append(commands, endSession(m.Client, m.currentSession), m.brokerSelectionModel.Focus())
 
 	case pam_proto.Stage_authModeSelection:
 		m.authenticationModel.Reset()
-
-		return m.authModeSelectionModel.Focus()
+		commands = append(commands, m.authModeSelectionModel.Focus())
 
 	case pam_proto.Stage_challenge:
-		return m.authenticationModel.Focus()
+		commands = append(commands, m.authenticationModel.Focus())
 	}
 
 	// TODO: error
-	return nil
+	return tea.Sequence(commands...)
 }
 
 // ExitStatus exposes the [PamReturnStatus] externally.

--- a/pam/internal/adapter/model.go
+++ b/pam/internal/adapter/model.go
@@ -100,7 +100,7 @@ type ChangeStage struct {
 // Init initializes the main model orchestrator.
 func (m *UIModel) Init() tea.Cmd {
 	m.exitStatus = pamError{status: pam.ErrSystem, msg: "model did not return anything"}
-	m.userSelectionModel = newUserSelectionModel(m.PamMTx)
+	m.userSelectionModel = newUserSelectionModel(m.PamMTx, m.ClientType)
 	var cmds []tea.Cmd
 	cmds = append(cmds, m.userSelectionModel.Init())
 

--- a/pam/internal/adapter/model.go
+++ b/pam/internal/adapter/model.go
@@ -99,7 +99,6 @@ type ChangeStage struct {
 
 // Init initializes the main model orchestrator.
 func (m *UIModel) Init() tea.Cmd {
-	m.exitStatus = pamError{status: pam.ErrSystem, msg: "model did not return anything"}
 	m.userSelectionModel = newUserSelectionModel(m.PamMTx, m.ClientType)
 	var cmds []tea.Cmd
 	cmds = append(cmds, m.userSelectionModel.Init())
@@ -152,6 +151,10 @@ func (m *UIModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 	// Exit cases
 	case PamReturnStatus:
+		if m.exitStatus != nil {
+			// Nothing to do, we're already exiting...
+			return m, nil
+		}
 		m.exitStatus = msg
 		return m, m.quit()
 
@@ -346,6 +349,9 @@ func (m *UIModel) changeStage(s pam_proto.Stage) tea.Cmd {
 
 // ExitStatus exposes the [PamReturnStatus] externally.
 func (m *UIModel) ExitStatus() PamReturnStatus {
+	if m.exitStatus == nil {
+		return pamError{status: pam.ErrSystem, msg: "model did not return anything"}
+	}
 	return m.exitStatus
 }
 

--- a/pam/internal/adapter/model.go
+++ b/pam/internal/adapter/model.go
@@ -373,9 +373,14 @@ func (m *UIModel) changeStage(s pam_proto.Stage) tea.Cmd {
 
 	case pam_proto.Stage_challenge:
 		commands = append(commands, m.authenticationModel.Focus())
+
+	default:
+		return sendEvent(pamError{
+			status: pam.ErrSystem,
+			msg:    fmt.Sprintf("unknown PAM stage: %q", s),
+		})
 	}
 
-	// TODO: error
 	return tea.Sequence(commands...)
 }
 

--- a/pam/internal/adapter/userselection.go
+++ b/pam/internal/adapter/userselection.go
@@ -1,6 +1,7 @@
 package adapter
 
 import (
+	"github.com/charmbracelet/bubbles/cursor"
 	"github.com/charmbracelet/bubbles/textinput"
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/msteinert/pam/v2"
@@ -10,7 +11,8 @@ import (
 type userSelectionModel struct {
 	textinput.Model
 
-	pamMTx pam.ModuleTransaction
+	pamMTx     pam.ModuleTransaction
+	clientType PamClientType
 }
 
 // userSelected events to select a new username.
@@ -26,8 +28,13 @@ func sendUserSelected(username string) tea.Cmd {
 }
 
 // newUserSelectionModel returns an initialized userSelectionModel.
-func newUserSelectionModel(pamMTx pam.ModuleTransaction) userSelectionModel {
+func newUserSelectionModel(pamMTx pam.ModuleTransaction, clientType PamClientType) userSelectionModel {
 	u := textinput.New()
+	if clientType != InteractiveTerminal {
+		// Cursor events are racy: https://github.com/charmbracelet/bubbletea/issues/909.
+		// FIXME: Avoid initializing the text input Model at all.
+		u.Cursor.SetMode(cursor.CursorHide)
+	}
 	u.Prompt = "Username: " // TODO: i18n
 	u.Placeholder = "user name"
 
@@ -35,7 +42,8 @@ func newUserSelectionModel(pamMTx pam.ModuleTransaction) userSelectionModel {
 	return userSelectionModel{
 		Model: u,
 
-		pamMTx: pamMTx,
+		pamMTx:     pamMTx,
+		clientType: clientType,
 	}
 }
 

--- a/pam/internal/adapter/userselection.go
+++ b/pam/internal/adapter/userselection.go
@@ -74,6 +74,10 @@ func (m userSelectionModel) Update(msg tea.Msg) (userSelectionModel, tea.Cmd) {
 		return m, nil
 	}
 
+	if m.clientType != InteractiveTerminal {
+		return m, nil
+	}
+
 	// interaction events
 	if !m.Focused() {
 		return m, nil

--- a/pam/internal/gdm/conversation.go
+++ b/pam/internal/gdm/conversation.go
@@ -145,6 +145,8 @@ func EmitEvent(pamMTx pam.ModuleTransaction, event Event) error {
 		evType = EventType_reselectAuthMode
 	case *EventData_UserSelected:
 		evType = EventType_userSelected
+	case *EventData_StartAuthentication:
+		evType = EventType_startAuthentication
 	default:
 		return fmt.Errorf("no known event type %#v", event)
 	}

--- a/pam/internal/gdm/conversation.go
+++ b/pam/internal/gdm/conversation.go
@@ -159,3 +159,37 @@ func EmitEvent(pamMTx pam.ModuleTransaction, event Event) error {
 
 	return nil
 }
+
+// DataConversationFunc is an adapter to allow the use of ordinary
+// functions as gdm conversation callbacks.
+type DataConversationFunc func(*Data) (*Data, error)
+
+// RespondPAMBinary is a conversation callback adapter.
+func (f DataConversationFunc) RespondPAMBinary(ptr pam.BinaryPointer) (pam.BinaryPointer, error) {
+	json, err := decodeJSONProtoMessage(ptr)
+	if err != nil {
+		return nil, err
+	}
+	gdmData, err := NewDataFromJSON(json)
+	if err != nil {
+		return nil, err
+	}
+	retData, err := f(gdmData)
+	if err != nil {
+		return nil, err
+	}
+	json, err = retData.JSON()
+	if err != nil {
+		return nil, err
+	}
+	msg, err := newJSONProtoMessage(json)
+	if err != nil {
+		return nil, err
+	}
+	return pam.BinaryPointer(msg), nil
+}
+
+// RespondPAM is a dummy conversation callback adapter to implement pam.BinaryPointerConversationFunc.
+func (f DataConversationFunc) RespondPAM(pam.Style, string) (string, error) {
+	return "", pam.ErrConv
+}

--- a/pam/internal/gdm/conversation.go
+++ b/pam/internal/gdm/conversation.go
@@ -143,6 +143,8 @@ func EmitEvent(pamMTx pam.ModuleTransaction, event Event) error {
 		evType = EventType_authEvent
 	case *EventData_ReselectAuthMode:
 		evType = EventType_reselectAuthMode
+	case *EventData_UserSelected:
+		evType = EventType_userSelected
 	default:
 		return fmt.Errorf("no known event type %#v", event)
 	}

--- a/pam/internal/gdm/conversation_test.go
+++ b/pam/internal/gdm/conversation_test.go
@@ -844,6 +844,10 @@ func TestDataEmitEvent(t *testing.T) {
 			event:         &EventData_UserSelected{},
 			wantEventType: EventType_userSelected,
 		},
+		"Emit event StartAuthentication": {
+			event:         &EventData_StartAuthentication{},
+			wantEventType: EventType_startAuthentication,
+		},
 
 		// Error cases
 		"Error on nil event": {

--- a/pam/internal/gdm/conversation_test.go
+++ b/pam/internal/gdm/conversation_test.go
@@ -840,6 +840,10 @@ func TestDataEmitEvent(t *testing.T) {
 			event:         &EventData_ReselectAuthMode{},
 			wantEventType: EventType_reselectAuthMode,
 		},
+		"Emit event UserSelected": {
+			event:         &EventData_UserSelected{},
+			wantEventType: EventType_userSelected,
+		},
 
 		// Error cases
 		"Error on nil event": {

--- a/pam/internal/gdm/extension.h
+++ b/pam/internal/gdm/extension.h
@@ -42,5 +42,5 @@ gdm_custom_json_request_init (GdmPamExtensionJSONProtocol *request,
                               const char                  *json)
 {
   GDM_PAM_EXTENSION_CUSTOM_JSON_REQUEST_INIT (request, proto_name,
-                                               proto_version, json);
+                                              proto_version, json);
 }

--- a/pam/internal/gdm/extension_test.go
+++ b/pam/internal/gdm/extension_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/ubuntu/authd/pam/internal/pam_test"
 )
 
-func TestMain(t *testing.T) {
+func TestExtension(t *testing.T) {
 	// We need to ensure that the the size of the data structures respects our
 	// expectations, so we check this at test time. It's not worth it doing this at
 	// runtime since the size of the data is not expected to change once compiled.

--- a/pam/internal/gdm/main_test.go
+++ b/pam/internal/gdm/main_test.go
@@ -1,0 +1,14 @@
+package gdm
+
+import (
+	"os"
+	"testing"
+
+	"github.com/ubuntu/authd/pam/internal/pam_test"
+)
+
+func TestMain(m *testing.M) {
+	exit := m.Run()
+	pam_test.MaybeDoLeakCheck()
+	os.Exit(exit)
+}

--- a/pam/internal/gdm_test/gdm_utils.go
+++ b/pam/internal/gdm_test/gdm_utils.go
@@ -1,0 +1,86 @@
+package gdm_test
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/ubuntu/authd"
+	"github.com/ubuntu/authd/pam/internal/gdm"
+	"github.com/ubuntu/authd/pam/internal/proto"
+)
+
+// RequireEqualData ensures that data is equal by checking the marshalled values.
+func RequireEqualData(t *testing.T, want any, actual any) {
+	t.Helper()
+
+	wantJSON, err := json.MarshalIndent(want, "", "  ")
+	require.NoError(t, err)
+	actualJSON, err := json.MarshalIndent(actual, "", "  ")
+	require.NoError(t, err)
+
+	require.Equal(t, string(wantJSON), string(actualJSON))
+}
+
+// DataToJSON is a test helper function to convert GDM data to JSON.
+func DataToJSON(t *testing.T, data *gdm.Data) string {
+	t.Helper()
+
+	json, err := data.JSON()
+	require.NoError(t, err)
+	return string(json)
+}
+
+// SelectUserEvent generates a SelectUser event.
+func SelectUserEvent(username string) *gdm.EventData {
+	return &gdm.EventData{
+		Type: gdm.EventType_userSelected,
+		Data: &gdm.EventData_UserSelected{
+			UserSelected: &gdm.Events_UserSelected{UserId: username},
+		},
+	}
+}
+
+// SelectBrokerEvent generates a SelectBroker event.
+func SelectBrokerEvent(brokerID string) *gdm.EventData {
+	return &gdm.EventData{
+		Type: gdm.EventType_brokerSelected,
+		Data: &gdm.EventData_BrokerSelected{
+			BrokerSelected: &gdm.Events_BrokerSelected{BrokerId: brokerID},
+		},
+	}
+}
+
+// ChangeStageEvent generates a ChangeStage event.
+func ChangeStageEvent(stage proto.Stage) *gdm.EventData {
+	return &gdm.EventData{
+		Type: gdm.EventType_stageChanged,
+		Data: &gdm.EventData_StageChanged{
+			StageChanged: &gdm.Events_StageChanged{Stage: stage},
+		},
+	}
+}
+
+// AuthModeSelectedEvent generates a AuthModeSelected event.
+func AuthModeSelectedEvent(authModeID string) *gdm.EventData {
+	return &gdm.EventData{
+		Type: gdm.EventType_authModeSelected,
+		Data: &gdm.EventData_AuthModeSelected{
+			AuthModeSelected: &gdm.Events_AuthModeSelected{
+				AuthModeId: authModeID,
+			},
+		},
+	}
+}
+
+// IsAuthenticatedEvent generates a IsAuthenticated event.
+func IsAuthenticatedEvent(item authd.IARequestAuthenticationDataItem) *gdm.EventData {
+	return &gdm.EventData{
+		Type: gdm.EventType_isAuthenticatedRequested,
+		Data: &gdm.EventData_IsAuthenticatedRequested{
+			IsAuthenticatedRequested: &gdm.Events_IsAuthenticatedRequested{
+				AuthenticationData: &authd.IARequest_AuthenticationData{Item: item},
+			},
+		},
+	}
+}

--- a/pam/internal/pam_test/module-transaction-dummy.go
+++ b/pam/internal/pam_test/module-transaction-dummy.go
@@ -232,7 +232,7 @@ func (m *ModuleTransactionDummy) StartConvMulti(requests []pam.ConvRequest) (
 	responses []pam.ConvResponse, err error) {
 	defer func() {
 		if err != nil {
-			err = errors.Join(pam.ErrConv, err)
+			err = fmt.Errorf("%w: %w", pam.ErrConv, err)
 		}
 	}()
 

--- a/pam/internal/pam_test/pam-client-dummy.go
+++ b/pam/internal/pam_test/pam-client-dummy.go
@@ -1,0 +1,594 @@
+package pam_test
+
+import (
+	"context"
+	"crypto/rsa"
+	"crypto/sha512"
+	"crypto/x509"
+	"encoding/base64"
+	"errors"
+	"fmt"
+	"slices"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/ubuntu/authd"
+	"github.com/ubuntu/authd/internal/brokers"
+	"github.com/ubuntu/authd/internal/log"
+	"golang.org/x/exp/maps"
+	"google.golang.org/grpc"
+)
+
+type options struct {
+	availableBrokersRet []*authd.ABResponse_BrokerInfo
+	availableBrokersErr error
+
+	getPreviousBrokerRet *string
+	getPreviousBrokerErr error
+
+	selectBrokerRet *authd.SBResponse
+	selectBrokerErr error
+
+	getAuthenticationModesRet []*authd.GAMResponse_AuthenticationMode
+	getAuthenticationModesErr error
+
+	selectAuthenticationModeRet *authd.UILayout
+	selectAuthenticationModeErr error
+
+	isAuthenticatedRet           *authd.IAResponse
+	isAuthenticatedErr           error
+	isAuthenticatedWantChallenge string
+	isAuthenticatedWantSkip      bool
+	isAuthenticatedWantWait      time.Duration
+	isAuthenticatedMessage       string
+	isAuthenticatedMaxRetries    int
+
+	endSessionErr error
+
+	defaultBrokerForUser       map[string]string
+	setDefaultBrokerForUserErr error
+
+	uiLayouts map[string]*authd.UILayout
+	authModes map[string]*authd.GAMResponse_AuthenticationMode
+
+	ignoreSessionIDChecks     bool
+	ignoreSessionIDGeneration bool
+}
+
+// DummyClient is a dummy implementation of [authd.PAMClient].
+type DummyClient struct {
+	options
+	mu sync.Mutex
+
+	privateKey    *rsa.PrivateKey
+	encryptionKey string
+
+	currentSessionID string
+	selectedBrokerID string
+	selectedUsername string
+	selectedLang     string
+}
+
+// DummyClientOptions is the function signature used to tweak the daemon creation.
+type DummyClientOptions func(*options)
+
+// WithAvailableBrokers is the option to define the AvailableBrokers return values.
+func WithAvailableBrokers(ret []*authd.ABResponse_BrokerInfo, err error) func(o *options) {
+	return func(o *options) {
+		o.availableBrokersRet = ret
+		o.availableBrokersErr = err
+	}
+}
+
+// WithPreviousBrokerForUser is the option to define the default broker ID for users.
+func WithPreviousBrokerForUser(user string, brokerID string) func(o *options) {
+	return func(o *options) {
+		o.defaultBrokerForUser[user] = brokerID
+	}
+}
+
+// WithGetPreviousBrokerReturn is the option to define the GetPreviousBroker return values.
+func WithGetPreviousBrokerReturn(ret *string, err error) func(o *options) {
+	return func(o *options) {
+		o.getPreviousBrokerRet = ret
+		o.getPreviousBrokerErr = err
+	}
+}
+
+// WithSelectBrokerReturn is the option to define the SelectBroker return values.
+func WithSelectBrokerReturn(ret *authd.SBResponse, err error) func(o *options) {
+	return func(o *options) {
+		o.selectBrokerRet = ret
+		o.selectBrokerErr = err
+	}
+}
+
+// WithGetAuthenticationModesReturn is the option to define the GetAuthenticationModes return values.
+func WithGetAuthenticationModesReturn(ret []*authd.GAMResponse_AuthenticationMode, err error) func(o *options) {
+	return func(o *options) {
+		o.getAuthenticationModesRet = ret
+		o.getAuthenticationModesErr = err
+	}
+}
+
+// WithSelectAuthenticationModeReturn is the option to define the SelectAuthenticationMode return values.
+func WithSelectAuthenticationModeReturn(ret *authd.UILayout, err error) func(o *options) {
+	return func(o *options) {
+		o.selectAuthenticationModeRet = ret
+		o.selectAuthenticationModeErr = err
+	}
+}
+
+// WithIsAuthenticatedReturn is the option to define the IsAuthenticated return values.
+func WithIsAuthenticatedReturn(ret *authd.IAResponse, err error) func(o *options) {
+	return func(o *options) {
+		o.isAuthenticatedRet = ret
+		o.isAuthenticatedErr = err
+	}
+}
+
+// WithIsAuthenticatedWantChallenge is the option to define the IsAuthenticated wanted challenge.
+func WithIsAuthenticatedWantChallenge(challenge string) func(o *options) {
+	return func(o *options) {
+		o.isAuthenticatedWantChallenge = challenge
+	}
+}
+
+// WithIsAuthenticatedWantSkip is the option to define the IsAuthenticated skip.
+func WithIsAuthenticatedWantSkip() func(o *options) {
+	return func(o *options) {
+		o.isAuthenticatedWantSkip = true
+	}
+}
+
+// WithIsAuthenticatedWantWait is the option to define the IsAuthenticated wait duration.
+func WithIsAuthenticatedWantWait(wait time.Duration) func(o *options) {
+	return func(o *options) {
+		o.isAuthenticatedWantWait = wait
+	}
+}
+
+// WithIsAuthenticatedMaxRetries is the option to define the IsAuthenticated max retries return values.
+func WithIsAuthenticatedMaxRetries(maxRetries int) func(o *options) {
+	return func(o *options) {
+		o.isAuthenticatedMaxRetries = maxRetries
+	}
+}
+
+// WithIsAuthenticatedMessage is the option to define the IsAuthenticated message return values.
+func WithIsAuthenticatedMessage(message string) func(o *options) {
+	return func(o *options) {
+		o.isAuthenticatedMessage = message
+	}
+}
+
+// WithEndSessionReturn is the option to define the EndSession return values.
+func WithEndSessionReturn(err error) func(o *options) {
+	return func(o *options) {
+		o.endSessionErr = err
+	}
+}
+
+// WithSetDefaultBrokerReturn is the option to define the SetDefaultBroker return values.
+func WithSetDefaultBrokerReturn(err error) func(o *options) {
+	return func(o *options) {
+		o.setDefaultBrokerForUserErr = err
+	}
+}
+
+// WithUILayout is the option to define the UI layouts supported return values.
+func WithUILayout(authModeID string, label string, uiLayout *authd.UILayout) func(o *options) {
+	return func(o *options) {
+		o.uiLayouts[authModeID] = uiLayout
+		o.authModes[authModeID] = &authd.GAMResponse_AuthenticationMode{Id: authModeID, Label: label}
+	}
+}
+
+// WithIgnoreSessionIDChecks is the option to ignore session ID checks.
+func WithIgnoreSessionIDChecks() func(o *options) {
+	return func(o *options) {
+		o.ignoreSessionIDChecks = true
+	}
+}
+
+// WithIgnoreSessionIDGeneration is the option to ignore session ID checks.
+func WithIgnoreSessionIDGeneration() func(o *options) {
+	return func(o *options) {
+		o.ignoreSessionIDGeneration = true
+	}
+}
+
+// NewDummyClient returns a Dummy client with the given options.
+func NewDummyClient(privateKey *rsa.PrivateKey, args ...DummyClientOptions) *DummyClient {
+	// Set default options.
+	dc := &DummyClient{
+		privateKey: privateKey,
+	}
+
+	if privateKey != nil {
+		pubASN1, err := x509.MarshalPKIXPublicKey(&privateKey.PublicKey)
+		if err != nil {
+			panic(err)
+		}
+		dc.encryptionKey = base64.StdEncoding.EncodeToString(pubASN1)
+	}
+
+	dc.defaultBrokerForUser = make(map[string]string)
+	dc.uiLayouts = make(map[string]*authd.UILayout)
+	dc.authModes = make(map[string]*authd.GAMResponse_AuthenticationMode)
+
+	// Apply given args.
+	for _, f := range args {
+		f(&dc.options)
+	}
+
+	if dc.selectBrokerRet != nil && dc.selectBrokerRet.EncryptionKey == "" {
+		dc.selectBrokerRet.EncryptionKey = dc.encryptionKey
+	}
+
+	return dc
+}
+
+// AvailableBrokers simulates AvailableBrokers using the provided parameters.
+func (dc *DummyClient) AvailableBrokers(ctx context.Context, in *authd.Empty, opts ...grpc.CallOption) (*authd.ABResponse, error) {
+	log.Debugf(ctx, "AvailableBrokers Called: %#v", in)
+	dc.mu.Lock()
+	defer dc.mu.Unlock()
+	return dc.availableBrokers()
+}
+
+func (dc *DummyClient) availableBrokers() (*authd.ABResponse, error) {
+	if dc.availableBrokersErr != nil {
+		return nil, dc.availableBrokersErr
+	}
+	return &authd.ABResponse{BrokersInfos: dc.availableBrokersRet}, nil
+}
+
+// GetPreviousBroker simulates GetPreviousBroker using the provided parameters.
+func (dc *DummyClient) GetPreviousBroker(ctx context.Context, in *authd.GPBRequest, opts ...grpc.CallOption) (*authd.GPBResponse, error) {
+	log.Debugf(ctx, "GetPreviousBroker Called: %#v", in)
+	dc.mu.Lock()
+	defer dc.mu.Unlock()
+	if dc.getPreviousBrokerErr != nil {
+		return nil, dc.getPreviousBrokerErr
+	}
+	if dc.getPreviousBrokerRet != nil {
+		return &authd.GPBResponse{PreviousBroker: dc.getPreviousBrokerRet}, nil
+	}
+	if in == nil {
+		return &authd.GPBResponse{}, nil
+	}
+	if in.Username == "" {
+		return nil, errors.New("no username provided")
+	}
+	brokerID := dc.defaultBrokerForUser[in.Username]
+	return &authd.GPBResponse{PreviousBroker: &brokerID}, nil
+}
+
+// SelectBroker simulates SelectBroker using the provided parameters.
+func (dc *DummyClient) SelectBroker(ctx context.Context, in *authd.SBRequest, opts ...grpc.CallOption) (*authd.SBResponse, error) {
+	log.Debugf(ctx, "SelectBroker Called: %#v", in)
+	dc.mu.Lock()
+	defer dc.mu.Unlock()
+	if dc.selectBrokerErr != nil {
+		return nil, dc.selectBrokerErr
+	}
+	if !dc.ignoreSessionIDChecks && dc.currentSessionID != "" {
+		if in != nil && dc.selectedUsername != in.Username {
+			return nil, fmt.Errorf("session %q is still active", dc.currentSessionID)
+		}
+	}
+	if in == nil {
+		return nil, errors.New("no input values provided")
+	}
+	if in.BrokerId == "" {
+		return nil, errors.New("no broker ID provided")
+	}
+	sessionID := dc.currentSessionID
+	if !dc.ignoreSessionIDGeneration && sessionID == "" {
+		sessionID = uuid.New().String()
+	}
+
+	if dc.selectBrokerRet != nil {
+		dc.selectedBrokerID = in.BrokerId
+		dc.selectedLang = in.Lang
+		dc.selectedUsername = in.Username
+
+		if dc.selectBrokerRet.SessionId != "" {
+			sessionID = dc.selectBrokerRet.SessionId
+		}
+
+		dc.currentSessionID = sessionID
+		if dc.ignoreSessionIDChecks || dc.selectBrokerRet.SessionId != "" {
+			return dc.selectBrokerRet, nil
+		}
+	}
+
+	brokers, err := dc.availableBrokers()
+	if err != nil {
+		return nil, err
+	}
+	if !slices.ContainsFunc(brokers.BrokersInfos, func(b *authd.ABResponse_BrokerInfo) bool {
+		return b.Id == in.BrokerId
+	}) {
+		return nil, fmt.Errorf("broker %q not found", in.BrokerId)
+	}
+	dc.selectedBrokerID = in.BrokerId
+	dc.selectedLang = in.Lang
+	dc.selectedUsername = in.Username
+	dc.currentSessionID = sessionID
+	return &authd.SBResponse{
+		SessionId:     dc.currentSessionID,
+		EncryptionKey: dc.encryptionKey,
+	}, nil
+}
+
+// GetAuthenticationModes simulates GetAuthenticationModes using the provided parameters.
+func (dc *DummyClient) GetAuthenticationModes(ctx context.Context, in *authd.GAMRequest, opts ...grpc.CallOption) (*authd.GAMResponse, error) {
+	log.Debugf(ctx, "GetAuthenticationModes Called: %#v", in)
+	dc.mu.Lock()
+	defer dc.mu.Unlock()
+	if dc.getAuthenticationModesErr != nil {
+		return nil, dc.getAuthenticationModesErr
+	}
+	if dc.getAuthenticationModesRet != nil {
+		return &authd.GAMResponse{
+			AuthenticationModes: dc.getAuthenticationModesRet,
+		}, nil
+	}
+	if in == nil {
+		return nil, errors.New("no input values provided")
+	}
+	if !dc.ignoreSessionIDChecks && in.SessionId == "" {
+		return nil, errors.New("no session ID provided")
+	}
+	if !dc.ignoreSessionIDChecks && dc.currentSessionID != in.SessionId {
+		return nil, fmt.Errorf("impossible to get authentication mode, session ID %q not found", in.SessionId)
+	}
+	authModes := maps.Values(dc.authModes)
+	slices.SortFunc(authModes,
+		func(a *authd.GAMResponse_AuthenticationMode, b *authd.GAMResponse_AuthenticationMode) int {
+			return strings.Compare(a.Id, b.Id)
+		})
+	return &authd.GAMResponse{
+		AuthenticationModes: authModes,
+	}, nil
+}
+
+// SelectAuthenticationMode simulates SelectAuthenticationMode using the provided parameters.
+func (dc *DummyClient) SelectAuthenticationMode(ctx context.Context, in *authd.SAMRequest, opts ...grpc.CallOption) (*authd.SAMResponse, error) {
+	log.Debugf(ctx, "SelectAuthenticationMode Called: %#v", in)
+	dc.mu.Lock()
+	defer dc.mu.Unlock()
+	if dc.selectAuthenticationModeErr != nil {
+		return nil, dc.selectAuthenticationModeErr
+	}
+	if dc.selectAuthenticationModeRet != nil {
+		return &authd.SAMResponse{
+			UiLayoutInfo: dc.selectAuthenticationModeRet,
+		}, nil
+	}
+	if in == nil {
+		return nil, errors.New("no input values provided")
+	}
+	if !dc.ignoreSessionIDChecks && in.SessionId == "" {
+		return nil, errors.New("no session ID provided")
+	}
+	if !dc.ignoreSessionIDChecks && dc.currentSessionID != in.SessionId {
+		return nil, fmt.Errorf("impossible to select authentication mode, session ID %q not found", in.SessionId)
+	}
+	if in.AuthenticationModeId == "" {
+		return nil, errors.New("no authentication mode ID provided")
+	}
+	uiLayout, ok := dc.uiLayouts[in.AuthenticationModeId]
+	if !ok {
+		return nil, fmt.Errorf("authentication mode %q not found", in.AuthenticationModeId)
+	}
+	return &authd.SAMResponse{UiLayoutInfo: uiLayout}, nil
+}
+
+// IsAuthenticated simulates IsAuthenticated using the provided parameters.
+func (dc *DummyClient) IsAuthenticated(ctx context.Context, in *authd.IARequest, opts ...grpc.CallOption) (*authd.IAResponse, error) {
+	dc.mu.Lock()
+	defer dc.mu.Unlock()
+	log.Debugf(ctx, "IsAuthenticated Called: %#v", in)
+	if dc.isAuthenticatedErr != nil {
+		return nil, dc.isAuthenticatedErr
+	}
+	if dc.isAuthenticatedRet != nil {
+		return dc.isAuthenticatedRet, nil
+	}
+	if in == nil {
+		return nil, errors.New("no input values provided")
+	}
+	if !dc.ignoreSessionIDChecks && in.SessionId == "" {
+		return nil, errors.New("no session ID provided")
+	}
+	if !dc.ignoreSessionIDChecks && dc.currentSessionID != in.SessionId {
+		return nil, fmt.Errorf("impossible to authenticate, session ID %q not found", in.SessionId)
+	}
+	if in.AuthenticationData == nil {
+		return nil, errors.New("no authentication data provided")
+	}
+
+	var msg string
+	if dc.isAuthenticatedMessage != "" {
+		msg = fmt.Sprintf(`{"message": "%s"}`, dc.isAuthenticatedMessage)
+	}
+
+	switch item := in.AuthenticationData.Item.(type) {
+	case *authd.IARequest_AuthenticationData_Challenge:
+		if dc.isAuthenticatedWantChallenge == "" {
+			return nil, errors.New("no wanted challenge provided")
+		}
+		return dc.handleChallenge(item.Challenge, msg)
+	case *authd.IARequest_AuthenticationData_Wait:
+		if dc.isAuthenticatedWantWait == 0 {
+			return nil, errors.New("no wanted wait provided")
+		}
+		time.Sleep(dc.isAuthenticatedWantWait)
+		return &authd.IAResponse{
+			Access: brokers.AuthGranted,
+			Msg:    msg,
+		}, nil
+	case *authd.IARequest_AuthenticationData_Skip:
+		if !dc.isAuthenticatedWantSkip {
+			return nil, errors.New("no wanted skip requested")
+		}
+		return &authd.IAResponse{Msg: msg}, nil
+	default:
+		return nil, errors.New("no authentication data provided")
+	}
+}
+
+func (dc *DummyClient) handleChallenge(challenge string, msg string) (*authd.IAResponse, error) {
+	if challenge == "" {
+		return nil, errors.New("no challenge provided")
+	}
+	ciphertext, err := base64.StdEncoding.DecodeString(challenge)
+	if err != nil {
+		return nil, err
+	}
+	if dc.privateKey == nil {
+		return nil, errors.New("no private key defined")
+	}
+	plaintext, err := rsa.DecryptOAEP(sha512.New(), nil, dc.privateKey, ciphertext, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	if string(plaintext) == dc.isAuthenticatedWantChallenge {
+		return &authd.IAResponse{
+			Access: brokers.AuthGranted,
+			Msg:    msg,
+		}, nil
+	}
+
+	dc.isAuthenticatedMaxRetries--
+	if dc.isAuthenticatedMaxRetries < 0 {
+		return &authd.IAResponse{
+			Access: brokers.AuthDenied,
+			Msg:    msg,
+		}, nil
+	}
+
+	return &authd.IAResponse{
+		Access: brokers.AuthRetry,
+		Msg:    msg,
+	}, nil
+}
+
+// EndSession simulates EndSession using the provided parameters.
+func (dc *DummyClient) EndSession(ctx context.Context, in *authd.ESRequest, opts ...grpc.CallOption) (*authd.Empty, error) {
+	log.Debugf(ctx, "EndSession Called: %#v", in)
+	dc.mu.Lock()
+	defer dc.mu.Unlock()
+	if dc.endSessionErr != nil {
+		return nil, dc.endSessionErr
+	}
+	if in == nil {
+		return nil, errors.New("no input values provided")
+	}
+	if !dc.ignoreSessionIDChecks && in.SessionId == "" {
+		return nil, errors.New("no session ID provided")
+	}
+	if !dc.ignoreSessionIDChecks && dc.currentSessionID != in.SessionId {
+		return nil, fmt.Errorf("impossible to end session %q, not found", in.SessionId)
+	}
+	dc.currentSessionID = ""
+	dc.selectedUsername = ""
+	return &authd.Empty{}, nil
+}
+
+// SetDefaultBrokerForUser simulates SetDefaultBrokerForUser using the provided parameters.
+func (dc *DummyClient) SetDefaultBrokerForUser(ctx context.Context, in *authd.SDBFURequest, opts ...grpc.CallOption) (*authd.Empty, error) {
+	log.Debugf(ctx, "SetDefaultBrokerForUser Called: %#v", in)
+	dc.mu.Lock()
+	defer dc.mu.Unlock()
+	if dc.setDefaultBrokerForUserErr != nil {
+		return nil, dc.setDefaultBrokerForUserErr
+	}
+	if in == nil {
+		return nil, errors.New("no input values provided")
+	}
+	if in.Username == "" {
+		return nil, errors.New("no valid username provided")
+	}
+	if in.BrokerId == "" {
+		return nil, errors.New("no valid broker ID provided")
+	}
+	dc.defaultBrokerForUser[in.Username] = in.BrokerId
+	return &authd.Empty{}, nil
+}
+
+// Utility functions for testing purposes.
+
+// SelectedUsername returns the selected Username on the client.
+func (dc *DummyClient) SelectedUsername() string {
+	dc.mu.Lock()
+	defer dc.mu.Unlock()
+	return dc.selectedUsername
+}
+
+// SelectedBrokerID returns the selected BrokerID on the client.
+func (dc *DummyClient) SelectedBrokerID() string {
+	dc.mu.Lock()
+	defer dc.mu.Unlock()
+	return dc.selectedBrokerID
+}
+
+// CurrentSessionID returns the selected BrokerID on the client.
+func (dc *DummyClient) CurrentSessionID() string {
+	dc.mu.Lock()
+	defer dc.mu.Unlock()
+	return dc.currentSessionID
+}
+
+// SelectedLang returns the selected Lang on the client.
+func (dc *DummyClient) SelectedLang() string {
+	dc.mu.Lock()
+	defer dc.mu.Unlock()
+	return dc.selectedLang
+}
+
+// FormUILayout returns an [authd.UILayout] for forms.
+func FormUILayout() *authd.UILayout {
+	required, optional := "required", "optional"
+	supportedEntries := "optional:chars,chars_password"
+	optionalWithBooleans := "optional:true,false"
+	return &authd.UILayout{
+		Type:   "form",
+		Label:  &required,
+		Entry:  &supportedEntries,
+		Wait:   &optionalWithBooleans,
+		Button: &optional,
+	}
+}
+
+// QrCodeUILayout returns an [authd.UILayout] for qr code.
+func QrCodeUILayout() *authd.UILayout {
+	required, optional := "required", "optional"
+	requiredWithBooleans := "required:true,false"
+	return &authd.UILayout{
+		Type:    "qrcode",
+		Content: &required,
+		Wait:    &requiredWithBooleans,
+		Label:   &optional,
+		Button:  &optional,
+	}
+}
+
+// NewPasswordUILayout returns an [authd.UILayout] for new password forms.
+func NewPasswordUILayout() *authd.UILayout {
+	required, optional := "required", "optional"
+	requiredWithBooleans := "required:true,false"
+	return &authd.UILayout{
+		Type:    "newpassword",
+		Content: &required,
+		Wait:    &requiredWithBooleans,
+		Label:   &optional,
+		Button:  &optional,
+	}
+}

--- a/pam/internal/pam_test/pam-client-dummy_test.go
+++ b/pam/internal/pam_test/pam-client-dummy_test.go
@@ -1,0 +1,1187 @@
+package pam_test
+
+import (
+	"context"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/sha512"
+	"crypto/x509"
+	"encoding/base64"
+	"errors"
+	"fmt"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+	"github.com/ubuntu/authd"
+	"github.com/ubuntu/authd/internal/brokers"
+)
+
+var errTest = errors.New("an error")
+var privateKey *rsa.PrivateKey
+
+func TestAvailableBrokers(t *testing.T) {
+	t.Parallel()
+
+	testCases := map[string]struct {
+		client authd.PAMClient
+
+		wantRet   *authd.ABResponse
+		wantError error
+	}{
+		"With empty options": {
+			client:  NewDummyClient(nil),
+			wantRet: &authd.ABResponse{},
+		},
+		"With Error return value": {
+			client:    NewDummyClient(nil, WithAvailableBrokers(nil, errTest)),
+			wantError: errTest,
+		},
+		"With defined return value": {
+			client: NewDummyClient(nil, WithAvailableBrokers([]*authd.ABResponse_BrokerInfo{
+				{
+					Id:        "testBroker",
+					Name:      "A test broker",
+					BrandIcon: ptrValue("/usr/share/icons/broker-icon.png"),
+				},
+			}, nil)),
+			wantRet: &authd.ABResponse{
+				BrokersInfos: []*authd.ABResponse_BrokerInfo{
+					{
+						Id:        "testBroker",
+						Name:      "A test broker",
+						BrandIcon: ptrValue("/usr/share/icons/broker-icon.png"),
+					},
+				},
+			},
+		},
+	}
+	for name, tc := range testCases {
+		tc := tc
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			ret, err := tc.client.AvailableBrokers(context.TODO(), nil)
+			require.ErrorIs(t, err, tc.wantError)
+			require.Equal(t, tc.wantRet, ret)
+		})
+	}
+}
+
+func TestGetPreviousBroker(t *testing.T) {
+	t.Parallel()
+
+	testCases := map[string]struct {
+		client authd.PAMClient
+		args   *authd.GPBRequest
+
+		wantRet   *authd.GPBResponse
+		wantError error
+	}{
+		"With empty options": {
+			client:  NewDummyClient(nil),
+			wantRet: &authd.GPBResponse{},
+		},
+		"With Error return value": {
+			client:    NewDummyClient(nil, WithGetPreviousBrokerReturn(nil, errTest)),
+			wantError: errTest,
+		},
+		"With defined return value": {
+			client: NewDummyClient(nil, WithGetPreviousBrokerReturn(ptrValue("my-previous-broker"), nil)),
+			wantRet: &authd.GPBResponse{
+				PreviousBroker: ptrValue("my-previous-broker"),
+			},
+		},
+		"With defined empty return value": {
+			client:  NewDummyClient(nil, WithGetPreviousBrokerReturn(nil, nil)),
+			wantRet: &authd.GPBResponse{},
+		},
+		"With predefined default for user empty return value": {
+			client: NewDummyClient(nil,
+				WithPreviousBrokerForUser("user0", "broker0"),
+				WithPreviousBrokerForUser("user1", "broker1"),
+			),
+			args:    &authd.GPBRequest{Username: "user1"},
+			wantRet: &authd.GPBResponse{PreviousBroker: ptrValue("broker1")},
+		},
+
+		// Error cases
+		"Error with missing user": {
+			client:    NewDummyClient(nil, WithGetPreviousBrokerReturn(nil, nil)),
+			args:      &authd.GPBRequest{},
+			wantError: errors.New("no username provided"),
+		},
+	}
+	for name, tc := range testCases {
+		tc := tc
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			ret, err := tc.client.GetPreviousBroker(context.TODO(), tc.args)
+			require.Equal(t, tc.wantError, err)
+			require.Equal(t, tc.wantRet, ret)
+		})
+	}
+}
+
+func TestSelectBroker(t *testing.T) {
+	t.Parallel()
+
+	pubASN1, err := x509.MarshalPKIXPublicKey(&privateKey.PublicKey)
+	require.NoError(t, err)
+	wantEncryptionKey := base64.StdEncoding.EncodeToString(pubASN1)
+
+	testCases := map[string]struct {
+		client            authd.PAMClient
+		args              *authd.SBRequest
+		reselectAgainUser string
+
+		wantGeneratedSessionID bool
+		wantRet                *authd.SBResponse
+		wantError              error
+	}{
+		"With Error return value": {
+			client:    NewDummyClient(nil, WithSelectBrokerReturn(nil, errTest)),
+			wantError: errTest,
+		},
+		"With valid args and generated return value": {
+			client: NewDummyClient(nil,
+				WithSelectBrokerReturn(nil, nil),
+				WithAvailableBrokers([]*authd.ABResponse_BrokerInfo{
+					{
+						Id:   "test-broker",
+						Name: "A test broker",
+					},
+				}, nil)),
+			args:                   &authd.SBRequest{BrokerId: "test-broker"},
+			wantGeneratedSessionID: true,
+		},
+		"With valid args and empty return value": {
+			client: NewDummyClient(nil,
+				WithSelectBrokerReturn(&authd.SBResponse{}, nil),
+				WithAvailableBrokers([]*authd.ABResponse_BrokerInfo{
+					{
+						Id:   "test-broker",
+						Name: "A test broker",
+					},
+				}, nil)),
+			args:                   &authd.SBRequest{BrokerId: "test-broker"},
+			wantRet:                &authd.SBResponse{},
+			wantGeneratedSessionID: true,
+		},
+		"With valid args and empty return value with ignored ID generation": {
+			client: NewDummyClient(nil,
+				WithIgnoreSessionIDGeneration(),
+				WithSelectBrokerReturn(&authd.SBResponse{}, nil),
+				WithAvailableBrokers([]*authd.ABResponse_BrokerInfo{
+					{
+						Id:   "test-broker",
+						Name: "A test broker",
+					},
+				}, nil)),
+			args:    &authd.SBRequest{BrokerId: "test-broker"},
+			wantRet: &authd.SBResponse{},
+		},
+		"With valid args and defined return value": {
+			client: NewDummyClient(nil,
+				WithSelectBrokerReturn(&authd.SBResponse{
+					SessionId:     "session-id",
+					EncryptionKey: "super-secret-encryption-key",
+				}, nil),
+				WithAvailableBrokers([]*authd.ABResponse_BrokerInfo{
+					{
+						Id:   "test-broker",
+						Name: "A test broker",
+					},
+				}, nil)),
+			args: &authd.SBRequest{BrokerId: "test-broker"},
+			wantRet: &authd.SBResponse{
+				SessionId:     "session-id",
+				EncryptionKey: "super-secret-encryption-key",
+			},
+		},
+		"With private key and valid args and empty return value": {
+			client: NewDummyClient(privateKey,
+				WithSelectBrokerReturn(&authd.SBResponse{}, nil),
+				WithAvailableBrokers([]*authd.ABResponse_BrokerInfo{
+					{
+						Id:   "test-broker",
+						Name: "A test broker",
+					},
+				}, nil)),
+			args: &authd.SBRequest{BrokerId: "test-broker"},
+			wantRet: &authd.SBResponse{
+				EncryptionKey: wantEncryptionKey,
+			},
+			wantGeneratedSessionID: true,
+		},
+		"With private key and valid args, empty return value ignoring session ID generation": {
+			client: NewDummyClient(privateKey,
+				WithIgnoreSessionIDGeneration(),
+				WithSelectBrokerReturn(&authd.SBResponse{}, nil),
+				WithAvailableBrokers([]*authd.ABResponse_BrokerInfo{
+					{
+						Id:   "test-broker",
+						Name: "A test broker",
+					},
+				}, nil)),
+			args: &authd.SBRequest{BrokerId: "test-broker"},
+			wantRet: &authd.SBResponse{
+				EncryptionKey: wantEncryptionKey,
+			},
+		},
+		"With private key and valid args and defined return value": {
+			client: NewDummyClient(privateKey,
+				WithSelectBrokerReturn(&authd.SBResponse{
+					SessionId:     "session-id",
+					EncryptionKey: "super-secret-encryption-key",
+				}, nil),
+				WithAvailableBrokers([]*authd.ABResponse_BrokerInfo{
+					{
+						Id:   "dummy-broker",
+						Name: "A Dummy broker",
+					},
+					{
+						Id:   "test-broker",
+						Name: "A test broker",
+					},
+				}, nil)),
+			args: &authd.SBRequest{BrokerId: "test-broker"},
+			wantRet: &authd.SBResponse{
+				SessionId:     "session-id",
+				EncryptionKey: "super-secret-encryption-key",
+			},
+		},
+		"With private key and valid args and defined return value without encryption key": {
+			client: NewDummyClient(privateKey,
+				WithSelectBrokerReturn(&authd.SBResponse{
+					SessionId: "session-id",
+				}, nil),
+				WithAvailableBrokers([]*authd.ABResponse_BrokerInfo{
+					{
+						Id:   "dummy-broker",
+						Name: "A Dummy broker",
+					},
+					{
+						Id:   "test-broker",
+						Name: "A test broker",
+					},
+				}, nil)),
+			args: &authd.SBRequest{BrokerId: "test-broker"},
+			wantRet: &authd.SBResponse{
+				SessionId:     "session-id",
+				EncryptionKey: wantEncryptionKey,
+			},
+		},
+		"Starting a session for same user is fine": {
+			client: NewDummyClient(nil,
+				WithSelectBrokerReturn(nil, nil),
+				WithAvailableBrokers([]*authd.ABResponse_BrokerInfo{
+					{
+						Id:   "test-broker",
+						Name: "A test broker",
+					},
+				}, nil)),
+			args: &authd.SBRequest{
+				BrokerId: "test-broker",
+				Username: "an-user",
+			},
+			reselectAgainUser:      "an-user",
+			wantGeneratedSessionID: true,
+			wantRet:                &authd.SBResponse{},
+		},
+		"Starting a session for another user is fine when ignoring ID checks": {
+			client: NewDummyClient(nil,
+				WithIgnoreSessionIDChecks(),
+				WithIgnoreSessionIDGeneration(),
+				WithSelectBrokerReturn(nil, nil),
+				WithAvailableBrokers([]*authd.ABResponse_BrokerInfo{
+					{
+						Id:   "test-broker",
+						Name: "A test broker",
+					},
+				}, nil)),
+			args: &authd.SBRequest{
+				BrokerId: "test-broker",
+				Username: "an-user",
+			},
+			reselectAgainUser: "another-user",
+			wantRet:           &authd.SBResponse{},
+		},
+
+		// Error cases
+		"Error with nil args and empty options": {
+			client:    NewDummyClient(nil),
+			wantError: errors.New("no input values provided"),
+		},
+		"Error with empty args empty options": {
+			client:    NewDummyClient(nil),
+			args:      &authd.SBRequest{},
+			wantError: errors.New("no broker ID provided"),
+		},
+		"Error on unknown broker id": {
+			client:    NewDummyClient(nil, WithSelectBrokerReturn(nil, nil)),
+			args:      &authd.SBRequest{BrokerId: "some-broker"},
+			wantError: fmt.Errorf(`broker "some-broker" not found`),
+		},
+		"Error on starting a session again": {
+			client: NewDummyClient(nil,
+				WithSelectBrokerReturn(nil, nil),
+				WithAvailableBrokers([]*authd.ABResponse_BrokerInfo{
+					{
+						Id:   "test-broker",
+						Name: "A test broker",
+					},
+				}, nil)),
+			args: &authd.SBRequest{
+				BrokerId: "test-broker",
+				Username: "an-user",
+			},
+			reselectAgainUser:      "another-user",
+			wantGeneratedSessionID: true,
+		},
+		"Error on broker fetching failed": {
+			client: NewDummyClient(nil,
+				WithSelectBrokerReturn(nil, nil),
+				WithAvailableBrokers(nil, errTest)),
+			args:      &authd.SBRequest{BrokerId: "test-broker"},
+			wantError: errTest,
+		},
+	}
+	for name, tc := range testCases {
+		tc := tc
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			ret, err := tc.client.SelectBroker(context.TODO(), tc.args)
+			require.Equal(t, tc.wantError, err)
+			if tc.wantGeneratedSessionID {
+				require.NotNil(t, ret)
+				_, err := uuid.Parse(ret.SessionId)
+				require.NoError(t, err)
+				if tc.wantRet != nil {
+					tc.wantRet.SessionId = ret.SessionId
+				} else {
+					tc.wantRet = ret
+				}
+			}
+			require.Equal(t, tc.wantRet, ret)
+			if err != nil {
+				require.Nil(t, ret)
+				return
+			}
+
+			dc, ok := tc.client.(*DummyClient)
+			require.True(t, ok, "Provided client is not a Dummy client")
+			if ret != nil {
+				require.Equal(t, ret.SessionId, dc.CurrentSessionID())
+			}
+
+			if tc.args == nil {
+				require.Empty(t, dc.SelectedBrokerID())
+				require.Empty(t, dc.SelectedLang())
+				require.Empty(t, dc.SelectedUsername())
+				return
+			}
+			require.Equal(t, tc.args.GetBrokerId(), dc.SelectedBrokerID())
+			require.Equal(t, tc.args.GetLang(), dc.SelectedLang())
+			require.Equal(t, tc.args.GetUsername(), dc.SelectedUsername())
+
+			if tc.reselectAgainUser != "" {
+				ret, err := tc.client.SelectBroker(context.TODO(), tc.args)
+				require.Nil(t, err)
+				require.Equal(t, tc.wantRet, ret)
+			}
+		})
+	}
+}
+
+func startBrokerSession(t *testing.T, client authd.PAMClient, brokerIdx int) string {
+	t.Helper()
+
+	brokers, err := client.AvailableBrokers(context.TODO(), nil)
+	require.NoError(t, err)
+	require.GreaterOrEqual(t, len(brokers.BrokersInfos), brokerIdx)
+	ret, err := client.SelectBroker(context.TODO(), &authd.SBRequest{
+		BrokerId: brokers.BrokersInfos[brokerIdx].Id,
+	})
+	require.NoError(t, err)
+	require.NotNil(t, ret)
+	return ret.SessionId
+}
+
+func TestGetAuthenticationModes(t *testing.T) {
+	t.Parallel()
+
+	testCases := map[string]struct {
+		client              authd.PAMClient
+		args                *authd.GAMRequest
+		skipBrokerSelection bool
+
+		wantRet   *authd.GAMResponse
+		wantError error
+	}{
+		"With Error return value": {
+			client:    NewDummyClient(nil, WithGetAuthenticationModesReturn(nil, errTest)),
+			wantError: errTest,
+		},
+		"With empty return value": {
+			client: NewDummyClient(nil,
+				WithAvailableBrokers([]*authd.ABResponse_BrokerInfo{{
+					Id:   "test-broker",
+					Name: "A test broker",
+				}}, nil),
+				WithSelectBrokerReturn(&authd.SBResponse{SessionId: "started-session-id"}, nil),
+				WithGetAuthenticationModesReturn(nil, nil),
+			),
+			args:    &authd.GAMRequest{SessionId: "started-session-id"},
+			wantRet: &authd.GAMResponse{AuthenticationModes: []*authd.GAMResponse_AuthenticationMode{}},
+		},
+		"With all modes return value": {
+			client: NewDummyClient(nil,
+				WithAvailableBrokers([]*authd.ABResponse_BrokerInfo{{
+					Id:   "test-broker",
+					Name: "A test broker",
+				}}, nil),
+				WithSelectBrokerReturn(&authd.SBResponse{SessionId: "started-session-id"}, nil),
+				WithGetAuthenticationModesReturn([]*authd.GAMResponse_AuthenticationMode{
+					{
+						Id:    "foo",
+						Label: "Bar",
+					},
+					{
+						Id:    "password",
+						Label: "Insert your password",
+					},
+				}, nil),
+			),
+			args: &authd.GAMRequest{SessionId: "started-session-id"},
+			wantRet: &authd.GAMResponse{
+				AuthenticationModes: []*authd.GAMResponse_AuthenticationMode{
+					{
+						Id:    "foo",
+						Label: "Bar",
+					},
+					{
+						Id:    "password",
+						Label: "Insert your password",
+					},
+				},
+			},
+		},
+		"With modes returned from values": {
+			client: NewDummyClient(nil,
+				WithAvailableBrokers([]*authd.ABResponse_BrokerInfo{{
+					Id:   "test-broker",
+					Name: "A test broker",
+				}}, nil),
+				WithSelectBrokerReturn(&authd.SBResponse{SessionId: "started-session-id"}, nil),
+				WithUILayout("foobar", "Baz", &authd.UILayout{}),
+				WithUILayout("password", "Insert your password", FormUILayout()),
+			),
+			args: &authd.GAMRequest{SessionId: "started-session-id"},
+			wantRet: &authd.GAMResponse{
+				AuthenticationModes: []*authd.GAMResponse_AuthenticationMode{
+					{
+						Id:    "foobar",
+						Label: "Baz",
+					},
+					{
+						Id:    "password",
+						Label: "Insert your password",
+					},
+				},
+			},
+		},
+		"With no session ID arg when enabled": {
+			client:  NewDummyClient(nil, WithIgnoreSessionIDChecks()),
+			args:    &authd.GAMRequest{},
+			wantRet: &authd.GAMResponse{AuthenticationModes: []*authd.GAMResponse_AuthenticationMode{}},
+		},
+
+		// Error cases
+		"Error with nil args and empty options": {
+			client:    NewDummyClient(nil),
+			wantError: errors.New("no input values provided"),
+		},
+		"Error with no session ID arg": {
+			client:    NewDummyClient(nil),
+			args:      &authd.GAMRequest{},
+			wantError: errors.New("no session ID provided"),
+		},
+		"Error with not-matching session ID": {
+			client:              NewDummyClient(nil),
+			args:                &authd.GAMRequest{SessionId: "session-id"},
+			skipBrokerSelection: true,
+			wantError:           errors.New(`impossible to get authentication mode, session ID "session-id" not found`),
+		},
+	}
+	for name, tc := range testCases {
+		tc := tc
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			if tc.args != nil && tc.args.SessionId != "" && !tc.skipBrokerSelection {
+				sessionID := startBrokerSession(t, tc.client, 0)
+				require.Equal(t, tc.args.SessionId, sessionID)
+			}
+
+			ret, err := tc.client.GetAuthenticationModes(context.TODO(), tc.args)
+			require.Equal(t, tc.wantError, err)
+			if err != nil {
+				require.Nil(t, ret)
+				return
+			}
+
+			require.Equal(t, tc.wantRet, ret)
+		})
+	}
+}
+
+func TestSelectAuthenticationModes(t *testing.T) {
+	t.Parallel()
+
+	testCases := map[string]struct {
+		client              authd.PAMClient
+		args                *authd.SAMRequest
+		skipBrokerSelection bool
+
+		wantRet   *authd.SAMResponse
+		wantError error
+	}{
+		"With Error return value": {
+			client:    NewDummyClient(nil, WithSelectAuthenticationModeReturn(nil, errTest)),
+			wantError: errTest,
+		},
+		"With empty return value": {
+			client: NewDummyClient(nil,
+				WithAvailableBrokers([]*authd.ABResponse_BrokerInfo{{
+					Id:   "test-broker",
+					Name: "A test broker",
+				}}, nil),
+				WithSelectBrokerReturn(&authd.SBResponse{SessionId: "started-session-id"}, nil),
+				WithSelectAuthenticationModeReturn(&authd.UILayout{}, nil),
+			),
+			args:    &authd.SAMRequest{SessionId: "started-session-id"},
+			wantRet: &authd.SAMResponse{UiLayoutInfo: &authd.UILayout{}},
+		},
+		"With all modes return value": {
+			client: NewDummyClient(nil,
+				WithAvailableBrokers([]*authd.ABResponse_BrokerInfo{{
+					Id:   "test-broker",
+					Name: "A test broker",
+				}}, nil),
+				WithSelectBrokerReturn(&authd.SBResponse{SessionId: "started-session-id"}, nil),
+				WithUILayout("password", "Write the password", FormUILayout()),
+				WithUILayout("pin", "Write the PIN number", FormUILayout()),
+				WithUILayout("qrcode", "Scan the QR code", QrCodeUILayout()),
+				WithUILayout("new-pass", "Update your password", NewPasswordUILayout()),
+			),
+			args: &authd.SAMRequest{
+				SessionId:            "started-session-id",
+				AuthenticationModeId: "qrcode",
+			},
+			wantRet: &authd.SAMResponse{UiLayoutInfo: QrCodeUILayout()},
+		},
+
+		// Error cases
+		"Error with nil args and empty options": {
+			client:    NewDummyClient(nil),
+			wantError: errors.New("no input values provided"),
+		},
+		"Error with no session ID arg": {
+			client:    NewDummyClient(nil),
+			args:      &authd.SAMRequest{},
+			wantError: errors.New("no session ID provided"),
+		},
+		"Error with not-matching session ID": {
+			client:              NewDummyClient(nil),
+			args:                &authd.SAMRequest{SessionId: "session-id"},
+			skipBrokerSelection: true,
+			wantError:           errors.New(`impossible to select authentication mode, session ID "session-id" not found`),
+		},
+		"Error with no authentication mode ID": {
+			client: NewDummyClient(nil,
+				WithAvailableBrokers([]*authd.ABResponse_BrokerInfo{{
+					Id:   "test-broker",
+					Name: "A test broker",
+				}}, nil),
+				WithSelectBrokerReturn(&authd.SBResponse{SessionId: "started-session-id"}, nil),
+				WithSelectAuthenticationModeReturn(nil, nil),
+			),
+			args:      &authd.SAMRequest{SessionId: "started-session-id"},
+			wantError: errors.New("no authentication mode ID provided"),
+		},
+		"Error unknown authentication mode ID": {
+			client: NewDummyClient(nil,
+				WithAvailableBrokers([]*authd.ABResponse_BrokerInfo{{
+					Id:   "test-broker",
+					Name: "A test broker",
+				}}, nil),
+				WithSelectBrokerReturn(&authd.SBResponse{SessionId: "started-session-id"}, nil),
+				WithSelectAuthenticationModeReturn(nil, nil),
+			),
+			args: &authd.SAMRequest{
+				SessionId:            "started-session-id",
+				AuthenticationModeId: "auth-mode-id",
+			},
+			wantError: errors.New(`authentication mode "auth-mode-id" not found`),
+		},
+	}
+	for name, tc := range testCases {
+		tc := tc
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			if tc.args != nil && tc.args.SessionId != "" && !tc.skipBrokerSelection {
+				sessionID := startBrokerSession(t, tc.client, 0)
+				require.Equal(t, tc.args.SessionId, sessionID)
+			}
+
+			ret, err := tc.client.SelectAuthenticationMode(context.TODO(), tc.args)
+			require.Equal(t, tc.wantError, err)
+			require.Equal(t, tc.wantRet, ret)
+		})
+	}
+}
+
+func TestIsAuthenticated(t *testing.T) {
+	t.Parallel()
+
+	testCases := map[string]struct {
+		client              authd.PAMClient
+		args                *authd.IARequest
+		skipBrokerSelection bool
+
+		wantRet   *authd.IAResponse
+		wantError error
+	}{
+		"With Error return value": {
+			client:    NewDummyClient(nil, WithIsAuthenticatedReturn(nil, errTest)),
+			wantError: errTest,
+		},
+		"With empty return value": {
+			client: NewDummyClient(nil,
+				WithAvailableBrokers([]*authd.ABResponse_BrokerInfo{{
+					Id:   "test-broker",
+					Name: "A test broker",
+				}}, nil),
+				WithSelectBrokerReturn(&authd.SBResponse{SessionId: "started-session-id"}, nil),
+				WithIsAuthenticatedReturn(&authd.IAResponse{}, nil),
+			),
+			args:    &authd.IARequest{SessionId: "started-session-id"},
+			wantRet: &authd.IAResponse{},
+		},
+		"With retry return value": {
+			client: NewDummyClient(nil,
+				WithAvailableBrokers([]*authd.ABResponse_BrokerInfo{{
+					Id:   "test-broker",
+					Name: "A test broker",
+				}}, nil),
+				WithSelectBrokerReturn(&authd.SBResponse{SessionId: "started-session-id"}, nil),
+				WithIsAuthenticatedReturn(&authd.IAResponse{
+					Access: brokers.AuthRetry,
+					Msg:    "Try again",
+				}, nil),
+			),
+			args: &authd.IARequest{SessionId: "started-session-id"},
+			wantRet: &authd.IAResponse{
+				Access: brokers.AuthRetry,
+				Msg:    "Try again",
+			},
+		},
+		"Invalid challenge": {
+			client: NewDummyClient(privateKey,
+				WithAvailableBrokers([]*authd.ABResponse_BrokerInfo{{
+					Id:   "test-broker",
+					Name: "A test broker",
+				}}, nil),
+				WithSelectBrokerReturn(&authd.SBResponse{SessionId: "started-session-id"}, nil),
+				WithIsAuthenticatedWantChallenge("super-secret-password"),
+			),
+			args: &authd.IARequest{
+				SessionId: "started-session-id",
+				AuthenticationData: &authd.IARequest_AuthenticationData{
+					Item: &authd.IARequest_AuthenticationData_Challenge{
+						Challenge: encryptAndEncodeChallenge(t, &privateKey.PublicKey, "invalid-password"),
+					},
+				},
+			},
+			wantRet: &authd.IAResponse{
+				Access: brokers.AuthDenied,
+			},
+		},
+		"Invalid challenge with message": {
+			client: NewDummyClient(privateKey,
+				WithAvailableBrokers([]*authd.ABResponse_BrokerInfo{{
+					Id:   "test-broker",
+					Name: "A test broker",
+				}}, nil),
+				WithSelectBrokerReturn(&authd.SBResponse{SessionId: "started-session-id"}, nil),
+				WithIsAuthenticatedWantChallenge("super-secret-password"),
+				WithIsAuthenticatedMessage("You're out!"),
+			),
+			args: &authd.IARequest{
+				SessionId: "started-session-id",
+				AuthenticationData: &authd.IARequest_AuthenticationData{
+					Item: &authd.IARequest_AuthenticationData_Challenge{
+						Challenge: encryptAndEncodeChallenge(t, &privateKey.PublicKey, "invalid-password"),
+					},
+				},
+			},
+			wantRet: &authd.IAResponse{
+				Access: brokers.AuthDenied,
+				Msg:    `{"message": "You're out!"}`,
+			},
+		},
+		"Retry challenge with message": {
+			client: NewDummyClient(privateKey,
+				WithAvailableBrokers([]*authd.ABResponse_BrokerInfo{{
+					Id:   "test-broker",
+					Name: "A test broker",
+				}}, nil),
+				WithSelectBrokerReturn(&authd.SBResponse{SessionId: "started-session-id"}, nil),
+				WithIsAuthenticatedWantChallenge("super-secret-password"),
+				WithIsAuthenticatedMaxRetries(1),
+				WithIsAuthenticatedMessage("try again!"),
+			),
+			args: &authd.IARequest{
+				SessionId: "started-session-id",
+				AuthenticationData: &authd.IARequest_AuthenticationData{
+					Item: &authd.IARequest_AuthenticationData_Challenge{
+						Challenge: encryptAndEncodeChallenge(t, &privateKey.PublicKey, "invalid-password"),
+					},
+				},
+			},
+			wantRet: &authd.IAResponse{
+				Access: brokers.AuthRetry,
+				Msg:    `{"message": "try again!"}`,
+			},
+		},
+		"Valid challenge": {
+			client: NewDummyClient(privateKey,
+				WithAvailableBrokers([]*authd.ABResponse_BrokerInfo{{
+					Id:   "test-broker",
+					Name: "A test broker",
+				}}, nil),
+				WithSelectBrokerReturn(&authd.SBResponse{SessionId: "started-session-id"}, nil),
+				WithIsAuthenticatedWantChallenge("super-secret-password"),
+			),
+			args: &authd.IARequest{
+				SessionId: "started-session-id",
+				AuthenticationData: &authd.IARequest_AuthenticationData{
+					Item: &authd.IARequest_AuthenticationData_Challenge{
+						Challenge: encryptAndEncodeChallenge(t, &privateKey.PublicKey, "super-secret-password"),
+					},
+				},
+			},
+			wantRet: &authd.IAResponse{
+				Access: brokers.AuthGranted,
+			},
+		},
+		"Valid challenge with message": {
+			client: NewDummyClient(privateKey,
+				WithAvailableBrokers([]*authd.ABResponse_BrokerInfo{{
+					Id:   "test-broker",
+					Name: "A test broker",
+				}}, nil),
+				WithSelectBrokerReturn(&authd.SBResponse{SessionId: "started-session-id"}, nil),
+				WithIsAuthenticatedWantChallenge("super-secret-password"),
+				WithIsAuthenticatedMessage("try again!"),
+			),
+			args: &authd.IARequest{
+				SessionId: "started-session-id",
+				AuthenticationData: &authd.IARequest_AuthenticationData{
+					Item: &authd.IARequest_AuthenticationData_Challenge{
+						Challenge: encryptAndEncodeChallenge(t, &privateKey.PublicKey, "super-secret-password"),
+					},
+				},
+			},
+			wantRet: &authd.IAResponse{
+				Access: brokers.AuthGranted,
+				Msg:    `{"message": "try again!"}`,
+			},
+		},
+		"Wait with message": {
+			client: NewDummyClient(privateKey,
+				WithAvailableBrokers([]*authd.ABResponse_BrokerInfo{{
+					Id:   "test-broker",
+					Name: "A test broker",
+				}}, nil),
+				WithSelectBrokerReturn(&authd.SBResponse{SessionId: "started-session-id"}, nil),
+				WithIsAuthenticatedWantWait(time.Microsecond*5),
+				WithIsAuthenticatedMessage("Wait done!"),
+			),
+			args: &authd.IARequest{
+				SessionId: "started-session-id",
+				AuthenticationData: &authd.IARequest_AuthenticationData{
+					Item: &authd.IARequest_AuthenticationData_Wait{Wait: "true"},
+				},
+			},
+			wantRet: &authd.IAResponse{
+				Access: brokers.AuthGranted,
+				Msg:    `{"message": "Wait done!"}`,
+			},
+		},
+		"Skip with message": {
+			client: NewDummyClient(privateKey,
+				WithAvailableBrokers([]*authd.ABResponse_BrokerInfo{{
+					Id:   "test-broker",
+					Name: "A test broker",
+				}}, nil),
+				WithSelectBrokerReturn(&authd.SBResponse{SessionId: "started-session-id"}, nil),
+				WithIsAuthenticatedWantSkip(),
+				WithIsAuthenticatedMessage("Skip done!"),
+			),
+			args: &authd.IARequest{
+				SessionId: "started-session-id",
+				AuthenticationData: &authd.IARequest_AuthenticationData{
+					Item: &authd.IARequest_AuthenticationData_Skip{Skip: "true"},
+				},
+			},
+			wantRet: &authd.IAResponse{
+				Msg: `{"message": "Skip done!"}`,
+			},
+		},
+
+		// Error cases
+		"Error with nil args and empty options": {
+			client:    NewDummyClient(nil),
+			wantError: errors.New("no input values provided"),
+		},
+		"Error with no session ID arg": {
+			client:    NewDummyClient(nil),
+			args:      &authd.IARequest{},
+			wantError: errors.New("no session ID provided"),
+		},
+		"Error with not-matching session ID": {
+			client:              NewDummyClient(nil),
+			args:                &authd.IARequest{SessionId: "session-id"},
+			skipBrokerSelection: true,
+			wantError:           errors.New(`impossible to authenticate, session ID "session-id" not found`),
+		},
+		"Error with no authentication data": {
+			client: NewDummyClient(nil,
+				WithAvailableBrokers([]*authd.ABResponse_BrokerInfo{{
+					Id:   "test-broker",
+					Name: "A test broker",
+				}}, nil),
+				WithSelectBrokerReturn(&authd.SBResponse{SessionId: "started-session-id"}, nil),
+			),
+			args:      &authd.IARequest{SessionId: "started-session-id"},
+			wantError: errors.New("no authentication data provided"),
+		},
+		"Error with invalid authentication data": {
+			client: NewDummyClient(nil,
+				WithAvailableBrokers([]*authd.ABResponse_BrokerInfo{{
+					Id:   "test-broker",
+					Name: "A test broker",
+				}}, nil),
+				WithSelectBrokerReturn(&authd.SBResponse{SessionId: "started-session-id"}, nil),
+				WithIsAuthenticatedWantChallenge("super-secret-password"),
+			),
+			args: &authd.IARequest{
+				SessionId:          "started-session-id",
+				AuthenticationData: &authd.IARequest_AuthenticationData{},
+			},
+			wantError: errors.New("no authentication data provided"),
+		},
+		"Error missing wanted challenge": {
+			client: NewDummyClient(nil,
+				WithAvailableBrokers([]*authd.ABResponse_BrokerInfo{{
+					Id:   "test-broker",
+					Name: "A test broker",
+				}}, nil),
+				WithSelectBrokerReturn(&authd.SBResponse{SessionId: "started-session-id"}, nil),
+			),
+			args: &authd.IARequest{
+				SessionId: "started-session-id",
+				AuthenticationData: &authd.IARequest_AuthenticationData{
+					Item: &authd.IARequest_AuthenticationData_Challenge{},
+				},
+			},
+			wantError: errors.New("no wanted challenge provided"),
+		},
+		"Error missing wanted wait": {
+			client: NewDummyClient(nil,
+				WithAvailableBrokers([]*authd.ABResponse_BrokerInfo{{
+					Id:   "test-broker",
+					Name: "A test broker",
+				}}, nil),
+				WithSelectBrokerReturn(&authd.SBResponse{SessionId: "started-session-id"}, nil),
+			),
+			args: &authd.IARequest{
+				SessionId: "started-session-id",
+				AuthenticationData: &authd.IARequest_AuthenticationData{
+					Item: &authd.IARequest_AuthenticationData_Wait{},
+				},
+			},
+			wantError: errors.New("no wanted wait provided"),
+		},
+		"Error missing wanted skip": {
+			client: NewDummyClient(nil,
+				WithAvailableBrokers([]*authd.ABResponse_BrokerInfo{{
+					Id:   "test-broker",
+					Name: "A test broker",
+				}}, nil),
+				WithSelectBrokerReturn(&authd.SBResponse{SessionId: "started-session-id"}, nil),
+			),
+			args: &authd.IARequest{
+				SessionId: "started-session-id",
+				AuthenticationData: &authd.IARequest_AuthenticationData{
+					Item: &authd.IARequest_AuthenticationData_Skip{},
+				},
+			},
+			wantError: errors.New("no wanted skip requested"),
+		},
+		"Error empty challenge": {
+			client: NewDummyClient(nil,
+				WithAvailableBrokers([]*authd.ABResponse_BrokerInfo{{
+					Id:   "test-broker",
+					Name: "A test broker",
+				}}, nil),
+				WithSelectBrokerReturn(&authd.SBResponse{SessionId: "started-session-id"}, nil),
+				WithIsAuthenticatedWantChallenge("challenge"),
+			),
+			args: &authd.IARequest{
+				SessionId: "started-session-id",
+				AuthenticationData: &authd.IARequest_AuthenticationData{
+					Item: &authd.IARequest_AuthenticationData_Challenge{},
+				},
+			},
+			wantError: errors.New("no challenge provided"),
+		},
+		"Error decoding challenge": {
+			client: NewDummyClient(nil,
+				WithAvailableBrokers([]*authd.ABResponse_BrokerInfo{{
+					Id:   "test-broker",
+					Name: "A test broker",
+				}}, nil),
+				WithSelectBrokerReturn(&authd.SBResponse{SessionId: "started-session-id"}, nil),
+				WithIsAuthenticatedWantChallenge("challenge"),
+			),
+			args: &authd.IARequest{
+				SessionId: "started-session-id",
+				AuthenticationData: &authd.IARequest_AuthenticationData{
+					Item: &authd.IARequest_AuthenticationData_Challenge{
+						Challenge: "Invalid base64",
+					},
+				},
+			},
+			wantError: base64.CorruptInputError(7),
+		},
+		"Error decrypting challenge per missing private key": {
+			client: NewDummyClient(nil,
+				WithAvailableBrokers([]*authd.ABResponse_BrokerInfo{{
+					Id:   "test-broker",
+					Name: "A test broker",
+				}}, nil),
+				WithSelectBrokerReturn(&authd.SBResponse{SessionId: "started-session-id"}, nil),
+				WithIsAuthenticatedWantChallenge("challenge"),
+			),
+			args: &authd.IARequest{
+				SessionId: "started-session-id",
+				AuthenticationData: &authd.IARequest_AuthenticationData{
+					Item: &authd.IARequest_AuthenticationData_Challenge{
+						Challenge: base64.StdEncoding.EncodeToString([]byte("Invalid encrypted key")),
+					},
+				},
+			},
+			wantError: errors.New("no private key defined"),
+		},
+		"Error decrypting invalid challenge": {
+			client: NewDummyClient(privateKey,
+				WithAvailableBrokers([]*authd.ABResponse_BrokerInfo{{
+					Id:   "test-broker",
+					Name: "A test broker",
+				}}, nil),
+				WithSelectBrokerReturn(&authd.SBResponse{SessionId: "started-session-id"}, nil),
+				WithIsAuthenticatedWantChallenge("challenge"),
+			),
+			args: &authd.IARequest{
+				SessionId: "started-session-id",
+				AuthenticationData: &authd.IARequest_AuthenticationData{
+					Item: &authd.IARequest_AuthenticationData_Challenge{
+						Challenge: base64.StdEncoding.EncodeToString([]byte("Invalid encrypted key")),
+					},
+				},
+			},
+			wantError: rsa.ErrDecryption,
+		},
+	}
+	for name, tc := range testCases {
+		tc := tc
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			if tc.args != nil && tc.args.SessionId != "" && !tc.skipBrokerSelection {
+				sessionID := startBrokerSession(t, tc.client, 0)
+				require.Equal(t, tc.args.SessionId, sessionID)
+			}
+
+			ret, err := tc.client.IsAuthenticated(context.TODO(), tc.args)
+			require.Equal(t, tc.wantError, err)
+			require.Equal(t, tc.wantRet, ret)
+		})
+	}
+}
+
+func encryptAndEncodeChallenge(t *testing.T, pubKey *rsa.PublicKey, challenge string) string {
+	t.Helper()
+
+	ciphertext, err := rsa.EncryptOAEP(sha512.New(), rand.Reader, pubKey, []byte(challenge), nil)
+	require.NoError(t, err)
+
+	// encrypt it to base64 and replace the challenge with it
+	base64Encoded := base64.StdEncoding.EncodeToString(ciphertext)
+	return base64Encoded
+}
+
+func TestEndSession(t *testing.T) {
+	t.Parallel()
+
+	testCases := map[string]struct {
+		client           authd.PAMClient
+		args             *authd.ESRequest
+		selectedBrokerID string
+
+		wantError error
+	}{
+		"With Error return value": {
+			client:    NewDummyClient(nil, WithEndSessionReturn(errTest)),
+			wantError: errTest,
+		},
+		"With valid return value": {
+			client: NewDummyClient(nil,
+				WithAvailableBrokers([]*authd.ABResponse_BrokerInfo{{
+					Id:        "test-broker",
+					Name:      "A test broker",
+					BrandIcon: ptrValue("/usr/share/icons/broker-icon.png"),
+				}}, nil),
+				WithSelectBrokerReturn(&authd.SBResponse{SessionId: "started-session-id"}, nil),
+				WithEndSessionReturn(nil),
+			),
+			args:             &authd.ESRequest{SessionId: "started-session-id"},
+			selectedBrokerID: "test-broker",
+		},
+
+		// Error cases
+		"Error with nil args and empty options": {
+			client:    NewDummyClient(nil),
+			wantError: errors.New("no input values provided"),
+		},
+		"Error with empty args empty options": {
+			client:    NewDummyClient(nil),
+			args:      &authd.ESRequest{},
+			wantError: errors.New("no session ID provided"),
+		},
+		"Error with not-matching session ID": {
+			client:    NewDummyClient(nil),
+			args:      &authd.ESRequest{SessionId: "a-session-id"},
+			wantError: errors.New(`impossible to end session "a-session-id", not found`),
+		},
+	}
+	for name, tc := range testCases {
+		tc := tc
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			dc, ok := tc.client.(*DummyClient)
+			require.True(t, ok, "Provided client is not a Dummy client")
+
+			if tc.args != nil && tc.args.SessionId != "" && tc.selectedBrokerID != "" {
+				ret, err := tc.client.SelectBroker(context.TODO(), &authd.SBRequest{
+					BrokerId: tc.selectedBrokerID,
+				})
+				require.NoError(t, err)
+				require.NotNil(t, ret)
+				require.Equal(t, tc.args.SessionId, ret.SessionId)
+				require.Equal(t, tc.args.SessionId, dc.CurrentSessionID())
+			}
+
+			ret, err := tc.client.EndSession(context.TODO(), tc.args)
+			require.Equal(t, tc.wantError, err)
+			if err != nil {
+				require.Nil(t, ret)
+				return
+			}
+
+			require.Equal(t, &authd.Empty{}, ret)
+			require.Empty(t, dc.CurrentSessionID())
+			require.Empty(t, dc.SelectedUsername())
+		})
+	}
+}
+
+func TestSetDefaultBrokerForUser(t *testing.T) {
+	t.Parallel()
+
+	testCases := map[string]struct {
+		client authd.PAMClient
+		args   *authd.SDBFURequest
+
+		wantError error
+	}{
+		"With empty options": {
+			client:    NewDummyClient(nil),
+			wantError: errors.New("no input values provided"),
+		},
+		"With Error return value": {
+			client:    NewDummyClient(nil, WithSetDefaultBrokerReturn(errTest)),
+			wantError: errTest,
+		},
+		"With valid arguments": {
+			client: NewDummyClient(nil, WithSetDefaultBrokerReturn(nil)),
+			args: &authd.SDBFURequest{
+				BrokerId: "broker-id",
+				Username: "username",
+			},
+		},
+
+		// Error cases
+		"Error if no user name is provided": {
+			client:    NewDummyClient(nil),
+			args:      &authd.SDBFURequest{BrokerId: "broker-id"},
+			wantError: errors.New("no valid username provided"),
+		},
+		"Error if no broker ID is provided": {
+			client:    NewDummyClient(nil),
+			args:      &authd.SDBFURequest{Username: "username"},
+			wantError: errors.New("no valid broker ID provided"),
+		},
+	}
+	for name, tc := range testCases {
+		tc := tc
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			ret, err := tc.client.SetDefaultBrokerForUser(context.TODO(), tc.args)
+			require.Equal(t, err, tc.wantError)
+			if err != nil {
+				require.Nil(t, ret)
+				return
+			}
+
+			require.Equal(t, &authd.Empty{}, ret)
+
+			if tc.args == nil {
+				return
+			}
+			retBroker, err := tc.client.GetPreviousBroker(context.TODO(),
+				&authd.GPBRequest{Username: tc.args.Username})
+			require.NoError(t, err)
+			require.Equal(t, tc.args.BrokerId, *retBroker.PreviousBroker)
+		})
+	}
+}
+
+func TestMain(m *testing.M) {
+	var err error
+	privateKey, err = rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		panic(fmt.Sprintf("could not create an valid rsa key: %v", err))
+	}
+	os.Exit(m.Run())
+}

--- a/pam/internal/pam_test/utils.go
+++ b/pam/internal/pam_test/utils.go
@@ -3,10 +3,21 @@ package pam_test
 
 /*
 #include <stdlib.h>
+#include <stdbool.h>
 
 #ifdef __SANITIZE_ADDRESS__
 #include <sanitizer/lsan_interface.h>
 #endif
+
+static inline bool
+have_asan_support (void)
+{
+#ifdef __SANITIZE_ADDRESS__
+	return true;
+#else
+	return false;
+#endif
+}
 
 static inline void
 maybe_do_leak_check (void)
@@ -35,6 +46,11 @@ func MaybeDoLeakCheck() {
 	runtime.GC()
 	time.Sleep(time.Millisecond * 10)
 	C.maybe_do_leak_check()
+}
+
+// IsAddressSanitizerActive can be used to detect if address sanitizer is active.
+func IsAddressSanitizerActive() bool {
+	return bool(C.have_asan_support())
 }
 
 func allocateCBytes(bytes []byte) pam.BinaryPointer {


### PR DESCRIPTION
Add a model to implement the communication between GDM and this pam
module using the JSON private protocol.

Added tests that mimic the behavior of what GDM ui should do,
implementing a pam transaction handler that supports the GDM binary
protocol.

This does not include fully integration tests yet, to make review _smaller_...

UDENG-1372