### PR TITLE
fix(pam/go-exec): Address SSH hangs by using simpler waitpid to monitor children lifetime 

### DIFF
--- a/pam/go-exec/module.c
+++ b/pam/go-exec/module.c
@@ -1155,6 +1155,19 @@ do_pam_action (pam_handle_t *pamh,
 {
   g_autoptr(GThread) thread = NULL;
 
+#ifndef AUTHD_TEST_EXEC_MODULE
+  /* These actions aren't implemented in the go side, so let's just simplify
+   * the code in this case, and return what the module would do.
+   * But if something changes, keep this in sync with pam.go!
+   */
+  if (g_str_equal (action, "setcred"))
+    return PAM_IGNORE;
+  if (g_str_equal (action, "open_session"))
+    return PAM_IGNORE;
+  if (g_str_equal (action, "close_session"))
+    return PAM_IGNORE;
+#endif
+
   thread = g_thread_new (action, do_pam_action_thread_adapter, &(ActionThreadArgs){
     .pamh = pamh,
     .action = action,

--- a/pam/go-exec/module.c
+++ b/pam/go-exec/module.c
@@ -427,7 +427,7 @@ on_pam_method_call (GDBusConnection       *connection,
                     const char            *method_name,
                     GVariant              *parameters,
                     GDBusMethodInvocation *invocation,
-                    void                 * user_data)
+                    void                  *user_data)
 {
   ActionData *action_data = user_data;
   pam_handle_t *pamh = action_data->module_data->pamh;
@@ -802,7 +802,7 @@ G_DEFINE_AUTOPTR_CLEANUP_FUNC (ProgramNameResetter, program_name_resetter)
 
 static char *
 get_program_name (const char *action,
-                  pam_handle_t *pamh)
+                  pam_handle_t * pamh)
 {
   g_autofree char *cmdline = NULL;
   g_autofree char *proc_name = NULL;
@@ -827,12 +827,12 @@ get_program_name (const char *action,
 }
 
 static gboolean
-handle_module_options (int           argc,
-                       const char  **argv,
-                       GPtrArray   **out_args,
-                       char       ***out_env_variables,
-                       char        **out_log_file,
-                       GError      **error)
+handle_module_options (int          argc,
+                       const char **argv,
+                       GPtrArray  **out_args,
+                       char      ***out_env_variables,
+                       char       **out_log_file,
+                       GError     **error)
 {
   g_autoptr(GOptionContext) options_context = NULL;
   g_autoptr(GStrvBuilder) strv_builder = NULL;

--- a/pam/integration-tests/gdm_test.go
+++ b/pam/integration-tests/gdm_test.go
@@ -501,5 +501,5 @@ func buildPAMModule(t *testing.T) string {
 func buildPAMWrapperModule(t *testing.T) string {
 	t.Helper()
 
-	return buildCPAMModule(t, []string{"./pam/go-loader/module.c"}, nil, "pam_authd_loader")
+	return buildCPAMModule(t, []string{"./pam/go-loader/module.c"}, nil, nil, "pam_authd_loader")
 }

--- a/pam/integration-tests/modulehelpers_test.go
+++ b/pam/integration-tests/modulehelpers_test.go
@@ -21,7 +21,7 @@ func getPkgConfigFlags(t *testing.T, args []string) []string {
 	return strings.Split(strings.TrimSpace(string(out)), " ")
 }
 
-func buildCPAMModule(t *testing.T, sources []string, pkgConfigDeps []string, soname string) string {
+func buildCPAMModule(t *testing.T, sources []string, pkgConfigDeps []string, cFlags []string, soname string) string {
 	t.Helper()
 
 	compiler := os.Getenv("CC")
@@ -47,9 +47,10 @@ func buildCPAMModule(t *testing.T, sources []string, pkgConfigDeps []string, son
 		"-DAUTHD_TEST_MODULE=1",
 	)
 	if len(pkgConfigDeps) > 0 {
-		cmd.Args = append(cmd.Args,
+		cFlags = append(cFlags,
 			getPkgConfigFlags(t, append([]string{"--cflags"}, pkgConfigDeps...))...)
 	}
+	cmd.Args = append(cmd.Args, cFlags...)
 
 	modulesPath := os.Getenv("AUTHD_PAM_MODULES_PATH")
 	if modulesPath != "" {

--- a/pam/pam.go
+++ b/pam/pam.go
@@ -358,7 +358,7 @@ func (h *pamModule) AcctMgmt(mTx pam.ModuleTransaction, flags pam.Flags, args []
 
 	brokerIDUsedToAuthenticate, ok := brokerData.(string)
 	if !ok {
-		msg := fmt.Sprintf("broker data as an invalid type %#v", brokerData)
+		msg := fmt.Sprintf("broker data has an invalid type %#v", brokerData)
 		log.Errorf(context.TODO(), msg)
 		if err := showPamMessage(mTx, pam.ErrorMsg, msg); err != nil {
 			log.Warningf(context.TODO(), "Impossible to show PAM message: %v", err)

--- a/pam/pam_test.go
+++ b/pam/pam_test.go
@@ -1,0 +1,18 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/msteinert/pam/v2"
+	"github.com/stretchr/testify/require"
+)
+
+func TestUnimplementedActions(t *testing.T) {
+	module := &pamModule{}
+
+	// If these gets changed, go-exec module should be also adapted accordingly
+	// together with TestExecModuleUnimplementedActions
+	require.Error(t, module.SetCred(nil, pam.Flags(0), nil), pam.ErrIgnore)
+	require.Error(t, module.OpenSession(nil, pam.Flags(0), nil), pam.ErrIgnore)
+	require.Error(t, module.CloseSession(nil, pam.Flags(0), nil), pam.ErrIgnore)
+}


### PR DESCRIPTION
As per my latest tests on main, I've noticed that once authd was performing `setcred` in SSHd, we were not properly reacting to the second call to it leading to a total hang when connecting to any authd-powered server, so went analyzing the causes and found the solution for it.

This is the main reason:

Instead of relying on signal as GLib does just use waitpid on a separate
thread as this is safer to use because our library might be loaded by
other applications that may set a different handler on SIGCHLD, breaking
us, and making our wait to be never-ending.

This is particularly the case of sshd, because it creates a subprocess
where actions are executed, replacing our SIGCHLD handler causing the
module to hang forever during a second call to setcred.

UDENG-2695