### PR TITLE
fix(debian): Add pwquality dictionary check dependencies

### DIFF
--- a/.github/workflows/qa.yaml
+++ b/.github/workflows/qa.yaml
@@ -15,7 +15,9 @@ env:
     libpwquality-dev
 
   test_apt_deps: >-
+    cracklib-runtime
     ffmpeg
+
   # In Rust the grpc stubs are generated at build time
   # so we always need to install the protobuf compilers
   # when building the NSS crate.

--- a/debian/control
+++ b/debian/control
@@ -3,6 +3,7 @@ Section: admin
 Priority: optional
 Maintainer: Ubuntu Developers <ubuntu-devel-discuss@lists.ubuntu.com>
 Build-Depends: debhelper-compat (= 13),
+               cracklib-runtime <!nocheck>,
                dbus <!nocheck>,
                dh-apport,
                dh-cargo,

--- a/pam/integration-tests/gdm_test.go
+++ b/pam/integration-tests/gdm_test.go
@@ -222,7 +222,7 @@ func TestGdmModule(t *testing.T) {
 						Challenge: "goodpass",
 					}),
 					gdm_test.IsAuthenticatedEvent(&authd.IARequest_AuthenticationData_Challenge{
-						Challenge: "foolinux",
+						Challenge: "password",
 					}),
 					gdm_test.IsAuthenticatedEvent(&authd.IARequest_AuthenticationData_Challenge{
 						Challenge: "newpass",

--- a/pam/internal/adapter/gdmmodel_test.go
+++ b/pam/internal/adapter/gdmmodel_test.go
@@ -485,7 +485,7 @@ func TestGdmModel(t *testing.T) {
 							Challenge: "newpass",
 						}}),
 						sendEvent(gdmTestSendAuthDataWhenReady{&authd.IARequest_AuthenticationData_Challenge{
-							Challenge: "foolinux",
+							Challenge: "password",
 						}}),
 						sendEvent(gdmTestSendAuthDataWhenReady{&authd.IARequest_AuthenticationData_Challenge{
 							Challenge: "gdm-good-password",


### PR DESCRIPTION
In order to do password dictionary checks we need to use cracklib, but the runtime isn't installed by default in debian so add a test dependency for it and, just in case, to debian too.

Also use the simplest password ever that would fail any dictionary check (and that's part of cracklib's cracklib-small dictionary)

It built fine at https://launchpad.net/~ubuntu-enterprise-desktop/+archive/ubuntu/authd/+sourcepub/16261392/+listing-archive-extra

UDENG-3575