### PR TITLE
fix: Stop calling runtime.GC when cleaning PAM module

### DIFF
--- a/pam/pam.go
+++ b/pam/pam.go
@@ -8,7 +8,6 @@ import (
 	"errors"
 	"fmt"
 	"os"
-	"runtime"
 	"slices"
 	"strings"
 	"time"
@@ -395,6 +394,4 @@ func (h *pamModule) CloseSession(pam.ModuleTransaction, pam.Flags, []string) err
 // go_pam_cleanup_module is called by the go-loader PAM module during onload.
 //
 //export go_pam_cleanup_module
-func go_pam_cleanup_module() {
-	runtime.GC()
-}
+func go_pam_cleanup_module() {}


### PR DESCRIPTION
This was causing deadlocks in a real system due to the multithreading aspect of Go, so we should not call this manually.