### PR TITLE
fix: ensure we fail authentication when user auth failed

### DIFF
--- a/debian/pam-configs/authd.in
+++ b/debian/pam-configs/authd.in
@@ -4,13 +4,13 @@ Priority: 1050
 
 Auth-Type: Primary
 Auth:
-	[success=end default=ignore]	pam_authd_exec.so @AUTHD_DAEMONS_PATH@/authd-pam
+	[success=end ignore=ignore default=die]	pam_authd_exec.so @AUTHD_DAEMONS_PATH@/authd-pam
 Account-Type: Additional
 Account:
 	[default=ignore success=ok user_unknown=ignore]	pam_authd_exec.so @AUTHD_DAEMONS_PATH@/authd-pam
 Password-Type: Primary
 Password:
-	[success=end default=ignore]	pam_authd_exec.so @AUTHD_DAEMONS_PATH@/authd-pam
+	[success=end ignore=ignore default=die]	pam_authd_exec.so @AUTHD_DAEMONS_PATH@/authd-pam
 Session-Type: Additional
 Session-Interactive-Only: yes
 Session:


### PR DESCRIPTION
Authd has a high priority in the PAM stack. When we don’t ignore on purpose the authentication to pass to other modules, we should fail immediately it.
We thus mirror requisite with still allowing the none authentication access part to be skipped.

UDENG-3413