### PR TITLE
pam/go-exec: Expose the server address using an env variable

### DIFF
--- a/pam/go-exec/module.c
+++ b/pam/go-exec/module.c
@@ -1061,6 +1061,8 @@ do_pam_action_thread (pam_handle_t *pamh,
     g_ptr_array_add (envp, g_strdup_printf ("TERM=%s", g_getenv ("TERM")));
   for (int i = 0; env_variables && env_variables[i]; ++i)
     g_ptr_array_add (envp, g_strdup (env_variables[i]));
+  g_ptr_array_add (envp, g_strdup_printf ("AUTHD_PAM_SERVER_ADDRESS=%s",
+                                          g_dbus_server_get_client_address (server)));
   /* FIXME: use g_ptr_array_new_null_terminated when we can use newer GLib. */
   g_ptr_array_add (envp, NULL);
 
@@ -1068,8 +1070,6 @@ do_pam_action_thread (pam_handle_t *pamh,
   g_ptr_array_insert (args, idx++, g_strdup (exe));
   g_ptr_array_insert (args, idx++, g_strdup ("-flags"));
   g_ptr_array_insert (args, idx++, g_strdup_printf ("%d", flags));
-  g_ptr_array_insert (args, idx++, g_strdup ("-server-address"));
-  g_ptr_array_insert (args, idx++, g_strdup (g_dbus_server_get_client_address (server)));
   g_ptr_array_insert (args, idx++, g_strdup (action));
   /* FIXME: use g_ptr_array_new_null_terminated when we can use newer GLib. */
   g_ptr_array_add (args, NULL);

--- a/pam/integration-tests/cmd/exec-client/client.go
+++ b/pam/integration-tests/cmd/exec-client/client.go
@@ -48,6 +48,11 @@ func mainFunc() error {
 		return fmt.Errorf("%w: not enough arguments", pam_test.ErrInvalid)
 	}
 
+	serverAddressEnv := os.Getenv("AUTHD_PAM_SERVER_ADDRESS")
+	if serverAddressEnv != "" {
+		*serverAddress = serverAddressEnv
+	}
+
 	if serverAddress == nil {
 		return fmt.Errorf("%w: no connection provided", pam_test.ErrInvalid)
 	}

--- a/pam/main-exec.go
+++ b/pam/main-exec.go
@@ -39,6 +39,11 @@ func mainFunc() error {
 		return errors.New("not enough arguments")
 	}
 
+	serverAddressEnv := os.Getenv("AUTHD_PAM_SERVER_ADDRESS")
+	if serverAddressEnv != "" {
+		*serverAddress = serverAddressEnv
+	}
+
 	if serverAddress == nil {
 		return fmt.Errorf("%w: no connection provided", pam.ErrSystem)
 	}


### PR DESCRIPTION
Even though the server will only allow connections from a specific PID (the one that it launched), it's still better not to expose infos that could give hint to potential attackers

UDENG-2831