### PR TITLE
fix(nss): Improve NSS error logs

### DIFF
--- a/nss/src/group/mod.rs
+++ b/nss/src/group/mod.rs
@@ -50,7 +50,7 @@ fn get_all_entries() -> Response<Vec<Group>> {
         match client.get_group_entries(req).await {
             Ok(r) => Response::Success(group_entries_to_groups(r.into_inner().entries)),
             Err(e) => {
-                error!("error when listing groups: {}", e.message());
+                error!("error when listing groups: {}", e.code().description());
                 super::grpc_status_to_nss_response(e)
             }
         }
@@ -81,7 +81,11 @@ fn get_entry_by_gid(gid: gid_t) -> Response<Group> {
         match client.get_group_by_gid(req).await {
             Ok(r) => Response::Success(group_entry_to_group(r.into_inner())),
             Err(e) => {
-                error!("error when getting group by gid: {}", e.message());
+                error!(
+                    "error when getting group by gid '{}': {}",
+                    gid,
+                    e.code().description()
+                );
                 super::grpc_status_to_nss_response(e)
             }
         }
@@ -107,12 +111,16 @@ fn get_entry_by_name(name: String) -> Response<Group> {
             }
         };
 
-        let mut req = Request::new(authd::GetGroupByNameRequest { name });
+        let mut req = Request::new(authd::GetGroupByNameRequest { name: name.clone() });
         req.set_timeout(REQUEST_TIMEOUT);
         match client.get_group_by_name(req).await {
             Ok(r) => Response::Success(group_entry_to_group(r.into_inner())),
             Err(e) => {
-                error!("error when getting group by name: {}", e.message());
+                error!(
+                    "error when getting group by name '{}': {}",
+                    name,
+                    e.code().description()
+                );
                 super::grpc_status_to_nss_response(e)
             }
         }

--- a/nss/src/passwd/mod.rs
+++ b/nss/src/passwd/mod.rs
@@ -50,7 +50,7 @@ fn get_all_entries() -> Response<Vec<Passwd>> {
         match client.get_passwd_entries(req).await {
             Ok(r) => Response::Success(passwd_entries_to_passwds(r.into_inner().entries)),
             Err(e) => {
-                error!("error when listing passwd: {}", e.message());
+                error!("error when listing passwd: {}", e.code().description());
                 super::grpc_status_to_nss_response(e)
             }
         }
@@ -81,7 +81,11 @@ fn get_entry_by_uid(uid: uid_t) -> Response<Passwd> {
         match client.get_passwd_by_uid(req).await {
             Ok(r) => Response::Success(passwd_entry_to_passwd(r.into_inner())),
             Err(e) => {
-                error!("error when getting passwd by uid: {}", e.message());
+                error!(
+                    "error when getting passwd by uid '{}': {}",
+                    uid,
+                    e.code().description()
+                );
                 super::grpc_status_to_nss_response(e)
             }
         }
@@ -108,14 +112,18 @@ fn get_entry_by_name(name: String) -> Response<Passwd> {
         };
 
         let mut req = Request::new(authd::GetPasswdByNameRequest {
-            name,
+            name: name.clone(),
             should_pre_check: should_pre_check(),
         });
         req.set_timeout(REQUEST_TIMEOUT);
         match client.get_passwd_by_name(req).await {
             Ok(r) => Response::Success(passwd_entry_to_passwd(r.into_inner())),
             Err(e) => {
-                error!("error when getting passwd by name: {}", e.message());
+                error!(
+                    "error when getting passwd by name '{}': {}",
+                    name,
+                    e.code().description()
+                );
                 super::grpc_status_to_nss_response(e)
             }
         }

--- a/nss/src/shadow/mod.rs
+++ b/nss/src/shadow/mod.rs
@@ -45,7 +45,7 @@ fn get_all_entries() -> Response<Vec<Shadow>> {
         match client.get_shadow_entries(req).await {
             Ok(r) => Response::Success(shadow_entries_to_shadows(r.into_inner().entries)),
             Err(e) => {
-                error!("error when listing shadow: {}", e.message());
+                error!("error when listing shadow: {}", e.code().description());
                 super::grpc_status_to_nss_response(e)
             }
         }
@@ -71,12 +71,16 @@ fn get_entry_by_name(name: String) -> Response<Shadow> {
             }
         };
 
-        let mut req = Request::new(authd::GetShadowByNameRequest { name });
+        let mut req = Request::new(authd::GetShadowByNameRequest { name: name.clone() });
         req.set_timeout(REQUEST_TIMEOUT);
         match client.get_shadow_by_name(req).await {
             Ok(r) => Response::Success(shadow_entry_to_shadow(r.into_inner())),
             Err(e) => {
-                error!("error when getting shadow by name: {}", e.message());
+                error!(
+                    "error when getting shadow by name '{}': {}",
+                    name,
+                    e.code().description()
+                );
                 super::grpc_status_to_nss_response(e)
             }
         }


### PR DESCRIPTION
NSS error messages lacked useful information due to missing data on the GRPC error. This improves the messages by a considerable amount by printing the actual value the module is querying for and the return status of the request.

Now we go from messages like:
```
authd: error when getting passwd by name:
```
To:
```
authd: error when getting passwd by name 'nonexistent': Some requested entity was not found
```

UDENG-3410