### PR TITLE
feat: authorizer to handle unix socket peer user

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -20,6 +20,7 @@ require (
 	github.com/ubuntu/decorate v0.0.0-20230606064312-bc4ac83958d6
 	go.etcd.io/bbolt v1.3.9
 	golang.org/x/exp v0.0.0-20230905200255-921286631fa9
+	golang.org/x/sys v0.19.0
 	golang.org/x/term v0.19.0
 	google.golang.org/grpc v1.63.2
 	google.golang.org/protobuf v1.33.0
@@ -60,7 +61,6 @@ require (
 	go.uber.org/multierr v1.9.0 // indirect
 	golang.org/x/net v0.23.0 // indirect
 	golang.org/x/sync v0.6.0 // indirect
-	golang.org/x/sys v0.19.0 // indirect
 	golang.org/x/text v0.14.0 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20240227224415-6ceb2ff114de // indirect
 )

--- a/internal/services/authorizer/authorizer.go
+++ b/internal/services/authorizer/authorizer.go
@@ -1,0 +1,63 @@
+// Package authorizer handles peer user detection and authorization.
+package authorizer
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/ubuntu/authd/internal/log"
+	"github.com/ubuntu/decorate"
+	"google.golang.org/grpc/peer"
+)
+
+// Authorizer is an abstraction of authorization process.
+type Authorizer struct {
+	rootUID uint32
+}
+
+type options struct {
+	rootUID uint32
+}
+
+var defaultOptions = options{
+	rootUID: 0,
+}
+
+// Option represents an optional function to override Authorizer default values.
+type Option func(*options)
+
+// New returns a new Authorizer.
+func New(args ...Option) Authorizer {
+	opts := defaultOptions
+	for _, arg := range args {
+		arg(&opts)
+	}
+
+	//nolint:gosimple // S1016 Those structs are not the same conceptually.
+	return Authorizer{
+		rootUID: opts.rootUID,
+	}
+}
+
+// IsRequestFromRoot returns nil if the request was performed by a root user.
+// The pid and uid are extracted from peerCredsInfo in the gRPC context.
+func (a Authorizer) IsRequestFromRoot(ctx context.Context) (err error) {
+	log.Debug(ctx, "Check if this grpc call is requested by root")
+	defer decorate.OnError(&err, "permission denied")
+
+	p, ok := peer.FromContext(ctx)
+	if !ok {
+		return errors.New("context request doesn't have grpc peer informations")
+	}
+	pci, ok := p.AuthInfo.(peerCredsInfo)
+	if !ok {
+		return errors.New("context request doesn't have valid grpc peer credential informations")
+	}
+
+	if pci.uid != a.rootUID {
+		return fmt.Errorf("this action is only allowed for root users. Current user is %d", pci.uid)
+	}
+
+	return nil
+}

--- a/internal/services/authorizer/authorizer_test.go
+++ b/internal/services/authorizer/authorizer_test.go
@@ -1,0 +1,79 @@
+package authorizer_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/ubuntu/authd/internal/services/authorizer"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials"
+	"google.golang.org/grpc/peer"
+)
+
+func TestNew(t *testing.T) {
+	t.Parallel()
+
+	a := authorizer.New()
+
+	require.NotNil(t, a, "New authorizer is created")
+}
+
+func TestIsRequestFromRoot(t *testing.T) {
+	t.Parallel()
+
+	tests := map[string]struct {
+		currentUserNotRoot bool
+		noPeerCredsInfo    bool
+		noAuthInfo         bool
+
+		wantErr bool
+	}{
+		"Granted if current user considered as root": {},
+
+		"Error as deny when current user is not root": {currentUserNotRoot: true, wantErr: true},
+		"Error as deny when missing peer creds Info":  {noPeerCredsInfo: true, wantErr: true},
+		"Error as deny when missing auth info creds":  {noAuthInfo: true, wantErr: true},
+	}
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			// Setup peer creds info
+			ctx := context.Background()
+			if !tc.noPeerCredsInfo {
+				var authInfo credentials.AuthInfo
+				if !tc.noAuthInfo {
+					uid := authorizer.CurrentUserUID()
+					authInfo = authorizer.NewTestPeerCredsInfo(uid, int32(uid))
+				}
+				p := peer.Peer{
+					AuthInfo: authInfo,
+				}
+				ctx = peer.NewContext(ctx, &p)
+			}
+
+			var opts []authorizer.Option
+			if !tc.currentUserNotRoot {
+				opts = append(opts, authorizer.WithCurrentUserAsRoot())
+			}
+			a := authorizer.New(opts...)
+
+			err := a.IsRequestFromRoot(ctx)
+
+			if tc.wantErr {
+				require.Error(t, err, "IsRequestFromRoot should deny access but didn't")
+				return
+			}
+			require.NoError(t, err, "IsRequestFromRoot should allow access but didn't")
+		})
+	}
+}
+
+func TestWithUnixPeerCreds(t *testing.T) {
+	t.Parallel()
+
+	g := grpc.NewServer(authorizer.WithUnixPeerCreds())
+
+	require.NotNil(t, g, "New grpc with Unix Peer Creds is created")
+}

--- a/internal/services/authorizer/authorizertests/authorizertests.go
+++ b/internal/services/authorizer/authorizertests/authorizertests.go
@@ -1,0 +1,39 @@
+// Package authorizertests are exported functions to be run in 3rd party package or integration tests.
+package authorizertests
+
+import (
+	//nolint:revive,nolintlint // needed for go:linkname, but only used in tests. nolintlint as false positive then.
+	_ "unsafe"
+
+	"github.com/ubuntu/authd/internal/services/authorizer"
+	"github.com/ubuntu/authd/internal/testsdetection"
+)
+
+// WithCurrentUserAsRoot returns an Option that sets the rootUID to the current user's UID.
+//
+//go:linkname WithCurrentUserAsRoot github.com/ubuntu/authd/internal/services/authorizer.withCurrentUserAsRoot
+func WithCurrentUserAsRoot() authorizer.Option
+
+// SetCurrentRootAsRoot mutates a default permission to the current user's UID if currentUserAsRoot is true.
+//
+//go:linkname SetCurrentRootAsRoot github.com/ubuntu/authd/internal/services/authorizer.(*Authorizer).setCurrentRootAsRoot
+func SetCurrentRootAsRoot(a *authorizer.Authorizer, currentUserAsRoot bool)
+
+/*
+ * Integration tests helpers
+ */
+
+//go:linkname defaultOptions github.com/ubuntu/authd/internal/services/authorizer.defaultOptions
+var defaultOptions struct {
+	rootUID uint32
+}
+
+//go:linkname currentUserUID github.com/ubuntu/authd/internal/services/authorizer.currentUserUID
+func currentUserUID() uint32
+
+// DefaultCurrentUserAsRoot mocks the current user as root for the authorizer.
+func DefaultCurrentUserAsRoot() {
+	testsdetection.MustBeTesting()
+
+	defaultOptions.rootUID = currentUserUID()
+}

--- a/internal/services/authorizer/export_test.go
+++ b/internal/services/authorizer/export_test.go
@@ -1,0 +1,13 @@
+package authorizer
+
+type PeerCredsInfo = peerCredsInfo
+
+//nolint:revive // This is a false positive as we returned a typed alias and not the private type.
+func NewTestPeerCredsInfo(uid uint32, pid int32) PeerCredsInfo {
+	return PeerCredsInfo{uid: uid, pid: pid}
+}
+
+var (
+	CurrentUserUID        = currentUserUID
+	WithCurrentUserAsRoot = withCurrentUserAsRoot
+)

--- a/internal/services/authorizer/internal_test.go
+++ b/internal/services/authorizer/internal_test.go
@@ -1,0 +1,98 @@
+package authorizer
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/credentials"
+)
+
+func TestPeerCredsInfoAuthType(t *testing.T) {
+	t.Parallel()
+
+	p := peerCredsInfo{
+		uid: 11111,
+		pid: 22222,
+	}
+
+	require.Equal(t, "uid: 11111, pid: 22222", p.AuthType(), "AuthType returns expected uid and pid")
+}
+
+func TestServerPeerCredsHandshake(t *testing.T) {
+	t.Parallel()
+
+	s := serverPeerCreds{}
+
+	socket := filepath.Join(t.TempDir(), "authd.sock")
+	l, err := net.Listen("unix", socket)
+	require.NoError(t, err, "couldn't listen on socket")
+	defer l.Close()
+
+	wg := sync.WaitGroup{}
+	wg.Add(1)
+	var clientErr error
+	go func() {
+		defer wg.Done()
+		unixAddr, err := net.ResolveUnixAddr("unix", socket)
+		if err != nil {
+			clientErr = fmt.Errorf("Couldn't resolve client socket address: %w", err)
+			return
+		}
+		conn, err := net.DialUnix("unix", nil, unixAddr)
+		if err != nil {
+			clientErr = fmt.Errorf("Couldn't contact unix socket: %w", err)
+			return
+		}
+		defer conn.Close()
+	}()
+
+	conn, err := l.Accept()
+	require.NoError(t, err, "Should accept connexion from client")
+
+	// ServerHandshake status check.
+	c, i, err := s.ServerHandshake(conn)
+
+	require.NoError(t, err, "ServerHandshake should not fail")
+	require.Equal(t, conn, c, "Connexion should match given connection")
+	uid := currentUserUID()
+	require.Equal(t, fmt.Sprintf("uid: %d, pid: %d", uid, os.Getpid()),
+		i.AuthType(), "uid or pid received doesn't match what we expected")
+
+	// ClientHandshake status check.
+	c, i, err = s.ClientHandshake(context.Background(), "unused", conn)
+
+	require.NoError(t, err, "ClientHandshake should not fail")
+	require.Equal(t, conn, c, "Connexion should match given connection")
+	require.Nil(t, i, "No authInfo should be returned")
+
+	err = l.Close()
+	require.NoError(t, err, "Teardown: should close listener successfully")
+	wg.Wait()
+
+	require.NoError(t, clientErr, "Client should not return an error")
+}
+
+func TestServerPeerCredsInvalidSocket(t *testing.T) {
+	t.Parallel()
+
+	s := serverPeerCreds{}
+	_, _, err := s.ServerHandshake(nil)
+	require.Error(t, err, "ServerHandshake should fail when there is no valid connection")
+}
+
+func TestServerPeerCredsInterface(t *testing.T) {
+	t.Parallel()
+
+	// This only ensure we can call the various methods of the implemented interface
+	s := serverPeerCreds{}
+
+	require.Nil(t, s.Clone(), "Clone should return nil")
+	require.Nil(t, s.OverrideServerName("unused"), "OverrideServerName is a no-op and should return nil")
+	require.Equal(t, credentials.ProtocolInfo{}, s.Info(), "Info should return an empty struct")
+}

--- a/internal/services/authorizer/servercreds.go
+++ b/internal/services/authorizer/servercreds.go
@@ -1,0 +1,72 @@
+package authorizer
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net"
+
+	"github.com/ubuntu/decorate"
+	"golang.org/x/sys/unix"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials"
+)
+
+// WithUnixPeerCreds returns the credentials of the caller.
+func WithUnixPeerCreds() grpc.ServerOption {
+	return grpc.Creds(serverPeerCreds{})
+}
+
+// serverPeerCreds encapsulates a TransportCredentials which extracts uid and pid of caller via Unix Socket SO_PEERCRED.
+type serverPeerCreds struct{}
+
+func (serverPeerCreds) ServerHandshake(conn net.Conn) (n net.Conn, c credentials.AuthInfo, err error) {
+	defer decorate.OnError(&err, "server handshake failed")
+
+	var cred *unix.Ucred
+	// net.Conn is an interface. Expect only *net.UnixConn types
+	uc, ok := conn.(*net.UnixConn)
+	if !ok {
+		return nil, nil, errors.New("unexpected socket type")
+	}
+
+	// Fetches raw network connection from UnixConn
+	raw, err := uc.SyscallConn()
+	if err != nil {
+		return nil, nil, fmt.Errorf("error opening raw connection: %v", err)
+	}
+
+	// The raw.Control() callback does not return an error directly.
+	// In order to capture errors, we wrap already defined variable 'errGetsockoptUcred' within the closure.
+	// 'err' is then the error returned by Control() itself.
+	var errGetsockoptUcred error
+	err = raw.Control(func(fd uintptr) {
+		cred, errGetsockoptUcred = unix.GetsockoptUcred(int(fd),
+			unix.SOL_SOCKET,
+			unix.SO_PEERCRED)
+	})
+	if errGetsockoptUcred != nil {
+		return nil, nil, fmt.Errorf("GetsockoptUcred() error: %v", errGetsockoptUcred)
+	}
+	if err != nil {
+		return nil, nil, fmt.Errorf("Control() error: %v", err)
+	}
+
+	return conn, peerCredsInfo{uid: cred.Uid, pid: cred.Pid}, nil
+}
+func (serverPeerCreds) ClientHandshake(_ context.Context, _ string, conn net.Conn) (net.Conn, credentials.AuthInfo, error) {
+	return conn, nil, nil
+}
+func (serverPeerCreds) Info() credentials.ProtocolInfo          { return credentials.ProtocolInfo{} }
+func (serverPeerCreds) Clone() credentials.TransportCredentials { return nil }
+func (serverPeerCreds) OverrideServerName(_ string) error       { return nil }
+
+type peerCredsInfo struct {
+	uid uint32
+	pid int32
+}
+
+// AuthType returns a string encrypting uid and pid of caller.
+func (p peerCredsInfo) AuthType() string {
+	return fmt.Sprintf("uid: %d, pid: %d", p.uid, p.pid)
+}

--- a/internal/services/authorizer/testutils.go
+++ b/internal/services/authorizer/testutils.go
@@ -36,3 +36,17 @@ func currentUserUID() uint32 {
 
 	return uint32(uid)
 }
+
+// setCurrentRootAsRoot mutates a default permission to the current user's UID if currentUserAsRoot is true.
+//
+//nolint:unused // false positive as used in authorizertests with linkname.
+func (a *Authorizer) setCurrentRootAsRoot(currentUserAsRoot bool) {
+	testsdetection.MustBeTesting()
+
+	if !currentUserAsRoot {
+		a.rootUID = defaultOptions.rootUID
+		return
+	}
+
+	a.rootUID = currentUserUID()
+}

--- a/internal/services/authorizer/testutils.go
+++ b/internal/services/authorizer/testutils.go
@@ -11,6 +11,16 @@ import (
 	"github.com/ubuntu/authd/internal/testsdetection"
 )
 
+// withCurrentUserAsRoot returns an Option that sets the rootUID to the current user's UID.
+func withCurrentUserAsRoot() Option {
+	testsdetection.MustBeTesting()
+
+	uid := currentUserUID()
+	return func(o *options) {
+		o.rootUID = uid
+	}
+}
+
 // currentUserUID returns the current user UID or panics.
 func currentUserUID() uint32 {
 	testsdetection.MustBeTesting()

--- a/internal/services/authorizer/testutils.go
+++ b/internal/services/authorizer/testutils.go
@@ -1,0 +1,28 @@
+package authorizer
+
+// All those functions and methods are only for tests.
+// They are not exported, and guarded by testing assertions.
+
+import (
+	"fmt"
+	"os/user"
+	"strconv"
+
+	"github.com/ubuntu/authd/internal/testsdetection"
+)
+
+// currentUserUID returns the current user UID or panics.
+func currentUserUID() uint32 {
+	testsdetection.MustBeTesting()
+
+	u, err := user.Current()
+	if err != nil {
+		panic(fmt.Sprintf("could not get current user: %v", err))
+	}
+	uid, err := strconv.Atoi(u.Uid)
+	if err != nil {
+		panic(fmt.Sprintf("current uid is not an int (%v): %v", u.Uid, err))
+	}
+
+	return uint32(uid)
+}


### PR DESCRIPTION
* The Authorizer can decode from a context then current per user id (and pid) which connected to an unix socket. Then, it provides methods for authorization. One of them is only authorizing if the current user is root.
* Add unit and package tests for it.
* Export test helpers for other package and integration tests  
    * Make available to other packages some helpers to modify authorizer creation or lifecycle.
    * Ensure we have helpers for integration tests too.
    * All those helpers can be run without panicking in other local or integration tests.

UDENG-2563
UDENG-2584