### PR TITLE
refactor: Use brokers.LocalBrokerName definition everywhere

### DIFF
--- a/internal/brokers/broker_test.go
+++ b/internal/brokers/broker_test.go
@@ -44,7 +44,7 @@ func TestNewBroker(t *testing.T) {
 		configFile string
 		wantErr    bool
 	}{
-		"No config means local broker":                        {name: "local"},
+		"No config means local broker":                        {name: brokers.LocalBrokerName},
 		"Successfully create broker with correct config file": {name: "broker", configFile: "valid"},
 
 		// General config errors

--- a/internal/brokers/manager_test.go
+++ b/internal/brokers/manager_test.go
@@ -106,12 +106,12 @@ func TestBrokerForUser(t *testing.T) {
 	m, err := brokers.NewManager(context.Background(), filepath.Join(brokerConfFixtures, "valid_brokers"), nil)
 	require.NoError(t, err, "Setup: could not create manager")
 
-	err = m.SetDefaultBrokerForUser("local", "user")
+	err = m.SetDefaultBrokerForUser(brokers.LocalBrokerName, "user")
 	require.NoError(t, err, "Setup: could not set default broker")
 
 	// Broker for user should return the assigned broker
 	got := m.BrokerForUser("user")
-	require.Equal(t, "local", got.ID, "BrokerForUser should return the assigned broker, but did not")
+	require.Equal(t, brokers.LocalBrokerName, got.ID, "BrokerForUser should return the assigned broker, but did not")
 
 	// Broker for user should return nil if no broker is assigned
 	got = m.BrokerForUser("no_broker")
@@ -128,7 +128,7 @@ func TestBrokerFromSessionID(t *testing.T) {
 		wantErr      bool
 	}{
 		"Successfully returns expected broker":       {sessionID: "success"},
-		"Returns local broker if sessionID is empty": {wantBrokerID: "local"},
+		"Returns local broker if sessionID is empty": {wantBrokerID: brokers.LocalBrokerName},
 
 		"Error if broker does not exist": {sessionID: "does not exist", wantErr: true},
 	}

--- a/pam/integration-tests/gdm_test.go
+++ b/pam/integration-tests/gdm_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/msteinert/pam/v2"
 	"github.com/stretchr/testify/require"
 	"github.com/ubuntu/authd"
+	"github.com/ubuntu/authd/internal/brokers"
 	"github.com/ubuntu/authd/internal/testutils"
 	grouptests "github.com/ubuntu/authd/internal/users/localgroups/tests"
 	"github.com/ubuntu/authd/pam/internal/gdm"
@@ -30,7 +31,6 @@ func init() {
 
 const (
 	exampleBrokerName = "ExampleBroker"
-	localBrokerName   = "local"
 	ignoredBrokerName = "<ignored-broker>"
 
 	passwordAuthID = "password"
@@ -186,7 +186,7 @@ func testGdmModule(t *testing.T, libPath string, args []string) {
 		},
 		"Error (ignored) on local broker causes fallback error": {
 			pamUser:    "user-foo",
-			brokerName: localBrokerName,
+			brokerName: brokers.LocalBrokerName,
 			wantPamInfoMessages: []string{
 				"auth=incomplete",
 			},

--- a/pam/internal/adapter/commands.go
+++ b/pam/internal/adapter/commands.go
@@ -9,6 +9,7 @@ import (
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/msteinert/pam/v2"
 	"github.com/ubuntu/authd"
+	"github.com/ubuntu/authd/internal/brokers"
 	"github.com/ubuntu/authd/internal/log"
 )
 
@@ -22,7 +23,7 @@ func sendEvent(msg tea.Msg) tea.Cmd {
 // startBrokerSession returns the sessionID after marking a broker as current.
 func startBrokerSession(client authd.PAMClient, brokerID, username string, mode authd.SessionMode) tea.Cmd {
 	return func() tea.Msg {
-		if brokerID == "local" {
+		if brokerID == brokers.LocalBrokerName {
 			return PamIgnore{LocalBrokerID: brokerID}
 		}
 


### PR DESCRIPTION
Avoid reusing the same local broker string everywhere, making it easier to change such ID in case we need in future, but also to making harder to errors due to typos.