### PR TITLE
feat(services/pam): Do not expose internal errors to client

### DIFF
--- a/internal/services/pam/testdata/TestIsAuthenticated/golden/denies_authentication_when_broker_times_out/IsAuthenticated
+++ b/internal/services/pam/testdata/TestIsAuthenticated/golden/denies_authentication_when_broker_times_out/IsAuthenticated
@@ -1,4 +1,4 @@
 FIRST CALL:
 	access: denied
-	msg: {"message": "denied by time out"}
+	msg: {"message":"authentication failure"}
 	err: <nil>

--- a/internal/services/pam/testdata/TestIsAuthenticated/golden/error_on_empty_data_even_if_granted/IsAuthenticated
+++ b/internal/services/pam/testdata/TestIsAuthenticated/golden/error_on_empty_data_even_if_granted/IsAuthenticated
@@ -1,4 +1,4 @@
 FIRST CALL:
 	access: 
 	msg: 
-	err: rpc error: code = Unknown desc = can't check authentication: missing key "userinfo" in returned message, got: {}
+	err: rpc error: code = Unknown desc = authentication failure

--- a/internal/services/pam/testdata/TestIsAuthenticated/golden/error_on_updating_local_groups_with_unexisting_file/IsAuthenticated
+++ b/internal/services/pam/testdata/TestIsAuthenticated/golden/error_on_updating_local_groups_with_unexisting_file/IsAuthenticated
@@ -1,4 +1,4 @@
 FIRST CALL:
 	access: 
 	msg: 
-	err: rpc error: code = Unknown desc = can't check authentication: failed to update user "TestIsAuthenticated/Error_on_updating_local_groups_with_unexisting_file_separator_success_with_local_groups": could not update local groups for user "TestIsAuthenticated/Error_on_updating_local_groups_with_unexisting_file_separator_success_with_local_groups": could not fetch existing local group: open testdata/TestIsAuthenticated/does_not_exists.group: no such file or directory
+	err: rpc error: code = Unknown desc = authentication failure

--- a/internal/services/pam/testdata/TestIsAuthenticated/golden/error_when_authenticating/IsAuthenticated
+++ b/internal/services/pam/testdata/TestIsAuthenticated/golden/error_when_authenticating/IsAuthenticated
@@ -1,4 +1,4 @@
 FIRST CALL:
 	access: 
 	msg: 
-	err: rpc error: code = Unknown desc = can't check authentication: broker "BrokerMock": IsAuthenticated errored out
+	err: rpc error: code = Unknown desc = authentication failure

--- a/internal/services/pam/testdata/TestIsAuthenticated/golden/error_when_broker_returns_invalid_access/IsAuthenticated
+++ b/internal/services/pam/testdata/TestIsAuthenticated/golden/error_when_broker_returns_invalid_access/IsAuthenticated
@@ -1,4 +1,4 @@
 FIRST CALL:
 	access: 
 	msg: 
-	err: rpc error: code = Unknown desc = can't check authentication: invalid access authentication key: invalid
+	err: rpc error: code = Unknown desc = authentication failure

--- a/internal/services/pam/testdata/TestIsAuthenticated/golden/error_when_broker_returns_invalid_data/IsAuthenticated
+++ b/internal/services/pam/testdata/TestIsAuthenticated/golden/error_when_broker_returns_invalid_data/IsAuthenticated
@@ -1,5 +1,4 @@
 FIRST CALL:
 	access: 
 	msg: 
-	err: rpc error: code = Unknown desc = can't check authentication: response returned by the broker is not a valid json: invalid character 'i' looking for beginning of value
-Broker returned: invalid
+	err: rpc error: code = Unknown desc = authentication failure

--- a/internal/services/pam/testdata/TestIsAuthenticated/golden/error_when_broker_returns_invalid_userinfo/IsAuthenticated
+++ b/internal/services/pam/testdata/TestIsAuthenticated/golden/error_when_broker_returns_invalid_userinfo/IsAuthenticated
@@ -1,4 +1,4 @@
 FIRST CALL:
 	access: 
 	msg: 
-	err: rpc error: code = Unknown desc = can't check authentication: message is not JSON formatted: json: cannot unmarshal string into Go value of type brokers.userInfo
+	err: rpc error: code = Unknown desc = authentication failure

--- a/internal/services/pam/testdata/TestIsAuthenticated/golden/error_when_broker_returns_username_different_than_the_one_selected/IsAuthenticated
+++ b/internal/services/pam/testdata/TestIsAuthenticated/golden/error_when_broker_returns_username_different_than_the_one_selected/IsAuthenticated
@@ -1,4 +1,4 @@
 FIRST CALL:
 	access: 
 	msg: 
-	err: rpc error: code = Unknown desc = can't check authentication: provided userinfo is invalid: username "different_username" does not match the selected username "TestIsAuthenticated/Error_when_broker_returns_username_different_than_the_one_selected_separator_IA_info_mismatching_user_name"
+	err: rpc error: code = Unknown desc = authentication failure

--- a/internal/services/pam/testdata/TestIsAuthenticated/golden/error_when_calling_second_time_without_cancelling/IsAuthenticated
+++ b/internal/services/pam/testdata/TestIsAuthenticated/golden/error_when_calling_second_time_without_cancelling/IsAuthenticated
@@ -5,4 +5,4 @@ FIRST CALL:
 SECOND CALL:
 	access: 
 	msg: 
-	err: rpc error: code = Unknown desc = can't check authentication: broker "BrokerMock": IsAuthenticated already running for session "TestIsAuthenticated/Error_when_calling_second_time_without_cancelling_separator_IA_second_call-session_id"
+	err: rpc error: code = Unknown desc = authentication failure

--- a/internal/services/pam/testdata/TestIsAuthenticated/golden/error_when_sessionid_is_empty/IsAuthenticated
+++ b/internal/services/pam/testdata/TestIsAuthenticated/golden/error_when_sessionid_is_empty/IsAuthenticated
@@ -1,4 +1,4 @@
 FIRST CALL:
 	access: 
 	msg: 
-	err: rpc error: code = InvalidArgument desc = can't check authentication: rpc error: code = InvalidArgument desc = no session ID provided
+	err: rpc error: code = Unknown desc = authentication failure

--- a/internal/services/pam/testdata/TestIsAuthenticated/golden/error_when_there_is_no_broker/IsAuthenticated
+++ b/internal/services/pam/testdata/TestIsAuthenticated/golden/error_when_there_is_no_broker/IsAuthenticated
@@ -1,4 +1,4 @@
 FIRST CALL:
 	access: 
 	msg: 
-	err: rpc error: code = Unknown desc = can't check authentication: no broker found for session "invalid-session"
+	err: rpc error: code = Unknown desc = authentication failure

--- a/pam/integration-tests/gdm_test.go
+++ b/pam/integration-tests/gdm_test.go
@@ -213,7 +213,7 @@ func TestGdmModule(t *testing.T) {
 		"Error on missing user": {
 			pamUser: ptrValue(""),
 			wantPamErrorMessages: []string{
-				"can't select broker: rpc error: code = InvalidArgument desc = can't start authentication transaction: rpc error: code = InvalidArgument desc = no user name provided",
+				"can't select broker: rpc error: code = Unknown desc = authentication failure",
 			},
 			wantError:       pam.ErrSystem,
 			wantAcctMgmtErr: pam_test.ErrIgnore,
@@ -279,7 +279,7 @@ func TestGdmModule(t *testing.T) {
 				},
 			},
 			wantPamErrorMessages: []string{
-				"invalid password 'really, it's not a goodpass!', should be 'goodpass'",
+				"authentication failure",
 			},
 			wantError:       pam.ErrAuth,
 			wantAcctMgmtErr: pam_test.ErrIgnore,
@@ -294,7 +294,7 @@ func TestGdmModule(t *testing.T) {
 				},
 			},
 			wantPamErrorMessages: []string{
-				"user not found",
+				"authentication failure",
 			},
 			wantError:       pam.ErrAuth,
 			wantAcctMgmtErr: pam_test.ErrIgnore,
@@ -311,7 +311,7 @@ func TestGdmModule(t *testing.T) {
 				},
 			},
 			wantPamErrorMessages: []string{
-				fido1AuthID + " should have wait set to true",
+				"authentication failure",
 			},
 			wantError:       pam.ErrAuth,
 			wantAcctMgmtErr: pam_test.ErrIgnore,

--- a/pam/integration-tests/testdata/TestCLIAuthenticate/golden/deny_authentication_if_max_attempts_reached
+++ b/pam/integration-tests/testdata/TestCLIAuthenticate/golden/deny_authentication_if_max_attempts_reached
@@ -133,7 +133,7 @@ Gimme your password
 > ./pam_authd login socket=${AUTHD_TESTS_CLI_AUTHENTICATE_TESTS_SOCK}
 Gimme your password
 >
-invalid password 'wrongpass', should be 'goodpass'
+authentication failure
 
 
 
@@ -166,7 +166,7 @@ invalid password 'wrongpass', should be 'goodpass'
 > ./pam_authd login socket=${AUTHD_TESTS_CLI_AUTHENTICATE_TESTS_SOCK}
 Gimme your password
 >
-invalid password 'wrongpass', should be 'goodpass'
+authentication failure
 
 
 
@@ -199,7 +199,7 @@ invalid password 'wrongpass', should be 'goodpass'
 > ./pam_authd login socket=${AUTHD_TESTS_CLI_AUTHENTICATE_TESTS_SOCK}
 Gimme your password
 >
-invalid password 'wrongpass', should be 'goodpass'
+authentication failure
 
 
 
@@ -232,7 +232,7 @@ invalid password 'wrongpass', should be 'goodpass'
 > ./pam_authd login socket=${AUTHD_TESTS_CLI_AUTHENTICATE_TESTS_SOCK}
 Gimme your password
 >
-invalid password 'wrongpass', should be 'goodpass'
+authentication failure
 
 
 
@@ -265,7 +265,7 @@ invalid password 'wrongpass', should be 'goodpass'
 > ./pam_authd login socket=${AUTHD_TESTS_CLI_AUTHENTICATE_TESTS_SOCK}
 Gimme your password
 >
-PAM Error Message: invalid password 'wrongpass', should be 'goodpass'
+PAM Error Message: authentication failure
 PAM Authenticate() for user "user-integration-max-attempts" exited with error (PAM exit code: 7)
 : Authentication failure
 PAM Info Message: acct=incomplete
@@ -298,7 +298,7 @@ dispatch
 > ./pam_authd login socket=${AUTHD_TESTS_CLI_AUTHENTICATE_TESTS_SOCK}
 Gimme your password
 >
-PAM Error Message: invalid password 'wrongpass', should be 'goodpass'
+PAM Error Message: authentication failure
 PAM Authenticate() for user "user-integration-max-attempts" exited with error (PAM exit code: 7)
 : Authentication failure
 PAM Info Message: acct=incomplete

--- a/pam/integration-tests/testdata/TestCLIAuthenticate/golden/deny_authentication_if_user_does_not_exist
+++ b/pam/integration-tests/testdata/TestCLIAuthenticate/golden/deny_authentication_if_user_does_not_exist
@@ -121,13 +121,13 @@ Username: user-unexistent
 
 
 
-PAM Error Message: can't select broker: rpc error: code = Unknown desc = can't start authenticat
-ion transaction: user "user-unexistent" does not exist
+PAM Error Message: can't select broker: rpc error: code = Unknown desc = authentication failure
 PAM Authenticate() for user "user-unexistent" exited with error (PAM exit code: 4): System error
 PAM Info Message: acct=incomplete
 PAM AcctMgmt() exited with error (PAM exit code: 25): The return value should be ignored by PAM
 dispatch
 >
+
 
 ────────────────────────────────────────────────────────────────────────────────
 > ./pam_authd login socket=${AUTHD_TESTS_CLI_AUTHENTICATE_TESTS_SOCK}
@@ -154,12 +154,12 @@ dispatch
 
 
 
-PAM Error Message: can't select broker: rpc error: code = Unknown desc = can't start authenticat
-ion transaction: user "user-unexistent" does not exist
+PAM Error Message: can't select broker: rpc error: code = Unknown desc = authentication failure
 PAM Authenticate() for user "user-unexistent" exited with error (PAM exit code: 4): System error
 PAM Info Message: acct=incomplete
 PAM AcctMgmt() exited with error (PAM exit code: 25): The return value should be ignored by PAM
 dispatch
 >
+
 
 ────────────────────────────────────────────────────────────────────────────────

--- a/pam/integration-tests/testdata/TestCLIAuthenticate/golden/deny_authentication_if_usernames_dont_match
+++ b/pam/integration-tests/testdata/TestCLIAuthenticate/golden/deny_authentication_if_usernames_dont_match
@@ -132,15 +132,15 @@ Gimme your password
 ────────────────────────────────────────────────────────────────────────────────
 > ./pam_authd login socket=${AUTHD_TESTS_CLI_AUTHENTICATE_TESTS_SOCK}
 Gimme your password
-PAM Error Message: authentication status failure: rpc error: code = Unknown desc = can't check a
-uthentication: provided userinfo is invalid: username "mismatching-username" does not match the
-selected username "user-mismatching-name"
+PAM Error Message: authentication status failure: rpc error: code = Unknown desc = authenticatio
+n failure
 PAM Authenticate() for user "user-mismatching-name" exited with error (PAM exit code: 4): System
  error
 PAM Info Message: acct=incomplete
 PAM AcctMgmt() exited with error (PAM exit code: 25): The return value should be ignored by PAM
 dispatch
 >
+
 
 
 
@@ -165,15 +165,15 @@ dispatch
 ────────────────────────────────────────────────────────────────────────────────
 > ./pam_authd login socket=${AUTHD_TESTS_CLI_AUTHENTICATE_TESTS_SOCK}
 Gimme your password
-PAM Error Message: authentication status failure: rpc error: code = Unknown desc = can't check a
-uthentication: provided userinfo is invalid: username "mismatching-username" does not match the
-selected username "user-mismatching-name"
+PAM Error Message: authentication status failure: rpc error: code = Unknown desc = authenticatio
+n failure
 PAM Authenticate() for user "user-mismatching-name" exited with error (PAM exit code: 4): System
  error
 PAM Info Message: acct=incomplete
 PAM AcctMgmt() exited with error (PAM exit code: 25): The return value should be ignored by PAM
 dispatch
 >
+
 
 
 

--- a/pam/integration-tests/testdata/TestCLIChangeAuthTok/golden/prevent_change_password_if_auth_fails
+++ b/pam/integration-tests/testdata/TestCLIChangeAuthTok/golden/prevent_change_password_if_auth_fails
@@ -133,7 +133,7 @@ Gimme your password
 > ./pam_authd passwd socket=${AUTHD_TESTS_CLI_AUTHTOK_TESTS_SOCK}
 Gimme your password
 >
-invalid password 'wrongpass', should be 'goodpass'
+authentication failure
 
 
 
@@ -166,7 +166,7 @@ invalid password 'wrongpass', should be 'goodpass'
 > ./pam_authd passwd socket=${AUTHD_TESTS_CLI_AUTHTOK_TESTS_SOCK}
 Gimme your password
 >
-invalid password 'wrongpass', should be 'goodpass'
+authentication failure
 
 
 
@@ -199,7 +199,7 @@ invalid password 'wrongpass', should be 'goodpass'
 > ./pam_authd passwd socket=${AUTHD_TESTS_CLI_AUTHTOK_TESTS_SOCK}
 Gimme your password
 >
-invalid password 'wrongpass', should be 'goodpass'
+authentication failure
 
 
 
@@ -232,7 +232,7 @@ invalid password 'wrongpass', should be 'goodpass'
 > ./pam_authd passwd socket=${AUTHD_TESTS_CLI_AUTHTOK_TESTS_SOCK}
 Gimme your password
 >
-invalid password 'wrongpass', should be 'goodpass'
+authentication failure
 
 
 
@@ -265,7 +265,7 @@ invalid password 'wrongpass', should be 'goodpass'
 > ./pam_authd passwd socket=${AUTHD_TESTS_CLI_AUTHTOK_TESTS_SOCK}
 Gimme your password
 >
-PAM Error Message: invalid password 'wrongpass', should be 'goodpass'
+PAM Error Message: authentication failure
 PAM ChangeAuthTok() for user "user-integration-max-attempts" exited with error (PAM exit code: 7
 ): Authentication failure
 PAM Info Message: acct=incomplete
@@ -298,7 +298,7 @@ dispatch
 > ./pam_authd passwd socket=${AUTHD_TESTS_CLI_AUTHTOK_TESTS_SOCK}
 Gimme your password
 >
-PAM Error Message: invalid password 'wrongpass', should be 'goodpass'
+PAM Error Message: authentication failure
 PAM ChangeAuthTok() for user "user-integration-max-attempts" exited with error (PAM exit code: 7
 ): Authentication failure
 PAM Info Message: acct=incomplete

--- a/pam/integration-tests/testdata/TestCLIChangeAuthTok/golden/prevent_change_password_if_user_does_not_exist
+++ b/pam/integration-tests/testdata/TestCLIChangeAuthTok/golden/prevent_change_password_if_user_does_not_exist
@@ -121,14 +121,14 @@ Username: user-unexistent
 
 
 
-PAM Error Message: can't select broker: rpc error: code = Unknown desc = can't start authenticat
-ion transaction: user "user-unexistent" does not exist
+PAM Error Message: can't select broker: rpc error: code = Unknown desc = authentication failure
 PAM ChangeAuthTok() for user "user-unexistent" exited with error (PAM exit code: 4): System erro
 r
 PAM Info Message: acct=incomplete
 PAM AcctMgmt() exited with error (PAM exit code: 25): The return value should be ignored by PAM
 dispatch
 >
+
 ────────────────────────────────────────────────────────────────────────────────
 > ./pam_authd passwd socket=${AUTHD_TESTS_CLI_AUTHTOK_TESTS_SOCK}
   Select your provider
@@ -154,12 +154,12 @@ dispatch
 
 
 
-PAM Error Message: can't select broker: rpc error: code = Unknown desc = can't start authenticat
-ion transaction: user "user-unexistent" does not exist
+PAM Error Message: can't select broker: rpc error: code = Unknown desc = authentication failure
 PAM ChangeAuthTok() for user "user-unexistent" exited with error (PAM exit code: 4): System erro
 r
 PAM Info Message: acct=incomplete
 PAM AcctMgmt() exited with error (PAM exit code: 25): The return value should be ignored by PAM
 dispatch
 >
+
 ────────────────────────────────────────────────────────────────────────────────

--- a/pam/integration-tests/testdata/TestCLIChangeAuthTok/golden/retry_if_new_password_is_rejected_by_broker
+++ b/pam/integration-tests/testdata/TestCLIChangeAuthTok/golden/retry_if_new_password_is_rejected_by_broker
@@ -234,7 +234,7 @@ Enter your new password
 
 New password:
 >
-new password does not match criteria: must be authd2404
+authentication failure
 
 
 
@@ -267,7 +267,7 @@ Enter your new password
 
 New password:
 > *********
-new password does not match criteria: must be authd2404
+authentication failure
 
 
 

--- a/pam/integration-tests/testdata/TestNativeAuthenticate/golden/deny_authentication_if_max_attempts_reached
+++ b/pam/integration-tests/testdata/TestNativeAuthenticate/golden/deny_authentication_if_max_attempts_reached
@@ -138,7 +138,7 @@ Username: user-integration-max-attempts
 Select broker: 2
 Insert 'r' to cancel the request and go back
 Gimme your password:
-invalid password 'wrongpass', should be 'goodpass'
+authentication failure
 Insert 'r' to cancel the request and go back
 Gimme your password:
 
@@ -171,10 +171,10 @@ Username: user-integration-max-attempts
 Select broker: 2
 Insert 'r' to cancel the request and go back
 Gimme your password:
-invalid password 'wrongpass', should be 'goodpass'
+authentication failure
 Insert 'r' to cancel the request and go back
 Gimme your password:
-invalid password 'wrongpass', should be 'goodpass'
+authentication failure
 Insert 'r' to cancel the request and go back
 Gimme your password:
 
@@ -204,13 +204,13 @@ Username: user-integration-max-attempts
 Select broker: 2
 Insert 'r' to cancel the request and go back
 Gimme your password:
-invalid password 'wrongpass', should be 'goodpass'
+authentication failure
 Insert 'r' to cancel the request and go back
 Gimme your password:
-invalid password 'wrongpass', should be 'goodpass'
+authentication failure
 Insert 'r' to cancel the request and go back
 Gimme your password:
-invalid password 'wrongpass', should be 'goodpass'
+authentication failure
 Insert 'r' to cancel the request and go back
 Gimme your password:
 
@@ -237,16 +237,16 @@ Username: user-integration-max-attempts
 Select broker: 2
 Insert 'r' to cancel the request and go back
 Gimme your password:
-invalid password 'wrongpass', should be 'goodpass'
+authentication failure
 Insert 'r' to cancel the request and go back
 Gimme your password:
-invalid password 'wrongpass', should be 'goodpass'
+authentication failure
 Insert 'r' to cancel the request and go back
 Gimme your password:
-invalid password 'wrongpass', should be 'goodpass'
+authentication failure
 Insert 'r' to cancel the request and go back
 Gimme your password:
-invalid password 'wrongpass', should be 'goodpass'
+authentication failure
 Insert 'r' to cancel the request and go back
 Gimme your password:
 
@@ -270,20 +270,20 @@ Username: user-integration-max-attempts
 Select broker: 2
 Insert 'r' to cancel the request and go back
 Gimme your password:
-invalid password 'wrongpass', should be 'goodpass'
+authentication failure
 Insert 'r' to cancel the request and go back
 Gimme your password:
-invalid password 'wrongpass', should be 'goodpass'
+authentication failure
 Insert 'r' to cancel the request and go back
 Gimme your password:
-invalid password 'wrongpass', should be 'goodpass'
+authentication failure
 Insert 'r' to cancel the request and go back
 Gimme your password:
-invalid password 'wrongpass', should be 'goodpass'
+authentication failure
 Insert 'r' to cancel the request and go back
 Gimme your password:
-invalid password 'wrongpass', should be 'goodpass'
-invalid password 'wrongpass', should be 'goodpass'
+authentication failure
+authentication failure
 PAM Authenticate() for user "user-integration-max-attempts" exited with error (PAM exit code: 7)
 : Authentication failure
 acct=incomplete
@@ -303,20 +303,20 @@ Username: user-integration-max-attempts
 Select broker: 2
 Insert 'r' to cancel the request and go back
 Gimme your password:
-invalid password 'wrongpass', should be 'goodpass'
+authentication failure
 Insert 'r' to cancel the request and go back
 Gimme your password:
-invalid password 'wrongpass', should be 'goodpass'
+authentication failure
 Insert 'r' to cancel the request and go back
 Gimme your password:
-invalid password 'wrongpass', should be 'goodpass'
+authentication failure
 Insert 'r' to cancel the request and go back
 Gimme your password:
-invalid password 'wrongpass', should be 'goodpass'
+authentication failure
 Insert 'r' to cancel the request and go back
 Gimme your password:
-invalid password 'wrongpass', should be 'goodpass'
-invalid password 'wrongpass', should be 'goodpass'
+authentication failure
+authentication failure
 PAM Authenticate() for user "user-integration-max-attempts" exited with error (PAM exit code: 7)
 : Authentication failure
 acct=incomplete

--- a/pam/integration-tests/testdata/TestNativeAuthenticate/golden/deny_authentication_if_user_does_not_exist
+++ b/pam/integration-tests/testdata/TestNativeAuthenticate/golden/deny_authentication_if_user_does_not_exist
@@ -103,13 +103,13 @@ Username: user-unexistent
 1 - local
 2 - ExampleBroker
 Select broker: 2
-can't select broker: rpc error: code = Unknown desc = can't start authentication transaction: us
-er "user-unexistent" does not exist
+can't select broker: rpc error: code = Unknown desc = authentication failure
 PAM Authenticate() for user "user-unexistent" exited with error (PAM exit code: 4): System error
 acct=incomplete
 PAM AcctMgmt() exited with error (PAM exit code: 25): The return value should be ignored by PAM
 dispatch
 >
+
 
 
 
@@ -136,13 +136,13 @@ Username: user-unexistent
 1 - local
 2 - ExampleBroker
 Select broker: 2
-can't select broker: rpc error: code = Unknown desc = can't start authentication transaction: us
-er "user-unexistent" does not exist
+can't select broker: rpc error: code = Unknown desc = authentication failure
 PAM Authenticate() for user "user-unexistent" exited with error (PAM exit code: 4): System error
 acct=incomplete
 PAM AcctMgmt() exited with error (PAM exit code: 25): The return value should be ignored by PAM
 dispatch
 >
+
 
 
 

--- a/pam/integration-tests/testdata/TestNativeAuthenticate/golden/deny_authentication_if_usernames_dont_match
+++ b/pam/integration-tests/testdata/TestNativeAuthenticate/golden/deny_authentication_if_usernames_dont_match
@@ -138,15 +138,15 @@ Username: user-mismatching-name
 Select broker: 2
 Insert 'r' to cancel the request and go back
 Gimme your password:
-authentication status failure: rpc error: code = Unknown desc = can't check authentication: prov
-ided userinfo is invalid: username "mismatching-username" does not match the selected username "
-user-mismatching-name"
+authentication status failure: rpc error: code = Unknown desc = authentication failure
 PAM Authenticate() for user "user-mismatching-name" exited with error (PAM exit code: 4): System
  error
 acct=incomplete
 PAM AcctMgmt() exited with error (PAM exit code: 25): The return value should be ignored by PAM
 dispatch
 >
+
+
 
 
 
@@ -171,15 +171,15 @@ Username: user-mismatching-name
 Select broker: 2
 Insert 'r' to cancel the request and go back
 Gimme your password:
-authentication status failure: rpc error: code = Unknown desc = can't check authentication: prov
-ided userinfo is invalid: username "mismatching-username" does not match the selected username "
-user-mismatching-name"
+authentication status failure: rpc error: code = Unknown desc = authentication failure
 PAM Authenticate() for user "user-mismatching-name" exited with error (PAM exit code: 4): System
  error
 acct=incomplete
 PAM AcctMgmt() exited with error (PAM exit code: 25): The return value should be ignored by PAM
 dispatch
 >
+
+
 
 
 

--- a/pam/integration-tests/testdata/TestNativeChangeAuthTok/golden/prevent_change_password_if_auth_fails
+++ b/pam/integration-tests/testdata/TestNativeChangeAuthTok/golden/prevent_change_password_if_auth_fails
@@ -138,7 +138,7 @@ Username: user-integration-max-attempts
 Select broker: 2
 Insert 'r' to cancel the request and go back
 Gimme your password:
-invalid password 'wrongpass', should be 'goodpass'
+authentication failure
 Insert 'r' to cancel the request and go back
 Gimme your password:
 
@@ -171,10 +171,10 @@ Username: user-integration-max-attempts
 Select broker: 2
 Insert 'r' to cancel the request and go back
 Gimme your password:
-invalid password 'wrongpass', should be 'goodpass'
+authentication failure
 Insert 'r' to cancel the request and go back
 Gimme your password:
-invalid password 'wrongpass', should be 'goodpass'
+authentication failure
 Insert 'r' to cancel the request and go back
 Gimme your password:
 
@@ -204,13 +204,13 @@ Username: user-integration-max-attempts
 Select broker: 2
 Insert 'r' to cancel the request and go back
 Gimme your password:
-invalid password 'wrongpass', should be 'goodpass'
+authentication failure
 Insert 'r' to cancel the request and go back
 Gimme your password:
-invalid password 'wrongpass', should be 'goodpass'
+authentication failure
 Insert 'r' to cancel the request and go back
 Gimme your password:
-invalid password 'wrongpass', should be 'goodpass'
+authentication failure
 Insert 'r' to cancel the request and go back
 Gimme your password:
 
@@ -237,16 +237,16 @@ Username: user-integration-max-attempts
 Select broker: 2
 Insert 'r' to cancel the request and go back
 Gimme your password:
-invalid password 'wrongpass', should be 'goodpass'
+authentication failure
 Insert 'r' to cancel the request and go back
 Gimme your password:
-invalid password 'wrongpass', should be 'goodpass'
+authentication failure
 Insert 'r' to cancel the request and go back
 Gimme your password:
-invalid password 'wrongpass', should be 'goodpass'
+authentication failure
 Insert 'r' to cancel the request and go back
 Gimme your password:
-invalid password 'wrongpass', should be 'goodpass'
+authentication failure
 Insert 'r' to cancel the request and go back
 Gimme your password:
 
@@ -270,20 +270,20 @@ Username: user-integration-max-attempts
 Select broker: 2
 Insert 'r' to cancel the request and go back
 Gimme your password:
-invalid password 'wrongpass', should be 'goodpass'
+authentication failure
 Insert 'r' to cancel the request and go back
 Gimme your password:
-invalid password 'wrongpass', should be 'goodpass'
+authentication failure
 Insert 'r' to cancel the request and go back
 Gimme your password:
-invalid password 'wrongpass', should be 'goodpass'
+authentication failure
 Insert 'r' to cancel the request and go back
 Gimme your password:
-invalid password 'wrongpass', should be 'goodpass'
+authentication failure
 Insert 'r' to cancel the request and go back
 Gimme your password:
-invalid password 'wrongpass', should be 'goodpass'
-invalid password 'wrongpass', should be 'goodpass'
+authentication failure
+authentication failure
 PAM ChangeAuthTok() for user "user-integration-max-attempts" exited with error (PAM exit code: 7
 ): Authentication failure
 acct=incomplete
@@ -303,20 +303,20 @@ Username: user-integration-max-attempts
 Select broker: 2
 Insert 'r' to cancel the request and go back
 Gimme your password:
-invalid password 'wrongpass', should be 'goodpass'
+authentication failure
 Insert 'r' to cancel the request and go back
 Gimme your password:
-invalid password 'wrongpass', should be 'goodpass'
+authentication failure
 Insert 'r' to cancel the request and go back
 Gimme your password:
-invalid password 'wrongpass', should be 'goodpass'
+authentication failure
 Insert 'r' to cancel the request and go back
 Gimme your password:
-invalid password 'wrongpass', should be 'goodpass'
+authentication failure
 Insert 'r' to cancel the request and go back
 Gimme your password:
-invalid password 'wrongpass', should be 'goodpass'
-invalid password 'wrongpass', should be 'goodpass'
+authentication failure
+authentication failure
 PAM ChangeAuthTok() for user "user-integration-max-attempts" exited with error (PAM exit code: 7
 ): Authentication failure
 acct=incomplete

--- a/pam/integration-tests/testdata/TestNativeChangeAuthTok/golden/prevent_change_password_if_user_does_not_exist
+++ b/pam/integration-tests/testdata/TestNativeChangeAuthTok/golden/prevent_change_password_if_user_does_not_exist
@@ -103,14 +103,14 @@ Username: user-unexistent
 1 - local
 2 - ExampleBroker
 Select broker: 2
-can't select broker: rpc error: code = Unknown desc = can't start authentication transaction: us
-er "user-unexistent" does not exist
+can't select broker: rpc error: code = Unknown desc = authentication failure
 PAM ChangeAuthTok() for user "user-unexistent" exited with error (PAM exit code: 4): System erro
 r
 acct=incomplete
 PAM AcctMgmt() exited with error (PAM exit code: 25): The return value should be ignored by PAM
 dispatch
 >
+
 
 
 
@@ -136,14 +136,14 @@ Username: user-unexistent
 1 - local
 2 - ExampleBroker
 Select broker: 2
-can't select broker: rpc error: code = Unknown desc = can't start authentication transaction: us
-er "user-unexistent" does not exist
+can't select broker: rpc error: code = Unknown desc = authentication failure
 PAM ChangeAuthTok() for user "user-unexistent" exited with error (PAM exit code: 4): System erro
 r
 acct=incomplete
 PAM AcctMgmt() exited with error (PAM exit code: 25): The return value should be ignored by PAM
 dispatch
 >
+
 
 
 


### PR DESCRIPTION
This is to mimic the behavior of other PAM modules better. They show a generic error message to avoid leaking information that could help attackers.

UDENG-3420
UDENG-3419
UDENG-3412
UDENG-3418