### PR TITLE
fix: remove comment from authd pam module to make it enable by default

### DIFF
--- a/debian/pam-configs/authd.in
+++ b/debian/pam-configs/authd.in
@@ -1,6 +1,5 @@
 Name: Authd authentication
 Default: yes
-# We need to come before some modules, such as pam_pwquality (it uses 1024), so we need a high priority number.
 Priority: 1050
 
 Auth-Type: Primary


### PR DESCRIPTION
Authd was not registered by pam-auth-update automatically due to the comment which is unsupported by this tool.

One a blank machine, which never got the request, this will now enable it by default.
There is no format supporting comments unfortunately after reading the upstream perl source.

UDENG-3408