### PR TITLE
maint: Bump go to 1.22.4 to fix vulnerability in net module

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/ubuntu/authd
 
 go 1.22.0
 
-toolchain go1.22.3
+toolchain go1.22.4
 
 require (
 	github.com/charmbracelet/bubbles v0.18.0

--- a/tools/go.mod
+++ b/tools/go.mod
@@ -2,7 +2,7 @@ module github.com/ubuntu/authd/tools
 
 go 1.22.0
 
-toolchain go1.22.3
+toolchain go1.22.4
 
 require (
 	github.com/golangci/golangci-lint v1.59.0


### PR DESCRIPTION
Fixes Vulnerability #1: GO-2024-2887
  The various Is methods (IsPrivate, IsLoopback, etc) did not work as expected
  for IPv4-mapped IPv6 addresses, returning false for addresses which would
  return true in their traditional IPv4 forms.

More info: https://pkg.go.dev/vuln/GO-2024-2887
  Standard library
    Found in: net@go1.21.0
    Fixed in: net@go1.22.4