### PR TITLE
feat(CI): save test artifacts on failures

### DIFF
--- a/.github/workflows/qa.yaml
+++ b/.github/workflows/qa.yaml
@@ -118,6 +118,12 @@ jobs:
         run: |
           set -eu
           cargo install grcov
+      - name: Prepare tests artifacts path
+        run: |
+          set -eu
+
+          artifacts_dir=$(mktemp -u --tmpdir authd-test-artifacts-XXXXXX)
+          echo AUTHD_TEST_ARTIFACTS_PATH="${artifacts_dir}" >> $GITHUB_ENV
       - name: Run tests (with coverage collection)
         run: |
           set -eu
@@ -166,3 +172,10 @@ jobs:
         with:
           directory: ./coverage/codecov
           token: ${{ secrets.CODECOV_TOKEN }}
+
+      - name: Upload test failures artifacts
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: authd-test-artifacts
+          path: ${{ env.AUTHD_TEST_ARTIFACTS_PATH }}

--- a/nss/integration-tests/integration_test.go
+++ b/nss/integration-tests/integration_test.go
@@ -22,7 +22,7 @@ func TestIntegration(t *testing.T) {
 	buildRustNSSLib(t)
 
 	// Create a default daemon to use for most test cases.
-	defaultSocket := "/tmp/nss-integration-tests.sock"
+	defaultSocket := filepath.Join(os.TempDir(), "nss-integration-tests.sock")
 	defaultDbState := "multiple_users_and_groups"
 	defaultOutputPath := filepath.Join(filepath.Dir(daemonPath), "gpasswd.output")
 	defaultGroupsFilePath := filepath.Join(testutils.TestFamilyPath(t), "gpasswd.group")

--- a/pam/integration-tests/cli_test.go
+++ b/pam/integration-tests/cli_test.go
@@ -268,8 +268,12 @@ func saveArtifactsForDebug(t *testing.T, artifacts []string) {
 		return
 	}
 
-	// We need to copy the artifacts to a temporary directory, since the test directory will be cleaned up.
-	tmpDir := filepath.Join("/tmp/authd-test-artifacts", testutils.GoldenPath(t))
+	// We need to copy the artifacts to another directory, since the test directory will be cleaned up.
+	artifactPath := os.Getenv("AUTHD_TEST_ARTIFACTS_PATH")
+	if artifactPath == "" {
+		artifactPath = filepath.Join(os.TempDir(), "authd-test-artifacts")
+	}
+	tmpDir := filepath.Join(artifactPath, testutils.GoldenPath(t))
 	if err := os.MkdirAll(tmpDir, 0750); err != nil && !os.IsExist(err) {
 		require.NoError(t, err, "Could not create temporary directory for artifacts")
 		return


### PR DESCRIPTION
In case of failures we should save the artifacts we have prepared so that can be inspected better (or we can watch the .gif files).