### PR TITLE
maint: reduce the usage of env variables in nss integration tests

### DIFF
--- a/nss/integration-tests/helper_test.go
+++ b/nss/integration-tests/helper_test.go
@@ -14,10 +14,8 @@ import (
 	"github.com/ubuntu/authd/internal/testutils"
 )
 
-var daemonPath string
-
 // buildRustNSSLib builds the NSS library and links the compiled file to libPath.
-func buildRustNSSLib(t *testing.T) {
+func buildRustNSSLib(t *testing.T) (libPath string, rustCovEnv []string) {
 	t.Helper()
 
 	projectRoot := testutils.ProjectRoot()
@@ -52,11 +50,13 @@ func buildRustNSSLib(t *testing.T) {
 	if err = os.Symlink(filepath.Join(target, "debug", "libnss_authd.so"), libPath); err != nil {
 		require.ErrorIs(t, err, os.ErrExist, "Setup: failed to create versioned link to the library")
 	}
+
+	return libPath, rustCovEnv
 }
 
 // outNSSCommandForLib returns the specific part for the nss command, filtering originOut.
 // It uses the locally build authd nss module for the integration tests.
-func outNSSCommandForLib(t *testing.T, socketPath, originOut string, shouldPreCheck bool, cmds ...string) (got string, err error) {
+func outNSSCommandForLib(t *testing.T, libPath, socketPath string, rustCovEnv []string, originOut string, shouldPreCheck bool, cmds ...string) (got string, err error) {
 	t.Helper()
 
 	// #nosec:G204 - we control the command arguments in tests

--- a/nss/integration-tests/integration_test.go
+++ b/nss/integration-tests/integration_test.go
@@ -13,13 +13,12 @@ import (
 	grouptests "github.com/ubuntu/authd/internal/users/localgroups/tests"
 )
 
-var libPath string
-var rustCovEnv []string
+var daemonPath string
 
 func TestIntegration(t *testing.T) {
 	t.Parallel()
 
-	buildRustNSSLib(t)
+	libPath, rustCovEnv := buildRustNSSLib(t)
 
 	// Create a default daemon to use for most test cases.
 	defaultSocket := filepath.Join(os.TempDir(), "nss-integration-tests.sock")
@@ -132,7 +131,7 @@ func TestIntegration(t *testing.T) {
 				cmds = append(cmds, tc.key)
 			}
 
-			got, err := outNSSCommandForLib(t, socketPath, originOuts[tc.db], tc.shouldPreCheck, cmds...)
+			got, err := outNSSCommandForLib(t, libPath, socketPath, rustCovEnv, originOuts[tc.db], tc.shouldPreCheck, cmds...)
 			if tc.wantErr {
 				require.Error(t, err, "Expected an error, but got none")
 				return
@@ -144,7 +143,7 @@ func TestIntegration(t *testing.T) {
 
 			// This is to check that some cache tasks, such as cleaning a corrupted database, work as expected.
 			if tc.wantSecondCall {
-				got, err := outNSSCommandForLib(t, socketPath, originOuts[tc.db], tc.shouldPreCheck, cmds...)
+				got, err := outNSSCommandForLib(t, libPath, socketPath, rustCovEnv, originOuts[tc.db], tc.shouldPreCheck, cmds...)
 				require.NoError(t, err, "Expected no error, but got %v", err)
 				require.Empty(t, got, "Expected empty output, but got %q", got)
 			}


### PR DESCRIPTION
The variables should be scoped by the tests themselves, in particular as those functions relies on each others.
Also, the global variables were set in the other files they were used on.