### PR TITLE
fix(pam): Do not use fullscreen views in interactive mode

### DIFF
--- a/pam/integration-tests/testdata/TestCLIAuthenticate/golden/authenticate_user_switching_broker
+++ b/pam/integration-tests/testdata/TestCLIAuthenticate/golden/authenticate_user_switching_broker
@@ -220,14 +220,14 @@ Gimme your password
 
 
 
-
-
-
-
-
 PAM Authenticate() for user "user-integration-switch-broker" exited with error (PAM exit code: 2
 5): The return value should be ignored by PAM dispatch:
 PAM AcctMgmt() exited with error (PAM exit code: 25): The return value should be ignored by PAM
+dispatch
+>
+
+
+
 ────────────────────────────────────────────────────────────────────────────────
 > ./pam_authd login socket=/tmp/pam-cli-authenticate-tests.sock
   Select your provider
@@ -253,12 +253,12 @@ PAM AcctMgmt() exited with error (PAM exit code: 25): The return value should be
 
 
 
-
-
-
-
-
 PAM Authenticate() for user "user-integration-switch-broker" exited with error (PAM exit code: 2
 5): The return value should be ignored by PAM dispatch:
 PAM AcctMgmt() exited with error (PAM exit code: 25): The return value should be ignored by PAM
+dispatch
+>
+
+
+
 ────────────────────────────────────────────────────────────────────────────────

--- a/pam/integration-tests/testdata/TestCLIAuthenticate/golden/deny_authentication_if_user_does_not_exist
+++ b/pam/integration-tests/testdata/TestCLIAuthenticate/golden/deny_authentication_if_user_does_not_exist
@@ -121,14 +121,14 @@ Username: user-unexistent
 
 
 
-
-
-
-
-
 PAM Error Message: can't select broker: rpc error: code = Unknown desc = can't start authenticat
 ion transaction: user "user-unexistent" does not exist
 PAM Authenticate() for user "user-unexistent" exited with error (PAM exit code: 4): System error
+: can't select broker: rpc error: code = Unknown desc = can't start authentication transaction:
+user "user-unexistent" does not exist
+PAM AcctMgmt() exited with error (PAM exit code: 25): The return value should be ignored by PAM
+dispatch
+>
 ────────────────────────────────────────────────────────────────────────────────
 > ./pam_authd login socket=/tmp/pam-cli-authenticate-tests.sock
   Select your provider
@@ -154,12 +154,12 @@ PAM Authenticate() for user "user-unexistent" exited with error (PAM exit code: 
 
 
 
-
-
-
-
-
 PAM Error Message: can't select broker: rpc error: code = Unknown desc = can't start authenticat
 ion transaction: user "user-unexistent" does not exist
 PAM Authenticate() for user "user-unexistent" exited with error (PAM exit code: 4): System error
+: can't select broker: rpc error: code = Unknown desc = can't start authentication transaction:
+user "user-unexistent" does not exist
+PAM AcctMgmt() exited with error (PAM exit code: 25): The return value should be ignored by PAM
+dispatch
+>
 ────────────────────────────────────────────────────────────────────────────────

--- a/pam/integration-tests/testdata/TestCLIAuthenticate/golden/exit_authd_if_local_broker_is_selected
+++ b/pam/integration-tests/testdata/TestCLIAuthenticate/golden/exit_authd_if_local_broker_is_selected
@@ -121,14 +121,14 @@ Username: user-local-broker
 
 
 
-
-
-
-
-
 PAM Authenticate() for user "user-local-broker" exited with error (PAM exit code: 25): The retur
 n value should be ignored by PAM dispatch:
 PAM AcctMgmt() exited with error (PAM exit code: 25): The return value should be ignored by PAM
+dispatch
+>
+
+
+
 ────────────────────────────────────────────────────────────────────────────────
 > ./pam_authd login socket=/tmp/pam-cli-authenticate-tests.sock
   Select your provider
@@ -154,12 +154,12 @@ PAM AcctMgmt() exited with error (PAM exit code: 25): The return value should be
 
 
 
-
-
-
-
-
 PAM Authenticate() for user "user-local-broker" exited with error (PAM exit code: 25): The retur
 n value should be ignored by PAM dispatch:
 PAM AcctMgmt() exited with error (PAM exit code: 25): The return value should be ignored by PAM
+dispatch
+>
+
+
+
 ────────────────────────────────────────────────────────────────────────────────

--- a/pam/integration-tests/testdata/TestCLIChangeAuthTok/golden/exit_authd_if_local_broker_is_selected
+++ b/pam/integration-tests/testdata/TestCLIChangeAuthTok/golden/exit_authd_if_local_broker_is_selected
@@ -121,14 +121,14 @@ Username: user-local-broker
 
 
 
-
-
-
-
-
 PAM ChangeAuthTok() for user "user-local-broker" exited with error (PAM exit code: 25): The retu
 rn value should be ignored by PAM dispatch:
 PAM AcctMgmt() exited with error (PAM exit code: 25): The return value should be ignored by PAM
+dispatch
+>
+
+
+
 ────────────────────────────────────────────────────────────────────────────────
 > ./pam_authd passwd socket=/tmp/pam-cli-chauthtok-tests.sock
   Select your provider
@@ -154,12 +154,12 @@ PAM AcctMgmt() exited with error (PAM exit code: 25): The return value should be
 
 
 
-
-
-
-
-
 PAM ChangeAuthTok() for user "user-local-broker" exited with error (PAM exit code: 25): The retu
 rn value should be ignored by PAM dispatch:
 PAM AcctMgmt() exited with error (PAM exit code: 25): The return value should be ignored by PAM
+dispatch
+>
+
+
+
 ────────────────────────────────────────────────────────────────────────────────

--- a/pam/internal/adapter/model.go
+++ b/pam/internal/adapter/model.go
@@ -156,8 +156,6 @@ func (m *UIModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case tea.WindowSizeMsg:
 		m.height = msg.Height
 		m.width = msg.Width
-		m.brokerSelectionModel.SetHeight(m.height - 3)
-		m.brokerSelectionModel.SetWidth(m.width)
 
 	// Exit cases
 	case PamReturnStatus:

--- a/pam/internal/adapter/model.go
+++ b/pam/internal/adapter/model.go
@@ -48,9 +48,6 @@ type UIModel struct {
 	// SessionMode is the mode of the session invoked by the module.
 	SessionMode authd.SessionMode
 
-	height int
-	width  int
-
 	sessionStartingForBroker string
 	currentSession           *sessionInfo
 
@@ -152,10 +149,6 @@ func (m *UIModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			}
 			return m, cmd
 		}
-
-	case tea.WindowSizeMsg:
-		m.height = msg.Height
-		m.width = msg.Width
 
 	// Exit cases
 	case PamReturnStatus:


### PR DESCRIPTION
pam/adapter: Do not resize brokwerselection window on window changes

In terminal mode we're monitoring the window size and eventually changing
the broker selection list (only) that forces a fullscreen view of them.

This is something that it's not needed on the kind of "app" we're
building because it brings user context away (e.g. What was I
authenticating for?!) but also it makes testing the interface very hard
because will make bubbletea to potentially hide some error messages (as golden files change shows).

This helps #233 