### PR TITLE
feat(qrcodemodel): Always include the content URI to the output

### DIFF
--- a/pam/integration-tests/testdata/TestCLIAuthenticate/golden/authenticate_user_with_qr_code
+++ b/pam/integration-tests/testdata/TestCLIAuthenticate/golden/authenticate_user_with_qr_code
@@ -147,10 +147,10 @@ Scan the qrcode or enter the code in the login page
 ████▄▄▄▄▄▄▄█▄█▄█▄█▄████▄▄▄▄▄▄████
 █████████████████████████████████
 ▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀
+       https://ubuntu.com
               1337
 
         [ Regenerate code ]
-
 
 
 
@@ -190,10 +190,10 @@ Scan the qrcode or enter the code in the login page
 ████▄▄▄▄▄▄▄█▄█▄█▄█▄████▄▄▄▄▄▄████
 █████████████████████████████████
 ▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀
+       https://ubuntu.com
               1337
 
         [ Regenerate code ]
-
 
 
 
@@ -233,10 +233,10 @@ Scan the qrcode or enter the code in the login page
 ████▄▄▄▄▄▄▄█▄█▄█▄█▄████▄▄▄▄▄▄████
 █████████████████████████████████
 ▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀
+       https://ubuntu.com
               1337
 
         [ Regenerate code ]
-
 
 
 
@@ -276,6 +276,7 @@ Scan the qrcode or enter the code in the login page
 ████▄▄▄▄▄▄▄█▄█▄█▄█▄████▄▄▄▄▄▄████
 █████████████████████████████████
 ▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀
+       https://ubuntu.com
               1337
 
 PAM Authenticate() for user "user-integration-qr-code" exited with success
@@ -296,7 +297,6 @@ PAM AcctMgmt() exited with success
 
 
 
-
 ────────────────────────────────────────────────────────────────────────────────
 > if [ -v AUTHD_PAM_CLI_TERM ]; then export TERM=${AUTHD_PAM_CLI_TERM}; fi
 > ./pam_authd login socket=${AUTHD_TESTS_CLI_AUTHENTICATE_TESTS_SOCK}
@@ -319,12 +319,12 @@ Scan the qrcode or enter the code in the login page
 ████▄▄▄▄▄▄▄█▄█▄█▄█▄████▄▄▄▄▄▄████
 █████████████████████████████████
 ▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀
+       https://ubuntu.com
               1337
 
 PAM Authenticate() for user "user-integration-qr-code" exited with success
 PAM AcctMgmt() exited with success
 >
-
 
 
 

--- a/pam/integration-tests/testdata/TestCLIAuthenticate/golden/authenticate_user_with_qr_code_in_a_tty
+++ b/pam/integration-tests/testdata/TestCLIAuthenticate/golden/authenticate_user_with_qr_code_in_a_tty
@@ -163,10 +163,10 @@ Scan the qrcode or enter the code in the login page
 ██████████████████████████████████████████████████████████████████
 ██████████████████████████████████████████████████████████████████
 ██████████████████████████████████████████████████████████████████
+                        https://ubuntu.com
                                1337
 
                         [ Regenerate code ]
-
 
 ────────────────────────────────────────────────────────────────────────────────
 > if [ -v AUTHD_PAM_CLI_TERM ]; then export TERM=${AUTHD_PAM_CLI_TERM}; fi
@@ -206,10 +206,10 @@ Scan the qrcode or enter the code in the login page
 ██████████████████████████████████████████████████████████████████
 ██████████████████████████████████████████████████████████████████
 ██████████████████████████████████████████████████████████████████
+                        https://ubuntu.com
                                1337
 
                         [ Regenerate code ]
-
 
 ────────────────────────────────────────────────────────────────────────────────
 > if [ -v AUTHD_PAM_CLI_TERM ]; then export TERM=${AUTHD_PAM_CLI_TERM}; fi
@@ -249,10 +249,10 @@ Scan the qrcode or enter the code in the login page
 ██████████████████████████████████████████████████████████████████
 ██████████████████████████████████████████████████████████████████
 ██████████████████████████████████████████████████████████████████
+                        https://ubuntu.com
                                1337
 
                         [ Regenerate code ]
-
 
 ────────────────────────────────────────────────────────────────────────────────
 > if [ -v AUTHD_PAM_CLI_TERM ]; then export TERM=${AUTHD_PAM_CLI_TERM}; fi
@@ -292,11 +292,11 @@ Scan the qrcode or enter the code in the login page
 ██████████████████████████████████████████████████████████████████
 ██████████████████████████████████████████████████████████████████
 ██████████████████████████████████████████████████████████████████
+                        https://ubuntu.com
                                1337
 
 PAM Authenticate() for user "user-integration-qr-code-tty" exited with success
 PAM AcctMgmt() exited with success
->
 ────────────────────────────────────────────────────────────────────────────────
 > if [ -v AUTHD_PAM_CLI_TERM ]; then export TERM=${AUTHD_PAM_CLI_TERM}; fi
 > ./pam_authd login socket=${AUTHD_TESTS_CLI_AUTHENTICATE_TESTS_SOCK}
@@ -335,9 +335,9 @@ Scan the qrcode or enter the code in the login page
 ██████████████████████████████████████████████████████████████████
 ██████████████████████████████████████████████████████████████████
 ██████████████████████████████████████████████████████████████████
+                        https://ubuntu.com
                                1337
 
 PAM Authenticate() for user "user-integration-qr-code-tty" exited with success
 PAM AcctMgmt() exited with success
->
 ────────────────────────────────────────────────────────────────────────────────

--- a/pam/integration-tests/testdata/TestCLIAuthenticate/golden/authenticate_user_with_qr_code_in_a_tty_session
+++ b/pam/integration-tests/testdata/TestCLIAuthenticate/golden/authenticate_user_with_qr_code_in_a_tty_session
@@ -163,10 +163,10 @@ Scan the qrcode or enter the code in the login page
 ██████████████████████████████████████████████████████████████████
 ██████████████████████████████████████████████████████████████████
 ██████████████████████████████████████████████████████████████████
+                        https://ubuntu.com
                                1337
 
                         [ Regenerate code ]
-
 
 ────────────────────────────────────────────────────────────────────────────────
 > if [ -v AUTHD_PAM_CLI_TERM ]; then export TERM=${AUTHD_PAM_CLI_TERM}; fi
@@ -206,10 +206,10 @@ Scan the qrcode or enter the code in the login page
 ██████████████████████████████████████████████████████████████████
 ██████████████████████████████████████████████████████████████████
 ██████████████████████████████████████████████████████████████████
+                        https://ubuntu.com
                                1337
 
                         [ Regenerate code ]
-
 
 ────────────────────────────────────────────────────────────────────────────────
 > if [ -v AUTHD_PAM_CLI_TERM ]; then export TERM=${AUTHD_PAM_CLI_TERM}; fi
@@ -249,10 +249,10 @@ Scan the qrcode or enter the code in the login page
 ██████████████████████████████████████████████████████████████████
 ██████████████████████████████████████████████████████████████████
 ██████████████████████████████████████████████████████████████████
+                        https://ubuntu.com
                                1337
 
                         [ Regenerate code ]
-
 
 ────────────────────────────────────────────────────────────────────────────────
 > if [ -v AUTHD_PAM_CLI_TERM ]; then export TERM=${AUTHD_PAM_CLI_TERM}; fi
@@ -292,11 +292,11 @@ Scan the qrcode or enter the code in the login page
 ██████████████████████████████████████████████████████████████████
 ██████████████████████████████████████████████████████████████████
 ██████████████████████████████████████████████████████████████████
+                        https://ubuntu.com
                                1337
 
 PAM Authenticate() for user "user-integration-qr-code-tty-session" exited with success
 PAM AcctMgmt() exited with success
->
 ────────────────────────────────────────────────────────────────────────────────
 > if [ -v AUTHD_PAM_CLI_TERM ]; then export TERM=${AUTHD_PAM_CLI_TERM}; fi
 > ./pam_authd login socket=${AUTHD_TESTS_CLI_AUTHENTICATE_TESTS_SOCK}
@@ -335,9 +335,9 @@ Scan the qrcode or enter the code in the login page
 ██████████████████████████████████████████████████████████████████
 ██████████████████████████████████████████████████████████████████
 ██████████████████████████████████████████████████████████████████
+                        https://ubuntu.com
                                1337
 
 PAM Authenticate() for user "user-integration-qr-code-tty-session" exited with success
 PAM AcctMgmt() exited with success
->
 ────────────────────────────────────────────────────────────────────────────────

--- a/pam/integration-tests/testdata/TestCLIAuthenticate/golden/authenticate_user_with_qr_code_in_screen
+++ b/pam/integration-tests/testdata/TestCLIAuthenticate/golden/authenticate_user_with_qr_code_in_screen
@@ -163,10 +163,10 @@ Scan the qrcode or enter the code in the login page
 ██████████████████████████████████████████████████████████████████
 ██████████████████████████████████████████████████████████████████
 ██████████████████████████████████████████████████████████████████
+                        https://ubuntu.com
                                1337
 
                         [ Regenerate code ]
-
 
 ────────────────────────────────────────────────────────────────────────────────
 > if [ -v AUTHD_PAM_CLI_TERM ]; then export TERM=${AUTHD_PAM_CLI_TERM}; fi
@@ -206,10 +206,10 @@ Scan the qrcode or enter the code in the login page
 ██████████████████████████████████████████████████████████████████
 ██████████████████████████████████████████████████████████████████
 ██████████████████████████████████████████████████████████████████
+                        https://ubuntu.com
                                1337
 
                         [ Regenerate code ]
-
 
 ────────────────────────────────────────────────────────────────────────────────
 > if [ -v AUTHD_PAM_CLI_TERM ]; then export TERM=${AUTHD_PAM_CLI_TERM}; fi
@@ -249,10 +249,10 @@ Scan the qrcode or enter the code in the login page
 ██████████████████████████████████████████████████████████████████
 ██████████████████████████████████████████████████████████████████
 ██████████████████████████████████████████████████████████████████
+                        https://ubuntu.com
                                1337
 
                         [ Regenerate code ]
-
 
 ────────────────────────────────────────────────────────────────────────────────
 > if [ -v AUTHD_PAM_CLI_TERM ]; then export TERM=${AUTHD_PAM_CLI_TERM}; fi
@@ -292,11 +292,11 @@ Scan the qrcode or enter the code in the login page
 ██████████████████████████████████████████████████████████████████
 ██████████████████████████████████████████████████████████████████
 ██████████████████████████████████████████████████████████████████
+                        https://ubuntu.com
                                1337
 
 PAM Authenticate() for user "user-integration-qr-code-screen" exited with success
 PAM AcctMgmt() exited with success
->
 ────────────────────────────────────────────────────────────────────────────────
 > if [ -v AUTHD_PAM_CLI_TERM ]; then export TERM=${AUTHD_PAM_CLI_TERM}; fi
 > ./pam_authd login socket=${AUTHD_TESTS_CLI_AUTHENTICATE_TESTS_SOCK}
@@ -335,9 +335,9 @@ Scan the qrcode or enter the code in the login page
 ██████████████████████████████████████████████████████████████████
 ██████████████████████████████████████████████████████████████████
 ██████████████████████████████████████████████████████████████████
+                        https://ubuntu.com
                                1337
 
 PAM Authenticate() for user "user-integration-qr-code-screen" exited with success
 PAM AcctMgmt() exited with success
->
 ────────────────────────────────────────────────────────────────────────────────

--- a/pam/internal/adapter/qrcodemodel.go
+++ b/pam/internal/adapter/qrcodemodel.go
@@ -111,7 +111,9 @@ func (m qrcodeModel) View() string {
 	qrcodeWidth := lipgloss.Width(qr)
 
 	style := centeredStyle.Width(qrcodeWidth)
-	fields = append(fields, style.Render(m.code))
+	if m.code != "" {
+		fields = append(fields, style.Render(m.code))
+	}
 
 	if m.buttonModel != nil {
 		fields = append(fields, style.Render(m.buttonModel.View()))

--- a/pam/internal/adapter/qrcodemodel.go
+++ b/pam/internal/adapter/qrcodemodel.go
@@ -111,6 +111,12 @@ func (m qrcodeModel) View() string {
 	qrcodeWidth := lipgloss.Width(qr)
 
 	style := centeredStyle.Width(qrcodeWidth)
+	renderedContent := m.content
+	if lipgloss.Width(m.content) < qrcodeWidth {
+		renderedContent = style.Render(m.content)
+	}
+	fields = append(fields, renderedContent)
+
 	if m.code != "" {
 		fields = append(fields, style.Render(m.code))
 	}


### PR DESCRIPTION
In some cases (e.g. small terminals, tty's) the qrcode is not properly
rendered or is not fully visible, so make the URI to be always written
so that it can be used also without a qrcode scanner

UDENG-3324