### PR TITLE
fix(pam/integration-tests): Use absolute paths for compiling and reference external files

### DIFF
--- a/internal/testutils/golden.go
+++ b/internal/testutils/golden.go
@@ -25,6 +25,7 @@ func init() {
 }
 
 type goldenOptions struct {
+	goldenDir  string
 	goldenPath string
 }
 
@@ -40,6 +41,15 @@ func WithGoldenPath(path string) GoldenOption {
 	}
 }
 
+// WithGoldenDir overrides the default directory for golden files used.
+func WithGoldenDir(dir string) GoldenOption {
+	return func(o *goldenOptions) {
+		if dir != "" {
+			o.goldenDir = dir
+		}
+	}
+}
+
 // LoadWithUpdateFromGolden loads the element from a plaintext golden file.
 // It will update the file if the update flag is used prior to loading it.
 func LoadWithUpdateFromGolden(t *testing.T, data string, opts ...GoldenOption) string {
@@ -51,6 +61,10 @@ func LoadWithUpdateFromGolden(t *testing.T, data string, opts ...GoldenOption) s
 
 	for _, opt := range opts {
 		opt(&o)
+	}
+
+	if o.goldenDir != "" {
+		o.goldenPath = filepath.Join(o.goldenDir, o.goldenPath)
 	}
 
 	if update {

--- a/internal/testutils/path.go
+++ b/internal/testutils/path.go
@@ -12,6 +12,13 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// CurrentDir returns the current file directory.
+func CurrentDir() string {
+	// p is the path to the caller file
+	_, p, _, _ := runtime.Caller(1)
+	return filepath.Dir(p)
+}
+
 // ProjectRoot returns the absolute path to the project root.
 func ProjectRoot() string {
 	// p is the path to the current file, in this case -> {PROJECT_ROOT}/internal/testutils/path.go

--- a/pam/integration-tests/gdm_test.go
+++ b/pam/integration-tests/gdm_test.go
@@ -361,7 +361,8 @@ func TestGdmModuleWithCWrapper(t *testing.T) {
 func buildPAMModule(t *testing.T) string {
 	t.Helper()
 
-	cmd := exec.Command("go", "build", "-C", "..")
+	cmd := exec.Command("go", "build", "-C", "pam")
+	cmd.Dir = testutils.ProjectRoot()
 	if testutils.CoverDir() != "" {
 		// -cover is a "positional flag", so it needs to come right after the "build" command.
 		cmd.Args = append(cmd.Args, "-cover")
@@ -392,6 +393,7 @@ func buildPAMWrapperModule(t *testing.T) string {
 
 	//nolint:gosec // G204 it's a test so we should allow using any compiler safely.
 	cmd := exec.Command(compiler)
+	cmd.Dir = testutils.CurrentDir()
 	soname := "pam_authd_loader"
 	libPath := filepath.Join(t.TempDir(), soname+".so")
 


### PR DESCRIPTION
PAM integration tests highly depend on C code and sometimes we need to debug them using the good old gdb or address sanitizer. This implies using `go test -c` to generate the binaries to inspect with the proper debug symbols.

At the current state to be able to run the tests from the generated binary, we need to `chdir` inside the integration-tests folder, but this is a bit annoying.

So basically this change allows to just do `go test -C ./pam/integration-tests -c` and `gdb --args ./pam/integration-tests/integration-tests.test -test.run TestCLI`. Tiny change but it makes my life happier :).

Since we're building the test files for local usage only, it's seems fine to use absolute paths to refer to any asset they build or require.