### PR TITLE
fix(tests): do not use local broker for pam test

### DIFF
--- a/internal/services/pam/testdata/TestGetPreviousBroker/get-previous-broker.db
+++ b/internal/services/pam/testdata/TestGetPreviousBroker/get-previous-broker.db
@@ -26,5 +26,5 @@ UserToGroups:
   "2222": '{"UID":2222,"GIDs":[22222,99999]}'
   "3333": '{"UID":3333,"GIDs":[33333,99999]}'
 UserToBroker:
-  "1111": '"local"'
+  "1111": '"MOCKBROKERID"'
   "2222": '"inactive-broker-id"'


### PR DESCRIPTION
We will not store the local broker in the database itself, so better to use a real broker there.
As we generate the mock broker id dynamically for the tests, change it on the fly.