### PR TITLE
fix(pam): pam account registration integration

### DIFF
--- a/debian/pam-configs/authd
+++ b/debian/pam-configs/authd
@@ -5,8 +5,9 @@ Priority: 280
 Auth-Type: Primary
 Auth:
 	[success=end default=ignore]	pam_go_loader.so pam_authd.so
+Account-Type: Additional
 Account:
-	[default=bad success=ok user_unknown=ignore]	pam_go_loader.so pam_authd.so
+	[default=ignore success=ok user_unknown=ignore]	pam_go_loader.so pam_authd.so
 Password-Type: Primary
 Password:
 	sufficient			pam_go_loader.so pam_authd.so


### PR DESCRIPTION
This ensures this is inserted at the correct place inside the pam stack. Use default=ignore to let the registration pass if we can't connect to authd.

UDENG-2495