### PR TITLE
ci: Use unique names for artifacts names

### DIFF
--- a/.github/workflows/qa.yaml
+++ b/.github/workflows/qa.yaml
@@ -121,7 +121,7 @@ jobs:
       - name: Upload scan build reports
         uses: actions/upload-artifact@v4
         with:
-          name: authd-test-artifacts
+          name: authd-${{ github.job }}-artifacts-${{ github.run_attempt }}
           path: ${{ env.SCAN_BUILD_REPORTS_PATH }}
 
   go-tests:
@@ -250,5 +250,5 @@ jobs:
         if: failure()
         uses: actions/upload-artifact@v4
         with:
-          name: authd-test-artifacts
+          name: authd-${{ github.job }}-artifacts-${{ github.run_attempt }}
           path: ${{ env.AUTHD_TEST_ARTIFACTS_PATH }}


### PR DESCRIPTION
Use both job id and the attempt so that we don't risk overwriting the previous values

This should avoid uploading artifacts failures such as in https://github.com/ubuntu/authd/actions/runs/9367176490/job/25786282242