### PR TITLE
fix: do not explicitly call description on nss error

### DIFF
--- a/nss/src/group/mod.rs
+++ b/nss/src/group/mod.rs
@@ -50,7 +50,7 @@ fn get_all_entries() -> Response<Vec<Group>> {
         match client.get_group_entries(req).await {
             Ok(r) => Response::Success(group_entries_to_groups(r.into_inner().entries)),
             Err(e) => {
-                error!("error when listing groups: {}", e.code().description());
+                error!("error when listing groups: {}", e.code());
                 super::grpc_status_to_nss_response(e)
             }
         }
@@ -81,11 +81,7 @@ fn get_entry_by_gid(gid: gid_t) -> Response<Group> {
         match client.get_group_by_gid(req).await {
             Ok(r) => Response::Success(group_entry_to_group(r.into_inner())),
             Err(e) => {
-                error!(
-                    "error when getting group by gid '{}': {}",
-                    gid,
-                    e.code().description()
-                );
+                error!("error when getting group by gid '{}': {}", gid, e.code());
                 super::grpc_status_to_nss_response(e)
             }
         }

--- a/nss/src/passwd/mod.rs
+++ b/nss/src/passwd/mod.rs
@@ -50,7 +50,7 @@ fn get_all_entries() -> Response<Vec<Passwd>> {
         match client.get_passwd_entries(req).await {
             Ok(r) => Response::Success(passwd_entries_to_passwds(r.into_inner().entries)),
             Err(e) => {
-                error!("error when listing passwd: {}", e.code().description());
+                error!("error when listing passwd: {}", e.code());
                 super::grpc_status_to_nss_response(e)
             }
         }
@@ -81,11 +81,7 @@ fn get_entry_by_uid(uid: uid_t) -> Response<Passwd> {
         match client.get_passwd_by_uid(req).await {
             Ok(r) => Response::Success(passwd_entry_to_passwd(r.into_inner())),
             Err(e) => {
-                error!(
-                    "error when getting passwd by uid '{}': {}",
-                    uid,
-                    e.code().description()
-                );
+                error!("error when getting passwd by uid '{}': {}", uid, e.code());
                 super::grpc_status_to_nss_response(e)
             }
         }
@@ -122,7 +118,7 @@ fn get_entry_by_name(name: String) -> Response<Passwd> {
                 error!(
                     "error when getting passwd by name '{}': {}",
                     name,
-                    e.code().description()
+                    e.code()
                 );
                 super::grpc_status_to_nss_response(e)
             }

--- a/nss/src/shadow/mod.rs
+++ b/nss/src/shadow/mod.rs
@@ -45,7 +45,7 @@ fn get_all_entries() -> Response<Vec<Shadow>> {
         match client.get_shadow_entries(req).await {
             Ok(r) => Response::Success(shadow_entries_to_shadows(r.into_inner().entries)),
             Err(e) => {
-                error!("error when listing shadow: {}", e.code().description());
+                error!("error when listing shadow: {}", e.code());
                 super::grpc_status_to_nss_response(e)
             }
         }
@@ -76,11 +76,7 @@ fn get_entry_by_name(name: String) -> Response<Shadow> {
         match client.get_shadow_by_name(req).await {
             Ok(r) => Response::Success(shadow_entry_to_shadow(r.into_inner())),
             Err(e) => {
-                error!(
-                    "error when getting shadow by name '{}': {}",
-                    name,
-                    e.code().description()
-                );
+                error!("error when getting shadow by name '{}': {}", name, e.code());
                 super::grpc_status_to_nss_response(e)
             }
         }


### PR DESCRIPTION
As in the documentation:
/// If you only need description in `println`, `format`, `log` and other
/// formatting contexts, you may want to use `Display` impl for `Code`
/// instead.

So, let’s use the display trait as the error macro is using format.

Note that this is prior the logging refactoring.