### PR TITLE
fix(pam): Do not try to change the password twice but only after preliminary checks

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -69,4 +69,4 @@ require (
 // FIXME: Use released version once we have one!
 // The branch below includes changes from this upstream PR:
 // - https://github.com/msteinert/pam/pull/13
-replace github.com/msteinert/pam/v2 => github.com/3v1n0/go-pam/v2 v2.0.0-20240218173232-e182844e4e11
+replace github.com/msteinert/pam/v2 => github.com/3v1n0/go-pam/v2 v2.0.0-20240321054421-f19903865176

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,5 @@
-github.com/3v1n0/go-pam/v2 v2.0.0-20240218173232-e182844e4e11 h1:zGS1p61QyPZKDpk53NMEy50eNhLB3GILQQf6LnEWgr4=
-github.com/3v1n0/go-pam/v2 v2.0.0-20240218173232-e182844e4e11/go.mod h1:KT28NNIcDFf3PcBmNI2mIGO4zZJ+9RSs/At2PB3IDVc=
+github.com/3v1n0/go-pam/v2 v2.0.0-20240321054421-f19903865176 h1:N5WwJAe15Lj1NsGqZ6f1/GXuZmZ46HVB4KwM52Lc8ds=
+github.com/3v1n0/go-pam/v2 v2.0.0-20240321054421-f19903865176/go.mod h1:KT28NNIcDFf3PcBmNI2mIGO4zZJ+9RSs/At2PB3IDVc=
 github.com/atotto/clipboard v0.1.4 h1:EH0zSVneZPSuFR11BlR9YppQTVDbh5+16AmcJi4g1z4=
 github.com/atotto/clipboard v0.1.4/go.mod h1:ZY9tmq7sm5xIbd9bOK4onWV4S6X0u6GY7Vn0Yu86PYI=
 github.com/aymanbagabas/go-osc52/v2 v2.0.1 h1:HwpRHbFMcZLEVr42D4p7XBqjyuxQH5SMiErDT4WkJ2k=

--- a/pam/pam.go
+++ b/pam/pam.go
@@ -210,6 +210,22 @@ func (h *pamModule) handleAuthRequest(mode authd.SessionMode, mTx pam.ModuleTran
 	}
 	logArgsIssues()
 
+	if mode == authd.SessionMode_PASSWD && flags&pam.PrelimCheck != 0 {
+		log.Debug(context.TODO(), "ChangeAuthTok, preliminary check")
+		_, closeConn, err := newClient(parsedArgs)
+		if err != nil {
+			log.Debugf(context.TODO(), "%s", err)
+			return fmt.Errorf("%w: %w", pam.ErrTryAgain, err)
+		}
+		closeConn()
+		return nil
+	}
+
+	if mode == authd.SessionMode_PASSWD {
+		log.Debugf(context.TODO(), "ChangeAuthTok, password update phase: %d",
+			flags&pam.UpdateAuthtok)
+	}
+
 	if gdm.IsPamExtensionSupported(gdm.PamExtensionCustomJSON) {
 		// Explicitly set the output to something so that the program
 		// won't try to init some terminal fancy things that also appear

--- a/pam/pam.go
+++ b/pam/pam.go
@@ -193,7 +193,12 @@ func (h *pamModule) Authenticate(mTx pam.ModuleTransaction, flags pam.Flags, arg
 // ChangeAuthTok is the method that is invoked during pam_sm_chauthtok request.
 func (h *pamModule) ChangeAuthTok(mTx pam.ModuleTransaction, flags pam.Flags, args []string) error {
 	parsedArgs, logArgsIssues := parseArgs(args)
-	return h.handleAuthRequest(authd.SessionMode_PASSWD, mTx, flags, parsedArgs, logArgsIssues)
+
+	err := h.handleAuthRequest(authd.SessionMode_PASSWD, mTx, flags, parsedArgs, logArgsIssues)
+	if errors.Is(err, pam.ErrPermDenied) {
+		return pam.ErrAuthtokRecovery
+	}
+	return err
 }
 
 func (h *pamModule) handleAuthRequest(mode authd.SessionMode, mTx pam.ModuleTransaction, flags pam.Flags, parsedArgs map[string]string, logArgsIssues func()) error {


### PR DESCRIPTION
As per pam_sm_chauthtok(3) PAM may call the function twice, with
different flags, so in such case just ignore the request and wait for
the next one to happen.