### PR TITLE
cleanup: Generate proto with go generate only if `proto` tag is provided

### DIFF
--- a/.github/workflows/qa.yaml
+++ b/.github/workflows/qa.yaml
@@ -45,6 +45,12 @@ jobs:
         run: |
           set -eu
           go run -tags pam_binary_cli ./pam login --exec-debug
+      - name: Generate Proto files
+        run: |
+          set -eu
+          find -name "*.pb.go" -delete -print
+          go generate -x -tags proto ./...
+          find -name "*.pb.go"
       - name: Generate PAM module
         run: |
           set -eu

--- a/generate_proto.go
+++ b/generate_proto.go
@@ -1,4 +1,4 @@
-//go:build generate
+//go:build generate && proto
 
 //go:generate tools/generate-proto.sh --with-grpc authd.proto
 

--- a/internal/daemon/testdata/grpctestservice/generate_proto.go
+++ b/internal/daemon/testdata/grpctestservice/generate_proto.go
@@ -1,4 +1,4 @@
-//go:build generate
+//go:build generate && proto
 
 //go:generate ../../../../tools/generate-proto.sh --with-grpc grpctestservice.proto
 

--- a/pam/internal/gdm/generate_proto.go
+++ b/pam/internal/gdm/generate_proto.go
@@ -1,0 +1,5 @@
+//go:build generate && proto
+
+//go:generate ../../../tools/generate-proto.sh -I../../.. -I../proto gdm.proto
+
+package gdm

--- a/pam/internal/gdm/protocol.go
+++ b/pam/internal/gdm/protocol.go
@@ -1,5 +1,3 @@
-//go:generate ../../../tools/generate-proto.sh -I../../.. -I../proto gdm.proto
-
 // Package gdm is the package for the GDM pam module handing.
 package gdm
 

--- a/pam/internal/proto/generate_proto.go
+++ b/pam/internal/proto/generate_proto.go
@@ -1,4 +1,4 @@
-//go:build generate
+//go:build generate && proto
 
 //go:generate ../../../tools/generate-proto.sh pam.proto
 

--- a/tools/generate-proto.sh
+++ b/tools/generate-proto.sh
@@ -4,7 +4,7 @@ set -euo pipefail
 
 if [ -v DEB_HOST_GNU_TYPE ]; then
     echo "Proto files should not be regenerated during package building"
-    exit 0
+    exit 1
 fi
 
 # TODO: Watch https://github.com/protocolbuffers/protobuf for any changes on the


### PR DESCRIPTION
Avoids generating proto files unless explicitly requested.

As per this it's now an error if the generation script is called during package build.

UDENG-3507
