### PR TITLE
testutils/coverage: Create coverage directory if provided

### DIFF
--- a/.github/workflows/qa.yaml
+++ b/.github/workflows/qa.yaml
@@ -138,7 +138,6 @@ jobs:
           cov_dir="$(pwd)/coverage"
           cod_cov_dir="$(pwd)/coverage/codecov"
           raw_cov_dir="${cov_dir}/raw"
-          mkdir -p "${raw_cov_dir}" "${cod_cov_dir}"
 
           # Overriding the default coverage directory is not an exported flag of go test (yet), so
           # we need to override it using the test.gocoverdir flag instead.

--- a/internal/testutils/coverage.go
+++ b/internal/testutils/coverage.go
@@ -64,10 +64,10 @@ func AppendCovEnv(env []string) []string {
 func CoverDir() string {
 	goCoverDirOnce.Do(func() {
 		for _, arg := range os.Args {
-			if !strings.HasPrefix(arg, "-test.gocoverdir=") {
+			goCoverDir, ok := strings.CutPrefix(arg, "-test.gocoverdir=")
+			if !ok {
 				continue
 			}
-			goCoverDir = strings.TrimPrefix(arg, "-test.gocoverdir=")
 
 			_, err := os.Stat(goCoverDir)
 			if err == nil {

--- a/internal/testutils/coverage.go
+++ b/internal/testutils/coverage.go
@@ -2,6 +2,7 @@ package testutils
 
 import (
 	"bufio"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -67,6 +68,18 @@ func CoverDir() string {
 				continue
 			}
 			goCoverDir = strings.TrimPrefix(arg, "-test.gocoverdir=")
+
+			_, err := os.Stat(goCoverDir)
+			if err == nil {
+				return
+			}
+			if !errors.Is(err, os.ErrNotExist) {
+				panic(err)
+			}
+			err = os.MkdirAll(goCoverDir, 0700)
+			if err != nil {
+				panic(err)
+			}
 		}
 	})
 	return goCoverDir


### PR DESCRIPTION
This also implies cleaning up it first if already existent because otherwise we may get broken reports when repeating the tests with a coverage dir set.

Basically I got tired of having to manually remove, and create a clean dir every time I wanted to run the tests, as not doing this implies that the coverage report is broken and not respecting the provided arguments.