### PR TITLE
tests: Update NSS integration tests expected error output

### DIFF
--- a/nss/integration-tests/helper_test.go
+++ b/nss/integration-tests/helper_test.go
@@ -55,7 +55,7 @@ func buildRustNSSLib(t *testing.T) (libPath string, rustCovEnv []string) {
 
 // getentOutputForLib returns the specific part for the nss command for the authd service.
 // It uses the locally build authd nss module for the integration tests.
-func getentOutputForLib(t *testing.T, libPath, socketPath string, rustCovEnv []string, shouldPreCheck bool, cmds ...string) (got string, err error) {
+func getentOutputForLib(t *testing.T, libPath, socketPath string, rustCovEnv []string, shouldPreCheck bool, cmds ...string) (got string, exitCode int) {
 	t.Helper()
 
 	// #nosec:G204 - we control the command arguments in tests
@@ -81,6 +81,8 @@ func getentOutputForLib(t *testing.T, libPath, socketPath string, rustCovEnv []s
 	cmd.Stdout = io.MultiWriter(os.Stdout, &out)
 	cmd.Stderr = os.Stderr
 
-	err = cmd.Run()
-	return out.String(), err
+	// We are only interested in the output and the exit code of the command, so we can ignore the error.
+	_ = cmd.Run()
+
+	return out.String(), cmd.ProcessState.ExitCode()
 }


### PR DESCRIPTION
We used to check the error returned by the execution of the subprocess. We are now checking if the getent command is returning the expected status code.

The `getent` command can have 4 possible status codes:
0 - Success;
1 - Missing arguments, or database unknown; (We don't care about this one, since it's a command misusage and has nothing to do with our module)
2 - One or more supplied keys could not be found in the database; (This is what we expect to receive in all of our error cases)
3 - Enumeration is not supported on this database. (Not sure what this one means, but I don't think it matters to us)

UDENG-2693