### PR TITLE
feat: Autoselect and return "local" for non authd users

### DIFF
--- a/internal/services/pam/pam_test.go
+++ b/internal/services/pam/pam_test.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"net"
 	"os"
+	"os/user"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -112,6 +113,13 @@ func TestGetPreviousBroker(t *testing.T) {
 	// Get brokerID from memory if it was already assigned // FIXME: how do we know this is from memory?
 	gotResp, _ = client.GetPreviousBroker(context.Background(), &authd.GPBRequest{Username: "userwithbroker"})
 	require.Equal(t, mockBrokerGeneratedID, gotResp.GetPreviousBroker(), "GetPreviousBroker should return expected brokerID from memory")
+
+	// Get local user and get it set to local broker
+	u, err := user.Current()
+	require.NoError(t, err, "Setup: could not fetch current user")
+	gotResp, err = client.GetPreviousBroker(context.Background(), &authd.GPBRequest{Username: u.Username})
+	require.NoError(t, err, "GetPreviousBroker should not return an error")
+	require.Equal(t, brokers.LocalBrokerName, gotResp.GetPreviousBroker(), "GetPreviousBroker should return expected brokerID from memory")
 
 	// Return empty when user does not exist
 	gotResp, _ = client.GetPreviousBroker(context.Background(), &authd.GPBRequest{Username: "nonexistent"})

--- a/internal/users/cache/db_test.go
+++ b/internal/users/cache/db_test.go
@@ -398,14 +398,19 @@ func TestBrokerForUser(t *testing.T) {
 
 	// Get existing BrokerForUser entry
 	gotID, err := c.BrokerForUser("user1")
-	require.NoError(t, err, "BrokerForUser for an existent entry should not return an error")
+	require.NoError(t, err, "BrokerForUser for an existent user should not return an error")
 	wantID := testutils.LoadWithUpdateFromGolden(t, gotID)
 	require.Equal(t, wantID, gotID, "BrokerForUser should return expected broker ID")
 
-	// Error when entry does not exist
+	// Get unassigned broker to existent user
+	gotID, err = c.BrokerForUser("user4")
+	require.NoError(t, err, "BrokerForUser for an existent user should not return an error")
+	require.Empty(t, gotID, "BrokerForUser should return empty broker ID for unassigned broker to existent user")
+
+	// Error when user does not exist
 	gotID, err = c.BrokerForUser("nonexistent")
-	require.Error(t, err, "BrokerForUser for a nonexistent entry should return an error")
-	require.Empty(t, gotID, "BrokerForUser should return empty string when entry does not exist")
+	require.Error(t, err, "BrokerForUser for a nonexistent user should return an error")
+	require.Empty(t, gotID, "BrokerForUser should return empty broker ID when user entry does not exist")
 }
 
 func TestRemoveDb(t *testing.T) {

--- a/internal/users/manager.go
+++ b/internal/users/manager.go
@@ -163,7 +163,10 @@ func (m *Manager) UpdateUser(u UserInfo) (err error) {
 // BrokerForUser returns the broker ID for the given user.
 func (m *Manager) BrokerForUser(username string) (string, error) {
 	brokerID, err := m.cache.BrokerForUser(username)
-	if err != nil {
+	// User not in cache.
+	if err != nil && errors.Is(err, cache.NoDataFoundError{}) {
+		return "", ErrNoDataFound{}
+	} else if err != nil {
 		return "", m.shouldClearDb(err)
 	}
 

--- a/internal/users/manager_test.go
+++ b/internal/users/manager_test.go
@@ -271,12 +271,13 @@ func TestBrokerForUser(t *testing.T) {
 		username string
 		dbFile   string
 
-		wantErr error
+		wantBrokerID string
+		wantErr      error
 	}{
-		"Successfully get broker for user": {username: "user1", dbFile: "multiple_users_and_groups_with_brokers"},
+		"Successfully get broker for user":                        {username: "user1", dbFile: "multiple_users_and_groups_with_brokers", wantBrokerID: "ExampleBrokerID"},
+		"Return no broker but in cache if user has no broker yet": {username: "user4", dbFile: "multiple_users_and_groups_with_brokers", wantBrokerID: ""},
 
 		"Error if user does not exist":  {username: "doesnotexist", dbFile: "multiple_users_and_groups_with_brokers", wantErr: cache.NoDataFoundError{}},
-		"Error if user has no broker":   {username: "user4", dbFile: "multiple_users_and_groups_with_brokers", wantErr: cache.NoDataFoundError{}},
 		"Error if db has invalid entry": {username: "user1", dbFile: "invalid_entry_in_userByName", wantErr: cache.ErrNeedsClearing},
 	}
 	for name, tc := range tests {
@@ -296,7 +297,7 @@ func TestBrokerForUser(t *testing.T) {
 				return
 			}
 
-			require.Equal(t, "ExampleBrokerID", brokerID, "BrokerForUser should return the expected brokerID, but did not")
+			require.Equal(t, tc.wantBrokerID, brokerID, "BrokerForUser should return the expected brokerID, but did not")
 		})
 	}
 }

--- a/pam/integration-tests/cli_test.go
+++ b/pam/integration-tests/cli_test.go
@@ -61,6 +61,7 @@ func TestCLIAuthenticate(t *testing.T) {
 		"Authenticate with warnings on unsupported arguments": {tape: "simple_auth_with_unsupported_args"},
 
 		"Remember last successful broker and mode": {tape: "remember_broker_and_mode"},
+		"Autoselect local broker for local user":   {tape: "local_user"},
 
 		"Deny authentication if max attempts reached": {tape: "max_attempts"},
 		"Deny authentication if user does not exist":  {tape: "unexistent_user"},

--- a/pam/integration-tests/testdata/TestCLIAuthenticate/golden/autoselect_local_broker_for_local_user
+++ b/pam/integration-tests/testdata/TestCLIAuthenticate/golden/autoselect_local_broker_for_local_user
@@ -1,0 +1,132 @@
+> ./pam_authd login socket=${AUTHD_TESTS_CLI_AUTHENTICATE_TESTS_SOCK}
+Username: user name
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+────────────────────────────────────────────────────────────────────────────────
+> ./pam_authd login socket=${AUTHD_TESTS_CLI_AUTHENTICATE_TESTS_SOCK}
+Username: root
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+────────────────────────────────────────────────────────────────────────────────
+> ./pam_authd login socket=${AUTHD_TESTS_CLI_AUTHENTICATE_TESTS_SOCK}
+  Select your provider
+
+> 1. local
+  2. ExampleBroker
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+PAM Info Message: auth=incomplete
+PAM Authenticate() for user "root" exited with error (PAM exit code: 31): Application needs to c
+all libpam again
+PAM AcctMgmt() exited with error (PAM exit code: 26): Critical error - immediate abort
+>
+
+
+
+────────────────────────────────────────────────────────────────────────────────
+> ./pam_authd login socket=${AUTHD_TESTS_CLI_AUTHENTICATE_TESTS_SOCK}
+  Select your provider
+
+> 1. local
+  2. ExampleBroker
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+PAM Info Message: auth=incomplete
+PAM Authenticate() for user "root" exited with error (PAM exit code: 31): Application needs to c
+all libpam again
+PAM AcctMgmt() exited with error (PAM exit code: 26): Critical error - immediate abort
+>
+
+
+
+────────────────────────────────────────────────────────────────────────────────

--- a/pam/integration-tests/testdata/tapes/local_user.tape
+++ b/pam/integration-tests/testdata/tapes/local_user.tape
@@ -1,0 +1,34 @@
+Output local_user.txt
+Output local_user.gif # If we don't specify a .gif output, it will create a default out.gif file.
+
+# Configuration header to standardize the output.
+# Does not work with the "Source" command.
+Set Width 800
+Set Height 500
+# TODO: Ideally, we should use Ubuntu Mono. However, the github runner is still on Jammy, which does not have it.
+# We should update this to use Ubuntu Mono once the runner is updated.
+Set FontFamily "Monospace"
+Set FontSize 13
+Set Padding 0
+Set Margin 0
+Set Shell bash
+
+Hide
+Type "./pam_authd login socket=${AUTHD_TESTS_CLI_AUTHENTICATE_TESTS_SOCK}"
+Enter
+Sleep 300ms
+Show
+
+Hide
+Escape
+Backspace
+Type "root"
+Sleep 300ms
+Show
+
+Hide
+Enter
+Sleep 300ms
+Show
+
+Sleep 300ms


### PR DESCRIPTION
This autoselect (even on first login) the local broker, any "local" users.
It means:
- Any users in the file service (passwd) will immediately being autoselected as local.
- Other "locally dealt but remote" users (handled by sss, winbind…) will be offered the broker prompt on its first login on the system. Once logged in once, even without authd installed, then the user will be reachable through NSS, and the "local" broker will then be autoselected.
- Any users in our cache will get through the traditional broker autoselection once the login was successful for this broker
- Any users not in our cache and not resolved through NSS will be offered the broker selection dialog.

For local users which can be resolved with NSS, the NSS request will only be performed once after the service starts for each user that aren’t in authd cache. We do not store it in our database to avoid syncing this list of local user with the ones existing on the system.

UDENG-2496