### PR TITLE
fix(tests): fix lostcancel occurrence in tests

### DIFF
--- a/internal/daemon/daemon_test.go
+++ b/internal/daemon/daemon_test.go
@@ -306,6 +306,7 @@ func createClientConnection(t *testing.T, socketPath string) (success bool, disc
 	select {
 	case <-connected:
 	case <-time.After(10 * time.Millisecond):
+		disconnect()
 		return false, func() {}
 	}
 


### PR DESCRIPTION
Addresses the following govet error:

    lostcancel: this return statement may be reached without using the disconnect var defined on line 296

Fixes UDENG-2287