### PR TITLE
maint: vulnerability fix in net module

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/ubuntu/authd
 
 go 1.22.0
 
-toolchain go1.22.2
+toolchain go1.22.3
 
 require (
 	github.com/charmbracelet/bubbles v0.18.0

--- a/tools/go.mod
+++ b/tools/go.mod
@@ -2,7 +2,7 @@ module github.com/ubuntu/authd/tools
 
 go 1.22.0
 
-toolchain go1.22.2
+toolchain go1.22.3
 
 require (
 	github.com/golangci/golangci-lint v1.57.2


### PR DESCRIPTION
Bump Go to 1.22.3

Fixes Vulnerability #1: GO-2024-2824
  Malformed DNS message can cause infinite loop in net
More info: https://pkg.go.dev/vuln/GO-2024-2824
  Standard library
    Found in: net@go1.22.2
    Fixed in: net@go1.22.3