### PR TITLE
debian/pam-configs/authd: Ignore connection errors

### DIFF
--- a/debian/pam-configs/authd.in
+++ b/debian/pam-configs/authd.in
@@ -4,13 +4,13 @@ Priority: 1050
 
 Auth-Type: Primary
 Auth:
-	[success=end ignore=ignore default=die]	pam_authd_exec.so @AUTHD_DAEMONS_PATH@/authd-pam
+	[success=end ignore=ignore default=die authinfo_unavail=ignore]	pam_authd_exec.so @AUTHD_DAEMONS_PATH@/authd-pam
 Account-Type: Additional
 Account:
-	[default=ignore success=ok user_unknown=ignore]	pam_authd_exec.so @AUTHD_DAEMONS_PATH@/authd-pam
+	[default=ignore success=ok user_unknown=ignore authinfo_unavail=ignore]	pam_authd_exec.so @AUTHD_DAEMONS_PATH@/authd-pam
 Password-Type: Primary
 Password:
-	[success=end ignore=ignore default=die]	pam_authd_exec.so @AUTHD_DAEMONS_PATH@/authd-pam
+	[success=end ignore=ignore default=die authinfo_unavail=ignore]	pam_authd_exec.so @AUTHD_DAEMONS_PATH@/authd-pam
 Session-Type: Additional
 Session-Interactive-Only: yes
 Session:


### PR DESCRIPTION
 - If authd ignored the request, then we should ignore too.
 - If we can't connect to authd, we should ignore to select next method.
 - If we fail hard for other reason, then user should not be authenticated.

Removed the handling of user_unknown case because we never return this from the PAM module for security reasons.

UDENG-5636