### PR TITLE
fix(services): Renaming  [Ss]etCurrentRootAsRoot => [Ss]etCurrent**User**AsRoot

### DIFF
--- a/internal/services/pam/pam_test.go
+++ b/internal/services/pam/pam_test.go
@@ -285,7 +285,7 @@ func TestGetAuthenticationModes(t *testing.T) {
 			}
 
 			// Now, set tests permissions for this use case
-			permissionstests.SetCurrentRootAsRoot(&pm, !tc.currentUserNotRoot)
+			permissionstests.SetCurrentUserAsRoot(&pm, !tc.currentUserNotRoot)
 
 			if tc.supportedUILayouts == nil {
 				tc.supportedUILayouts = []*authd.UILayout{requiredEntry}
@@ -379,7 +379,7 @@ func TestSelectAuthenticationMode(t *testing.T) {
 			}
 
 			// Now, set tests permissions for this use case
-			permissionstests.SetCurrentRootAsRoot(&pm, !tc.currentUserNotRoot)
+			permissionstests.SetCurrentUserAsRoot(&pm, !tc.currentUserNotRoot)
 
 			samReq := &authd.SAMRequest{
 				SessionId:            tc.sessionID,
@@ -476,7 +476,7 @@ func TestIsAuthenticated(t *testing.T) {
 			}
 
 			// Now, set tests permissions for this use case
-			permissionstests.SetCurrentRootAsRoot(&pm, !tc.currentUserNotRoot)
+			permissionstests.SetCurrentUserAsRoot(&pm, !tc.currentUserNotRoot)
 
 			var firstCall, secondCall string
 			ctx, cancel := context.WithCancel(context.Background())
@@ -638,7 +638,7 @@ func TestEndSession(t *testing.T) {
 			}
 
 			// Now, set tests permissions for this use case
-			permissionstests.SetCurrentRootAsRoot(&pm, !tc.currentUserNotRoot)
+			permissionstests.SetCurrentUserAsRoot(&pm, !tc.currentUserNotRoot)
 
 			esReq := &authd.ESRequest{
 				SessionId: tc.sessionID,

--- a/internal/services/permissions/permissionstests/permissionstests.go
+++ b/internal/services/permissions/permissionstests/permissionstests.go
@@ -25,10 +25,10 @@ func init() {
 //go:linkname WithCurrentUserAsRoot github.com/ubuntu/authd/internal/services/permissions.withCurrentUserAsRoot
 func WithCurrentUserAsRoot() permissions.Option
 
-// SetCurrentRootAsRoot mutates a default permission to the current user's UID if currentUserAsRoot is true.
+// SetCurrentUserAsRoot mutates a default permission to the current user's UID if currentUserAsRoot is true.
 //
-//go:linkname SetCurrentRootAsRoot github.com/ubuntu/authd/internal/services/permissions.(*Manager).setCurrentRootAsRoot
-func SetCurrentRootAsRoot(m *permissions.Manager, currentUserAsRoot bool)
+//go:linkname SetCurrentUserAsRoot github.com/ubuntu/authd/internal/services/permissions.(*Manager).setCurrentUserAsRoot
+func SetCurrentUserAsRoot(m *permissions.Manager, currentUserAsRoot bool)
 
 /*
  * Integration tests helpers

--- a/internal/services/permissions/testutils.go
+++ b/internal/services/permissions/testutils.go
@@ -37,10 +37,10 @@ func currentUserUID() uint32 {
 	return uint32(uid)
 }
 
-// setCurrentRootAsRoot mutates a default permission to the current user's UID if currentUserAsRoot is true.
+// setCurrentUserAsRoot mutates a default permission to the current user's UID if currentUserAsRoot is true.
 //
 //nolint:unused // false positive as used in permissionstests with linkname.
-func (m *Manager) setCurrentRootAsRoot(currentUserAsRoot bool) {
+func (m *Manager) setCurrentUserAsRoot(currentUserAsRoot bool) {
 	testsdetection.MustBeTesting()
 
 	if !currentUserAsRoot {


### PR DESCRIPTION
Based on the fact that the property being mutated is dependent on `currentUserAsRoot`, I believe the method name needs adjustment.