### PR TITLE
pam/go-exec: Fix a deadlock that happens if an invalid logpath is provided

### DIFF
--- a/pam/go-exec/module.c
+++ b/pam/go-exec/module.c
@@ -1007,15 +1007,15 @@ do_pam_action_thread (pam_handle_t *pamh,
   else
     log_file_fd = dup (STDERR_FILENO);
 
-  if (log_file_fd == -1)
+  action_data.log_file_fd = g_steal_fd (&log_file_fd);
+  G_UNLOCK (logger);
+
+  if (action_data.log_file_fd == -1)
     {
       g_warning ("Impossible to open log file %s: %s",
                  (log_file && *log_file != '\0') ? log_file : "<sderr>",
                  g_strerror (errno));
     }
-
-  action_data.log_file_fd = g_steal_fd (&log_file_fd);
-  G_UNLOCK (logger);
 
   locker = g_mutex_locker_new (&G_LOCK_NAME (exec_module));
 

--- a/pam/integration-tests/exec_test.go
+++ b/pam/integration-tests/exec_test.go
@@ -276,6 +276,27 @@ func TestExecModule(t *testing.T) {
 		})
 	}
 
+	// These tests are meant to check the exec client arguments.
+	actionArgs := map[string]struct {
+		moduleArgs []string
+	}{
+		"Do not deadlock if invalid log path is provided": {
+			[]string{"--exec-log", "/not-existent/file-path.log"},
+		},
+	}
+	for name, tc := range actionArgs {
+		t.Run("ActionArgs "+name, func(t *testing.T) {
+			t.Parallel()
+			t.Cleanup(pam_test.MaybeDoLeakCheck)
+
+			moduleArgs := append(getModuleArgs(t, "", nil), tc.moduleArgs...)
+			moduleArgs = append(moduleArgs, "--", execClient)
+			serviceFile := createServiceFile(t, execServiceName, libPath, moduleArgs)
+			tx := preparePamTransactionForServiceFile(t, serviceFile, "", nil)
+			performAllPAMActions(t, tx, pam.Flags(0), nil)
+		})
+	}
+
 	// These tests are checking Get/Set item and ensuring those values are matching
 	// both inside the client and in the calling application.
 	itemsTests := map[string]struct {


### PR DESCRIPTION
If opening the log file fails, we may try to warn while we're still holding the logger lock file, causing a deadlock.

Fix this and add a test ensuring we're covered by this.