### PR TITLE
fix: Add timeout when connecting to authd socket in PAM

### DIFF
--- a/nss/src/lib.rs
+++ b/nss/src/lib.rs
@@ -22,7 +22,7 @@ mod logs;
 
 mod client;
 
-const REQUEST_TIMEOUT: Duration = Duration::from_secs(10);
+const REQUEST_TIMEOUT: Duration = Duration::from_secs(5);
 
 /// socket_path returns the socket path to connect to the gRPC server.
 ///


### PR DESCRIPTION
This call could hang forever if the file was present but not ready yet, so we should add a timeout instead to prevent deadlocks.

UDENG-2508