### PR TITLE
fix(tests): Handle failures during debian packaging builds

### DIFF
--- a/internal/daemon/daemon_test.go
+++ b/internal/daemon/daemon_test.go
@@ -306,7 +306,7 @@ func createClientConnection(t *testing.T, socketPath string) (success bool, disc
 	}()
 	select {
 	case <-connected:
-	case <-time.After(10 * time.Millisecond):
+	case <-time.After(5 * time.Second):
 		disconnect()
 		return false, func() {}
 	}

--- a/internal/testutils/daemon.go
+++ b/internal/testutils/daemon.go
@@ -116,7 +116,7 @@ paths:
 	require.NoError(t, err, "Setup: could not connect to the daemon on %s", opts.socketPath)
 	defer conn.Close()
 
-	waitCtx, cancel := context.WithTimeout(ctx, time.Second*5)
+	waitCtx, cancel := context.WithTimeout(ctx, time.Second*30)
 	defer cancel()
 
 	// Block until the daemon is started and ready to accept connections.


### PR DESCRIPTION
Fix some issues I got while building packages both locally (with sbuild, that as per commit 4a98eca runs as fakeroot) and in the PPA, mostly due to builders not being fast enough when spawning lots of parallel tests.

See failures: 
 - https://launchpad.net/~3v1n0/+archive/ubuntu/authd/+build/28517439
 - https://launchpad.net/~3v1n0/+archive/ubuntu/authd/+build/28517440

UDENG-3044