### PR TITLE
fix(pam): Start broker and user selection only if required, without touching terminal

### DIFF
--- a/examplebroker/broker.go
+++ b/examplebroker/broker.go
@@ -89,6 +89,7 @@ var (
 	exampleUsers   = map[string]userInfoBroker{
 		"user1":             {Password: "goodpass"},
 		"user2":             {Password: "goodpass"},
+		"user3":             {Password: "goodpass"},
 		"user-mfa":          {Password: "goodpass"},
 		"user-needs-reset":  {Password: "goodpass"},
 		"user-can-reset":    {Password: "goodpass"},

--- a/pam/integration-tests/cli_test.go
+++ b/pam/integration-tests/cli_test.go
@@ -102,10 +102,10 @@ func TestCLIAuthenticate(t *testing.T) {
 			require.NoError(t, err, "Could not read output file of tape %q", tc.tape)
 
 			// We need to format the output a little bit, since the txt file can have some noise at the beginning.
-			var got string
-			splitTmp := strings.Split(string(tmp), "\n")
+			got := string(tmp)
+			splitTmp := strings.Split(got, "\n")
 			for i, str := range splitTmp {
-				if strings.HasPrefix(str, fmt.Sprintf("> ./pam_authd login socket=${%s}", socketPathEnv)) {
+				if strings.Contains(str, " ./pam_authd login socket=$") {
 					got = strings.Join(splitTmp[i:], "\n")
 					break
 				}
@@ -195,10 +195,10 @@ func TestCLIChangeAuthTok(t *testing.T) {
 			require.NoError(t, err, "Could not read output file of tape %q", tc.tape)
 
 			// We need to format the output a little bit, since the txt file can have some noise at the beginning.
-			var got string
-			splitTmp := strings.Split(string(tmp), "\n")
+			got := string(tmp)
+			splitTmp := strings.Split(got, "\n")
 			for i, str := range splitTmp {
-				if strings.HasPrefix(str, fmt.Sprintf("> ./pam_authd passwd socket=${%s}", socketPathEnv)) {
+				if strings.Contains(str, " ./pam_authd passwd socket=$") {
 					got = strings.Join(splitTmp[i:], "\n")
 					break
 				}

--- a/pam/integration-tests/cli_test.go
+++ b/pam/integration-tests/cli_test.go
@@ -45,6 +45,7 @@ func TestCLIAuthenticate(t *testing.T) {
 		currentUserNotRoot bool
 	}{
 		"Authenticate user successfully":                      {tape: "simple_auth"},
+		"Authenticate user successfully with preset user":     {tape: "simple_auth_with_preset_user"},
 		"Authenticate user with mfa":                          {tape: "mfa_auth"},
 		"Authenticate user with form mode with button":        {tape: "form_with_button"},
 		"Authenticate user with qr code":                      {tape: "qr_code"},
@@ -56,8 +57,9 @@ func TestCLIAuthenticate(t *testing.T) {
 		"Authenticate user and add it to local group":         {tape: "local_group"},
 		"Authenticate with warnings on unsupported arguments": {tape: "simple_auth_with_unsupported_args"},
 
-		"Remember last successful broker and mode": {tape: "remember_broker_and_mode"},
-		"Autoselect local broker for local user":   {tape: "local_user"},
+		"Remember last successful broker and mode":      {tape: "remember_broker_and_mode"},
+		"Autoselect local broker for local user":        {tape: "local_user"},
+		"Autoselect local broker for local user preset": {tape: "local_user_preset"},
 
 		"Deny authentication if current user is not considered as root": {tape: "not_root", currentUserNotRoot: true},
 

--- a/pam/integration-tests/testdata/TestCLIAuthenticate/golden/authenticate_user_successfully_with_preset_user
+++ b/pam/integration-tests/testdata/TestCLIAuthenticate/golden/authenticate_user_successfully_with_preset_user
@@ -1,0 +1,132 @@
+> env AUTHD_PAM_CLI_USER=user3 ./pam_authd login socket=${AUTHD_TESTS_CLI_AUTHENTICATE_TESTS_SOC
+K}
+  Select your provider
+
+> 1. local
+  2. ExampleBroker
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+────────────────────────────────────────────────────────────────────────────────
+> env AUTHD_PAM_CLI_USER=user3 ./pam_authd login socket=${AUTHD_TESTS_CLI_AUTHENTICATE_TESTS_SOC
+K}
+Gimme your password
+>
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+────────────────────────────────────────────────────────────────────────────────
+> env AUTHD_PAM_CLI_USER=user3 ./pam_authd login socket=${AUTHD_TESTS_CLI_AUTHENTICATE_TESTS_SOC
+K}
+Gimme your password
+PAM Authenticate() for user "user3" exited with success
+PAM AcctMgmt() exited with success
+>
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+────────────────────────────────────────────────────────────────────────────────
+> env AUTHD_PAM_CLI_USER=user3 ./pam_authd login socket=${AUTHD_TESTS_CLI_AUTHENTICATE_TESTS_SOC
+K}
+Gimme your password
+PAM Authenticate() for user "user3" exited with success
+PAM AcctMgmt() exited with success
+>
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+────────────────────────────────────────────────────────────────────────────────

--- a/pam/integration-tests/testdata/TestCLIAuthenticate/golden/autoselect_local_broker_for_local_user
+++ b/pam/integration-tests/testdata/TestCLIAuthenticate/golden/autoselect_local_broker_for_local_user
@@ -65,67 +65,67 @@ Username: root
 
 ────────────────────────────────────────────────────────────────────────────────
 > ./pam_authd login socket=${AUTHD_TESTS_CLI_AUTHENTICATE_TESTS_SOCK}
-  Select your provider
-
-> 1. local
-  2. ExampleBroker
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
 PAM Info Message: auth=incomplete
 PAM Authenticate() for user "root" exited with error (PAM exit code: 25): The return value shoul
 d be ignored by PAM dispatch
 PAM AcctMgmt() exited with error (PAM exit code: 26): Critical error - immediate abort
 >
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
 
 
 
 ────────────────────────────────────────────────────────────────────────────────
 > ./pam_authd login socket=${AUTHD_TESTS_CLI_AUTHENTICATE_TESTS_SOCK}
-  Select your provider
-
-> 1. local
-  2. ExampleBroker
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
 PAM Info Message: auth=incomplete
 PAM Authenticate() for user "root" exited with error (PAM exit code: 25): The return value shoul
 d be ignored by PAM dispatch
 PAM AcctMgmt() exited with error (PAM exit code: 26): Critical error - immediate abort
 >
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
 
 
 

--- a/pam/integration-tests/testdata/TestCLIAuthenticate/golden/autoselect_local_broker_for_local_user_preset
+++ b/pam/integration-tests/testdata/TestCLIAuthenticate/golden/autoselect_local_broker_for_local_user_preset
@@ -1,0 +1,99 @@
+> env AUTHD_PAM_CLI_USER=root ./pam_authd login socket=${AUTHD_TESTS_CLI_AUTHENTICATE_TESTS_SOCK
+}
+PAM Info Message: auth=incomplete
+PAM Authenticate() for user "root" exited with error (PAM exit code: 25): The return value shoul
+d be ignored by PAM dispatch
+PAM AcctMgmt() exited with error (PAM exit code: 26): Critical error - immediate abort
+>
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+────────────────────────────────────────────────────────────────────────────────
+> env AUTHD_PAM_CLI_USER=root ./pam_authd login socket=${AUTHD_TESTS_CLI_AUTHENTICATE_TESTS_SOCK
+}
+PAM Info Message: auth=incomplete
+PAM Authenticate() for user "root" exited with error (PAM exit code: 25): The return value shoul
+d be ignored by PAM dispatch
+PAM AcctMgmt() exited with error (PAM exit code: 26): Critical error - immediate abort
+>
+>
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+────────────────────────────────────────────────────────────────────────────────
+> env AUTHD_PAM_CLI_USER=root ./pam_authd login socket=${AUTHD_TESTS_CLI_AUTHENTICATE_TESTS_SOCK
+}
+PAM Info Message: auth=incomplete
+PAM Authenticate() for user "root" exited with error (PAM exit code: 25): The return value shoul
+d be ignored by PAM dispatch
+PAM AcctMgmt() exited with error (PAM exit code: 26): Critical error - immediate abort
+>
+>
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+────────────────────────────────────────────────────────────────────────────────

--- a/pam/integration-tests/testdata/tapes/local_user_preset.tape
+++ b/pam/integration-tests/testdata/tapes/local_user_preset.tape
@@ -1,0 +1,27 @@
+Output local_user_preset.txt
+Output local_user_preset.gif # If we don't specify a .gif output, it will create a default out.gif file.
+
+# Configuration header to standardize the output.
+# Does not work with the "Source" command.
+Set Width 800
+Set Height 500
+# TODO: Ideally, we should use Ubuntu Mono. However, the github runner is still on Jammy, which does not have it.
+# We should update this to use Ubuntu Mono once the runner is updated.
+Set FontFamily "Monospace"
+Set FontSize 13
+Set Padding 0
+Set Margin 0
+Set Shell bash
+
+Hide
+Type "env AUTHD_PAM_CLI_USER=root ./pam_authd login socket=${AUTHD_TESTS_CLI_AUTHENTICATE_TESTS_SOCK}"
+Enter
+Sleep 300ms
+Show
+
+Hide
+Enter
+Sleep 300ms
+Show
+
+Sleep 300ms

--- a/pam/integration-tests/testdata/tapes/simple_auth_with_preset_user.tape
+++ b/pam/integration-tests/testdata/tapes/simple_auth_with_preset_user.tape
@@ -1,0 +1,33 @@
+Output simple_auth_with_preset_user.txt
+Output simple_auth_with_preset_user.gif # If we don't specify a .gif output, it will create a default out.gif file.
+
+# Configuration header to standardize the output.
+# Does not work with the "Source" command.
+Set Width 800
+Set Height 500
+# TODO: Ideally, we should use Ubuntu Mono. However, the github runner is still on Jammy, which does not have it.
+# We should update this to use Ubuntu Mono once the runner is updated.
+Set FontFamily "Monospace"
+Set FontSize 13
+Set Padding 0
+Set Margin 0
+Set Shell bash
+
+Hide
+Type "env AUTHD_PAM_CLI_USER=user3 ./pam_authd login socket=${AUTHD_TESTS_CLI_AUTHENTICATE_TESTS_SOCK}"
+Enter
+Sleep 300ms
+Show
+
+Hide
+Type "2"
+Sleep 300ms
+Show
+
+Hide
+Type "goodpass"
+Enter
+Sleep 2s
+Show
+
+Sleep 300ms

--- a/pam/internal/adapter/gdmmodel_test.go
+++ b/pam/internal/adapter/gdmmodel_test.go
@@ -1139,19 +1139,16 @@ func TestGdmModel(t *testing.T) {
 			),
 			messages: []tea.Msg{
 				userSelected{username: "daemon-selected-user-and-broker"},
-				gdmTestWaitForStage{stage: proto.Stage_brokerSelection},
 			},
 			wantUsername:       "daemon-selected-user-and-broker",
 			wantSelectedBroker: firstBrokerInfo.Id,
 			wantGdmRequests: []gdm.RequestType{
 				gdm.RequestType_uiLayoutCapabilities,
-				gdm.RequestType_changeStage, // -> broker Selection
 			},
 			wantGdmEvents: []gdm.EventType{
 				gdm.EventType_userSelected,
 				gdm.EventType_brokersReceived,
 			},
-			wantStage: pam_proto.Stage_brokerSelection,
 			wantExitStatus: pamError{
 				status: pam.ErrSystem,
 				msg:    "can't select broker: error during broker selection",
@@ -1170,14 +1167,12 @@ func TestGdmModel(t *testing.T) {
 			wantSelectedBroker: firstBrokerInfo.Id,
 			wantGdmRequests: []gdm.RequestType{
 				gdm.RequestType_uiLayoutCapabilities,
-				gdm.RequestType_changeStage, // -> broker Selection
 			},
 			wantGdmEvents: []gdm.EventType{
 				gdm.EventType_userSelected,
 				gdm.EventType_brokersReceived,
 				gdm.EventType_brokerSelected,
 			},
-			wantStage: pam_proto.Stage_brokerSelection,
 			wantExitStatus: pamError{
 				status: pam.ErrSystem,
 				msg:    "no session ID returned by broker",
@@ -1190,20 +1185,17 @@ func TestGdmModel(t *testing.T) {
 			)...),
 			messages: []tea.Msg{
 				userSelected{username: "daemon-selected-user-and-broker"},
-				gdmTestWaitForStage{stage: pam_proto.Stage_brokerSelection},
 			},
 			wantUsername:       "daemon-selected-user-and-broker",
 			wantSelectedBroker: firstBrokerInfo.Id,
 			wantGdmRequests: []gdm.RequestType{
 				gdm.RequestType_uiLayoutCapabilities,
-				gdm.RequestType_changeStage, // -> broker Selection
 			},
 			wantGdmEvents: []gdm.EventType{
 				gdm.EventType_userSelected,
 				gdm.EventType_brokersReceived,
 				gdm.EventType_brokerSelected,
 			},
-			wantStage: pam_proto.Stage_brokerSelection,
 			wantExitStatus: pamError{
 				status: pam.ErrSystem,
 				msg:    "no encryption key returned by broker",
@@ -1224,13 +1216,11 @@ func TestGdmModel(t *testing.T) {
 			wantSelectedBroker: firstBrokerInfo.Id,
 			wantGdmRequests: []gdm.RequestType{
 				gdm.RequestType_uiLayoutCapabilities,
-				gdm.RequestType_changeStage, // -> broker Selection
 			},
 			wantGdmEvents: []gdm.EventType{
 				gdm.EventType_userSelected,
 				gdm.EventType_brokersReceived,
 			},
-			wantStage: pam_proto.Stage_brokerSelection,
 			wantExitStatus: pamError{
 				status: pam.ErrSystem,
 				msg:    "encryption key sent by broker is not a valid base64 encoded string: illegal base64 data at input byte 2",
@@ -1247,19 +1237,16 @@ func TestGdmModel(t *testing.T) {
 			),
 			messages: []tea.Msg{
 				userSelected{username: "daemon-selected-user-and-broker"},
-				gdmTestWaitForStage{stage: proto.Stage_brokerSelection},
 			},
 			wantUsername:       "daemon-selected-user-and-broker",
 			wantSelectedBroker: firstBrokerInfo.Id,
 			wantGdmRequests: []gdm.RequestType{
 				gdm.RequestType_uiLayoutCapabilities,
-				gdm.RequestType_changeStage, // -> broker Selection
 			},
 			wantGdmEvents: []gdm.EventType{
 				gdm.EventType_userSelected,
 				gdm.EventType_brokersReceived,
 			},
-			wantStage: pam_proto.Stage_brokerSelection,
 			wantExitStatus: pamError{
 				status: pam.ErrSystem,
 				msg:    gdmTestIgnoredMessage,

--- a/pam/internal/adapter/model.go
+++ b/pam/internal/adapter/model.go
@@ -171,9 +171,7 @@ func (m *UIModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 
 		// Got user and brokers? Time to auto or manually select.
-		return m, tea.Sequence(
-			m.changeStage(pam_proto.Stage_brokerSelection),
-			AutoSelectForUser(m.Client, m.username()))
+		return m, AutoSelectForUser(m.Client, m.username())
 
 	case BrokerSelected:
 		log.Debugf(context.TODO(), "%#v", msg)

--- a/pam/internal/adapter/model.go
+++ b/pam/internal/adapter/model.go
@@ -119,7 +119,6 @@ func (m *UIModel) Init() tea.Cmd {
 	m.authenticationModel = newAuthenticationModel(m.Client, m.ClientType)
 	cmds = append(cmds, m.authenticationModel.Init())
 
-	cmds = append(cmds, m.changeStage(pam_proto.Stage_userSelection))
 	return tea.Batch(cmds...)
 }
 

--- a/pam/main-cli.go
+++ b/pam/main-cli.go
@@ -22,6 +22,7 @@ func main() {
 	execModule := os.Getenv("AUTHD_PAM_EXEC_MODULE")
 	cliPath := os.Getenv("AUTHD_PAM_CLI_PATH")
 	testName := os.Getenv("AUTHD_PAM_CLI_TEST_NAME")
+	pamUser := os.Getenv("AUTHD_PAM_CLI_USER")
 
 	tmpDir, err := os.MkdirTemp(os.TempDir(), "pam-cli-tester-")
 	if err != nil {
@@ -73,7 +74,7 @@ func main() {
 		log.Fatalf("Can't create service file %s: %v", serviceFile, err)
 	}
 
-	tx, err := pam.StartConfDir(filepath.Base(serviceFile), "", pam.ConversationFunc(
+	tx, err := pam.StartConfDir(filepath.Base(serviceFile), pamUser, pam.ConversationFunc(
 		func(style pam.Style, msg string) (string, error) {
 			switch style {
 			case pam.TextInfo:


### PR DESCRIPTION
Ensure that terminal output is not touched unless we really need to.

This is something that is also required for #314 so having it earlier would help that PR too.

UDENG-2608