### PR TITLE
refactor(NSS): Tune logging to Info instead of Debug

### DIFF
--- a/nss/integration-tests/helper_test.go
+++ b/nss/integration-tests/helper_test.go
@@ -63,7 +63,7 @@ func outNSSCommandForLib(t *testing.T, socketPath, originOut string, shouldPreCh
 	cmd := exec.Command(cmds[0], cmds[1:]...)
 	cmd.Env = append(cmd.Env, rustCovEnv...)
 	cmd.Env = append(cmd.Env,
-		"AUTHD_NSS_DEBUG=stderr",
+		"AUTHD_NSS_INFO=stderr",
 		// NSS needs both LD_PRELOAD and LD_LIBRARY_PATH to load the module library
 		fmt.Sprintf("LD_PRELOAD=%s:%s", libPath, os.Getenv("LD_PRELOAD")),
 		fmt.Sprintf("LD_LIBRARY_PATH=%s:%s", filepath.Dir(libPath), os.Getenv("LD_LIBRARY_PATH")),

--- a/nss/src/client/mod.rs
+++ b/nss/src/client/mod.rs
@@ -4,7 +4,7 @@ use tokio::net::UnixStream;
 use tonic::transport::{Channel, Endpoint, Uri};
 use tower::service_fn;
 
-use crate::{debug, REQUEST_TIMEOUT};
+use crate::{info, REQUEST_TIMEOUT};
 
 pub mod authd {
     tonic::include_proto!("authd");
@@ -22,7 +22,7 @@ pub async fn new_client() -> Result<NssClient<Channel>, Box<dyn Error>> {
         return Err("NSS lookup performed through systemd, skipping...".into());
     }
 
-    debug!("Connecting to authd on {}...", super::socket_path());
+    info!("Connecting to authd on {}...", super::socket_path());
 
     // The URL must have a valid format, even though we don't use it.
     let ch = Endpoint::try_from("https://not-used:404")?

--- a/nss/src/lib.rs
+++ b/nss/src/lib.rs
@@ -33,7 +33,7 @@ fn socket_path() -> String {
     match std::env::var("AUTHD_NSS_SOCKET") {
         Ok(s) => return s,
         Err(err) => {
-            debug!(
+            info!(
                 "AUTHD_NSS_SOCKET not set or badly configured, using default value: {}",
                 err
             );

--- a/nss/src/logs/mod.rs
+++ b/nss/src/logs/mod.rs
@@ -4,10 +4,10 @@ use std::env;
 use syslog::{BasicLogger, Facility, Formatter3164};
 
 #[macro_export]
-macro_rules! debug {
+macro_rules! info {
     ($($arg:tt)*) => {
         let log_prefix = "authd:";
-        log::debug!("{} {}", log_prefix, format_args!($($arg)*));
+        log::info!("{} {}", log_prefix, format_args!($($arg)*));
     }
 }
 
@@ -22,15 +22,15 @@ macro_rules! error {
 /// init_logger initialize the global logger with a default level set to info. This function is only
 /// required to be called once and is a no-op on subsequent calls.
 ///
-/// The log level can be set to debug by setting the environment variable AUTHD_NSS_DEBUG.
+/// The log level can be set to info by setting the environment variable AUTHD_NSS_INFO.
 pub fn init_logger() {
     if log::logger().enabled(&Metadata::builder().build()) {
         return;
     }
 
-    let mut level = LevelFilter::Info;
-    if let Ok(target) = env::var("AUTHD_NSS_DEBUG") {
-        level = LevelFilter::Debug;
+    let mut level = LevelFilter::Error;
+    if let Ok(target) = env::var("AUTHD_NSS_INFO") {
+        level = LevelFilter::Info;
         match target {
             s if s == *"stderr" => init_stderr_logger(level),
             _ => init_sys_logger(level),
@@ -39,7 +39,7 @@ pub fn init_logger() {
         init_sys_logger(level);
     }
 
-    debug!("Log level set to {:?}", level);
+    info!("Log level set to {:?}", level);
 }
 
 /// init_sys_logger initializes a global log that prints messages to the system logs.
@@ -66,11 +66,11 @@ fn init_sys_logger(log_level: LevelFilter) {
         return;
     };
 
-    debug!("Log output set to syslog");
+    info!("Log output set to syslog");
 }
 
 /// init_stderr_logger initializes a global log that prints the messages to stderr.
 fn init_stderr_logger(log_level: LevelFilter) {
     SimpleLogger::new().with_level(log_level).init().unwrap();
-    debug!("Log output set to stderr");
+    info!("Log output set to stderr");
 }


### PR DESCRIPTION
When using the Debug level, we were getting spammed by a lot of gRPC connection logs from tonic and it looks like we can't control the logging level individually. So, instead, let's tune down our log messages to Info instead of Debug so that we can have a cleaner output of what we want.