### PR TITLE
feat: detect traditional and integration tests

### DIFF
--- a/internal/testsdetection/integrationtests.go
+++ b/internal/testsdetection/integrationtests.go
@@ -1,0 +1,7 @@
+//go:build integrationtests
+
+package testsdetection
+
+func init() {
+	integrationtests = true
+}

--- a/internal/testsdetection/testdata/binary.go
+++ b/internal/testsdetection/testdata/binary.go
@@ -1,0 +1,19 @@
+package main
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/ubuntu/authd/internal/testsdetection"
+)
+
+func main() {
+	defer func() {
+		// Catch the panic so that we can get the coverage from it.
+		if r := recover(); r != nil {
+			fmt.Fprintf(os.Stderr, "Panic: %v\n", r)
+			os.Exit(2)
+		}
+	}()
+	testsdetection.MustBeTesting()
+}

--- a/internal/testsdetection/testsdetection.go
+++ b/internal/testsdetection/testsdetection.go
@@ -1,0 +1,15 @@
+// Package testsdetection helps in deciding if we are currently running under integration or tests.
+package testsdetection
+
+import (
+	"testing"
+)
+
+var integrationtests = false
+
+// MustBeTesting panics if we are not running under tests or integration tests.
+func MustBeTesting() {
+	if !testing.Testing() && !integrationtests {
+		panic("This can only be called in tests")
+	}
+}

--- a/internal/testsdetection/testsdetection_test.go
+++ b/internal/testsdetection/testsdetection_test.go
@@ -1,0 +1,87 @@
+package testsdetection_test
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/ubuntu/authd/internal/testsdetection"
+)
+
+var coverDir string
+
+func TestMustBeTestingInTests(t *testing.T) {
+	t.Parallel()
+
+	defer func() {
+		r := recover()
+		require.Nil(t, r, "MustBeTesting should not panic as we are running in tests")
+	}()
+
+	testsdetection.MustBeTesting()
+}
+
+func TestMustBeTestingInProcess(t *testing.T) {
+	t.Parallel()
+
+	tests := map[string]struct {
+		integrationtestsTag bool
+
+		wantPanic bool
+	}{
+		"Pass when called in an integration tests build": {integrationtestsTag: true, wantPanic: false},
+
+		"Error (panics) when called in non tests and no integration tests": {integrationtestsTag: false, wantPanic: true},
+	}
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			temp := t.TempDir()
+			testBinary := filepath.Join(temp, "testbin")
+
+			buildCmd := []string{"build", "-o", testBinary}
+			if tc.integrationtestsTag {
+				buildCmd = append(buildCmd, "-tags=integrationtests")
+			}
+			env := os.Environ()
+			if coverDir != "" {
+				buildCmd = append(buildCmd, "-cover")
+				env = append(env, "GOCOVERDIR="+coverDir)
+			}
+			buildCmd = append(buildCmd, "testdata/binary.go")
+
+			//nolint:gosec // G204 we are in control of the arguments in our tests.
+			out, err := exec.Command("go", buildCmd...).CombinedOutput()
+			require.NoErrorf(t, err, "Setup: Could not build test binary: %s", out)
+
+			// Execute our subprocess
+			//nolint:gosec // G204 we are in control of the arguments in our tests.
+			cmd := exec.Command(testBinary)
+			cmd.Env = env
+			out, err = cmd.CombinedOutput()
+
+			if tc.wantPanic {
+				require.Errorf(t, err, "MustBeTesting should have panicked the subprocess: %s", string(out))
+				return
+			}
+			require.NoErrorf(t, err, "MustBeTesting should have returned without panicking the subprocess", string(out))
+		})
+	}
+}
+
+func TestMain(m *testing.M) {
+	if testing.CoverMode() != "" {
+		for _, arg := range os.Args {
+			if !strings.HasPrefix(arg, "-test.gocoverdir=") {
+				continue
+			}
+			coverDir = strings.TrimPrefix(arg, "-test.gocoverdir=")
+		}
+	}
+
+	m.Run()
+}

--- a/internal/testutils/golden.go
+++ b/internal/testutils/golden.go
@@ -84,9 +84,9 @@ func LoadWithUpdateFromGoldenYAML[E any](t *testing.T, got E, opts ...GoldenOpti
 	return wantDeserialized
 }
 
-// NormalizeGoldenName returns the name of the golden file with illegal Windows
+// NormalizeName returns the name of the golden file with illegal Windows
 // characters replaced or removed.
-func NormalizeGoldenName(t *testing.T, name string) string {
+func NormalizeName(t *testing.T, name string) string {
 	t.Helper()
 
 	name = strings.ReplaceAll(name, `\`, "_")
@@ -112,7 +112,7 @@ func GoldenPath(t *testing.T) string {
 	path := filepath.Join(TestFamilyPath(t), "golden")
 	_, sub, found := strings.Cut(t.Name(), "/")
 	if found {
-		path = filepath.Join(path, NormalizeGoldenName(t, sub))
+		path = filepath.Join(path, NormalizeName(t, sub))
 	}
 
 	return path

--- a/internal/testutils/golden.go
+++ b/internal/testutils/golden.go
@@ -84,8 +84,7 @@ func LoadWithUpdateFromGoldenYAML[E any](t *testing.T, got E, opts ...GoldenOpti
 	return wantDeserialized
 }
 
-// NormalizeName returns the name of the golden file with illegal Windows
-// characters replaced or removed.
+// NormalizeName transforms name input with illegal characters replaced or removed.
 func NormalizeName(t *testing.T, name string) string {
 	t.Helper()
 


### PR DESCRIPTION
Add `MustBeTesting` assertion to ensure we run in tests. This assertion will panic if we don’t run in traditional tests (gotest)
or integration tests.

Add tests for detection tests
Those tests address:
- traditional tests detection started by go test
- integration tests detection for a binary built with the
  integrationtests tag.
- ensure we don’t falsy report integration tests for binary without the
  tag.

Hook up coverage report, even for the subprocess, with this.

UDENG-2563
UDENG-2584
