### PR TITLE
pam/integration-tests/cli: Increase the wait times on MFA test

### DIFF
--- a/pam/integration-tests/testdata/tapes/cli/mfa_auth.tape
+++ b/pam/integration-tests/testdata/tapes/cli/mfa_auth.tape
@@ -54,12 +54,12 @@ Show
 
 Hide
 Escape
-Sleep 300ms
+Sleep 500ms
 Show
 
 Hide
 Enter
-Sleep 300ms
+Sleep 500ms
 Show
 
 Hide
@@ -68,12 +68,12 @@ Show
 
 Hide
 Escape
-Sleep 300ms
+Sleep 500ms
 Show
 
 Hide
 Enter
-Sleep 300ms
+Sleep 1s
 Show
 
 Hide


### PR DESCRIPTION
The test is quite unreliable [1] when running in CI or under pressure, so let's see if we can make it more stable by increasing the wait times, until vhs will support officially the wait feature.

[1] https://github.com/ubuntu/authd/actions/runs/9765222175/job/26955414933

UDENG-3549