### PR TITLE
fix(pam/go-exec): Use per-action log handlers to log write logs

### DIFF
--- a/.github/workflows/qa.yaml
+++ b/.github/workflows/qa.yaml
@@ -132,6 +132,8 @@ jobs:
   go-tests:
     name: "Go: Tests"
     runs-on: ubuntu-latest
+    env:
+      AUTHD_PAM_MODULES_PATH: /lib/x86_64-linux-gnu/security
     steps:
       - name: Install dependencies
         run: |

--- a/pam/integration-tests/modulehelpers_test.go
+++ b/pam/integration-tests/modulehelpers_test.go
@@ -41,6 +41,7 @@ func buildCPAMModule(t *testing.T, sources []string, pkgConfigDeps []string, son
 	cmd.Args = append(cmd.Args, sources...)
 	cmd.Args = append(cmd.Args,
 		"-Wall",
+		"-Werror",
 		"-g3",
 		"-O0",
 		"-DAUTHD_TEST_MODULE=1",


### PR DESCRIPTION
Only manage the module log domain by default so that loader apps won't
be affected and we ensure that every action can have its logging file.

This fixes a race that we hit in tests in arm since in some scenarios
it could happen that:
 - pam_authd_exec.so is loaded by PAM
 - libglib is also loaded in memory as its dependency
 - pam_authd_exec.so is unloaded but libglib in memory is not unloaded
 - loading again pam_authd_exec.so in the same test binary may end up
   setting the glib writer function again, which leads to an assertion.

This is not the case anymore since we have a local writer that is
invoked only when our log handler is called

UDENG-2665