### PR TITLE
feat(pam/gdmmodel): Add support for password quality check

### DIFF
--- a/examplebroker/broker.go
+++ b/examplebroker/broker.go
@@ -169,6 +169,12 @@ func (b *Broker) NewSession(ctx context.Context, username, lang, mode string) (s
 		info.neededAuthSteps = 3
 	}
 
+	if _, ok := exampleUsers[username]; !ok && strings.HasPrefix(username, "user-needs-reset-integration") {
+		exampleUsers[username] = userInfoBroker{Password: "goodpass"}
+		info.neededAuthSteps = 2
+		info.pwdChange = mustReset
+	}
+
 	pubASN1, err := x509.MarshalPKIXPublicKey(&b.privateKey.PublicKey)
 	if err != nil {
 		return "", "", err

--- a/examplebroker/broker.go
+++ b/examplebroker/broker.go
@@ -629,8 +629,15 @@ func (b *Broker) handleIsAuthenticated(ctx context.Context, sessionInfo sessionI
 		exampleUsersMu.Lock()
 		defer exampleUsersMu.Unlock()
 
-		if challenge != "authd2404" {
-			return AuthRetry, `{"message": "new password does not match criteria: must be authd2404"}`, nil
+		expectedChallenge := "authd2404"
+		// Reset the password to default if it had already been changed.
+		// As at PAM level we'd refuse a previous password to be re-used.
+		if exampleUsers[sessionInfo.username].Password == expectedChallenge {
+			expectedChallenge = "goodpass"
+		}
+
+		if challenge != expectedChallenge {
+			return AuthRetry, fmt.Sprintf(`{"message": "new password does not match criteria: must be '%s'"}`, expectedChallenge), nil
 		}
 		exampleUsers[sessionInfo.username] = userInfoBroker{Password: challenge}
 	}

--- a/pam/integration-tests/testdata/TestCLIChangeAuthTok/golden/retry_if_new_password_is_rejected_by_broker
+++ b/pam/integration-tests/testdata/TestCLIChangeAuthTok/golden/retry_if_new_password_is_rejected_by_broker
@@ -394,3 +394,366 @@ PAM AcctMgmt() exited with success
 
 
 ────────────────────────────────────────────────────────────────────────────────
+> ./pam_authd passwd socket=${AUTHD_TESTS_CLI_AUTHTOK_TESTS_SOCK}
+Enter your new password
+
+New password:
+> *********
+Confirm password:
+PAM ChangeAuthTok() for user "user-integration-invalid-new-password" exited with success
+PAM AcctMgmt() exited with success
+> ./pam_authd passwd socket=${AUTHD_TESTS_CLI_AUTHTOK_TESTS_SOCK}
+Username: user name
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+────────────────────────────────────────────────────────────────────────────────
+> ./pam_authd passwd socket=${AUTHD_TESTS_CLI_AUTHTOK_TESTS_SOCK}
+Enter your new password
+
+New password:
+> *********
+Confirm password:
+PAM ChangeAuthTok() for user "user-integration-invalid-new-password" exited with success
+PAM AcctMgmt() exited with success
+> ./pam_authd passwd socket=${AUTHD_TESTS_CLI_AUTHTOK_TESTS_SOCK}
+Username: user-integration-invalid-new-password
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+────────────────────────────────────────────────────────────────────────────────
+> ./pam_authd passwd socket=${AUTHD_TESTS_CLI_AUTHTOK_TESTS_SOCK}
+Enter your new password
+
+New password:
+> *********
+Confirm password:
+PAM ChangeAuthTok() for user "user-integration-invalid-new-password" exited with success
+PAM AcctMgmt() exited with success
+> ./pam_authd passwd socket=${AUTHD_TESTS_CLI_AUTHTOK_TESTS_SOCK}
+Gimme your password
+>
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+────────────────────────────────────────────────────────────────────────────────
+> ./pam_authd passwd socket=${AUTHD_TESTS_CLI_AUTHTOK_TESTS_SOCK}
+Enter your new password
+
+New password:
+> *********
+Confirm password:
+PAM ChangeAuthTok() for user "user-integration-invalid-new-password" exited with success
+PAM AcctMgmt() exited with success
+> ./pam_authd passwd socket=${AUTHD_TESTS_CLI_AUTHTOK_TESTS_SOCK}
+Enter your new password
+
+New password:
+>
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+────────────────────────────────────────────────────────────────────────────────
+> ./pam_authd passwd socket=${AUTHD_TESTS_CLI_AUTHTOK_TESTS_SOCK}
+Enter your new password
+
+New password:
+> *********
+Confirm password:
+PAM ChangeAuthTok() for user "user-integration-invalid-new-password" exited with success
+PAM AcctMgmt() exited with success
+> ./pam_authd passwd socket=${AUTHD_TESTS_CLI_AUTHTOK_TESTS_SOCK}
+Enter your new password
+
+New password:
+> *********
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+────────────────────────────────────────────────────────────────────────────────
+> ./pam_authd passwd socket=${AUTHD_TESTS_CLI_AUTHTOK_TESTS_SOCK}
+Enter your new password
+
+New password:
+> *********
+Confirm password:
+PAM ChangeAuthTok() for user "user-integration-invalid-new-password" exited with success
+PAM AcctMgmt() exited with success
+> ./pam_authd passwd socket=${AUTHD_TESTS_CLI_AUTHTOK_TESTS_SOCK}
+Enter your new password
+
+New password:
+> *********
+Confirm password:
+> *********
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+────────────────────────────────────────────────────────────────────────────────
+> ./pam_authd passwd socket=${AUTHD_TESTS_CLI_AUTHTOK_TESTS_SOCK}
+Enter your new password
+
+New password:
+> *********
+Confirm password:
+PAM ChangeAuthTok() for user "user-integration-invalid-new-password" exited with success
+PAM AcctMgmt() exited with success
+> ./pam_authd passwd socket=${AUTHD_TESTS_CLI_AUTHTOK_TESTS_SOCK}
+Enter your new password
+
+New password:
+>
+new password does not match criteria: must be 'goodpass'
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+────────────────────────────────────────────────────────────────────────────────
+> ./pam_authd passwd socket=${AUTHD_TESTS_CLI_AUTHTOK_TESTS_SOCK}
+Enter your new password
+
+New password:
+> *********
+Confirm password:
+PAM ChangeAuthTok() for user "user-integration-invalid-new-password" exited with success
+PAM AcctMgmt() exited with success
+> ./pam_authd passwd socket=${AUTHD_TESTS_CLI_AUTHTOK_TESTS_SOCK}
+Enter your new password
+
+New password:
+> ********
+new password does not match criteria: must be 'goodpass'
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+────────────────────────────────────────────────────────────────────────────────
+> ./pam_authd passwd socket=${AUTHD_TESTS_CLI_AUTHTOK_TESTS_SOCK}
+Enter your new password
+
+New password:
+> *********
+Confirm password:
+PAM ChangeAuthTok() for user "user-integration-invalid-new-password" exited with success
+PAM AcctMgmt() exited with success
+> ./pam_authd passwd socket=${AUTHD_TESTS_CLI_AUTHTOK_TESTS_SOCK}
+Enter your new password
+
+New password:
+> ********
+Confirm password:
+> ********
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+────────────────────────────────────────────────────────────────────────────────
+> ./pam_authd passwd socket=${AUTHD_TESTS_CLI_AUTHTOK_TESTS_SOCK}
+Enter your new password
+
+New password:
+> *********
+Confirm password:
+PAM ChangeAuthTok() for user "user-integration-invalid-new-password" exited with success
+PAM AcctMgmt() exited with success
+> ./pam_authd passwd socket=${AUTHD_TESTS_CLI_AUTHTOK_TESTS_SOCK}
+Enter your new password
+
+New password:
+> ********
+Confirm password:
+PAM ChangeAuthTok() for user "user-integration-invalid-new-password" exited with success
+PAM AcctMgmt() exited with success
+>
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+────────────────────────────────────────────────────────────────────────────────
+> ./pam_authd passwd socket=${AUTHD_TESTS_CLI_AUTHTOK_TESTS_SOCK}
+Enter your new password
+
+New password:
+> *********
+Confirm password:
+PAM ChangeAuthTok() for user "user-integration-invalid-new-password" exited with success
+PAM AcctMgmt() exited with success
+> ./pam_authd passwd socket=${AUTHD_TESTS_CLI_AUTHTOK_TESTS_SOCK}
+Enter your new password
+
+New password:
+> ********
+Confirm password:
+PAM ChangeAuthTok() for user "user-integration-invalid-new-password" exited with success
+PAM AcctMgmt() exited with success
+>
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+────────────────────────────────────────────────────────────────────────────────

--- a/pam/integration-tests/testdata/TestCLIChangeAuthTok/golden/retry_if_new_password_is_rejected_by_broker
+++ b/pam/integration-tests/testdata/TestCLIChangeAuthTok/golden/retry_if_new_password_is_rejected_by_broker
@@ -234,7 +234,7 @@ Enter your new password
 
 New password:
 >
-new password does not match criteria: must be authd2404
+new password does not match criteria: must be 'authd2404'
 
 
 
@@ -267,7 +267,7 @@ Enter your new password
 
 New password:
 > *********
-new password does not match criteria: must be authd2404
+new password does not match criteria: must be 'authd2404'
 
 
 

--- a/pam/integration-tests/testdata/TestNativeChangeAuthTok/golden/retry_if_new_password_is_rejected_by_broker
+++ b/pam/integration-tests/testdata/TestNativeChangeAuthTok/golden/retry_if_new_password_is_rejected_by_broker
@@ -30,9 +30,37 @@ Username:
 
 
 
+
+
+
+
+
+
+
+
+
+
+
+
+
+
 ────────────────────────────────────────────────────────────────────────────────
 > ./pam_authd passwd socket=${AUTHD_TESTS_CLI_AUTHTOK_TESTS_SOCK} force_native_client=true
 Username: user-integration-invalid-new-password
+
+
+
+
+
+
+
+
+
+
+
+
+
+
 
 
 
@@ -96,6 +124,20 @@ Select broker:
 
 
 
+
+
+
+
+
+
+
+
+
+
+
+
+
+
 ────────────────────────────────────────────────────────────────────────────────
 > ./pam_authd passwd socket=${AUTHD_TESTS_CLI_AUTHTOK_TESTS_SOCK} force_native_client=true
 Username: user-integration-invalid-new-password
@@ -105,6 +147,20 @@ Username: user-integration-invalid-new-password
 Select broker: 2
 Insert 'r' to cancel the request and go back
 Gimme your password:
+
+
+
+
+
+
+
+
+
+
+
+
+
+
 
 
 
@@ -140,6 +196,20 @@ Insert 'r' to cancel the request and go back
 Gimme your password:
 Insert 'r' to cancel the request and go back
 Enter your new password:
+
+
+
+
+
+
+
+
+
+
+
+
+
+
 
 
 
@@ -195,6 +265,20 @@ Enter your new password:
 
 
 
+
+
+
+
+
+
+
+
+
+
+
+
+
+
 ────────────────────────────────────────────────────────────────────────────────
 > ./pam_authd passwd socket=${AUTHD_TESTS_CLI_AUTHTOK_TESTS_SOCK} force_native_client=true
 Username: user-integration-invalid-new-password
@@ -208,6 +292,20 @@ Insert 'r' to cancel the request and go back
 Enter your new password:
 Repeat the previously inserted password or insert 'r' to cancel the request and go back
 Enter your new password:
+
+
+
+
+
+
+
+
+
+
+
+
+
+
 
 
 
@@ -261,6 +359,20 @@ Enter your new password:
 
 
 
+
+
+
+
+
+
+
+
+
+
+
+
+
+
 ────────────────────────────────────────────────────────────────────────────────
 > ./pam_authd passwd socket=${AUTHD_TESTS_CLI_AUTHTOK_TESTS_SOCK} force_native_client=true
 Username: user-integration-invalid-new-password
@@ -279,6 +391,20 @@ Insert 'r' to cancel the request and go back
 Enter your new password:
 Repeat the previously inserted password or insert 'r' to cancel the request and go back
 Enter your new password:
+
+
+
+
+
+
+
+
+
+
+
+
+
+
 
 
 
@@ -327,28 +453,9 @@ PAM AcctMgmt() exited with success
 
 
 
-────────────────────────────────────────────────────────────────────────────────
-> ./pam_authd passwd socket=${AUTHD_TESTS_CLI_AUTHTOK_TESTS_SOCK} force_native_client=true
-Username: user-integration-invalid-new-password
-== Broker selection (use 'r' to go back) ==
-1 - local
-2 - ExampleBroker
-Select broker: 2
-Insert 'r' to cancel the request and go back
-Gimme your password:
-Insert 'r' to cancel the request and go back
-Enter your new password:
-Repeat the previously inserted password or insert 'r' to cancel the request and go back
-Enter your new password:
-new password does not match criteria: must be 'authd2404'
-Insert 'r' to cancel the request and go back
-Enter your new password:
-Repeat the previously inserted password or insert 'r' to cancel the request and go back
-Enter your new password:
-PAM ChangeAuthTok() for user "user-integration-invalid-new-password" exited with success
-PAM AcctMgmt() exited with success
->
->
+
+
+
 
 
 
@@ -384,6 +491,584 @@ PAM AcctMgmt() exited with success
 >
 
 
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+────────────────────────────────────────────────────────────────────────────────
+> ./pam_authd passwd socket=${AUTHD_TESTS_CLI_AUTHTOK_TESTS_SOCK} force_native_client=true
+Username: user-integration-invalid-new-password
+== Broker selection (use 'r' to go back) ==
+1 - local
+2 - ExampleBroker
+Select broker: 2
+Insert 'r' to cancel the request and go back
+Gimme your password:
+Insert 'r' to cancel the request and go back
+Enter your new password:
+Repeat the previously inserted password or insert 'r' to cancel the request and go back
+Enter your new password:
+new password does not match criteria: must be 'authd2404'
+Insert 'r' to cancel the request and go back
+Enter your new password:
+Repeat the previously inserted password or insert 'r' to cancel the request and go back
+Enter your new password:
+PAM ChangeAuthTok() for user "user-integration-invalid-new-password" exited with success
+PAM AcctMgmt() exited with success
+>
+>
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+────────────────────────────────────────────────────────────────────────────────
+> ./pam_authd passwd socket=${AUTHD_TESTS_CLI_AUTHTOK_TESTS_SOCK} force_native_client=true
+Username: user-integration-invalid-new-password
+== Broker selection (use 'r' to go back) ==
+1 - local
+2 - ExampleBroker
+Select broker: 2
+Insert 'r' to cancel the request and go back
+Gimme your password:
+Insert 'r' to cancel the request and go back
+Enter your new password:
+Repeat the previously inserted password or insert 'r' to cancel the request and go back
+Enter your new password:
+new password does not match criteria: must be 'authd2404'
+Insert 'r' to cancel the request and go back
+Enter your new password:
+Repeat the previously inserted password or insert 'r' to cancel the request and go back
+Enter your new password:
+PAM ChangeAuthTok() for user "user-integration-invalid-new-password" exited with success
+PAM AcctMgmt() exited with success
+>
+> ./pam_authd passwd socket=${AUTHD_TESTS_CLI_AUTHTOK_TESTS_SOCK} force_native_client=true
+Username:
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+────────────────────────────────────────────────────────────────────────────────
+> ./pam_authd passwd socket=${AUTHD_TESTS_CLI_AUTHTOK_TESTS_SOCK} force_native_client=true
+Username: user-integration-invalid-new-password
+== Broker selection (use 'r' to go back) ==
+1 - local
+2 - ExampleBroker
+Select broker: 2
+Insert 'r' to cancel the request and go back
+Gimme your password:
+Insert 'r' to cancel the request and go back
+Enter your new password:
+Repeat the previously inserted password or insert 'r' to cancel the request and go back
+Enter your new password:
+new password does not match criteria: must be 'authd2404'
+Insert 'r' to cancel the request and go back
+Enter your new password:
+Repeat the previously inserted password or insert 'r' to cancel the request and go back
+Enter your new password:
+PAM ChangeAuthTok() for user "user-integration-invalid-new-password" exited with success
+PAM AcctMgmt() exited with success
+>
+> ./pam_authd passwd socket=${AUTHD_TESTS_CLI_AUTHTOK_TESTS_SOCK} force_native_client=true
+Username: user-integration-invalid-new-password
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+────────────────────────────────────────────────────────────────────────────────
+> ./pam_authd passwd socket=${AUTHD_TESTS_CLI_AUTHTOK_TESTS_SOCK} force_native_client=true
+Username: user-integration-invalid-new-password
+== Broker selection (use 'r' to go back) ==
+1 - local
+2 - ExampleBroker
+Select broker: 2
+Insert 'r' to cancel the request and go back
+Gimme your password:
+Insert 'r' to cancel the request and go back
+Enter your new password:
+Repeat the previously inserted password or insert 'r' to cancel the request and go back
+Enter your new password:
+new password does not match criteria: must be 'authd2404'
+Insert 'r' to cancel the request and go back
+Enter your new password:
+Repeat the previously inserted password or insert 'r' to cancel the request and go back
+Enter your new password:
+PAM ChangeAuthTok() for user "user-integration-invalid-new-password" exited with success
+PAM AcctMgmt() exited with success
+>
+> ./pam_authd passwd socket=${AUTHD_TESTS_CLI_AUTHTOK_TESTS_SOCK} force_native_client=true
+Username: user-integration-invalid-new-password
+Insert 'r' to cancel the request and go back
+Gimme your password:
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+────────────────────────────────────────────────────────────────────────────────
+> ./pam_authd passwd socket=${AUTHD_TESTS_CLI_AUTHTOK_TESTS_SOCK} force_native_client=true
+Username: user-integration-invalid-new-password
+== Broker selection (use 'r' to go back) ==
+1 - local
+2 - ExampleBroker
+Select broker: 2
+Insert 'r' to cancel the request and go back
+Gimme your password:
+Insert 'r' to cancel the request and go back
+Enter your new password:
+Repeat the previously inserted password or insert 'r' to cancel the request and go back
+Enter your new password:
+new password does not match criteria: must be 'authd2404'
+Insert 'r' to cancel the request and go back
+Enter your new password:
+Repeat the previously inserted password or insert 'r' to cancel the request and go back
+Enter your new password:
+PAM ChangeAuthTok() for user "user-integration-invalid-new-password" exited with success
+PAM AcctMgmt() exited with success
+>
+> ./pam_authd passwd socket=${AUTHD_TESTS_CLI_AUTHTOK_TESTS_SOCK} force_native_client=true
+Username: user-integration-invalid-new-password
+Insert 'r' to cancel the request and go back
+Gimme your password:
+Insert 'r' to cancel the request and go back
+Enter your new password:
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+────────────────────────────────────────────────────────────────────────────────
+> ./pam_authd passwd socket=${AUTHD_TESTS_CLI_AUTHTOK_TESTS_SOCK} force_native_client=true
+Username: user-integration-invalid-new-password
+== Broker selection (use 'r' to go back) ==
+1 - local
+2 - ExampleBroker
+Select broker: 2
+Insert 'r' to cancel the request and go back
+Gimme your password:
+Insert 'r' to cancel the request and go back
+Enter your new password:
+Repeat the previously inserted password or insert 'r' to cancel the request and go back
+Enter your new password:
+new password does not match criteria: must be 'authd2404'
+Insert 'r' to cancel the request and go back
+Enter your new password:
+Repeat the previously inserted password or insert 'r' to cancel the request and go back
+Enter your new password:
+PAM ChangeAuthTok() for user "user-integration-invalid-new-password" exited with success
+PAM AcctMgmt() exited with success
+>
+> ./pam_authd passwd socket=${AUTHD_TESTS_CLI_AUTHTOK_TESTS_SOCK} force_native_client=true
+Username: user-integration-invalid-new-password
+Insert 'r' to cancel the request and go back
+Gimme your password:
+Insert 'r' to cancel the request and go back
+Enter your new password:
+Repeat the previously inserted password or insert 'r' to cancel the request and go back
+Enter your new password:
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+────────────────────────────────────────────────────────────────────────────────
+> ./pam_authd passwd socket=${AUTHD_TESTS_CLI_AUTHTOK_TESTS_SOCK} force_native_client=true
+Username: user-integration-invalid-new-password
+== Broker selection (use 'r' to go back) ==
+1 - local
+2 - ExampleBroker
+Select broker: 2
+Insert 'r' to cancel the request and go back
+Gimme your password:
+Insert 'r' to cancel the request and go back
+Enter your new password:
+Repeat the previously inserted password or insert 'r' to cancel the request and go back
+Enter your new password:
+new password does not match criteria: must be 'authd2404'
+Insert 'r' to cancel the request and go back
+Enter your new password:
+Repeat the previously inserted password or insert 'r' to cancel the request and go back
+Enter your new password:
+PAM ChangeAuthTok() for user "user-integration-invalid-new-password" exited with success
+PAM AcctMgmt() exited with success
+>
+> ./pam_authd passwd socket=${AUTHD_TESTS_CLI_AUTHTOK_TESTS_SOCK} force_native_client=true
+Username: user-integration-invalid-new-password
+Insert 'r' to cancel the request and go back
+Gimme your password:
+Insert 'r' to cancel the request and go back
+Enter your new password:
+Repeat the previously inserted password or insert 'r' to cancel the request and go back
+Enter your new password:
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+────────────────────────────────────────────────────────────────────────────────
+> ./pam_authd passwd socket=${AUTHD_TESTS_CLI_AUTHTOK_TESTS_SOCK} force_native_client=true
+Username: user-integration-invalid-new-password
+== Broker selection (use 'r' to go back) ==
+1 - local
+2 - ExampleBroker
+Select broker: 2
+Insert 'r' to cancel the request and go back
+Gimme your password:
+Insert 'r' to cancel the request and go back
+Enter your new password:
+Repeat the previously inserted password or insert 'r' to cancel the request and go back
+Enter your new password:
+new password does not match criteria: must be 'authd2404'
+Insert 'r' to cancel the request and go back
+Enter your new password:
+Repeat the previously inserted password or insert 'r' to cancel the request and go back
+Enter your new password:
+PAM ChangeAuthTok() for user "user-integration-invalid-new-password" exited with success
+PAM AcctMgmt() exited with success
+>
+> ./pam_authd passwd socket=${AUTHD_TESTS_CLI_AUTHTOK_TESTS_SOCK} force_native_client=true
+Username: user-integration-invalid-new-password
+Insert 'r' to cancel the request and go back
+Gimme your password:
+Insert 'r' to cancel the request and go back
+Enter your new password:
+Repeat the previously inserted password or insert 'r' to cancel the request and go back
+Enter your new password:
+new password does not match criteria: must be 'goodpass'
+Insert 'r' to cancel the request and go back
+Enter your new password:
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+────────────────────────────────────────────────────────────────────────────────
+> ./pam_authd passwd socket=${AUTHD_TESTS_CLI_AUTHTOK_TESTS_SOCK} force_native_client=true
+Username: user-integration-invalid-new-password
+== Broker selection (use 'r' to go back) ==
+1 - local
+2 - ExampleBroker
+Select broker: 2
+Insert 'r' to cancel the request and go back
+Gimme your password:
+Insert 'r' to cancel the request and go back
+Enter your new password:
+Repeat the previously inserted password or insert 'r' to cancel the request and go back
+Enter your new password:
+new password does not match criteria: must be 'authd2404'
+Insert 'r' to cancel the request and go back
+Enter your new password:
+Repeat the previously inserted password or insert 'r' to cancel the request and go back
+Enter your new password:
+PAM ChangeAuthTok() for user "user-integration-invalid-new-password" exited with success
+PAM AcctMgmt() exited with success
+>
+> ./pam_authd passwd socket=${AUTHD_TESTS_CLI_AUTHTOK_TESTS_SOCK} force_native_client=true
+Username: user-integration-invalid-new-password
+Insert 'r' to cancel the request and go back
+Gimme your password:
+Insert 'r' to cancel the request and go back
+Enter your new password:
+Repeat the previously inserted password or insert 'r' to cancel the request and go back
+Enter your new password:
+new password does not match criteria: must be 'goodpass'
+Insert 'r' to cancel the request and go back
+Enter your new password:
+Repeat the previously inserted password or insert 'r' to cancel the request and go back
+Enter your new password:
+
+
+
+
+
+
+
+
+
+
+
+
+
+────────────────────────────────────────────────────────────────────────────────
+> ./pam_authd passwd socket=${AUTHD_TESTS_CLI_AUTHTOK_TESTS_SOCK} force_native_client=true
+Username: user-integration-invalid-new-password
+== Broker selection (use 'r' to go back) ==
+1 - local
+2 - ExampleBroker
+Select broker: 2
+Insert 'r' to cancel the request and go back
+Gimme your password:
+Insert 'r' to cancel the request and go back
+Enter your new password:
+Repeat the previously inserted password or insert 'r' to cancel the request and go back
+Enter your new password:
+new password does not match criteria: must be 'authd2404'
+Insert 'r' to cancel the request and go back
+Enter your new password:
+Repeat the previously inserted password or insert 'r' to cancel the request and go back
+Enter your new password:
+PAM ChangeAuthTok() for user "user-integration-invalid-new-password" exited with success
+PAM AcctMgmt() exited with success
+>
+> ./pam_authd passwd socket=${AUTHD_TESTS_CLI_AUTHTOK_TESTS_SOCK} force_native_client=true
+Username: user-integration-invalid-new-password
+Insert 'r' to cancel the request and go back
+Gimme your password:
+Insert 'r' to cancel the request and go back
+Enter your new password:
+Repeat the previously inserted password or insert 'r' to cancel the request and go back
+Enter your new password:
+new password does not match criteria: must be 'goodpass'
+Insert 'r' to cancel the request and go back
+Enter your new password:
+Repeat the previously inserted password or insert 'r' to cancel the request and go back
+Enter your new password:
+PAM ChangeAuthTok() for user "user-integration-invalid-new-password" exited with success
+PAM AcctMgmt() exited with success
+>
+
+
+
+
+
+
+
+
+
+
+────────────────────────────────────────────────────────────────────────────────
+> ./pam_authd passwd socket=${AUTHD_TESTS_CLI_AUTHTOK_TESTS_SOCK} force_native_client=true
+Username: user-integration-invalid-new-password
+== Broker selection (use 'r' to go back) ==
+1 - local
+2 - ExampleBroker
+Select broker: 2
+Insert 'r' to cancel the request and go back
+Gimme your password:
+Insert 'r' to cancel the request and go back
+Enter your new password:
+Repeat the previously inserted password or insert 'r' to cancel the request and go back
+Enter your new password:
+new password does not match criteria: must be 'authd2404'
+Insert 'r' to cancel the request and go back
+Enter your new password:
+Repeat the previously inserted password or insert 'r' to cancel the request and go back
+Enter your new password:
+PAM ChangeAuthTok() for user "user-integration-invalid-new-password" exited with success
+PAM AcctMgmt() exited with success
+>
+> ./pam_authd passwd socket=${AUTHD_TESTS_CLI_AUTHTOK_TESTS_SOCK} force_native_client=true
+Username: user-integration-invalid-new-password
+Insert 'r' to cancel the request and go back
+Gimme your password:
+Insert 'r' to cancel the request and go back
+Enter your new password:
+Repeat the previously inserted password or insert 'r' to cancel the request and go back
+Enter your new password:
+new password does not match criteria: must be 'goodpass'
+Insert 'r' to cancel the request and go back
+Enter your new password:
+Repeat the previously inserted password or insert 'r' to cancel the request and go back
+Enter your new password:
+PAM ChangeAuthTok() for user "user-integration-invalid-new-password" exited with success
+PAM AcctMgmt() exited with success
+>
+>
+
+
+
+
+
+
+
+
+
+────────────────────────────────────────────────────────────────────────────────
+> ./pam_authd passwd socket=${AUTHD_TESTS_CLI_AUTHTOK_TESTS_SOCK} force_native_client=true
+Username: user-integration-invalid-new-password
+== Broker selection (use 'r' to go back) ==
+1 - local
+2 - ExampleBroker
+Select broker: 2
+Insert 'r' to cancel the request and go back
+Gimme your password:
+Insert 'r' to cancel the request and go back
+Enter your new password:
+Repeat the previously inserted password or insert 'r' to cancel the request and go back
+Enter your new password:
+new password does not match criteria: must be 'authd2404'
+Insert 'r' to cancel the request and go back
+Enter your new password:
+Repeat the previously inserted password or insert 'r' to cancel the request and go back
+Enter your new password:
+PAM ChangeAuthTok() for user "user-integration-invalid-new-password" exited with success
+PAM AcctMgmt() exited with success
+>
+> ./pam_authd passwd socket=${AUTHD_TESTS_CLI_AUTHTOK_TESTS_SOCK} force_native_client=true
+Username: user-integration-invalid-new-password
+Insert 'r' to cancel the request and go back
+Gimme your password:
+Insert 'r' to cancel the request and go back
+Enter your new password:
+Repeat the previously inserted password or insert 'r' to cancel the request and go back
+Enter your new password:
+new password does not match criteria: must be 'goodpass'
+Insert 'r' to cancel the request and go back
+Enter your new password:
+Repeat the previously inserted password or insert 'r' to cancel the request and go back
+Enter your new password:
+PAM ChangeAuthTok() for user "user-integration-invalid-new-password" exited with success
+PAM AcctMgmt() exited with success
+>
+>
 
 
 

--- a/pam/integration-tests/testdata/TestNativeChangeAuthTok/golden/retry_if_new_password_is_rejected_by_broker
+++ b/pam/integration-tests/testdata/TestNativeChangeAuthTok/golden/retry_if_new_password_is_rejected_by_broker
@@ -173,9 +173,9 @@ Insert 'r' to cancel the request and go back
 Gimme your password:
 Insert 'r' to cancel the request and go back
 Enter your new password:
-The password is shorter than 8 characters
-Insert 'r' to cancel the request and go back
+Repeat the previously inserted password or insert 'r' to cancel the request and go back
 Enter your new password:
+
 
 
 
@@ -204,78 +204,6 @@ Username: user-integration-invalid-new-password
 Select broker: 2
 Insert 'r' to cancel the request and go back
 Gimme your password:
-Insert 'r' to cancel the request and go back
-Enter your new password:
-The password is shorter than 8 characters
-Insert 'r' to cancel the request and go back
-Enter your new password:
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-────────────────────────────────────────────────────────────────────────────────
-> ./pam_authd passwd socket=${AUTHD_TESTS_CLI_AUTHTOK_TESTS_SOCK} force_native_client=true
-Username: user-integration-invalid-new-password
-== Broker selection (use 'r' to go back) ==
-1 - local
-2 - ExampleBroker
-Select broker: 2
-Insert 'r' to cancel the request and go back
-Gimme your password:
-Insert 'r' to cancel the request and go back
-Enter your new password:
-The password is shorter than 8 characters
-Insert 'r' to cancel the request and go back
-Enter your new password:
-The password is shorter than 8 characters
-Insert 'r' to cancel the request and go back
-Enter your new password:
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-────────────────────────────────────────────────────────────────────────────────
-> ./pam_authd passwd socket=${AUTHD_TESTS_CLI_AUTHTOK_TESTS_SOCK} force_native_client=true
-Username: user-integration-invalid-new-password
-== Broker selection (use 'r' to go back) ==
-1 - local
-2 - ExampleBroker
-Select broker: 2
-Insert 'r' to cancel the request and go back
-Gimme your password:
-Insert 'r' to cancel the request and go back
-Enter your new password:
-The password is shorter than 8 characters
-Insert 'r' to cancel the request and go back
-Enter your new password:
-The password is shorter than 8 characters
 Insert 'r' to cancel the request and go back
 Enter your new password:
 Repeat the previously inserted password or insert 'r' to cancel the request and go back
@@ -294,6 +222,12 @@ Enter your new password:
 
 
 
+
+
+
+
+
+
 ────────────────────────────────────────────────────────────────────────────────
 > ./pam_authd passwd socket=${AUTHD_TESTS_CLI_AUTHTOK_TESTS_SOCK} force_native_client=true
 Username: user-integration-invalid-new-password
@@ -303,19 +237,19 @@ Username: user-integration-invalid-new-password
 Select broker: 2
 Insert 'r' to cancel the request and go back
 Gimme your password:
-Insert 'r' to cancel the request and go back
-Enter your new password:
-The password is shorter than 8 characters
-Insert 'r' to cancel the request and go back
-Enter your new password:
-The password is shorter than 8 characters
 Insert 'r' to cancel the request and go back
 Enter your new password:
 Repeat the previously inserted password or insert 'r' to cancel the request and go back
 Enter your new password:
-PAM ChangeAuthTok() for user "user-integration-invalid-new-password" exited with success
-PAM AcctMgmt() exited with success
->
+new password does not match criteria: must be 'authd2404'
+Insert 'r' to cancel the request and go back
+Enter your new password:
+
+
+
+
+
+
 
 
 
@@ -338,10 +272,42 @@ Insert 'r' to cancel the request and go back
 Gimme your password:
 Insert 'r' to cancel the request and go back
 Enter your new password:
-The password is shorter than 8 characters
+Repeat the previously inserted password or insert 'r' to cancel the request and go back
+Enter your new password:
+new password does not match criteria: must be 'authd2404'
 Insert 'r' to cancel the request and go back
 Enter your new password:
-The password is shorter than 8 characters
+Repeat the previously inserted password or insert 'r' to cancel the request and go back
+Enter your new password:
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+────────────────────────────────────────────────────────────────────────────────
+> ./pam_authd passwd socket=${AUTHD_TESTS_CLI_AUTHTOK_TESTS_SOCK} force_native_client=true
+Username: user-integration-invalid-new-password
+== Broker selection (use 'r' to go back) ==
+1 - local
+2 - ExampleBroker
+Select broker: 2
+Insert 'r' to cancel the request and go back
+Gimme your password:
+Insert 'r' to cancel the request and go back
+Enter your new password:
+Repeat the previously inserted password or insert 'r' to cancel the request and go back
+Enter your new password:
+new password does not match criteria: must be 'authd2404'
 Insert 'r' to cancel the request and go back
 Enter your new password:
 Repeat the previously inserted password or insert 'r' to cancel the request and go back
@@ -349,7 +315,8 @@ Enter your new password:
 PAM ChangeAuthTok() for user "user-integration-invalid-new-password" exited with success
 PAM AcctMgmt() exited with success
 >
->
+
+
 
 
 
@@ -371,10 +338,9 @@ Insert 'r' to cancel the request and go back
 Gimme your password:
 Insert 'r' to cancel the request and go back
 Enter your new password:
-The password is shorter than 8 characters
-Insert 'r' to cancel the request and go back
+Repeat the previously inserted password or insert 'r' to cancel the request and go back
 Enter your new password:
-The password is shorter than 8 characters
+new password does not match criteria: must be 'authd2404'
 Insert 'r' to cancel the request and go back
 Enter your new password:
 Repeat the previously inserted password or insert 'r' to cancel the request and go back
@@ -383,6 +349,40 @@ PAM ChangeAuthTok() for user "user-integration-invalid-new-password" exited with
 PAM AcctMgmt() exited with success
 >
 >
+
+
+
+
+
+
+
+
+
+
+
+────────────────────────────────────────────────────────────────────────────────
+> ./pam_authd passwd socket=${AUTHD_TESTS_CLI_AUTHTOK_TESTS_SOCK} force_native_client=true
+Username: user-integration-invalid-new-password
+== Broker selection (use 'r' to go back) ==
+1 - local
+2 - ExampleBroker
+Select broker: 2
+Insert 'r' to cancel the request and go back
+Gimme your password:
+Insert 'r' to cancel the request and go back
+Enter your new password:
+Repeat the previously inserted password or insert 'r' to cancel the request and go back
+Enter your new password:
+new password does not match criteria: must be 'authd2404'
+Insert 'r' to cancel the request and go back
+Enter your new password:
+Repeat the previously inserted password or insert 'r' to cancel the request and go back
+Enter your new password:
+PAM ChangeAuthTok() for user "user-integration-invalid-new-password" exited with success
+PAM AcctMgmt() exited with success
+>
+>
+
 
 
 

--- a/pam/integration-tests/testdata/tapes/cli/passwd_rejected.tape
+++ b/pam/integration-tests/testdata/tapes/cli/passwd_rejected.tape
@@ -74,4 +74,64 @@ Enter
 Sleep 2s
 Show
 
+Sleep 1s
+
+# Repeat again, to check that we can use still use another new password
+
+Hide
+Type "./pam_authd passwd socket=${AUTHD_TESTS_CLI_AUTHTOK_TESTS_SOCK}"
+Enter
+Sleep 300ms
+Show
+
+Hide
+Escape
+Backspace
+Type "user-integration-invalid-new-password"
+Sleep 300ms
+Show
+
+Hide
+Enter
+Sleep 300ms
+Show
+
+Hide
+Type "authd2404"
+Enter
+Sleep 2s
+Show
+
+Hide
+Type "noble2404"
+Sleep 300ms
+Show
+
+Hide
+Enter
+Type "noble2404"
+Sleep 300ms
+Show
+
+Hide
+Enter
+Sleep 2s
+Show
+
+Hide
+Type "goodpass"
+Sleep 300ms
+Show
+
+Hide
+Enter
+Type "goodpass"
+Sleep 300ms
+Show
+
+Hide
+Enter
+Sleep 2s
+Show
+
 Sleep 300ms

--- a/pam/integration-tests/testdata/tapes/native/passwd_rejected.tape
+++ b/pam/integration-tests/testdata/tapes/native/passwd_rejected.tape
@@ -4,7 +4,9 @@ Output passwd_rejected.gif # If we don't specify a .gif output, it will create a
 # Configuration header to standardize the output.
 # Does not work with the "Source" command.
 Set Width 800
-Set Height 500
+# We need high terminal view, as vhs doesn't scroll:
+#  https://github.com/charmbracelet/vhs/issues/404
+Set Height 700
 # TODO: Ideally, we should use Ubuntu Mono. However, the github runner is still on Jammy, which does not have it.
 # We should update this to use Ubuntu Mono once the runner is updated.
 Set FontFamily "Monospace"
@@ -65,6 +67,65 @@ Show
 
 Hide
 Type "authd2404"
+Enter
+Sleep 300ms
+Show
+
+Hide
+Enter
+Sleep 2s
+Show
+
+# Repeat again, to check that we can use still use another new password
+
+Sleep 1s
+
+Hide
+Type "./pam_authd passwd socket=${AUTHD_TESTS_CLI_AUTHTOK_TESTS_SOCK} force_native_client=true"
+Enter
+Sleep 300ms
+Show
+
+Hide
+Type "user-integration-invalid-new-password"
+Sleep 300ms
+Show
+
+Hide
+Enter
+Sleep 300ms
+Show
+
+Hide
+Type "authd2404"
+Enter
+Sleep 2s
+Show
+
+Hide
+Type "noble2404"
+Enter
+Sleep 300ms
+Show
+
+Hide
+Type "noble2404"
+Sleep 300ms
+Show
+
+Hide
+Enter
+Sleep 2s
+Show
+
+Hide
+Type "goodpass"
+Enter
+Sleep 300ms
+Show
+
+Hide
+Type "goodpass"
 Enter
 Sleep 300ms
 Show

--- a/pam/integration-tests/testdata/tapes/native/passwd_rejected.tape
+++ b/pam/integration-tests/testdata/tapes/native/passwd_rejected.tape
@@ -42,13 +42,13 @@ Sleep 2s
 Show
 
 Hide
-Type "badpass"
+Type "noble2404"
 Enter
 Sleep 300ms
 Show
 
 Hide
-Type "badpass"
+Type "noble2404"
 Sleep 300ms
 Show
 

--- a/pam/internal/adapter/authentication.go
+++ b/pam/internal/adapter/authentication.go
@@ -191,11 +191,14 @@ func (m *authenticationModel) Update(msg tea.Msg) (authModel authenticationModel
 		return *m, tea.Sequence(m.cancelIsAuthenticated(), sendEvent(AuthModeSelected{}))
 
 	case newPasswordCheck:
-		res := newPasswordCheckResult{ctx: msg.ctx, challenge: msg.challenge}
-		if err := checkChallengeQuality(m.currentChallenge, msg.challenge); err != nil {
-			res.msg = err.Error()
+		currentChallenge := m.currentChallenge
+		return *m, func() tea.Msg {
+			res := newPasswordCheckResult{ctx: msg.ctx, challenge: msg.challenge}
+			if err := checkChallengeQuality(currentChallenge, msg.challenge); err != nil {
+				res.msg = err.Error()
+			}
+			return res
 		}
-		return *m, sendEvent(res)
 
 	case newPasswordCheckResult:
 		if m.clientType != Gdm {

--- a/pam/internal/adapter/gdmmodel_test.go
+++ b/pam/internal/adapter/gdmmodel_test.go
@@ -502,7 +502,7 @@ func TestGdmModel(t *testing.T) {
 				gdm.EventType_startAuthentication,
 				gdm.EventType_authEvent, // retry
 				gdm.EventType_startAuthentication,
-				gdm.EventType_authEvent, // denied
+				gdm.EventType_authEvent, // granted
 			},
 			wantMessages: []tea.Msg{
 				startAuthentication{},

--- a/pam/internal/adapter/nativemodel.go
+++ b/pam/internal/adapter/nativemodel.go
@@ -723,7 +723,7 @@ func (m nativeModel) newPasswordChallenge(previousChallenge *string) tea.Cmd {
 	}
 
 	if previousChallenge == nil {
-		return sendEvent(newPasswordCheck{challenge})
+		return sendEvent(newPasswordCheck{challenge: challenge})
 	}
 	if challenge != *previousChallenge {
 		err := m.sendError("Password entries don't match")

--- a/pam/internal/adapter/newpasswordmodel.go
+++ b/pam/internal/adapter/newpasswordmodel.go
@@ -102,7 +102,7 @@ func (m newPasswordModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				// First entry is focused
 				if m.focusIndex == 0 {
 					// Check password quality
-					return m, sendEvent(newPasswordCheck{m.passwordEntries[0].Value()})
+					return m, sendEvent(newPasswordCheck{challenge: m.passwordEntries[0].Value()})
 				}
 
 				// Second entry is focused

--- a/pam/internal/pam_test/pam-client-dummy.go
+++ b/pam/internal/pam_test/pam-client-dummy.go
@@ -590,12 +590,13 @@ func QrCodeUILayout() *authd.UILayout {
 // NewPasswordUILayout returns an [authd.UILayout] for new password forms.
 func NewPasswordUILayout() *authd.UILayout {
 	required, optional := "required", "optional"
-	requiredWithBooleans := "required:true,false"
+	optionalWithBooleans := "optional:true,false"
+	supportedEntries := "optional:chars,chars_password"
 	return &authd.UILayout{
-		Type:    "newpassword",
-		Content: &required,
-		Wait:    &requiredWithBooleans,
-		Label:   &optional,
-		Button:  &optional,
+		Type:   "newpassword",
+		Label:  &required,
+		Entry:  &supportedEntries,
+		Wait:   &optionalWithBooleans,
+		Button: &optional,
 	}
 }


### PR DESCRIPTION
Support checking for password quality when logging-in with GDM, due to the nature of GDM model, we can only provide the final check after the user as typed the password twice, but that's still better than not having the check at all.

To keep the GDM model agnostic to the change, handle this only in the `authentication` backend, so that in the gdm case it's also doing an extra step to check the challenge before passing the data to the broker.

Add tests to handle the newpassword layout in gdm, since we had not them yet.

UDENG-3374