### PR TITLE
cleanup(pam/integration-tests/cli): Do not build the module and pam clients for each test

### DIFF
--- a/pam/integration-tests/cli_test.go
+++ b/pam/integration-tests/cli_test.go
@@ -28,6 +28,9 @@ func TestCLIAuthenticate(t *testing.T) {
 	currentDir, err := os.Getwd()
 	require.NoError(t, err, "Setup: Could not get current directory for the tests")
 
+	clientPath := t.TempDir()
+	cliEnv := prepareClientTest(t, clientPath)
+
 	tests := map[string]struct {
 		tape string
 
@@ -71,8 +74,10 @@ func TestCLIAuthenticate(t *testing.T) {
 			t.Parallel()
 
 			outDir := t.TempDir()
+			err := os.Symlink(filepath.Join(clientPath, "pam_authd"),
+				filepath.Join(outDir, "pam_authd"))
+			require.NoError(t, err, "Setup: symlinking the pam client")
 
-			cliEnv := prepareClientTest(t, outDir)
 			cliLog := prepareCLILogging(t)
 			t.Cleanup(func() {
 				saveArtifactsForDebug(t, []string{


### PR DESCRIPTION
Since commit d1a75d811, for the cli tests we call prepareClientTest() for each test in order to get the client folder, however this also implies building the test client, the module and the exec client for each test even though this is not needed, since we can share those binaries.

So just call this once in the main test.

Ideally this should make CI a little quicker.