### PR TITLE
fix(pam): Fix supported UI layout for the QR Code

### DIFF
--- a/pam/internal/adapter/authmodeselection.go
+++ b/pam/internal/adapter/authmodeselection.go
@@ -102,7 +102,7 @@ func (m *authModeSelectionModel) Init() tea.Cmd {
 				{
 					Type:    "qrcode",
 					Content: &required,
-					Code:    &required,
+					Code:    &optional,
 					Wait:    &requiredWithBooleans,
 					Label:   &optional,
 					Button:  &optional,


### PR DESCRIPTION
The additional code entry in the layout must be optional, not required. Otherwise, this invalidates QR Codes with no code associated with them.