### PR TITLE
fix: Increase sleep time in some `internal/daemon` tests

### DIFF
--- a/internal/daemon/daemon_test.go
+++ b/internal/daemon/daemon_test.go
@@ -236,7 +236,7 @@ func TestQuit(t *testing.T) {
 			}()
 
 			// make sure Serve() is called. Even std golang grpc has this timeout in tests
-			time.Sleep(time.Millisecond * 10)
+			time.Sleep(100 * time.Millisecond)
 
 			var disconnectClient func()
 			if tc.activeConnection {
@@ -253,7 +253,7 @@ func TestQuit(t *testing.T) {
 				d.Quit(context.Background(), tc.force)
 			}()
 
-			time.Sleep(10 * time.Millisecond)
+			time.Sleep(100 * time.Millisecond)
 
 			// Any new connection is disallowed
 			connected, _ := createClientConnection(t, socketPath)


### PR DESCRIPTION
These tests sometimes failed (both in CI and in Launchpad) likely due to slower runners not being able to setup the expected behavior in the amount of time that we gave them, so increasing the wait time should prevent this from happening.