### PR TITLE
No env for gpasswd mock

### DIFF
--- a/cmd/authd/integrationtests.go
+++ b/cmd/authd/integrationtests.go
@@ -16,10 +16,10 @@ func init() {
 		permissionstestutils.DefaultCurrentUserAsRoot()
 	}
 
-	gpasswdArgs := os.Getenv("TESTS_GPASSWD_ARGS")
-	grpFilePath := os.Getenv("TESTS_GPASSWD_GRP_FILE_PATH")
+	gpasswdArgs := os.Getenv("AUTHD_INTEGRATIONTESTS_GPASSWD_ARGS")
+	grpFilePath := os.Getenv("AUTHD_INTEGRATIONTESTS_GPASSWD_GRP_FILE_PATH")
 	if gpasswdArgs == "" || grpFilePath == "" {
-		panic("TESTS_GPASSWD_ARGS and TESTS_GPASSWD_GRP_FILE_PATH must be set")
+		panic("AUTHD_INTEGRATIONTESTS_GPASSWD_ARGS and AUTHD_INTEGRATIONTESTS_GPASSWD_GRP_FILE_PATH must be set")
 	}
 	localgroupstestutils.SetGpasswdCmd(strings.Split(gpasswdArgs, "-sep-"))
 	localgroupstestutils.SetGroupPath(grpFilePath)

--- a/cmd/authd/integrationtests.go
+++ b/cmd/authd/integrationtests.go
@@ -21,6 +21,6 @@ func init() {
 	if gpasswdArgs == "" || grpFilePath == "" {
 		panic("AUTHD_INTEGRATIONTESTS_GPASSWD_ARGS and AUTHD_INTEGRATIONTESTS_GPASSWD_GRP_FILE_PATH must be set")
 	}
-	localgroupstestutils.SetGpasswdCmd(strings.Split(gpasswdArgs, "-sep-"))
+	localgroupstestutils.SetGpasswdCmd(strings.Split(gpasswdArgs, " "))
 	localgroupstestutils.SetGroupPath(grpFilePath)
 }

--- a/internal/users/localgroups/localgroups_test.go
+++ b/internal/users/localgroups/localgroups_test.go
@@ -1,7 +1,6 @@
 package localgroups_test
 
 import (
-	"fmt"
 	"os"
 	"path/filepath"
 	"testing"
@@ -70,9 +69,9 @@ func TestUpdateLocalGroups(t *testing.T) {
 
 			groupFilePath := filepath.Join("testdata", tc.groupFilePath)
 			cmdArgs := []string{"env", "GO_WANT_HELPER_PROCESS=1",
-				fmt.Sprintf("GO_WANT_HELPER_PROCESS_DEST=%s", destCmdsFile),
-				fmt.Sprintf("GO_WANT_HELPER_PROCESS_GROUPFILE=%s", groupFilePath),
-				os.Args[0], "-test.run=TestMockgpasswd", "--"}
+				os.Args[0], "-test.run=TestMockgpasswd", "--",
+				groupFilePath, destCmdsFile,
+			}
 
 			err := localgroups.Update(tc.username, tc.groups, localgroups.WithGroupPath(groupFilePath), localgroups.WithGpasswdCmd(cmdArgs))
 			if tc.wantErr {
@@ -133,9 +132,8 @@ func TestCleanLocalGroups(t *testing.T) {
 			destCmdsFile := filepath.Join(t.TempDir(), "gpasswd.output")
 			groupFilePath := filepath.Join("testdata", tc.groupFilePath)
 			gpasswdCmd := []string{"env", "GO_WANT_HELPER_PROCESS=1",
-				fmt.Sprintf("GO_WANT_HELPER_PROCESS_DEST=%s", destCmdsFile),
-				fmt.Sprintf("GO_WANT_HELPER_PROCESS_GROUPFILE=%s", groupFilePath),
 				os.Args[0], "-test.run=TestMockgpasswd", "--",
+				groupFilePath, destCmdsFile,
 			}
 
 			if tc.getUsersReturn == nil {
@@ -211,9 +209,8 @@ func TestCleanUserFromLocalGroups(t *testing.T) {
 			destCmdsFile := filepath.Join(t.TempDir(), "gpasswd.output")
 			groupFilePath := filepath.Join("testdata", tc.groupFilePath)
 			gpasswdCmd := []string{"env", "GO_WANT_HELPER_PROCESS=1",
-				fmt.Sprintf("GO_WANT_HELPER_PROCESS_DEST=%s", destCmdsFile),
-				fmt.Sprintf("GO_WANT_HELPER_PROCESS_GROUPFILE=%s", groupFilePath),
 				os.Args[0], "-test.run=TestMockgpasswd", "--",
+				groupFilePath, destCmdsFile,
 			}
 			if tc.wantMockFailure {
 				gpasswdCmd = append(gpasswdCmd, "gpasswdfail")

--- a/internal/users/localgroups/testutils/gpasswd.go
+++ b/internal/users/localgroups/testutils/gpasswd.go
@@ -32,8 +32,12 @@ func Mockgpasswd(_ *testing.T) {
 		args = args[1:]
 		break
 	}
+	groupsFilePath, outputFilePath := args[0], args[1]
 
-	d, err := os.ReadFile(os.Getenv("GO_WANT_HELPER_PROCESS_GROUPFILE"))
+	// args are now the real args passed by authd.
+	args = args[2:]
+
+	d, err := os.ReadFile(groupsFilePath)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Mock: error reading group file: %v", err)
 		os.Exit(1)
@@ -52,8 +56,7 @@ func Mockgpasswd(_ *testing.T) {
 		os.Exit(1)
 	}
 
-	dest := os.Getenv("GO_WANT_HELPER_PROCESS_DEST")
-	f, err := os.OpenFile(dest, os.O_WRONLY|os.O_APPEND|os.O_CREATE, 0600)
+	f, err := os.OpenFile(outputFilePath, os.O_WRONLY|os.O_APPEND|os.O_CREATE, 0600)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Mock: error opening file in append mode: %v", err)
 		os.Exit(1)
@@ -80,33 +83,31 @@ func SetupGPasswdMock(t *testing.T, localGroupsFilepath string) string {
 
 	destCmdsFile := filepath.Join(t.TempDir(), "gpasswd.output")
 	SetGpasswdCmd([]string{"env", "GO_WANT_HELPER_PROCESS=1",
-		fmt.Sprintf("GO_WANT_HELPER_PROCESS_DEST=%s", destCmdsFile),
-		fmt.Sprintf("GO_WANT_HELPER_PROCESS_GROUPFILE=%s", localGroupsFilepath),
-		os.Args[0], "-test.run=TestMockgpasswd", "--"})
+		os.Args[0], "-test.run=TestMockgpasswd", "--",
+		localGroupsFilePath, destCmdsFile,
+	})
 
 	return destCmdsFile
 }
 
-// GPasswdMockEnv return the environment variables needed to run the gpasswd mock through the binary setup used in
-// integration tests. In order to enable it, the binary must be built with the tag integrationtests.
-func GPasswdMockEnv(t *testing.T, outputFilePath, groupsFilePath string) []string {
+// AuthdIntegrationTestsEnvWithGpasswdMock returns the environment to pass to the authd daemon to use the gpasswd
+// mock. In order to enable it, the authd binary must be built with the tag integrationtests.
+// You need to install a TestMockgpasswd (generally calling Mockgpasswd) in your integration tests files.
+func AuthdIntegrationTestsEnvWithGpasswdMock(t *testing.T, outputFilePath, groupsFilePath string) []string {
 	t.Helper()
 
-	gpasswdArgs := []string{
-		"env",
-		"GO_WANT_HELPER_PROCESS=1",
-		fmt.Sprintf("GO_WANT_HELPER_PROCESS_DEST=%s", outputFilePath),
-		fmt.Sprintf("GO_WANT_HELPER_PROCESS_GROUPFILE=%s", groupsFilePath),
-	}
+	gpasswdArgs := append([]string{
+		"env", "GO_WANT_HELPER_PROCESS=1"},
+		os.Args...)
+	gpasswdArgs = append(gpasswdArgs,
+		"-test.run=TestMockgpasswd", "--",
+		groupsFilePath, outputFilePath,
+	)
 
-	gpasswdArgs = append(gpasswdArgs, args...)
-	gpasswdArgs = append(gpasswdArgs, "-test.run=TestMockgpasswd", "--")
-	env := []string{
+	return []string{
 		"AUTHD_INTEGRATIONTESTS_GPASSWD_ARGS=" + strings.Join(gpasswdArgs, " "),
 		"AUTHD_INTEGRATIONTESTS_GPASSWD_GRP_FILE_PATH=" + groupsFilePath,
 	}
-
-	return env
 }
 
 // IdempotentGPasswdOutput sort and trim spaces around mock gpasswd output.

--- a/internal/users/localgroups/testutils/gpasswd.go
+++ b/internal/users/localgroups/testutils/gpasswd.go
@@ -73,18 +73,18 @@ func Mockgpasswd(_ *testing.T) {
 // SetupGPasswdMock setup the gpasswd mock and return the path to the file where the commands will be written.
 //
 // Tests that require this can not be run in parallel.
-func SetupGPasswdMock(t *testing.T, localGroupsFilepath string) string {
+func SetupGPasswdMock(t *testing.T, groupsFilePath string) string {
 	t.Helper()
 
 	origin := defaultOptions
 	t.Cleanup(func() { defaultOptions = origin })
 
-	SetGroupPath(localGroupsFilepath)
+	SetGroupPath(groupsFilePath)
 
 	destCmdsFile := filepath.Join(t.TempDir(), "gpasswd.output")
 	SetGpasswdCmd([]string{"env", "GO_WANT_HELPER_PROCESS=1",
 		os.Args[0], "-test.run=TestMockgpasswd", "--",
-		localGroupsFilePath, destCmdsFile,
+		groupsFilePath, destCmdsFile,
 	})
 
 	return destCmdsFile

--- a/internal/users/localgroups/testutils/gpasswd.go
+++ b/internal/users/localgroups/testutils/gpasswd.go
@@ -19,7 +19,7 @@ import (
 
 // Mockgpasswd is the gpasswd mock.
 func Mockgpasswd(_ *testing.T) {
-	if os.Getenv("GO_WANT_HELPER_PROCESS_DEST") == "" {
+	if os.Getenv("GO_WANT_HELPER_PROCESS") == "" {
 		return
 	}
 

--- a/internal/users/localgroups/testutils/gpasswd.go
+++ b/internal/users/localgroups/testutils/gpasswd.go
@@ -99,15 +99,6 @@ func GPasswdMockEnv(t *testing.T, outputFilePath, groupsFilePath string) []strin
 		fmt.Sprintf("GO_WANT_HELPER_PROCESS_GROUPFILE=%s", groupsFilePath),
 	}
 
-	// Ignore the --update flag when updating golden files
-	var args []string
-	for _, arg := range os.Args {
-		if arg == "-update" || arg == "--update" {
-			continue
-		}
-		args = append(args, arg)
-	}
-
 	gpasswdArgs = append(gpasswdArgs, args...)
 	gpasswdArgs = append(gpasswdArgs, "-test.run=TestMockgpasswd", "--")
 	env := []string{

--- a/internal/users/localgroups/testutils/gpasswd.go
+++ b/internal/users/localgroups/testutils/gpasswd.go
@@ -111,8 +111,8 @@ func GPasswdMockEnv(t *testing.T, outputFilePath, groupsFilePath string) []strin
 	gpasswdArgs = append(gpasswdArgs, args...)
 	gpasswdArgs = append(gpasswdArgs, "-test.run=TestMockgpasswd", "--")
 	env := []string{
-		"TESTS_GPASSWD_ARGS=" + strings.Join(gpasswdArgs, "-sep-"),
-		"TESTS_GPASSWD_GRP_FILE_PATH=" + groupsFilePath,
+		"AUTHD_INTEGRATIONTESTS_GPASSWD_ARGS=" + strings.Join(gpasswdArgs, "-sep-"),
+		"AUTHD_INTEGRATIONTESTS_GPASSWD_GRP_FILE_PATH=" + groupsFilePath,
 	}
 
 	return env

--- a/internal/users/localgroups/testutils/gpasswd.go
+++ b/internal/users/localgroups/testutils/gpasswd.go
@@ -111,7 +111,7 @@ func GPasswdMockEnv(t *testing.T, outputFilePath, groupsFilePath string) []strin
 	gpasswdArgs = append(gpasswdArgs, args...)
 	gpasswdArgs = append(gpasswdArgs, "-test.run=TestMockgpasswd", "--")
 	env := []string{
-		"AUTHD_INTEGRATIONTESTS_GPASSWD_ARGS=" + strings.Join(gpasswdArgs, "-sep-"),
+		"AUTHD_INTEGRATIONTESTS_GPASSWD_ARGS=" + strings.Join(gpasswdArgs, " "),
 		"AUTHD_INTEGRATIONTESTS_GPASSWD_GRP_FILE_PATH=" + groupsFilePath,
 	}
 

--- a/nss/integration-tests/integration_test.go
+++ b/nss/integration-tests/integration_test.go
@@ -28,7 +28,7 @@ func TestIntegration(t *testing.T) {
 	defaultOutputPath := filepath.Join(filepath.Dir(daemonPath), "gpasswd.output")
 	defaultGroupsFilePath := filepath.Join(testutils.TestFamilyPath(t), "gpasswd.group")
 
-	env := append(localgroupstestutils.GPasswdMockEnv(t, defaultOutputPath, defaultGroupsFilePath), "AUTHD_INTEGRATIONTESTS_CURRENT_USER_AS_ROOT=1")
+	env := append(localgroupstestutils.AuthdIntegrationTestsEnvWithGpasswdMock(t, defaultOutputPath, defaultGroupsFilePath), "AUTHD_INTEGRATIONTESTS_CURRENT_USER_AS_ROOT=1")
 	ctx, cancel := context.WithCancel(context.Background())
 	_, stopped := testutils.RunDaemon(ctx, t, daemonPath,
 		testutils.WithSocketPath(defaultSocket),
@@ -122,7 +122,7 @@ func TestIntegration(t *testing.T) {
 
 				var daemonStopped chan struct{}
 				ctx, cancel := context.WithCancel(context.Background())
-				env := localgroupstestutils.GPasswdMockEnv(t, outPath, groupsFilePath)
+				env := localgroupstestutils.AuthdIntegrationTestsEnvWithGpasswdMock(t, outPath, groupsFilePath)
 				if !tc.currentUserNotRoot {
 					env = append(env, "AUTHD_INTEGRATIONTESTS_CURRENT_USER_AS_ROOT=1")
 				}

--- a/pam/integration-tests/cli_test.go
+++ b/pam/integration-tests/cli_test.go
@@ -246,7 +246,7 @@ func runAuthd(t *testing.T, gpasswdOutput, groupsFile string, currentUserAsRoot 
 	t.Helper()
 
 	ctx, cancel := context.WithCancel(context.Background())
-	env := localgroupstestutils.GPasswdMockEnv(t, gpasswdOutput, groupsFile)
+	env := localgroupstestutils.AuthdIntegrationTestsEnvWithGpasswdMock(t, gpasswdOutput, groupsFile)
 	if currentUserAsRoot {
 		env = append(env, authdCurrentUserRootEnvVariableContent)
 	}

--- a/pam/integration-tests/gdm_test.go
+++ b/pam/integration-tests/gdm_test.go
@@ -275,7 +275,7 @@ func testGdmModule(t *testing.T, libPath string, args []string) {
 			// make assumptions whether the state of the broker and each test
 			// should run in parallel and work the same way in any order is ran.
 			ctx, cancel := context.WithCancel(context.Background())
-			env := append(localgroupstestutils.GPasswdMockEnv(t, gpasswdOutput, groupsFile), authdCurrentUserRootEnvVariableContent)
+			env := append(localgroupstestutils.AuthdIntegrationTestsEnvWithGpasswdMock(t, gpasswdOutput, groupsFile), authdCurrentUserRootEnvVariableContent)
 			socketPath, stopped := testutils.RunDaemon(ctx, t, daemonPath, testutils.WithEnvironment(env...))
 			t.Cleanup(func() {
 				cancel()
@@ -382,7 +382,7 @@ func TestGdmModuleAuthenticateWithoutGdmExtension(t *testing.T) {
 	gpasswdOutput := filepath.Join(t.TempDir(), "gpasswd.output")
 	groupsFile := filepath.Join(testutils.TestFamilyPath(t), "gpasswd.group")
 	ctx, cancel := context.WithCancel(context.Background())
-	env := append(localgroupstestutils.GPasswdMockEnv(t, gpasswdOutput, groupsFile), authdCurrentUserRootEnvVariableContent)
+	env := append(localgroupstestutils.AuthdIntegrationTestsEnvWithGpasswdMock(t, gpasswdOutput, groupsFile), authdCurrentUserRootEnvVariableContent)
 	socketPath, stopped := testutils.RunDaemon(ctx, t, daemonPath, testutils.WithEnvironment(env...))
 	t.Cleanup(func() {
 		cancel()
@@ -424,7 +424,7 @@ func TestGdmModuleAcctMgmtWithoutGdmExtension(t *testing.T) {
 	gpasswdOutput := filepath.Join(t.TempDir(), "gpasswd.output")
 	groupsFile := filepath.Join(testutils.TestFamilyPath(t), "gpasswd.group")
 	ctx, cancel := context.WithCancel(context.Background())
-	env := append(localgroupstestutils.GPasswdMockEnv(t, gpasswdOutput, groupsFile), authdCurrentUserRootEnvVariableContent)
+	env := append(localgroupstestutils.AuthdIntegrationTestsEnvWithGpasswdMock(t, gpasswdOutput, groupsFile), authdCurrentUserRootEnvVariableContent)
 	socketPath, stopped := testutils.RunDaemon(ctx, t, daemonPath, testutils.WithEnvironment(env...))
 	t.Cleanup(func() {
 		cancel()


### PR DESCRIPTION
Pass mock control as arguments and not env variable

This allows use to better alignement with the rest of our mock behaviour control, without relying on internal env variable.
Those are now the first arguments for the mock, after -- and before the arguments passed to the cmdline itself.
Strip them to the cmdline.

UDENG-2955
