### PR TITLE
maint: simplify NSS integration tests by targetting our service directly

### DIFF
--- a/nss/integration-tests/integration_test.go
+++ b/nss/integration-tests/integration_test.go
@@ -43,7 +43,6 @@ func TestIntegration(t *testing.T) {
 		cacheDB string
 
 		noDaemon       bool
-		noCustomSocket bool
 		wantSecondCall bool
 		shouldPreCheck bool
 
@@ -97,7 +96,7 @@ func TestIntegration(t *testing.T) {
 			}
 
 			var socketPath string
-			if !tc.noDaemon && !tc.noCustomSocket {
+			if !tc.noDaemon {
 				socketPath = defaultSocket
 				if tc.cacheDB != defaultDbState {
 					// Run a new daemon with a different cache state for special test cases.


### PR DESCRIPTION
This way, we don't need to have an original output storage and remove it from each commands.

Also, all errors are directly the one from our service.

Remove also an unused variable.