### PR TITLE
maint: downgrade NSS lib errors to info

### DIFF
--- a/nss/src/group/mod.rs
+++ b/nss/src/group/mod.rs
@@ -1,4 +1,4 @@
-use crate::{error, REQUEST_TIMEOUT};
+use crate::{info, REQUEST_TIMEOUT};
 use libc::gid_t;
 use libnss::group::{Group, GroupHooks};
 use libnss::interop::Response;
@@ -31,7 +31,7 @@ fn get_all_entries() -> Response<Vec<Group>> {
     let rt = match Builder::new_current_thread().enable_all().build() {
         Ok(rt) => rt,
         Err(e) => {
-            error!("could not create runtime for NSS: {}", e);
+            info!("could not create runtime for NSS: {}", e);
             return Response::Unavail;
         }
     };
@@ -40,7 +40,7 @@ fn get_all_entries() -> Response<Vec<Group>> {
         let mut client = match client::new_client().await {
             Ok(c) => c,
             Err(e) => {
-                error!("could not connect to gRPC server: {}", e);
+                info!("could not connect to gRPC server: {}", e);
                 return Response::Unavail;
             }
         };
@@ -50,7 +50,7 @@ fn get_all_entries() -> Response<Vec<Group>> {
         match client.get_group_entries(req).await {
             Ok(r) => Response::Success(group_entries_to_groups(r.into_inner().entries)),
             Err(e) => {
-                error!("error when listing groups: {}", e.code());
+                info!("error when listing groups: {}", e.code());
                 super::grpc_status_to_nss_response(e)
             }
         }
@@ -62,7 +62,7 @@ fn get_entry_by_gid(gid: gid_t) -> Response<Group> {
     let rt = match Builder::new_current_thread().enable_all().build() {
         Ok(rt) => rt,
         Err(e) => {
-            error!("could not create runtime for NSS: {}", e);
+            info!("could not create runtime for NSS: {}", e);
             return Response::Unavail;
         }
     };
@@ -71,7 +71,7 @@ fn get_entry_by_gid(gid: gid_t) -> Response<Group> {
         let mut client = match client::new_client().await {
             Ok(c) => c,
             Err(e) => {
-                error!("could not connect to gRPC server: {}", e);
+                info!("could not connect to gRPC server: {}", e);
                 return Response::Unavail;
             }
         };
@@ -81,7 +81,7 @@ fn get_entry_by_gid(gid: gid_t) -> Response<Group> {
         match client.get_group_by_gid(req).await {
             Ok(r) => Response::Success(group_entry_to_group(r.into_inner())),
             Err(e) => {
-                error!("error when getting group by gid '{}': {}", gid, e.code());
+                info!("error when getting group by gid '{}': {}", gid, e.code());
                 super::grpc_status_to_nss_response(e)
             }
         }
@@ -93,7 +93,7 @@ fn get_entry_by_name(name: String) -> Response<Group> {
     let rt = match Builder::new_current_thread().enable_all().build() {
         Ok(rt) => rt,
         Err(e) => {
-            error!("could not create runtime for NSS: {}", e);
+            info!("could not create runtime for NSS: {}", e);
             return Response::Unavail;
         }
     };
@@ -102,7 +102,7 @@ fn get_entry_by_name(name: String) -> Response<Group> {
         let mut client = match client::new_client().await {
             Ok(c) => c,
             Err(e) => {
-                error!("could not connect to gRPC server: {}", e);
+                info!("could not connect to gRPC server: {}", e);
                 return Response::Unavail;
             }
         };
@@ -112,7 +112,7 @@ fn get_entry_by_name(name: String) -> Response<Group> {
         match client.get_group_by_name(req).await {
             Ok(r) => Response::Success(group_entry_to_group(r.into_inner())),
             Err(e) => {
-                error!(
+                info!(
                     "error when getting group by name '{}': {}",
                     name,
                     e.code().description()

--- a/nss/src/logs/mod.rs
+++ b/nss/src/logs/mod.rs
@@ -15,7 +15,7 @@ macro_rules! info {
 macro_rules! error {
     ($($arg:tt)*) => {
         let log_prefix = "authd:";
-        log::error!("{} {}", log_prefix, format_args!($($arg)*));
+        log::info!("{} {}", log_prefix, format_args!($($arg)*));
     }
 }
 

--- a/nss/src/logs/mod.rs
+++ b/nss/src/logs/mod.rs
@@ -11,14 +11,6 @@ macro_rules! info {
     }
 }
 
-#[macro_export]
-macro_rules! error {
-    ($($arg:tt)*) => {
-        let log_prefix = "authd:";
-        log::info!("{} {}", log_prefix, format_args!($($arg)*));
-    }
-}
-
 /// init_logger initialize the global logger with a default level set to info. This function is only
 /// required to be called once and is a no-op on subsequent calls.
 ///

--- a/nss/src/passwd/mod.rs
+++ b/nss/src/passwd/mod.rs
@@ -1,4 +1,4 @@
-use crate::{error, REQUEST_TIMEOUT};
+use crate::{info, REQUEST_TIMEOUT};
 use libc::uid_t;
 use libnss::interop::Response;
 use libnss::passwd::{Passwd, PasswdHooks};
@@ -31,7 +31,7 @@ fn get_all_entries() -> Response<Vec<Passwd>> {
     let rt = match Builder::new_current_thread().enable_all().build() {
         Ok(rt) => rt,
         Err(e) => {
-            error!("could not create runtime for NSS: {}", e);
+            info!("could not create runtime for NSS: {}", e);
             return Response::Unavail;
         }
     };
@@ -40,7 +40,7 @@ fn get_all_entries() -> Response<Vec<Passwd>> {
         let mut client = match client::new_client().await {
             Ok(c) => c,
             Err(e) => {
-                error!("could not connect to gRPC server: {}", e);
+                info!("could not connect to gRPC server: {}", e);
                 return Response::Unavail;
             }
         };
@@ -50,7 +50,7 @@ fn get_all_entries() -> Response<Vec<Passwd>> {
         match client.get_passwd_entries(req).await {
             Ok(r) => Response::Success(passwd_entries_to_passwds(r.into_inner().entries)),
             Err(e) => {
-                error!("error when listing passwd: {}", e.code());
+                info!("error when listing passwd: {}", e.code());
                 super::grpc_status_to_nss_response(e)
             }
         }
@@ -62,7 +62,7 @@ fn get_entry_by_uid(uid: uid_t) -> Response<Passwd> {
     let rt = match Builder::new_current_thread().enable_all().build() {
         Ok(rt) => rt,
         Err(e) => {
-            error!("could not create runtime for NSS: {}", e);
+            info!("could not create runtime for NSS: {}", e);
             return Response::Unavail;
         }
     };
@@ -71,7 +71,7 @@ fn get_entry_by_uid(uid: uid_t) -> Response<Passwd> {
         let mut client = match client::new_client().await {
             Ok(c) => c,
             Err(e) => {
-                error!("could not connect to gRPC server: {}", e);
+                info!("could not connect to gRPC server: {}", e);
                 return Response::Unavail;
             }
         };
@@ -81,7 +81,7 @@ fn get_entry_by_uid(uid: uid_t) -> Response<Passwd> {
         match client.get_passwd_by_uid(req).await {
             Ok(r) => Response::Success(passwd_entry_to_passwd(r.into_inner())),
             Err(e) => {
-                error!("error when getting passwd by uid '{}': {}", uid, e.code());
+                info!("error when getting passwd by uid '{}': {}", uid, e.code());
                 super::grpc_status_to_nss_response(e)
             }
         }
@@ -93,7 +93,7 @@ fn get_entry_by_name(name: String) -> Response<Passwd> {
     let rt = match Builder::new_current_thread().enable_all().build() {
         Ok(rt) => rt,
         Err(e) => {
-            error!("could not create runtime for NSS: {}", e);
+            info!("could not create runtime for NSS: {}", e);
             return Response::Unavail;
         }
     };
@@ -102,7 +102,7 @@ fn get_entry_by_name(name: String) -> Response<Passwd> {
         let mut client = match client::new_client().await {
             Ok(c) => c,
             Err(e) => {
-                error!("could not connect to gRPC server: {}", e);
+                info!("could not connect to gRPC server: {}", e);
                 return Response::Unavail;
             }
         };
@@ -115,11 +115,7 @@ fn get_entry_by_name(name: String) -> Response<Passwd> {
         match client.get_passwd_by_name(req).await {
             Ok(r) => Response::Success(passwd_entry_to_passwd(r.into_inner())),
             Err(e) => {
-                error!(
-                    "error when getting passwd by name '{}': {}",
-                    name,
-                    e.code()
-                );
+                info!("error when getting passwd by name '{}': {}", name, e.code());
                 super::grpc_status_to_nss_response(e)
             }
         }

--- a/nss/src/shadow/mod.rs
+++ b/nss/src/shadow/mod.rs
@@ -1,4 +1,4 @@
-use crate::{error, REQUEST_TIMEOUT};
+use crate::{info, REQUEST_TIMEOUT};
 use libnss::interop::Response;
 use libnss::shadow::{Shadow, ShadowHooks};
 use tokio::runtime::Builder;
@@ -26,7 +26,7 @@ fn get_all_entries() -> Response<Vec<Shadow>> {
     let rt = match Builder::new_current_thread().enable_all().build() {
         Ok(rt) => rt,
         Err(e) => {
-            error!("could not create runtime for NSS: {}", e);
+            info!("could not create runtime for NSS: {}", e);
             return Response::Unavail;
         }
     };
@@ -35,7 +35,7 @@ fn get_all_entries() -> Response<Vec<Shadow>> {
         let mut client = match client::new_client().await {
             Ok(c) => c,
             Err(e) => {
-                error!("could not connect to gRPC server: {}", e);
+                info!("could not connect to gRPC server: {}", e);
                 return Response::Unavail;
             }
         };
@@ -45,7 +45,7 @@ fn get_all_entries() -> Response<Vec<Shadow>> {
         match client.get_shadow_entries(req).await {
             Ok(r) => Response::Success(shadow_entries_to_shadows(r.into_inner().entries)),
             Err(e) => {
-                error!("error when listing shadow: {}", e.code());
+                info!("error when listing shadow: {}", e.code());
                 super::grpc_status_to_nss_response(e)
             }
         }
@@ -57,7 +57,7 @@ fn get_entry_by_name(name: String) -> Response<Shadow> {
     let rt = match Builder::new_current_thread().enable_all().build() {
         Ok(rt) => rt,
         Err(e) => {
-            error!("could not create runtime for NSS: {}", e);
+            info!("could not create runtime for NSS: {}", e);
             return Response::Unavail;
         }
     };
@@ -66,7 +66,7 @@ fn get_entry_by_name(name: String) -> Response<Shadow> {
         let mut client = match client::new_client().await {
             Ok(c) => c,
             Err(e) => {
-                error!("could not connect to gRPC server: {}", e);
+                info!("could not connect to gRPC server: {}", e);
                 return Response::Unavail;
             }
         };
@@ -76,7 +76,7 @@ fn get_entry_by_name(name: String) -> Response<Shadow> {
         match client.get_shadow_by_name(req).await {
             Ok(r) => Response::Success(shadow_entry_to_shadow(r.into_inner())),
             Err(e) => {
-                error!("error when getting shadow by name '{}': {}", name, e.code());
+                info!("error when getting shadow by name '{}': {}", name, e.code());
                 super::grpc_status_to_nss_response(e)
             }
         }


### PR DESCRIPTION
That way, we don’t spam logs for 3rd party applications using our library as they are the one which should control the output to the user. We send back those errors in a NSS format anyway to the caller already.

We thus only print details when AUTHD_NSS_INFO=stderr is set.

UDENG-3409