### PR TITLE
feat(pam): Cleanup logging, disable info messages in terminal mode and use journal when possible

### DIFF
--- a/internal/log/log.go
+++ b/internal/log/log.go
@@ -91,7 +91,7 @@ func SetHandler(handler Handler) {
 }
 
 func log(context context.Context, level Level, args ...interface{}) {
-	if !logrus.IsLevelEnabled(level) {
+	if !IsLevelEnabled(level) {
 		return
 	}
 
@@ -99,7 +99,7 @@ func log(context context.Context, level Level, args ...interface{}) {
 }
 
 func logf(context context.Context, level Level, format string, args ...interface{}) {
-	if !logrus.IsLevelEnabled(level) {
+	if !IsLevelEnabled(level) {
 		return
 	}
 

--- a/internal/log/log.go
+++ b/internal/log/log.go
@@ -17,6 +17,8 @@ var (
 	SetFormatter = logrus.SetFormatter
 	// SetLevel sets the standard logger level.
 	SetLevel = logrus.SetLevel
+	// SetOutput sets the log output.
+	SetOutput = logrus.SetOutput
 	// SetReportCaller sets whether the standard logger will include the calling method as a field.
 	SetReportCaller = logrus.SetReportCaller
 )

--- a/internal/log/log.go
+++ b/internal/log/log.go
@@ -3,6 +3,9 @@ package log
 
 import (
 	"context"
+	"fmt"
+	"maps"
+	"sync"
 
 	"github.com/sirupsen/logrus"
 )
@@ -10,9 +13,19 @@ import (
 type (
 	// TextFormatter is the text formatter for the logs.
 	TextFormatter = logrus.TextFormatter
+
+	// Level is the log level for the logs.
+	Level = logrus.Level
+
+	// Handler is the log handler function.
+	Handler = func(_ context.Context, _ Level, format string, args ...interface{})
 )
 
 var (
+	// GetLevel gets the standard logger level.
+	GetLevel = logrus.GetLevel
+	// IsLevelEnabled checks if the log level is greater than the level param.
+	IsLevelEnabled = logrus.IsLevelEnabled
 	// SetFormatter sets the standard logger formatter.
 	SetFormatter = logrus.SetFormatter
 	// SetLevel sets the standard logger level.
@@ -24,48 +37,123 @@ var (
 )
 
 const (
+	// ErrorLevel level. Logs. Used for errors that should definitely be noted.
+	// Commonly used for hooks to send errors to an error tracking service.
+	ErrorLevel = logrus.ErrorLevel
+	// WarnLevel level. Non-critical entries that deserve eyes.
+	WarnLevel = logrus.WarnLevel
 	// InfoLevel level. General operational entries about what's going on inside the application.
 	InfoLevel = logrus.InfoLevel
 	// DebugLevel level. Usually only enabled when debugging. Very verbose logging.
 	DebugLevel = logrus.DebugLevel
 )
 
-// Debug is a temporary placeholder.
-func Debug(_ context.Context, args ...interface{}) {
-	logrus.Debug(args...)
+func logFuncAdapter(logrusFunc func(args ...interface{})) Handler {
+	return func(_ context.Context, _ Level, format string, args ...interface{}) {
+		logrusFunc(fmt.Sprintf(format, args...))
+	}
 }
 
-// Debugf is a temporary placeholder.
-func Debugf(_ context.Context, format string, args ...interface{}) {
-	logrus.Debugf(format, args...)
+var defaultHandlers = map[Level]Handler{
+	DebugLevel: logFuncAdapter(logrus.Debug),
+	InfoLevel:  logFuncAdapter(logrus.Info),
+	WarnLevel:  logFuncAdapter(logrus.Warn),
+	ErrorLevel: logFuncAdapter(logrus.Error),
+}
+var handlers = maps.Clone(defaultHandlers)
+var handlersMu = sync.RWMutex{}
+
+// SetLevelHandler allows to define the default handler function for a given level.
+func SetLevelHandler(level Level, handler Handler) {
+	handlersMu.Lock()
+	defer handlersMu.Unlock()
+	if handler == nil {
+		h, ok := defaultHandlers[level]
+		if !ok {
+			return
+		}
+		handler = h
+	}
+	handlers[level] = handler
 }
 
-// Info is a temporary placeholder.
-func Info(_ context.Context, args ...interface{}) {
-	logrus.Info(args...)
+// SetHandler allows to define the default handler function for all log levels.
+func SetHandler(handler Handler) {
+	handlersMu.Lock()
+	defer handlersMu.Unlock()
+	if handler == nil {
+		handlers = maps.Clone(defaultHandlers)
+		return
+	}
+	for _, level := range logrus.AllLevels {
+		handlers[level] = handler
+	}
 }
 
-// Warning is a temporary placeholder.
-func Warning(_ context.Context, args ...interface{}) {
-	logrus.Warning(args...)
+func log(context context.Context, level Level, args ...interface{}) {
+	if !logrus.IsLevelEnabled(level) {
+		return
+	}
+
+	logf(context, level, fmt.Sprint(args...))
 }
 
-// Warningf is a temporary placeholder.
-func Warningf(_ context.Context, format string, args ...interface{}) {
-	logrus.Warningf(format, args...)
+func logf(context context.Context, level Level, format string, args ...interface{}) {
+	if !logrus.IsLevelEnabled(level) {
+		return
+	}
+
+	handlersMu.RLock()
+	handler := handlers[level]
+	handlersMu.RUnlock()
+
+	handler(context, level, format, args...)
 }
 
-// Error is a temporary placeholder.
-func Error(_ context.Context, args ...interface{}) {
-	logrus.Error(args...)
+// Debug outputs messages with the level [DebugLevel] (when that is enabled) using the
+// configured logging handler.
+func Debug(context context.Context, args ...interface{}) {
+	log(context, DebugLevel, args...)
 }
 
-// Errorf is a temporary placeholder.
-func Errorf(_ context.Context, format string, args ...interface{}) {
-	logrus.Errorf(format, args...)
+// Debugf outputs messages with the level [DebugLevel] (when that is enabled) using the
+// configured logging handler.
+func Debugf(context context.Context, format string, args ...interface{}) {
+	logf(context, DebugLevel, format, args...)
 }
 
-// Infof is a temporary placeholder.
-func Infof(_ context.Context, format string, args ...interface{}) {
-	logrus.Infof(format, args...)
+// Info outputs messages with the level [InfoLevel] (when that is enabled) using the
+// configured logging handler.
+func Info(context context.Context, args ...interface{}) {
+	log(context, InfoLevel, args...)
+}
+
+// Infof outputs messages with the level [InfoLevel] (when that is enabled) using the
+// configured logging handler.
+func Infof(context context.Context, format string, args ...interface{}) {
+	logf(context, InfoLevel, format, args...)
+}
+
+// Warning outputs messages with the level [WarningLevel] (when that is enabled) using the
+// configured logging handler.
+func Warning(context context.Context, args ...interface{}) {
+	log(context, WarnLevel, args...)
+}
+
+// Warningf outputs messages with the level [WarningLevel] (when that is enabled) using the
+// configured logging handler.
+func Warningf(context context.Context, format string, args ...interface{}) {
+	logf(context, WarnLevel, format, args...)
+}
+
+// Error outputs messages with the level [ErrorLevel] (when that is enabled) using the
+// configured logging handler.
+func Error(context context.Context, args ...interface{}) {
+	log(context, ErrorLevel, args...)
+}
+
+// Errorf outputs messages with the level [ErrorLevel] (when that is enabled) using the
+// configured logging handler.
+func Errorf(context context.Context, format string, args ...interface{}) {
+	logf(context, ErrorLevel, format, args...)
 }

--- a/internal/log/log_test.go
+++ b/internal/log/log_test.go
@@ -1,0 +1,208 @@
+package log_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/ubuntu/authd/internal/log"
+)
+
+var supportedLevels = []log.Level{
+	log.ErrorLevel,
+	log.WarnLevel,
+	log.InfoLevel,
+	log.DebugLevel,
+}
+
+func TestLevelEnabled(t *testing.T) {
+	// This can't be parallel.
+	defaultLevel := log.GetLevel()
+	t.Cleanup(func() {
+		log.SetLevel(defaultLevel)
+	})
+
+	for _, level := range supportedLevels {
+		t.Run(fmt.Sprintf("Set log level to %s", level), func(t *testing.T) {
+			log.SetLevel(level)
+			require.Equal(t, level, log.GetLevel(), "Log Level should not match %v", level)
+			require.True(t, log.IsLevelEnabled(level), "Log level %v should be enabled", level)
+		})
+	}
+}
+
+func callLogHandler(ctx context.Context, level log.Level, args ...any) {
+	switch level {
+	case log.ErrorLevel:
+		log.Error(ctx, args...)
+	case log.WarnLevel:
+		log.Warning(ctx, args...)
+	case log.InfoLevel:
+		log.Info(ctx, args...)
+	case log.DebugLevel:
+		log.Debug(ctx, args...)
+	}
+}
+
+func callLogHandlerf(ctx context.Context, level log.Level, format string, args ...any) {
+	switch level {
+	case log.ErrorLevel:
+		log.Errorf(ctx, format, args...)
+	case log.WarnLevel:
+		log.Warningf(ctx, format, args...)
+	case log.InfoLevel:
+		log.Infof(ctx, format, args...)
+	case log.DebugLevel:
+		log.Debugf(ctx, format, args...)
+	}
+}
+
+func TestSetLevelHandler(t *testing.T) {
+	defaultLevel := log.GetLevel()
+	t.Cleanup(func() {
+		log.SetLevel(defaultLevel)
+		for _, level := range supportedLevels {
+			log.SetLevelHandler(level, nil)
+		}
+	})
+
+	for _, level := range supportedLevels {
+		t.Run(fmt.Sprintf("Set log handler for %s", level), func(t *testing.T) {
+			handlerCalled := false
+			wantArgs := []any{true, 5.5, []string{"bar"}}
+			wantCtx := context.TODO()
+			log.SetLevelHandler(level, func(ctx context.Context, l log.Level, format string, args ...interface{}) {
+				handlerCalled = true
+				require.Equal(t, wantCtx, ctx, "Context should match expected")
+				require.Equal(t, level, l, "Log level should match %v", l)
+				require.Equal(t, fmt.Sprint(wantArgs...), format, "Format should match")
+			})
+
+			log.SetLevel(level)
+
+			callLogHandler(wantCtx, level, wantArgs...)
+			require.True(t, handlerCalled, "Handler should have been called")
+
+			handlerCalled = false
+			callLogHandler(wantCtx, level+1, wantArgs...)
+			require.False(t, handlerCalled, "Handler should not have been called")
+
+			handlerCalled = false
+			log.SetLevelHandler(level, nil)
+
+			callLogHandler(wantCtx, level, wantArgs...)
+			require.False(t, handlerCalled, "Handler should not have been called")
+		})
+	}
+
+	for _, level := range supportedLevels {
+		t.Run(fmt.Sprintf("Set log handler for %s, using formatting", level), func(t *testing.T) {
+			handlerCalled := false
+			wantArgs := []any{true, 5.5, []string{"bar"}}
+			wantFormat := "Bool is %v, float is %f, array is %v"
+			wantCtx := context.TODO()
+			log.SetLevelHandler(level, func(ctx context.Context, l log.Level, format string, args ...interface{}) {
+				handlerCalled = true
+				require.Equal(t, wantCtx, ctx, "Context should match expected")
+				require.Equal(t, level, l, "Log level should match %v", l)
+				require.Equal(t, wantFormat, format, "Format should match")
+				require.Equal(t, wantArgs, args, "Arguments should match")
+			})
+
+			handlerCalled = false
+			callLogHandlerf(wantCtx, level, wantFormat, wantArgs...)
+
+			handlerCalled = false
+			callLogHandlerf(wantCtx, level+1, wantFormat, wantArgs...)
+			require.False(t, handlerCalled, "Handler should not have been called")
+
+			handlerCalled = false
+			log.SetLevelHandler(level, nil)
+
+			callLogHandlerf(wantCtx, level, wantFormat, wantArgs...)
+			require.False(t, handlerCalled, "Handle should not have been called")
+		})
+	}
+
+	log.SetLevelHandler(log.Level(99999999), nil)
+}
+
+func TestSetHandler(t *testing.T) {
+	defaultLevel := log.GetLevel()
+	t.Cleanup(func() {
+		log.SetLevel(defaultLevel)
+		log.SetHandler(nil)
+	})
+
+	handlerCalled := false
+	wantLevel := log.Level(0)
+	wantArgs := []any{true, 5.5, []string{"bar"}}
+	wantCtx := context.TODO()
+
+	log.SetHandler(func(ctx context.Context, l log.Level, format string, args ...interface{}) {
+		handlerCalled = true
+		require.Equal(t, wantCtx, ctx, "Context should match expected")
+		require.Equal(t, wantLevel, l, "Log level should match %v", l)
+		require.Equal(t, fmt.Sprint(wantArgs...), format, "Format should match")
+	})
+	for _, level := range supportedLevels {
+		t.Run(fmt.Sprintf("Set log handler, testing level %s", level), func(t *testing.T) {})
+
+		wantLevel = level
+		handlerCalled = false
+		log.SetLevel(level)
+		callLogHandler(wantCtx, level, wantArgs...)
+		require.True(t, handlerCalled, "Handler should have been called")
+
+		handlerCalled = false
+		log.SetLevel(level - 1)
+		callLogHandler(wantCtx, level, wantArgs...)
+		require.False(t, handlerCalled, "Handler should not have been called")
+	}
+
+	log.SetHandler(nil)
+	for _, level := range supportedLevels {
+		t.Run(fmt.Sprintf("Set log handler, ignoring level %s", level), func(t *testing.T) {})
+
+		wantLevel = level
+		handlerCalled = false
+		log.SetLevel(level)
+		callLogHandler(wantCtx, level, wantArgs...)
+		require.False(t, handlerCalled, "Handler should not have been called")
+	}
+
+	wantFormat := "Bool is %v, float is %f, array is %v"
+	log.SetHandler(func(ctx context.Context, l log.Level, format string, args ...interface{}) {
+		handlerCalled = true
+		require.Equal(t, wantCtx, ctx, "Context should match expected")
+		require.Equal(t, wantLevel, l, "Log level should match %v", l)
+		require.Equal(t, wantFormat, format, "Format should match")
+		require.Equal(t, wantArgs, args, "Arguments should match")
+	})
+	for _, level := range supportedLevels {
+		t.Run(fmt.Sprintf("Set log handler, testing level %s", level), func(t *testing.T) {})
+
+		wantLevel = level
+		handlerCalled = false
+		log.SetLevel(level)
+		callLogHandlerf(wantCtx, level, wantFormat, wantArgs...)
+		require.True(t, handlerCalled, "Handler should have been called")
+
+		handlerCalled = false
+		log.SetLevel(level - 1)
+		callLogHandlerf(wantCtx, level, wantFormat, wantArgs...)
+		require.False(t, handlerCalled, "Handler should not have been called")
+	}
+
+	log.SetHandler(nil)
+	for _, level := range supportedLevels {
+		t.Run(fmt.Sprintf("Set log handler, ignoring level %s", level), func(t *testing.T) {})
+
+		wantLevel = level
+		handlerCalled = false
+		log.SetLevel(level)
+		callLogHandlerf(wantCtx, level, wantFormat, wantArgs...)
+		require.False(t, handlerCalled, "Handler should not have been called")
+	}
+}

--- a/pam/integration-tests/testdata/TestCLIAuthenticate/golden/authenticate_user_switching_broker
+++ b/pam/integration-tests/testdata/TestCLIAuthenticate/golden/authenticate_user_switching_broker
@@ -222,12 +222,12 @@ Gimme your password
 
 PAM Authenticate() for user "user-integration-switch-broker" exited with error (PAM exit code: 2
 5): The return value should be ignored by PAM dispatch:
+PAM Error Message: Can't set default broker ("local") for "user-integration-switch-broker": rpc
+error: code = Unknown desc = can't set default broker "local" for user "user-integration-switch-
+broker": no result matching user-integration-switch-broker in UserByName
 PAM AcctMgmt() exited with error (PAM exit code: 25): The return value should be ignored by PAM
 dispatch
 >
-
-
-
 ────────────────────────────────────────────────────────────────────────────────
 > ./pam_authd login socket=${AUTHD_TESTS_CLI_AUTHENTICATE_TESTS_SOCK}
   Select your provider
@@ -255,10 +255,10 @@ dispatch
 
 PAM Authenticate() for user "user-integration-switch-broker" exited with error (PAM exit code: 2
 5): The return value should be ignored by PAM dispatch:
+PAM Error Message: Can't set default broker ("local") for "user-integration-switch-broker": rpc
+error: code = Unknown desc = can't set default broker "local" for user "user-integration-switch-
+broker": no result matching user-integration-switch-broker in UserByName
 PAM AcctMgmt() exited with error (PAM exit code: 25): The return value should be ignored by PAM
 dispatch
 >
-
-
-
 ────────────────────────────────────────────────────────────────────────────────

--- a/pam/integration-tests/testdata/TestCLIAuthenticate/golden/exit_authd_if_local_broker_is_selected
+++ b/pam/integration-tests/testdata/TestCLIAuthenticate/golden/exit_authd_if_local_broker_is_selected
@@ -123,12 +123,12 @@ Username: user-local-broker
 
 PAM Authenticate() for user "user-local-broker" exited with error (PAM exit code: 25): The retur
 n value should be ignored by PAM dispatch:
+PAM Error Message: Can't set default broker ("local") for "user-local-broker": rpc error: code =
+ Unknown desc = can't set default broker "local" for user "user-local-broker": no result matchin
+g user-local-broker in UserByName
 PAM AcctMgmt() exited with error (PAM exit code: 25): The return value should be ignored by PAM
 dispatch
 >
-
-
-
 ────────────────────────────────────────────────────────────────────────────────
 > ./pam_authd login socket=${AUTHD_TESTS_CLI_AUTHENTICATE_TESTS_SOCK}
   Select your provider
@@ -156,10 +156,10 @@ dispatch
 
 PAM Authenticate() for user "user-local-broker" exited with error (PAM exit code: 25): The retur
 n value should be ignored by PAM dispatch:
+PAM Error Message: Can't set default broker ("local") for "user-local-broker": rpc error: code =
+ Unknown desc = can't set default broker "local" for user "user-local-broker": no result matchin
+g user-local-broker in UserByName
 PAM AcctMgmt() exited with error (PAM exit code: 25): The return value should be ignored by PAM
 dispatch
 >
-
-
-
 ────────────────────────────────────────────────────────────────────────────────

--- a/pam/integration-tests/testdata/TestCLIChangeAuthTok/golden/exit_authd_if_local_broker_is_selected
+++ b/pam/integration-tests/testdata/TestCLIChangeAuthTok/golden/exit_authd_if_local_broker_is_selected
@@ -123,12 +123,12 @@ Username: user-local-broker
 
 PAM ChangeAuthTok() for user "user-local-broker" exited with error (PAM exit code: 25): The retu
 rn value should be ignored by PAM dispatch:
+PAM Error Message: Can't set default broker ("local") for "user-local-broker": rpc error: code =
+ Unknown desc = can't set default broker "local" for user "user-local-broker": no result matchin
+g user-local-broker in UserByName
 PAM AcctMgmt() exited with error (PAM exit code: 25): The return value should be ignored by PAM
 dispatch
 >
-
-
-
 ────────────────────────────────────────────────────────────────────────────────
 > ./pam_authd passwd socket=${AUTHD_TESTS_CLI_AUTHTOK_TESTS_SOCK}
   Select your provider
@@ -156,10 +156,10 @@ dispatch
 
 PAM ChangeAuthTok() for user "user-local-broker" exited with error (PAM exit code: 25): The retu
 rn value should be ignored by PAM dispatch:
+PAM Error Message: Can't set default broker ("local") for "user-local-broker": rpc error: code =
+ Unknown desc = can't set default broker "local" for user "user-local-broker": no result matchin
+g user-local-broker in UserByName
 PAM AcctMgmt() exited with error (PAM exit code: 25): The return value should be ignored by PAM
 dispatch
 >
-
-
-
 ────────────────────────────────────────────────────────────────────────────────

--- a/pam/internal/adapter/authentication.go
+++ b/pam/internal/adapter/authentication.go
@@ -143,7 +143,7 @@ func (m *authenticationModel) Update(msg tea.Msg) (authenticationModel, tea.Cmd)
 		return *m, nil
 
 	case isAuthenticatedResultReceived:
-		log.Infof(context.TODO(), "isAuthenticatedResultReceived: %v", msg.access)
+		log.Debugf(context.TODO(), "isAuthenticatedResultReceived: %v", msg.access)
 		switch msg.access {
 		case brokers.AuthGranted:
 			infoMsg, err := dataToMsg(msg.msg)

--- a/pam/internal/adapter/authentication.go
+++ b/pam/internal/adapter/authentication.go
@@ -130,6 +130,7 @@ func (m *authenticationModel) Update(msg tea.Msg) (authenticationModel, tea.Cmd)
 		return *m, sendEvent(AuthModeSelected{})
 
 	case isAuthenticatedRequested:
+		log.Debugf(context.TODO(), "%#v", msg)
 		m.cancelIsAuthenticated()
 		ctx, cancel := context.WithCancel(context.Background())
 		m.cancelIsAuthenticated = cancel
@@ -139,11 +140,12 @@ func (m *authenticationModel) Update(msg tea.Msg) (authenticationModel, tea.Cmd)
 		return *m, sendIsAuthenticated(ctx, m.client, m.currentSessionID, &authd.IARequest_AuthenticationData{Item: msg.item})
 
 	case isAuthenticatedCancelled:
+		log.Debugf(context.TODO(), "%#v", msg)
 		m.cancelIsAuthenticated()
 		return *m, nil
 
 	case isAuthenticatedResultReceived:
-		log.Debugf(context.TODO(), "isAuthenticatedResultReceived: %v", msg.access)
+		log.Debugf(context.TODO(), "%#v", msg)
 		switch msg.access {
 		case brokers.AuthGranted:
 			infoMsg, err := dataToMsg(msg.msg)

--- a/pam/internal/adapter/authmodeselection.go
+++ b/pam/internal/adapter/authmodeselection.go
@@ -280,7 +280,7 @@ func getAuthenticationModes(client authd.PAMClient, sessionID string, uiLayouts 
 				msg:    "no supported authentication mode available for this provider",
 			}
 		}
-		log.Info(context.TODO(), authModes)
+		log.Debug(context.TODO(), "authModes", authModes)
 
 		return authModesReceived{
 			authModes: authModes,

--- a/pam/internal/adapter/authmodeselection.go
+++ b/pam/internal/adapter/authmodeselection.go
@@ -121,6 +121,7 @@ func (m *authModeSelectionModel) Init() tea.Cmd {
 func (m authModeSelectionModel) Update(msg tea.Msg) (authModeSelectionModel, tea.Cmd) {
 	switch msg := msg.(type) {
 	case supportedUILayoutsReceived:
+		log.Debugf(context.TODO(), "%#v", msg)
 		if len(msg.layouts) == 0 {
 			return m, sendEvent(pamError{
 				status: pam.ErrCredUnavail,
@@ -133,6 +134,7 @@ func (m authModeSelectionModel) Update(msg tea.Msg) (authModeSelectionModel, tea
 		return m, sendEvent(GetAuthenticationModesRequested{})
 
 	case authModesReceived:
+		log.Debugf(context.TODO(), "%#v", msg)
 		m.availableAuthModes = msg.authModes
 
 		var allAuthModes []list.Item
@@ -156,6 +158,7 @@ func (m authModeSelectionModel) Update(msg tea.Msg) (authModeSelectionModel, tea
 		return m, tea.Sequence(cmds...)
 
 	case authModeSelected:
+		log.Debugf(context.TODO(), "%#v", msg)
 		// Ensure auth mode id is valid
 		if !validAuthModeID(msg.id, m.availableAuthModes) {
 			log.Infof(context.TODO(), "authentication mode %q is not part of currently available authentication mode", msg.id)

--- a/pam/internal/adapter/brokerselection.go
+++ b/pam/internal/adapter/brokerselection.go
@@ -72,6 +72,7 @@ func (m brokerSelectionModel) Init() tea.Cmd {
 func (m brokerSelectionModel) Update(msg tea.Msg) (brokerSelectionModel, tea.Cmd) {
 	switch msg := msg.(type) {
 	case brokersListReceived:
+		log.Debugf(context.TODO(), "%#v", msg)
 		if len(msg.brokers) == 0 {
 			return m, sendEvent(pamError{
 				status: pam.ErrAuthinfoUnavail,
@@ -94,6 +95,7 @@ func (m brokerSelectionModel) Update(msg tea.Msg) (brokerSelectionModel, tea.Cmd
 		return m, tea.Batch(cmds...)
 
 	case brokerSelected:
+		log.Debugf(context.TODO(), "%#v", msg)
 		broker := brokerFromID(msg.brokerID, m.availableBrokers)
 		if broker == nil {
 			log.Infof(context.TODO(), "broker %q is not part of current active brokers", msg.brokerID)

--- a/pam/internal/adapter/model.go
+++ b/pam/internal/adapter/model.go
@@ -152,6 +152,7 @@ func (m *UIModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 	// Exit cases
 	case PamReturnStatus:
+		log.Debugf(context.TODO(), "%#v", msg)
 		if m.exitStatus != nil {
 			// Nothing to do, we're already exiting...
 			return m, nil
@@ -161,6 +162,7 @@ func (m *UIModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 	// Events
 	case UsernameOrBrokerListReceived:
+		log.Debugf(context.TODO(), "%#v", msg)
 		if m.username() == "" {
 			return m, nil
 		}
@@ -174,6 +176,7 @@ func (m *UIModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			AutoSelectForUser(m.Client, m.username()))
 
 	case BrokerSelected:
+		log.Debugf(context.TODO(), "%#v", msg)
 		if m.sessionStartingForBroker == "" {
 			m.sessionStartingForBroker = msg.BrokerID
 			return m, startBrokerSession(m.Client, msg.BrokerID, m.username(), m.SessionMode)
@@ -182,6 +185,7 @@ func (m *UIModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			return m, tea.Sequence(endSession(m.Client, m.currentSession), sendEvent(msg))
 		}
 	case SessionStarted:
+		log.Debugf(context.TODO(), "%#v", msg)
 		m.sessionStartingForBroker = ""
 		pubASN1, err := base64.StdEncoding.DecodeString(msg.encryptionKey)
 		if err != nil {
@@ -214,9 +218,11 @@ func (m *UIModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m, sendEvent(GetAuthenticationModesRequested{})
 
 	case ChangeStage:
+		log.Debugf(context.TODO(), "%#v", msg)
 		return m, m.changeStage(msg.Stage)
 
 	case GetAuthenticationModesRequested:
+		log.Debugf(context.TODO(), "%#v", msg)
 		if m.currentSession == nil || !m.authModeSelectionModel.IsReady() {
 			return m, nil
 		}
@@ -227,6 +233,7 @@ func (m *UIModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		)
 
 	case AuthModeSelected:
+		log.Debugf(context.TODO(), "%#v", msg)
 		if m.currentSession == nil {
 			return m, nil
 		}
@@ -243,7 +250,7 @@ func (m *UIModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m, getLayout(m.Client, m.currentSession.sessionID, msg.ID)
 
 	case UILayoutReceived:
-		log.Debug(context.TODO(), "UILayoutReceived", msg.layout)
+		log.Debugf(context.TODO(), "%#v", msg)
 		if m.currentSession == nil {
 			return m, nil
 		}
@@ -259,6 +266,7 @@ func (m *UIModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.changeStage(pam_proto.Stage_challenge))
 
 	case SessionEnded:
+		log.Debugf(context.TODO(), "%#v", msg)
 		m.sessionStartingForBroker = ""
 		m.currentSession = nil
 		return m, nil

--- a/pam/internal/adapter/model.go
+++ b/pam/internal/adapter/model.go
@@ -243,7 +243,7 @@ func (m *UIModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m, getLayout(m.Client, m.currentSession.sessionID, msg.ID)
 
 	case UILayoutReceived:
-		log.Info(context.TODO(), "UILayoutReceived")
+		log.Debug(context.TODO(), "UILayoutReceived", msg.layout)
 		if m.currentSession == nil {
 			return m, nil
 		}

--- a/pam/internal/adapter/userselection.go
+++ b/pam/internal/adapter/userselection.go
@@ -1,10 +1,13 @@
 package adapter
 
 import (
+	"context"
+
 	"github.com/charmbracelet/bubbles/cursor"
 	"github.com/charmbracelet/bubbles/textinput"
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/msteinert/pam/v2"
+	"github.com/ubuntu/authd/internal/log"
 )
 
 // userSelectionModel allows selecting from PAM or interactively an user.
@@ -63,6 +66,7 @@ func (m *userSelectionModel) Init() tea.Cmd {
 func (m userSelectionModel) Update(msg tea.Msg) (userSelectionModel, tea.Cmd) {
 	switch msg := msg.(type) {
 	case userSelected:
+		log.Debugf(context.TODO(), "%#v", msg)
 		if msg.username != "" {
 			// synchronise our internal validated field and the text one.
 			m.SetValue(msg.username)

--- a/pam/main-cli.go
+++ b/pam/main-cli.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"path/filepath"
 
 	"github.com/msteinert/pam/v2"
 	"github.com/sirupsen/logrus"
@@ -16,7 +17,12 @@ import (
 // Simulating pam on the CLI for manual testing.
 func main() {
 	log.SetLevel(log.DebugLevel)
-	f, err := os.OpenFile("/tmp/logdebug", os.O_CREATE|os.O_APPEND|os.O_RDWR, 0600)
+	logDir := os.Getenv("AUTHD_PAM_CLI_LOG_DIR")
+	if logDir == "" {
+		logDir = os.TempDir()
+	}
+	logPath := filepath.Join(logDir, "authd-pam-cli.log")
+	f, err := os.OpenFile(logPath, os.O_CREATE|os.O_APPEND|os.O_RDWR, 0600)
 	if err != nil {
 		panic(err)
 	}

--- a/pam/main-cli.go
+++ b/pam/main-cli.go
@@ -10,13 +10,11 @@ import (
 
 	"github.com/msteinert/pam/v2"
 	"github.com/sirupsen/logrus"
-	"github.com/ubuntu/authd/internal/log"
 	"github.com/ubuntu/authd/pam/internal/pam_test"
 )
 
 // Simulating pam on the CLI for manual testing.
 func main() {
-	log.SetLevel(log.DebugLevel)
 	logDir := os.Getenv("AUTHD_PAM_CLI_LOG_DIR")
 	if logDir == "" {
 		logDir = os.TempDir()
@@ -58,6 +56,9 @@ func main() {
 		panic("Unknown PAM operation: " + action)
 	}
 
+	defaultArgs := []string{"debug=true"}
+
+	args = append(defaultArgs, args...)
 	pamRes := pamFunc(mTx, pam.Flags(0), args)
 	user, _ := mTx.GetItem(pam.User)
 

--- a/pam/pam.go
+++ b/pam/pam.go
@@ -236,7 +236,9 @@ func (h *pamModule) AcctMgmt(mTx pam.ModuleTransaction, flags pam.Flags, args []
 	}
 
 	if user == "" {
-		log.Infof(context.TODO(), "can't get user from PAM")
+		if err := showPamMessage(mTx, pam.ErrorMsg, "Can't get user from PAM"); err != nil {
+			log.Warningf(context.TODO(), "Impossible to show PAM message: %v", err)
+		}
 		return pam.ErrIgnore
 	}
 
@@ -252,7 +254,11 @@ func (h *pamModule) AcctMgmt(mTx pam.ModuleTransaction, flags pam.Flags, args []
 		Username: user,
 	}
 	if _, err := client.SetDefaultBrokerForUser(context.TODO(), &req); err != nil {
-		log.Infof(context.TODO(), "Can't set default broker  (%q) for %q: %v", brokerIDUsedToAuthenticate, user, err)
+		msg := fmt.Sprintf("Can't set default broker (%q) for %q: %v",
+			brokerIDUsedToAuthenticate, user, err)
+		if err := showPamMessage(mTx, pam.ErrorMsg, msg); err != nil {
+			log.Warningf(context.TODO(), "Impossible to show PAM message: %v", err)
+		}
 		return pam.ErrIgnore
 	}
 

--- a/pam/pam.go
+++ b/pam/pam.go
@@ -129,8 +129,19 @@ func initLogging(args map[string]string) (func(), error) {
 		}, nil
 	}
 
+	disableTerminalLogging := func() {
+		if log.IsLevelEnabled(log.DebugLevel) {
+			return
+		}
+		if term.IsTerminal(int(os.Stdin.Fd())) {
+			return
+		}
+		log.SetLevel(log.WarnLevel)
+	}
+
 	if !journal.Enabled() || args["disable_journal"] == "true" {
 		log.SetHandler(nil)
+		disableTerminalLogging()
 		return resetLevel, nil
 	}
 


### PR DESCRIPTION
Log messages in the pam module were incomplete and at times they were using an higher priority than expected, and when authenticating with sudo or friends in an interactive terminal they were often spamming the session, breaking the bubbletea interface.

At the same time when running the module in such scenario or when it is loaded from other components such as ssh or desktop environments, it wasn't easy to debug it.

Said this:
 - Use PAM messages more to output errors when the interactive interface is over
 - Add client output to the integration tests logs
 - Add more debug messages where it matters
 - Implement `log` so that logging handlers can be defined for each level
 - Add a journal log handler that uses systemd journal as output
 - Use warning level logging in interactive terminals
 - pam module now supports these arguments:
   - `disable_journal` to disable journal integration
   - `debug` to use debug level when enabled (I was considering exposing `loglevel` but that's probably too much)
   - `logfile` to write the log to a provided file, in such case journal is not used.

UDENG-2441