### PR TITLE
feat: Validate username returned by the broker

### DIFF
--- a/examplebroker/broker.go
+++ b/examplebroker/broker.go
@@ -87,15 +87,16 @@ type userInfoBroker struct {
 var (
 	exampleUsersMu = sync.RWMutex{}
 	exampleUsers   = map[string]userInfoBroker{
-		"user1":             {Password: "goodpass"},
-		"user2":             {Password: "goodpass"},
-		"user3":             {Password: "goodpass"},
-		"user-mfa":          {Password: "goodpass"},
-		"user-needs-reset":  {Password: "goodpass"},
-		"user-can-reset":    {Password: "goodpass"},
-		"user-local-groups": {Password: "goodpass"},
-		"user-pre-check":    {Password: "goodpass"},
-		"user-sudo":         {Password: "goodpass"},
+		"user1":                 {Password: "goodpass"},
+		"user2":                 {Password: "goodpass"},
+		"user3":                 {Password: "goodpass"},
+		"user-mfa":              {Password: "goodpass"},
+		"user-needs-reset":      {Password: "goodpass"},
+		"user-can-reset":        {Password: "goodpass"},
+		"user-local-groups":     {Password: "goodpass"},
+		"user-pre-check":        {Password: "goodpass"},
+		"user-sudo":             {Password: "goodpass"},
+		"user-mismatching-name": {Password: "goodpass"},
 	}
 )
 
@@ -780,11 +781,15 @@ func userInfoFromName(name string) string {
 		Gecos:  "gecos for " + name,
 	}
 
-	if name == "user-local-groups" {
+	switch name {
+	case "user-local-groups":
 		user.Groups = append(user.Groups, groupJSONInfo{Name: "localgroup", UGID: ""})
-	}
-	if name == "user-sudo" {
+
+	case "user-sudo":
 		user.Groups = append(user.Groups, groupJSONInfo{Name: "sudo", UGID: ""}, groupJSONInfo{Name: "admin", UGID: ""})
+
+	case "user-mismatching-name":
+		user.Name = "mismatching-username"
 	}
 
 	// only used for tests, we can ignore the template execution error as the returned data will be failing.

--- a/internal/brokers/export_test.go
+++ b/internal/brokers/export_test.go
@@ -62,3 +62,10 @@ func (b *Broker) LayoutValidatorsString(sessionID string) string {
 	}
 	return s
 }
+
+// AddOngoingUserRequest adds an ongoing user request to the broker for tests.
+func (b *Broker) AddOngoingUserRequest(sessionID, username string) {
+	b.ongoingUserRequestsMu.Lock()
+	defer b.ongoingUserRequestsMu.Unlock()
+	b.ongoingUserRequests[sessionID] = username
+}

--- a/internal/brokers/testdata/TestIsAuthenticated/golden/adds_default_groups_even_if_broker_did_not_set_them
+++ b/internal/brokers/testdata/TestIsAuthenticated/golden/adds_default_groups_even_if_broker_did_not_set_them
@@ -1,4 +1,4 @@
 FIRST CALL:
 	access: granted
-	data: {"Name":"IA_info_empty_groups","UID":98803,"Gecos":"gecos for IA_info_empty_groups","Dir":"/home/IA_info_empty_groups","Shell":"/bin/sh/IA_info_empty_groups","Groups":[{"Name":"IA_info_empty_groups","GID":98803}]}
+	data: {"Name":"TestIsAuthenticated/Adds_default_groups_even_if_broker_did_not_set_them_separator_IA_info_empty_groups","UID":98803,"Gecos":"gecos for IA_info_empty_groups","Dir":"/home/IA_info_empty_groups","Shell":"/bin/sh/IA_info_empty_groups","Groups":[{"Name":"TestIsAuthenticated/Adds_default_groups_even_if_broker_did_not_set_them_separator_IA_info_empty_groups","GID":98803}]}
 	err: <nil>

--- a/internal/brokers/testdata/TestIsAuthenticated/golden/error_when_broker_returns_userinfo_with_mismatching_username
+++ b/internal/brokers/testdata/TestIsAuthenticated/golden/error_when_broker_returns_userinfo_with_mismatching_username
@@ -1,0 +1,4 @@
+FIRST CALL:
+	access: 
+	data: 
+	err: provided userinfo is invalid: username "different_username" does not match the selected username "TestIsAuthenticated/Error_when_broker_returns_userinfo_with_mismatching_username_separator_IA_info_mismatching_user_name"

--- a/internal/brokers/testdata/TestIsAuthenticated/golden/error_when_calling_isauthenticated_a_second_time_without_cancelling
+++ b/internal/brokers/testdata/TestIsAuthenticated/golden/error_when_calling_isauthenticated_a_second_time_without_cancelling
@@ -1,6 +1,6 @@
 FIRST CALL:
 	access: granted
-	data: {"Name":"IA_second_call","UID":69902,"Gecos":"gecos for IA_second_call","Dir":"/home/IA_second_call","Shell":"/bin/sh/IA_second_call","Groups":[{"Name":"IA_second_call","GID":69902},{"Name":"group-IA_second_call","GID":69608}]}
+	data: {"Name":"TestIsAuthenticated/Error_when_calling_IsAuthenticated_a_second_time_without_cancelling_separator_IA_second_call","UID":69902,"Gecos":"gecos for IA_second_call","Dir":"/home/IA_second_call","Shell":"/bin/sh/IA_second_call","Groups":[{"Name":"TestIsAuthenticated/Error_when_calling_IsAuthenticated_a_second_time_without_cancelling_separator_IA_second_call","GID":69902},{"Name":"group-IA_second_call","GID":69608}]}
 	err: <nil>
 SECOND CALL:
 	access: 

--- a/internal/brokers/testdata/TestIsAuthenticated/golden/no_error_when_broker_returns_userinfo_with_empty_gecos
+++ b/internal/brokers/testdata/TestIsAuthenticated/golden/no_error_when_broker_returns_userinfo_with_empty_gecos
@@ -1,4 +1,4 @@
 FIRST CALL:
 	access: granted
-	data: {"Name":"IA_info_empty_gecos","UID":92651,"Gecos":"","Dir":"/home/IA_info_empty_gecos","Shell":"/bin/sh/IA_info_empty_gecos","Groups":[{"Name":"IA_info_empty_gecos","GID":92651},{"Name":"group-IA_info_empty_gecos","GID":92357}]}
+	data: {"Name":"TestIsAuthenticated/No_error_when_broker_returns_userinfo_with_empty_gecos_separator_IA_info_empty_gecos","UID":92651,"Gecos":"","Dir":"/home/IA_info_empty_gecos","Shell":"/bin/sh/IA_info_empty_gecos","Groups":[{"Name":"TestIsAuthenticated/No_error_when_broker_returns_userinfo_with_empty_gecos_separator_IA_info_empty_gecos","GID":92651},{"Name":"group-IA_info_empty_gecos","GID":92357}]}
 	err: <nil>

--- a/internal/brokers/testdata/TestIsAuthenticated/golden/no_error_when_broker_returns_userinfo_with_group_with_empty_ugid
+++ b/internal/brokers/testdata/TestIsAuthenticated/golden/no_error_when_broker_returns_userinfo_with_group_with_empty_ugid
@@ -1,4 +1,4 @@
 FIRST CALL:
 	access: granted
-	data: {"Name":"IA_info_empty_ugid","UID":88158,"Gecos":"gecos for IA_info_empty_ugid","Dir":"/home/IA_info_empty_ugid","Shell":"/bin/sh/IA_info_empty_ugid","Groups":[{"Name":"IA_info_empty_ugid","GID":88158},{"Name":"group-IA_info_empty_ugid","GID":null}]}
+	data: {"Name":"TestIsAuthenticated/No_error_when_broker_returns_userinfo_with_group_with_empty_UGID_separator_IA_info_empty_ugid","UID":88158,"Gecos":"gecos for IA_info_empty_ugid","Dir":"/home/IA_info_empty_ugid","Shell":"/bin/sh/IA_info_empty_ugid","Groups":[{"Name":"TestIsAuthenticated/No_error_when_broker_returns_userinfo_with_group_with_empty_UGID_separator_IA_info_empty_ugid","GID":88158},{"Name":"group-IA_info_empty_ugid","GID":null}]}
 	err: <nil>

--- a/internal/brokers/testdata/TestIsAuthenticated/golden/successfully_authenticate
+++ b/internal/brokers/testdata/TestIsAuthenticated/golden/successfully_authenticate
@@ -1,4 +1,4 @@
 FIRST CALL:
 	access: granted
-	data: {"Name":"success","UID":82162,"Gecos":"gecos for success","Dir":"/home/success","Shell":"/bin/sh/success","Groups":[{"Name":"success","GID":82162},{"Name":"group-success","GID":81868}]}
+	data: {"Name":"TestIsAuthenticated/Successfully_authenticate_separator_success","UID":82162,"Gecos":"gecos for success","Dir":"/home/success","Shell":"/bin/sh/success","Groups":[{"Name":"TestIsAuthenticated/Successfully_authenticate_separator_success","GID":82162},{"Name":"group-success","GID":81868}]}
 	err: <nil>

--- a/internal/brokers/testdata/TestIsAuthenticated/golden/successfully_authenticate_after_cancelling_first_call
+++ b/internal/brokers/testdata/TestIsAuthenticated/golden/successfully_authenticate_after_cancelling_first_call
@@ -4,5 +4,5 @@ FIRST CALL:
 	err: <nil>
 SECOND CALL:
 	access: granted
-	data: {"Name":"IA_second_call","UID":69902,"Gecos":"gecos for IA_second_call","Dir":"/home/IA_second_call","Shell":"/bin/sh/IA_second_call","Groups":[{"Name":"IA_second_call","GID":69902},{"Name":"group-IA_second_call","GID":69608}]}
+	data: {"Name":"TestIsAuthenticated/Successfully_authenticate_after_cancelling_first_call_separator_IA_second_call","UID":69902,"Gecos":"gecos for IA_second_call","Dir":"/home/IA_second_call","Shell":"/bin/sh/IA_second_call","Groups":[{"Name":"TestIsAuthenticated/Successfully_authenticate_after_cancelling_first_call_separator_IA_second_call","GID":69902},{"Name":"group-IA_second_call","GID":69608}]}
 	err: <nil>

--- a/internal/services/pam/pam_test.go
+++ b/internal/services/pam/pam_test.go
@@ -424,12 +424,13 @@ func TestIsAuthenticated(t *testing.T) {
 		"Error when there is no broker": {sessionID: "invalid-session"},
 
 		// broker errors
-		"Error when authenticating":                         {username: "IA_error"},
-		"Error on empty data even if granted":               {username: "IA_empty_data"},
-		"Error when broker returns invalid access":          {username: "IA_invalid_access"},
-		"Error when broker returns invalid data":            {username: "IA_invalid_data"},
-		"Error when broker returns invalid userinfo":        {username: "IA_invalid_userinfo"},
-		"Error when calling second time without cancelling": {username: "IA_second_call", secondCall: true},
+		"Error when authenticating":                                          {username: "IA_error"},
+		"Error on empty data even if granted":                                {username: "IA_empty_data"},
+		"Error when broker returns invalid access":                           {username: "IA_invalid_access"},
+		"Error when broker returns invalid data":                             {username: "IA_invalid_data"},
+		"Error when broker returns invalid userinfo":                         {username: "IA_invalid_userinfo"},
+		"Error when broker returns username different than the one selected": {username: "IA_info_mismatching_user_name"},
+		"Error when calling second time without cancelling":                  {username: "IA_second_call", secondCall: true},
 
 		// local group error
 		"Error on updating local groups with unexisting file": {username: "success_with_local_groups", localGroupsFile: "does_not_exists.group"},

--- a/internal/services/pam/testdata/TestIsAuthenticated/golden/error_on_updating_local_groups_with_unexisting_file/IsAuthenticated
+++ b/internal/services/pam/testdata/TestIsAuthenticated/golden/error_on_updating_local_groups_with_unexisting_file/IsAuthenticated
@@ -1,4 +1,4 @@
 FIRST CALL:
 	access: 
 	msg: 
-	err: rpc error: code = Unknown desc = can't check authentication: failed to update user "success_with_local_groups": could not update local groups for user "success_with_local_groups": could not fetch existing local group: open testdata/TestIsAuthenticated/does_not_exists.group: no such file or directory
+	err: rpc error: code = Unknown desc = can't check authentication: failed to update user "TestIsAuthenticated/Error_on_updating_local_groups_with_unexisting_file_separator_success_with_local_groups": could not update local groups for user "TestIsAuthenticated/Error_on_updating_local_groups_with_unexisting_file_separator_success_with_local_groups": could not fetch existing local group: open testdata/TestIsAuthenticated/does_not_exists.group: no such file or directory

--- a/internal/services/pam/testdata/TestIsAuthenticated/golden/error_when_broker_returns_username_different_than_the_one_selected/IsAuthenticated
+++ b/internal/services/pam/testdata/TestIsAuthenticated/golden/error_when_broker_returns_username_different_than_the_one_selected/IsAuthenticated
@@ -1,0 +1,4 @@
+FIRST CALL:
+	access: 
+	msg: 
+	err: rpc error: code = Unknown desc = can't check authentication: provided userinfo is invalid: username "different_username" does not match the selected username "TestIsAuthenticated/Error_when_broker_returns_username_different_than_the_one_selected_separator_IA_info_mismatching_user_name"

--- a/internal/services/pam/testdata/TestIsAuthenticated/golden/error_when_broker_returns_username_different_than_the_one_selected/cache.db
+++ b/internal/services/pam/testdata/TestIsAuthenticated/golden/error_when_broker_returns_username_different_than_the_one_selected/cache.db
@@ -1,0 +1,7 @@
+GroupByID: {}
+GroupByName: {}
+GroupToUsers: {}
+UserByID: {}
+UserByName: {}
+UserToBroker: {}
+UserToGroups: {}

--- a/internal/services/pam/testdata/TestIsAuthenticated/golden/error_when_calling_second_time_without_cancelling/cache.db
+++ b/internal/services/pam/testdata/TestIsAuthenticated/golden/error_when_calling_second_time_without_cancelling/cache.db
@@ -1,16 +1,16 @@
 GroupByID:
     "73625": '{"Name":"group-IA_second_call","GID":73625}'
-    "73793": '{"Name":"IA_second_call","GID":73793}'
+    "73793": '{"Name":"TestIsAuthenticated/Error_when_calling_second_time_without_cancelling_separator_IA_second_call","GID":73793}'
 GroupByName:
-    IA_second_call: '{"Name":"IA_second_call","GID":73793}'
+    TestIsAuthenticated/Error_when_calling_second_time_without_cancelling_separator_IA_second_call: '{"Name":"TestIsAuthenticated/Error_when_calling_second_time_without_cancelling_separator_IA_second_call","GID":73793}'
     group-IA_second_call: '{"Name":"group-IA_second_call","GID":73625}'
 GroupToUsers:
     "73625": '{"GID":73625,"UIDs":[73793]}'
     "73793": '{"GID":73793,"UIDs":[73793]}'
 UserByID:
-    "73793": '{"Name":"IA_second_call","UID":73793,"GID":73793,"Gecos":"gecos for IA_second_call","Dir":"/home/IA_second_call","Shell":"/bin/sh/IA_second_call","LastPwdChange":-1,"MaxPwdAge":-1,"PwdWarnPeriod":-1,"PwdInactivity":-1,"MinPwdAge":-1,"ExpirationDate":-1,"LastLogin":"ABCDETIME"}'
+    "73793": '{"Name":"TestIsAuthenticated/Error_when_calling_second_time_without_cancelling_separator_IA_second_call","UID":73793,"GID":73793,"Gecos":"gecos for IA_second_call","Dir":"/home/IA_second_call","Shell":"/bin/sh/IA_second_call","LastPwdChange":-1,"MaxPwdAge":-1,"PwdWarnPeriod":-1,"PwdInactivity":-1,"MinPwdAge":-1,"ExpirationDate":-1,"LastLogin":"ABCDETIME"}'
 UserByName:
-    IA_second_call: '{"Name":"IA_second_call","UID":73793,"GID":73793,"Gecos":"gecos for IA_second_call","Dir":"/home/IA_second_call","Shell":"/bin/sh/IA_second_call","LastPwdChange":-1,"MaxPwdAge":-1,"PwdWarnPeriod":-1,"PwdInactivity":-1,"MinPwdAge":-1,"ExpirationDate":-1,"LastLogin":"ABCDETIME"}'
+    TestIsAuthenticated/Error_when_calling_second_time_without_cancelling_separator_IA_second_call: '{"Name":"TestIsAuthenticated/Error_when_calling_second_time_without_cancelling_separator_IA_second_call","UID":73793,"GID":73793,"Gecos":"gecos for IA_second_call","Dir":"/home/IA_second_call","Shell":"/bin/sh/IA_second_call","LastPwdChange":-1,"MaxPwdAge":-1,"PwdWarnPeriod":-1,"PwdInactivity":-1,"MinPwdAge":-1,"ExpirationDate":-1,"LastLogin":"ABCDETIME"}'
 UserToBroker: {}
 UserToGroups:
     "73793": '{"UID":73793,"GIDs":[73793,73625]}'

--- a/internal/services/pam/testdata/TestIsAuthenticated/golden/successfully_authenticate/cache.db
+++ b/internal/services/pam/testdata/TestIsAuthenticated/golden/successfully_authenticate/cache.db
@@ -1,16 +1,16 @@
 GroupByID:
     "91357": '{"Name":"group-success","GID":91357}'
-    "91525": '{"Name":"success","GID":91525}'
+    "91525": '{"Name":"TestIsAuthenticated/Successfully_authenticate_separator_success","GID":91525}'
 GroupByName:
+    TestIsAuthenticated/Successfully_authenticate_separator_success: '{"Name":"TestIsAuthenticated/Successfully_authenticate_separator_success","GID":91525}'
     group-success: '{"Name":"group-success","GID":91357}'
-    success: '{"Name":"success","GID":91525}'
 GroupToUsers:
     "91357": '{"GID":91357,"UIDs":[91525]}'
     "91525": '{"GID":91525,"UIDs":[91525]}'
 UserByID:
-    "91525": '{"Name":"success","UID":91525,"GID":91525,"Gecos":"gecos for success","Dir":"/home/success","Shell":"/bin/sh/success","LastPwdChange":-1,"MaxPwdAge":-1,"PwdWarnPeriod":-1,"PwdInactivity":-1,"MinPwdAge":-1,"ExpirationDate":-1,"LastLogin":"ABCDETIME"}'
+    "91525": '{"Name":"TestIsAuthenticated/Successfully_authenticate_separator_success","UID":91525,"GID":91525,"Gecos":"gecos for success","Dir":"/home/success","Shell":"/bin/sh/success","LastPwdChange":-1,"MaxPwdAge":-1,"PwdWarnPeriod":-1,"PwdInactivity":-1,"MinPwdAge":-1,"ExpirationDate":-1,"LastLogin":"ABCDETIME"}'
 UserByName:
-    success: '{"Name":"success","UID":91525,"GID":91525,"Gecos":"gecos for success","Dir":"/home/success","Shell":"/bin/sh/success","LastPwdChange":-1,"MaxPwdAge":-1,"PwdWarnPeriod":-1,"PwdInactivity":-1,"MinPwdAge":-1,"ExpirationDate":-1,"LastLogin":"ABCDETIME"}'
+    TestIsAuthenticated/Successfully_authenticate_separator_success: '{"Name":"TestIsAuthenticated/Successfully_authenticate_separator_success","UID":91525,"GID":91525,"Gecos":"gecos for success","Dir":"/home/success","Shell":"/bin/sh/success","LastPwdChange":-1,"MaxPwdAge":-1,"PwdWarnPeriod":-1,"PwdInactivity":-1,"MinPwdAge":-1,"ExpirationDate":-1,"LastLogin":"ABCDETIME"}'
 UserToBroker: {}
 UserToGroups:
     "91525": '{"UID":91525,"GIDs":[91525,91357]}'

--- a/internal/services/pam/testdata/TestIsAuthenticated/golden/successfully_authenticate_if_first_call_is_canceled/cache.db
+++ b/internal/services/pam/testdata/TestIsAuthenticated/golden/successfully_authenticate_if_first_call_is_canceled/cache.db
@@ -1,16 +1,16 @@
 GroupByID:
     "73625": '{"Name":"group-IA_second_call","GID":73625}'
-    "73793": '{"Name":"IA_second_call","GID":73793}'
+    "73793": '{"Name":"TestIsAuthenticated/Successfully_authenticate_if_first_call_is_canceled_separator_IA_second_call","GID":73793}'
 GroupByName:
-    IA_second_call: '{"Name":"IA_second_call","GID":73793}'
+    TestIsAuthenticated/Successfully_authenticate_if_first_call_is_canceled_separator_IA_second_call: '{"Name":"TestIsAuthenticated/Successfully_authenticate_if_first_call_is_canceled_separator_IA_second_call","GID":73793}'
     group-IA_second_call: '{"Name":"group-IA_second_call","GID":73625}'
 GroupToUsers:
     "73625": '{"GID":73625,"UIDs":[73793]}'
     "73793": '{"GID":73793,"UIDs":[73793]}'
 UserByID:
-    "73793": '{"Name":"IA_second_call","UID":73793,"GID":73793,"Gecos":"gecos for IA_second_call","Dir":"/home/IA_second_call","Shell":"/bin/sh/IA_second_call","LastPwdChange":-1,"MaxPwdAge":-1,"PwdWarnPeriod":-1,"PwdInactivity":-1,"MinPwdAge":-1,"ExpirationDate":-1,"LastLogin":"ABCDETIME"}'
+    "73793": '{"Name":"TestIsAuthenticated/Successfully_authenticate_if_first_call_is_canceled_separator_IA_second_call","UID":73793,"GID":73793,"Gecos":"gecos for IA_second_call","Dir":"/home/IA_second_call","Shell":"/bin/sh/IA_second_call","LastPwdChange":-1,"MaxPwdAge":-1,"PwdWarnPeriod":-1,"PwdInactivity":-1,"MinPwdAge":-1,"ExpirationDate":-1,"LastLogin":"ABCDETIME"}'
 UserByName:
-    IA_second_call: '{"Name":"IA_second_call","UID":73793,"GID":73793,"Gecos":"gecos for IA_second_call","Dir":"/home/IA_second_call","Shell":"/bin/sh/IA_second_call","LastPwdChange":-1,"MaxPwdAge":-1,"PwdWarnPeriod":-1,"PwdInactivity":-1,"MinPwdAge":-1,"ExpirationDate":-1,"LastLogin":"ABCDETIME"}'
+    TestIsAuthenticated/Successfully_authenticate_if_first_call_is_canceled_separator_IA_second_call: '{"Name":"TestIsAuthenticated/Successfully_authenticate_if_first_call_is_canceled_separator_IA_second_call","UID":73793,"GID":73793,"Gecos":"gecos for IA_second_call","Dir":"/home/IA_second_call","Shell":"/bin/sh/IA_second_call","LastPwdChange":-1,"MaxPwdAge":-1,"PwdWarnPeriod":-1,"PwdInactivity":-1,"MinPwdAge":-1,"ExpirationDate":-1,"LastLogin":"ABCDETIME"}'
 UserToBroker: {}
 UserToGroups:
     "73793": '{"UID":73793,"GIDs":[73793,73625]}'

--- a/internal/services/pam/testdata/TestIsAuthenticated/golden/update_existing_db_on_success/cache.db
+++ b/internal/services/pam/testdata/TestIsAuthenticated/golden/update_existing_db_on_success/cache.db
@@ -1,20 +1,20 @@
 GroupByID:
     "88888": '{"Name":"othergroup","GID":88888}'
     "91357": '{"Name":"group-success","GID":91357}'
-    "91525": '{"Name":"success","GID":91525}'
+    "91525": '{"Name":"TestIsAuthenticated/Update_existing_DB_on_success_separator_success","GID":91525}'
 GroupByName:
+    TestIsAuthenticated/Update_existing_DB_on_success_separator_success: '{"Name":"TestIsAuthenticated/Update_existing_DB_on_success_separator_success","GID":91525}'
     group-success: '{"Name":"group-success","GID":91357}'
-    success: '{"Name":"success","GID":91525}'
 GroupToUsers:
     "88888": '{"GID":88888,"UIDs":[77777]}'
     "91357": '{"GID":91357,"UIDs":[91525]}'
     "91525": '{"GID":91525,"UIDs":[91525]}'
 UserByID:
     "77777": '{"Name":"otheruser","UID":77777,"GID":88888,"Gecos":"gecos for other user","Dir":"/home/otheruser","Shell":"/bin/sh/otheruser","LastPwdChange":-1,"MaxPwdAge":-1,"PwdWarnPeriod":-1,"PwdInactivity":-1,"MinPwdAge":-1,"ExpirationDate":-1,"LastLogin":"AAAAATIME"}'
-    "91525": '{"Name":"success","UID":91525,"GID":91525,"Gecos":"gecos for success","Dir":"/home/success","Shell":"/bin/sh/success","LastPwdChange":-1,"MaxPwdAge":-1,"PwdWarnPeriod":-1,"PwdInactivity":-1,"MinPwdAge":-1,"ExpirationDate":-1,"LastLogin":"ABCDETIME"}'
+    "91525": '{"Name":"TestIsAuthenticated/Update_existing_DB_on_success_separator_success","UID":91525,"GID":91525,"Gecos":"gecos for success","Dir":"/home/success","Shell":"/bin/sh/success","LastPwdChange":-1,"MaxPwdAge":-1,"PwdWarnPeriod":-1,"PwdInactivity":-1,"MinPwdAge":-1,"ExpirationDate":-1,"LastLogin":"ABCDETIME"}'
 UserByName:
+    TestIsAuthenticated/Update_existing_DB_on_success_separator_success: '{"Name":"TestIsAuthenticated/Update_existing_DB_on_success_separator_success","UID":91525,"GID":91525,"Gecos":"gecos for success","Dir":"/home/success","Shell":"/bin/sh/success","LastPwdChange":-1,"MaxPwdAge":-1,"PwdWarnPeriod":-1,"PwdInactivity":-1,"MinPwdAge":-1,"ExpirationDate":-1,"LastLogin":"ABCDETIME"}'
     otheruser: '{"Name":"otheruser","UID":77777,"GID":88888,"Gecos":"gecos for other user","Dir":"/home/otheruser","Shell":"/bin/sh/otheruser","LastPwdChange":-1,"MaxPwdAge":-1,"PwdWarnPeriod":-1,"PwdInactivity":-1,"MinPwdAge":-1,"ExpirationDate":-1,"LastLogin":"AAAAATIME"}'
-    success: '{"Name":"success","UID":91525,"GID":91525,"Gecos":"gecos for success","Dir":"/home/success","Shell":"/bin/sh/success","LastPwdChange":-1,"MaxPwdAge":-1,"PwdWarnPeriod":-1,"PwdInactivity":-1,"MinPwdAge":-1,"ExpirationDate":-1,"LastLogin":"ABCDETIME"}'
 UserToBroker: {}
 UserToGroups:
     "77777": '{"UID":77777,"GIDs":[88888]}'

--- a/internal/services/pam/testdata/TestIsAuthenticated/golden/update_local_groups/cache.db
+++ b/internal/services/pam/testdata/TestIsAuthenticated/golden/update_local_groups/cache.db
@@ -1,16 +1,16 @@
 GroupByID:
     "82691": '{"Name":"group-success_with_local_groups","GID":82691}'
-    "82859": '{"Name":"success_with_local_groups","GID":82859}'
+    "82859": '{"Name":"TestIsAuthenticated/Update_local_groups_separator_success_with_local_groups","GID":82859}'
 GroupByName:
+    TestIsAuthenticated/Update_local_groups_separator_success_with_local_groups: '{"Name":"TestIsAuthenticated/Update_local_groups_separator_success_with_local_groups","GID":82859}'
     group-success_with_local_groups: '{"Name":"group-success_with_local_groups","GID":82691}'
-    success_with_local_groups: '{"Name":"success_with_local_groups","GID":82859}'
 GroupToUsers:
     "82691": '{"GID":82691,"UIDs":[82859]}'
     "82859": '{"GID":82859,"UIDs":[82859]}'
 UserByID:
-    "82859": '{"Name":"success_with_local_groups","UID":82859,"GID":82859,"Gecos":"gecos for success_with_local_groups","Dir":"/home/success_with_local_groups","Shell":"/bin/sh/success_with_local_groups","LastPwdChange":-1,"MaxPwdAge":-1,"PwdWarnPeriod":-1,"PwdInactivity":-1,"MinPwdAge":-1,"ExpirationDate":-1,"LastLogin":"ABCDETIME"}'
+    "82859": '{"Name":"TestIsAuthenticated/Update_local_groups_separator_success_with_local_groups","UID":82859,"GID":82859,"Gecos":"gecos for success_with_local_groups","Dir":"/home/success_with_local_groups","Shell":"/bin/sh/success_with_local_groups","LastPwdChange":-1,"MaxPwdAge":-1,"PwdWarnPeriod":-1,"PwdInactivity":-1,"MinPwdAge":-1,"ExpirationDate":-1,"LastLogin":"ABCDETIME"}'
 UserByName:
-    success_with_local_groups: '{"Name":"success_with_local_groups","UID":82859,"GID":82859,"Gecos":"gecos for success_with_local_groups","Dir":"/home/success_with_local_groups","Shell":"/bin/sh/success_with_local_groups","LastPwdChange":-1,"MaxPwdAge":-1,"PwdWarnPeriod":-1,"PwdInactivity":-1,"MinPwdAge":-1,"ExpirationDate":-1,"LastLogin":"ABCDETIME"}'
+    TestIsAuthenticated/Update_local_groups_separator_success_with_local_groups: '{"Name":"TestIsAuthenticated/Update_local_groups_separator_success_with_local_groups","UID":82859,"GID":82859,"Gecos":"gecos for success_with_local_groups","Dir":"/home/success_with_local_groups","Shell":"/bin/sh/success_with_local_groups","LastPwdChange":-1,"MaxPwdAge":-1,"PwdWarnPeriod":-1,"PwdInactivity":-1,"MinPwdAge":-1,"ExpirationDate":-1,"LastLogin":"ABCDETIME"}'
 UserToBroker: {}
 UserToGroups:
     "82859": '{"UID":82859,"GIDs":[82859,82691]}'

--- a/internal/services/pam/testdata/TestIsAuthenticated/golden/update_local_groups/gpasswd.output
+++ b/internal/services/pam/testdata/TestIsAuthenticated/golden/update_local_groups/gpasswd.output
@@ -1,2 +1,2 @@
---add success_with_local_groups localgroup3
---delete success_with_local_groups localgroup2
+--add TestIsAuthenticated/Update_local_groups_separator_success_with_local_groups localgroup1
+--add TestIsAuthenticated/Update_local_groups_separator_success_with_local_groups localgroup3

--- a/internal/testutils/broker.go
+++ b/internal/testutils/broker.go
@@ -240,7 +240,7 @@ func (b *BrokerBusMock) IsAuthenticated(sessionID, authenticationData string) (a
 	}()
 
 	access = authGranted
-	data = fmt.Sprintf(`{"userinfo": %s}`, userInfoFromName(parsedID, nil))
+	data = fmt.Sprintf(`{"userinfo": %s}`, userInfoFromName(sessionID, nil))
 
 	switch parsedID {
 	case "IA_timeout":
@@ -260,7 +260,7 @@ func (b *BrokerBusMock) IsAuthenticated(sessionID, authenticationData string) (a
 			data = ""
 		case <-time.After(2 * time.Second):
 			access = authGranted
-			data = fmt.Sprintf(`{"userinfo": %s}`, userInfoFromName(parsedID, nil))
+			data = fmt.Sprintf(`{"userinfo": %s}`, userInfoFromName(sessionID, nil))
 		}
 
 	case "IA_next":
@@ -269,7 +269,7 @@ func (b *BrokerBusMock) IsAuthenticated(sessionID, authenticationData string) (a
 
 	case "success_with_local_groups":
 		extragroups := []groupJSONInfo{{Name: "localgroup1"}, {Name: "localgroup3"}}
-		data = fmt.Sprintf(`{"userinfo": %s}`, userInfoFromName(parsedID, extragroups))
+		data = fmt.Sprintf(`{"userinfo": %s}`, userInfoFromName(sessionID, extragroups))
 
 	case "IA_invalid_access":
 		access = "invalid"
@@ -350,9 +350,11 @@ type groupJSONInfo struct {
 }
 
 // userInfoFromName transform a given name to the strinfigy userinfo string.
-func userInfoFromName(parsedID string, extraGroups []groupJSONInfo) string {
+func userInfoFromName(sessionID string, extraGroups []groupJSONInfo) string {
 	// Default values
-	name := parsedID
+	parsedID := parseSessionID(sessionID)
+
+	name := strings.TrimSuffix(sessionID, "-session_id")
 	group := "group-" + parsedID
 	home := "/home/" + parsedID
 	shell := "/bin/sh/" + parsedID
@@ -363,6 +365,8 @@ func userInfoFromName(parsedID string, extraGroups []groupJSONInfo) string {
 	switch parsedID {
 	case "IA_info_empty_user_name":
 		name = ""
+	case "IA_info_mismatching_user_name":
+		name = "different_username"
 	case "IA_info_empty_group_name":
 		group = ""
 	case "IA_info_empty_uuid":

--- a/pam/integration-tests/cli_test.go
+++ b/pam/integration-tests/cli_test.go
@@ -65,6 +65,7 @@ func TestCLIAuthenticate(t *testing.T) {
 
 		"Deny authentication if max attempts reached": {tape: "max_attempts"},
 		"Deny authentication if user does not exist":  {tape: "unexistent_user"},
+		"Deny authentication if usernames dont match": {tape: "mismatch_username"},
 
 		"Exit authd if local broker is selected": {tape: "local_broker"},
 		"Exit authd if user sigints":             {tape: "sigint"},

--- a/pam/integration-tests/testdata/TestCLIAuthenticate/golden/deny_authentication_if_usernames_dont_match
+++ b/pam/integration-tests/testdata/TestCLIAuthenticate/golden/deny_authentication_if_usernames_dont_match
@@ -1,0 +1,198 @@
+> ./pam_authd login socket=${AUTHD_TESTS_CLI_AUTHENTICATE_TESTS_SOCK}
+Username: user name
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+────────────────────────────────────────────────────────────────────────────────
+> ./pam_authd login socket=${AUTHD_TESTS_CLI_AUTHENTICATE_TESTS_SOCK}
+Username: user-mismatching-name
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+────────────────────────────────────────────────────────────────────────────────
+> ./pam_authd login socket=${AUTHD_TESTS_CLI_AUTHENTICATE_TESTS_SOCK}
+  Select your provider
+
+> 1. local
+  2. ExampleBroker
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+────────────────────────────────────────────────────────────────────────────────
+> ./pam_authd login socket=${AUTHD_TESTS_CLI_AUTHENTICATE_TESTS_SOCK}
+Gimme your password
+>
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+────────────────────────────────────────────────────────────────────────────────
+> ./pam_authd login socket=${AUTHD_TESTS_CLI_AUTHENTICATE_TESTS_SOCK}
+Gimme your password
+PAM Error Message: authentication status failure: rpc error: code = Unknown desc = can't check a
+uthentication: provided userinfo is invalid: username "mismatching-username" does not match the
+selected username "user-mismatching-name"
+PAM Authenticate() for user "user-mismatching-name" exited with error (PAM exit code: 4): System
+ error
+PAM Info Message: acct=incomplete
+PAM AcctMgmt() exited with error (PAM exit code: 25): The return value should be ignored by PAM
+dispatch
+>
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+────────────────────────────────────────────────────────────────────────────────
+> ./pam_authd login socket=${AUTHD_TESTS_CLI_AUTHENTICATE_TESTS_SOCK}
+Gimme your password
+PAM Error Message: authentication status failure: rpc error: code = Unknown desc = can't check a
+uthentication: provided userinfo is invalid: username "mismatching-username" does not match the
+selected username "user-mismatching-name"
+PAM Authenticate() for user "user-mismatching-name" exited with error (PAM exit code: 4): System
+ error
+PAM Info Message: acct=incomplete
+PAM AcctMgmt() exited with error (PAM exit code: 25): The return value should be ignored by PAM
+dispatch
+>
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+────────────────────────────────────────────────────────────────────────────────

--- a/pam/integration-tests/testdata/tapes/mismatch_username.tape
+++ b/pam/integration-tests/testdata/tapes/mismatch_username.tape
@@ -1,0 +1,45 @@
+Output mismatch_username.txt
+Output mismatch_username.gif # If we don't specify a .gif output, it will create a default out.gif file.
+
+# Configuration header to standardize the output.
+# Does not work with the "Source" command.
+Set Width 800
+Set Height 500
+# TODO: Ideally, we should use Ubuntu Mono. However, the github runner is still on Jammy, which does not have it.
+# We should update this to use Ubuntu Mono once the runner is updated.
+Set FontFamily "Monospace"
+Set FontSize 13
+Set Padding 0
+Set Margin 0
+Set Shell bash
+
+Hide
+Type "./pam_authd login socket=${AUTHD_TESTS_CLI_AUTHENTICATE_TESTS_SOCK}"
+Enter
+Sleep 300ms
+Show
+
+Hide
+Escape
+Backspace
+Type "user-mismatching-name"
+Sleep 300ms
+Show
+
+Hide
+Enter
+Sleep 300ms
+Show
+
+Hide
+Type "2"
+Sleep 300ms
+Show
+
+Hide
+Type "goodpass"
+Enter
+Sleep 2s
+Show
+
+Sleep 300ms


### PR DESCRIPTION
The broker could return a username different from what was selected locally and the authentication would be granted. To prevent this from happening, we should check if the username returned by the broker is the same as the one first selected in PAM.

UDENG-2515