### PR TITLE
maint(ci): align coverage reporting with Pro for WSL project

### DIFF
--- a/.github/workflows/qa.yaml
+++ b/.github/workflows/qa.yaml
@@ -112,8 +112,9 @@ jobs:
 
           # The coverage is not written if the output directory does not exist, so we need to create it.
           cov_dir="$(pwd)/coverage"
+          cod_cov_dir="$(pwd)/coverage/codecov"
           raw_cov_dir="${cov_dir}/raw"
-          mkdir -p "${raw_cov_dir}"
+          mkdir -p "${raw_cov_dir}" "${cod_cov_dir}"
 
           # Overriding the default coverage directory is not an exported flag of go test (yet), so
           # we need to override it using the test.gocoverdir flag instead.
@@ -127,7 +128,7 @@ jobs:
           cat "${raw_cov_dir}/rust-cov/rust2go_coverage" >>"${cov_dir}/coverage.out"
 
           # Filter out the testutils package and the pb.go file
-          grep -v -e "testutils" -e "pb.go" "${cov_dir}/coverage.out" >"${cov_dir}/coverage.out.filtered"
+          grep -v -e "testutils" -e "pb.go" "${cov_dir}/coverage.out" >"${cod_cov_dir}/coverage.out.filtered"
 
       - name: Run tests (with race detector)
         run: |
@@ -145,6 +146,5 @@ jobs:
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v4
         with:
-          file: coverage/coverage.out.filtered
-          disable_search: true
+          directory: ./coverage/codecov
           token: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
We use a directory strategy to ship it, which is compatible with multiple platforms using a relative directory, and rely on autosearch so that only this subdirectory contains all codecov related content.