### PR TITLE
fix: Add timeout to requests and skip dbus NSS lookup on dbus mock

### DIFF
--- a/nss/src/client/mod.rs
+++ b/nss/src/client/mod.rs
@@ -4,7 +4,7 @@ use tokio::net::UnixStream;
 use tonic::transport::{Channel, Endpoint, Uri};
 use tower::service_fn;
 
-use crate::debug;
+use crate::{debug, REQUEST_TIMEOUT};
 
 pub mod authd {
     tonic::include_proto!("authd");
@@ -26,6 +26,7 @@ pub async fn new_client() -> Result<NssClient<Channel>, Box<dyn Error>> {
 
     // The URL must have a valid format, even though we don't use it.
     let ch = Endpoint::try_from("https://not-used:404")?
+        .connect_timeout(REQUEST_TIMEOUT)
         .connect_with_connector(service_fn(|_: Uri| {
             UnixStream::connect(super::socket_path())
         }))

--- a/nss/src/group/mod.rs
+++ b/nss/src/group/mod.rs
@@ -1,4 +1,4 @@
-use crate::error;
+use crate::{error, REQUEST_TIMEOUT};
 use libc::gid_t;
 use libnss::group::{Group, GroupHooks};
 use libnss::interop::Response;
@@ -45,8 +45,9 @@ fn get_all_entries() -> Response<Vec<Group>> {
             }
         };
 
-        let request = Request::new(authd::Empty {});
-        match client.get_group_entries(request).await {
+        let mut req = Request::new(authd::Empty {});
+        req.set_timeout(REQUEST_TIMEOUT);
+        match client.get_group_entries(req).await {
             Ok(r) => Response::Success(group_entries_to_groups(r.into_inner().entries)),
             Err(e) => {
                 error!("error when listing groups: {}", e.message());
@@ -75,7 +76,8 @@ fn get_entry_by_gid(gid: gid_t) -> Response<Group> {
             }
         };
 
-        let req = Request::new(authd::GetByIdRequest { id: gid });
+        let mut req = Request::new(authd::GetByIdRequest { id: gid });
+        req.set_timeout(REQUEST_TIMEOUT);
         match client.get_group_by_gid(req).await {
             Ok(r) => Response::Success(group_entry_to_group(r.into_inner())),
             Err(e) => {
@@ -105,7 +107,8 @@ fn get_entry_by_name(name: String) -> Response<Group> {
             }
         };
 
-        let req = Request::new(authd::GetGroupByNameRequest { name });
+        let mut req = Request::new(authd::GetGroupByNameRequest { name });
+        req.set_timeout(REQUEST_TIMEOUT);
         match client.get_group_by_name(req).await {
             Ok(r) => Response::Success(group_entry_to_group(r.into_inner())),
             Err(e) => {

--- a/nss/src/lib.rs
+++ b/nss/src/lib.rs
@@ -1,5 +1,8 @@
 #[macro_use]
-extern crate lazy_static; // used by libnss_*_hooks macros
+extern crate lazy_static;
+use std::time::Duration;
+
+// used by libnss_*_hooks macros
 use libnss::{interop::Response, libnss_group_hooks, libnss_passwd_hooks, libnss_shadow_hooks};
 
 mod passwd;
@@ -18,6 +21,8 @@ libnss_shadow_hooks!(authd, AuthdShadow);
 mod logs;
 
 mod client;
+
+const REQUEST_TIMEOUT: Duration = Duration::from_secs(10);
 
 /// socket_path returns the socket path to connect to the gRPC server.
 ///

--- a/nss/src/passwd/mod.rs
+++ b/nss/src/passwd/mod.rs
@@ -1,4 +1,4 @@
-use crate::error;
+use crate::{error, REQUEST_TIMEOUT};
 use libc::uid_t;
 use libnss::interop::Response;
 use libnss::passwd::{Passwd, PasswdHooks};
@@ -45,7 +45,8 @@ fn get_all_entries() -> Response<Vec<Passwd>> {
             }
         };
 
-        let req = Request::new(authd::Empty {});
+        let mut req = Request::new(authd::Empty {});
+        req.set_timeout(REQUEST_TIMEOUT);
         match client.get_passwd_entries(req).await {
             Ok(r) => Response::Success(passwd_entries_to_passwds(r.into_inner().entries)),
             Err(e) => {
@@ -75,7 +76,8 @@ fn get_entry_by_uid(uid: uid_t) -> Response<Passwd> {
             }
         };
 
-        let req = Request::new(authd::GetByIdRequest { id: uid });
+        let mut req = Request::new(authd::GetByIdRequest { id: uid });
+        req.set_timeout(REQUEST_TIMEOUT);
         match client.get_passwd_by_uid(req).await {
             Ok(r) => Response::Success(passwd_entry_to_passwd(r.into_inner())),
             Err(e) => {
@@ -105,10 +107,11 @@ fn get_entry_by_name(name: String) -> Response<Passwd> {
             }
         };
 
-        let req = Request::new(authd::GetPasswdByNameRequest {
+        let mut req = Request::new(authd::GetPasswdByNameRequest {
             name,
             should_pre_check: should_pre_check(),
         });
+        req.set_timeout(REQUEST_TIMEOUT);
         match client.get_passwd_by_name(req).await {
             Ok(r) => Response::Success(passwd_entry_to_passwd(r.into_inner())),
             Err(e) => {

--- a/nss/src/shadow/mod.rs
+++ b/nss/src/shadow/mod.rs
@@ -1,4 +1,4 @@
-use crate::error;
+use crate::{error, REQUEST_TIMEOUT};
 use libnss::interop::Response;
 use libnss::shadow::{Shadow, ShadowHooks};
 use tokio::runtime::Builder;
@@ -40,7 +40,8 @@ fn get_all_entries() -> Response<Vec<Shadow>> {
             }
         };
 
-        let req = Request::new(authd::Empty {});
+        let mut req = Request::new(authd::Empty {});
+        req.set_timeout(REQUEST_TIMEOUT);
         match client.get_shadow_entries(req).await {
             Ok(r) => Response::Success(shadow_entries_to_shadows(r.into_inner().entries)),
             Err(e) => {
@@ -70,7 +71,8 @@ fn get_entry_by_name(name: String) -> Response<Shadow> {
             }
         };
 
-        let req = Request::new(authd::GetShadowByNameRequest { name });
+        let mut req = Request::new(authd::GetShadowByNameRequest { name });
+        req.set_timeout(REQUEST_TIMEOUT);
         match client.get_shadow_by_name(req).await {
             Ok(r) => Response::Success(shadow_entry_to_shadow(r.into_inner())),
             Err(e) => {


### PR DESCRIPTION
dbus can do some NSS calls and, if this happens during authd startup, the daemon will hang (this mainly affected cases where we wanted to run authd with the examplebroker built-in as, in order to do that, we were running a separate system bus of our own).

To prevent this from happening again and to add layers of protection, our NSS requests will have a timeout and we are also skipping the dbus calls to NSS in our dbus mock.

UDENG-2511
UDENG-2510