### PR TITLE
fix(pam/nativemodel): Select local broker if user does not exist on SSH connection

### DIFF
--- a/examplebroker/broker.go
+++ b/examplebroker/broker.go
@@ -726,6 +726,9 @@ func (b *Broker) CancelIsAuthenticated(ctx context.Context, sessionID string) {
 
 // UserPreCheck checks if the user is known to the broker.
 func (b *Broker) UserPreCheck(ctx context.Context, username string) (string, error) {
+	if strings.HasPrefix(username, "user-integration-pre-check") {
+		return userInfoFromName(username), nil
+	}
 	if _, exists := exampleUsers[username]; !exists {
 		return "", fmt.Errorf("user %q does not exist", username)
 	}

--- a/pam/integration-tests/cmd/exec-client/modulewrapper.go
+++ b/pam/integration-tests/cmd/exec-client/modulewrapper.go
@@ -19,7 +19,7 @@ func newModuleWrapper(serverAddress string) (pam.ModuleTransaction, func(), erro
 	return &moduleWrapper{mTx}, closeFunc, err
 }
 
-// SimulateClientPanic forces the client to painc with the provided text.
+// SimulateClientPanic forces the client to panic with the provided text.
 func (m *moduleWrapper) SimulateClientPanic(text string) {
 	panic(text)
 }

--- a/pam/integration-tests/testdata/TestNativeAuthenticate/golden/authenticate_user_on_ssh_service
+++ b/pam/integration-tests/testdata/TestNativeAuthenticate/golden/authenticate_user_on_ssh_service
@@ -1,0 +1,132 @@
+> ./pam_authd login socket=${AUTHD_TESTS_CLI_AUTHENTICATE_TESTS_SOCK} force_native_client=true
+== Broker selection (use 'r' to go back) ==
+1 - local
+2 - ExampleBroker
+Select broker:
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+────────────────────────────────────────────────────────────────────────────────
+> ./pam_authd login socket=${AUTHD_TESTS_CLI_AUTHENTICATE_TESTS_SOCK} force_native_client=true
+== Broker selection (use 'r' to go back) ==
+1 - local
+2 - ExampleBroker
+Select broker: 2
+Insert 'r' to cancel the request and go back
+Gimme your password:
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+────────────────────────────────────────────────────────────────────────────────
+> ./pam_authd login socket=${AUTHD_TESTS_CLI_AUTHENTICATE_TESTS_SOCK} force_native_client=true
+== Broker selection (use 'r' to go back) ==
+1 - local
+2 - ExampleBroker
+Select broker: 2
+Insert 'r' to cancel the request and go back
+Gimme your password:
+PAM Authenticate() for user "user-integration-pre-check-ssh-service" exited with success
+PAM AcctMgmt() exited with success
+>
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+────────────────────────────────────────────────────────────────────────────────
+> ./pam_authd login socket=${AUTHD_TESTS_CLI_AUTHENTICATE_TESTS_SOCK} force_native_client=true
+== Broker selection (use 'r' to go back) ==
+1 - local
+2 - ExampleBroker
+Select broker: 2
+Insert 'r' to cancel the request and go back
+Gimme your password:
+PAM Authenticate() for user "user-integration-pre-check-ssh-service" exited with success
+PAM AcctMgmt() exited with success
+>
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+────────────────────────────────────────────────────────────────────────────────

--- a/pam/integration-tests/testdata/TestNativeAuthenticate/golden/authenticate_user_on_ssh_service_with_custom_name_and_auth_info_env
+++ b/pam/integration-tests/testdata/TestNativeAuthenticate/golden/authenticate_user_on_ssh_service_with_custom_name_and_auth_info_env
@@ -1,0 +1,132 @@
+> ./pam_authd login socket=${AUTHD_TESTS_CLI_AUTHENTICATE_TESTS_SOCK} force_native_client=true
+== Broker selection (use 'r' to go back) ==
+1 - local
+2 - ExampleBroker
+Select broker:
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+────────────────────────────────────────────────────────────────────────────────
+> ./pam_authd login socket=${AUTHD_TESTS_CLI_AUTHENTICATE_TESTS_SOCK} force_native_client=true
+== Broker selection (use 'r' to go back) ==
+1 - local
+2 - ExampleBroker
+Select broker: 2
+Insert 'r' to cancel the request and go back
+Gimme your password:
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+────────────────────────────────────────────────────────────────────────────────
+> ./pam_authd login socket=${AUTHD_TESTS_CLI_AUTHENTICATE_TESTS_SOCK} force_native_client=true
+== Broker selection (use 'r' to go back) ==
+1 - local
+2 - ExampleBroker
+Select broker: 2
+Insert 'r' to cancel the request and go back
+Gimme your password:
+PAM Authenticate() for user "user-integration-pre-check-ssh-auth-info" exited with success
+PAM AcctMgmt() exited with success
+>
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+────────────────────────────────────────────────────────────────────────────────
+> ./pam_authd login socket=${AUTHD_TESTS_CLI_AUTHENTICATE_TESTS_SOCK} force_native_client=true
+== Broker selection (use 'r' to go back) ==
+1 - local
+2 - ExampleBroker
+Select broker: 2
+Insert 'r' to cancel the request and go back
+Gimme your password:
+PAM Authenticate() for user "user-integration-pre-check-ssh-auth-info" exited with success
+PAM AcctMgmt() exited with success
+>
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+────────────────────────────────────────────────────────────────────────────────

--- a/pam/integration-tests/testdata/TestNativeAuthenticate/golden/authenticate_user_on_ssh_service_with_custom_name_and_connection_env
+++ b/pam/integration-tests/testdata/TestNativeAuthenticate/golden/authenticate_user_on_ssh_service_with_custom_name_and_connection_env
@@ -1,0 +1,132 @@
+> ./pam_authd login socket=${AUTHD_TESTS_CLI_AUTHENTICATE_TESTS_SOCK} force_native_client=true
+== Broker selection (use 'r' to go back) ==
+1 - local
+2 - ExampleBroker
+Select broker:
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+────────────────────────────────────────────────────────────────────────────────
+> ./pam_authd login socket=${AUTHD_TESTS_CLI_AUTHENTICATE_TESTS_SOCK} force_native_client=true
+== Broker selection (use 'r' to go back) ==
+1 - local
+2 - ExampleBroker
+Select broker: 2
+Insert 'r' to cancel the request and go back
+Gimme your password:
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+────────────────────────────────────────────────────────────────────────────────
+> ./pam_authd login socket=${AUTHD_TESTS_CLI_AUTHENTICATE_TESTS_SOCK} force_native_client=true
+== Broker selection (use 'r' to go back) ==
+1 - local
+2 - ExampleBroker
+Select broker: 2
+Insert 'r' to cancel the request and go back
+Gimme your password:
+PAM Authenticate() for user "user-integration-pre-check-ssh-connection" exited with success
+PAM AcctMgmt() exited with success
+>
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+────────────────────────────────────────────────────────────────────────────────
+> ./pam_authd login socket=${AUTHD_TESTS_CLI_AUTHENTICATE_TESTS_SOCK} force_native_client=true
+== Broker selection (use 'r' to go back) ==
+1 - local
+2 - ExampleBroker
+Select broker: 2
+Insert 'r' to cancel the request and go back
+Gimme your password:
+PAM Authenticate() for user "user-integration-pre-check-ssh-connection" exited with success
+PAM AcctMgmt() exited with success
+>
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+────────────────────────────────────────────────────────────────────────────────

--- a/pam/integration-tests/testdata/TestNativeAuthenticate/golden/exit_if_user_is_not_pre-checked_on_custom_ssh_service_with_auth_info_env
+++ b/pam/integration-tests/testdata/TestNativeAuthenticate/golden/exit_if_user_is_not_pre-checked_on_custom_ssh_service_with_auth_info_env
@@ -1,0 +1,66 @@
+> ./pam_authd login socket=${AUTHD_TESTS_CLI_AUTHENTICATE_TESTS_SOCK} force_native_client=true
+auth=incomplete
+PAM Authenticate() for user "user-integration-ssh-auth-info" exited with error (PAM exit code: 2
+5): The return value should be ignored by PAM dispatch
+PAM AcctMgmt() exited with error (PAM exit code: 26): Critical error - immediate abort
+>
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+────────────────────────────────────────────────────────────────────────────────
+> ./pam_authd login socket=${AUTHD_TESTS_CLI_AUTHENTICATE_TESTS_SOCK} force_native_client=true
+auth=incomplete
+PAM Authenticate() for user "user-integration-ssh-auth-info" exited with error (PAM exit code: 2
+5): The return value should be ignored by PAM dispatch
+PAM AcctMgmt() exited with error (PAM exit code: 26): Critical error - immediate abort
+>
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+────────────────────────────────────────────────────────────────────────────────

--- a/pam/integration-tests/testdata/TestNativeAuthenticate/golden/exit_if_user_is_not_pre-checked_on_custom_ssh_service_with_connection_env
+++ b/pam/integration-tests/testdata/TestNativeAuthenticate/golden/exit_if_user_is_not_pre-checked_on_custom_ssh_service_with_connection_env
@@ -1,0 +1,66 @@
+> ./pam_authd login socket=${AUTHD_TESTS_CLI_AUTHENTICATE_TESTS_SOCK} force_native_client=true
+auth=incomplete
+PAM Authenticate() for user "user-integration-ssh-connection" exited with error (PAM exit code:
+25): The return value should be ignored by PAM dispatch
+PAM AcctMgmt() exited with error (PAM exit code: 26): Critical error - immediate abort
+>
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+────────────────────────────────────────────────────────────────────────────────
+> ./pam_authd login socket=${AUTHD_TESTS_CLI_AUTHENTICATE_TESTS_SOCK} force_native_client=true
+auth=incomplete
+PAM Authenticate() for user "user-integration-ssh-connection" exited with error (PAM exit code:
+25): The return value should be ignored by PAM dispatch
+PAM AcctMgmt() exited with error (PAM exit code: 26): Critical error - immediate abort
+>
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+────────────────────────────────────────────────────────────────────────────────

--- a/pam/integration-tests/testdata/TestNativeAuthenticate/golden/exit_if_user_is_not_pre-checked_on_ssh_service
+++ b/pam/integration-tests/testdata/TestNativeAuthenticate/golden/exit_if_user_is_not_pre-checked_on_ssh_service
@@ -1,0 +1,66 @@
+> ./pam_authd login socket=${AUTHD_TESTS_CLI_AUTHENTICATE_TESTS_SOCK} force_native_client=true
+auth=incomplete
+PAM Authenticate() for user "user-integration-ssh-service" exited with error (PAM exit code: 25)
+: The return value should be ignored by PAM dispatch
+PAM AcctMgmt() exited with error (PAM exit code: 26): Critical error - immediate abort
+>
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+────────────────────────────────────────────────────────────────────────────────
+> ./pam_authd login socket=${AUTHD_TESTS_CLI_AUTHENTICATE_TESTS_SOCK} force_native_client=true
+auth=incomplete
+PAM Authenticate() for user "user-integration-ssh-service" exited with error (PAM exit code: 25)
+: The return value should be ignored by PAM dispatch
+PAM AcctMgmt() exited with error (PAM exit code: 26): Critical error - immediate abort
+>
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+────────────────────────────────────────────────────────────────────────────────

--- a/pam/integration-tests/testdata/tapes/native/local_ssh.tape
+++ b/pam/integration-tests/testdata/tapes/native/local_ssh.tape
@@ -1,0 +1,22 @@
+Output local_ssh.txt
+Output local_ssh.gif # If we don't specify a .gif output, it will create a default out.gif file.
+
+# Configuration header to standardize the output.
+# Does not work with the "Source" command.
+Set Width 800
+Set Height 500
+# TODO: Ideally, we should use Ubuntu Mono. However, the github runner is still on Jammy, which does not have it.
+# We should update this to use Ubuntu Mono once the runner is updated.
+Set FontFamily "Monospace"
+Set FontSize 13
+Set Padding 0
+Set Margin 0
+Set Shell bash
+
+Hide
+Type "./pam_authd login socket=${AUTHD_TESTS_CLI_AUTHENTICATE_TESTS_SOCK} force_native_client=true"
+Enter
+Sleep 1s
+Show
+
+Sleep 300ms

--- a/pam/integration-tests/testdata/tapes/native/simple_ssh_auth.tape
+++ b/pam/integration-tests/testdata/tapes/native/simple_ssh_auth.tape
@@ -1,0 +1,34 @@
+Output simple_ssh_auth.txt
+Output simple_ssh_auth.gif # If we don't specify a .gif output, it will create a default out.gif file.
+
+# Configuration header to standardize the output.
+# Does not work with the "Source" command.
+Set Width 800
+Set Height 500
+# TODO: Ideally, we should use Ubuntu Mono. However, the github runner is still on Jammy, which does not have it.
+# We should update this to use Ubuntu Mono once the runner is updated.
+Set FontFamily "Monospace"
+Set FontSize 13
+Set Padding 0
+Set Margin 0
+Set Shell bash
+
+Hide
+Type "./pam_authd login socket=${AUTHD_TESTS_CLI_AUTHENTICATE_TESTS_SOCK} force_native_client=true"
+Enter
+Sleep 300ms
+Show
+
+Hide
+Type "2"
+Enter
+Sleep 500ms
+Show
+
+Hide
+Type "goodpass"
+Enter
+Sleep 2s
+Show
+
+Sleep 300ms

--- a/pam/internal/adapter/model.go
+++ b/pam/internal/adapter/model.go
@@ -43,6 +43,8 @@ type UIModel struct {
 	PamMTx pam.ModuleTransaction
 	// Client is the [authd.PAMClient] handle used to communicate with authd.
 	Client authd.PAMClient
+	// NssClient is the [authd.NSSClient] handle used to communicate with authd.
+	NssClient authd.NSSClient
 	// PamClientType is the kind of the PAM client we're handling.
 	ClientType PamClientType
 	// SessionMode is the mode of the session invoked by the module.
@@ -108,7 +110,7 @@ func (m *UIModel) Init() tea.Cmd {
 		m.gdmModel = gdmModel{pamMTx: m.PamMTx}
 		cmds = append(cmds, m.gdmModel.Init())
 	case Native:
-		m.nativeModel = nativeModel{pamMTx: m.PamMTx}
+		m.nativeModel = nativeModel{pamMTx: m.PamMTx, nssClient: m.NssClient}
 		cmds = append(cmds, m.nativeModel.Init())
 	}
 

--- a/pam/main-cli.go
+++ b/pam/main-cli.go
@@ -26,6 +26,7 @@ func main() {
 	cliPath := os.Getenv("AUTHD_PAM_CLI_PATH")
 	testName := os.Getenv("AUTHD_PAM_CLI_TEST_NAME")
 	pamUser := os.Getenv("AUTHD_PAM_CLI_USER")
+	pamEnvs := os.Getenv("AUTHD_PAM_CLI_ENVS")
 	pamService := os.Getenv("AUTHD_PAM_CLI_SERVICE")
 
 	tmpDir, err := os.MkdirTemp(os.TempDir(), "pam-cli-tester-")
@@ -96,6 +97,15 @@ func main() {
 	err = tx.PutEnv("AUTHD_PAM_CLI_TEST_NAME=" + testName)
 	if err != nil {
 		log.Fatalf("Impossible to set environment: %v", err)
+	}
+
+	if pamEnvs != "" {
+		for _, env := range strings.Split(pamEnvs, "\n") {
+			err = tx.PutEnv(env)
+			if err != nil {
+				log.Fatalf("Impossible to set environment: %v", err)
+			}
+		}
 	}
 
 	var resultMsg string

--- a/pam/pam.go
+++ b/pam/pam.go
@@ -315,6 +315,10 @@ func (h *pamModule) handleAuthRequest(mode authd.SessionMode, mTx pam.ModuleTran
 		SessionMode: mode,
 	}
 
+	if pamClientType == adapter.Native && isSSHSession(mTx) {
+		appState.NssClient = authd.NewNSSClient(conn)
+	}
+
 	if err := mTx.SetData(authenticationBrokerIDKey, nil); err != nil {
 		return err
 	}
@@ -459,6 +463,25 @@ func getSocketPath(args map[string]string) string {
 		return val
 	}
 	return consts.DefaultSocketPath
+}
+
+func isSSHSession(mTx pam.ModuleTransaction) bool {
+	service, _ := mTx.GetItem(pam.Service)
+	if service == "sshd" {
+		return true
+	}
+
+	envs, err := mTx.GetEnvList()
+	if err != nil {
+		return false
+	}
+	if _, ok := envs["SSH_CONNECTION"]; ok {
+		return true
+	}
+	if _, ok := envs["SSH_AUTH_INFO_0"]; ok {
+		return true
+	}
+	return false
 }
 
 // SetCred is the method that is invoked during pam_setcred request.

--- a/pam/pam.go
+++ b/pam/pam.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"slices"
 	"strings"
+	"time"
 
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/coreos/go-systemd/journal"
@@ -227,9 +228,13 @@ func (h *pamModule) handleAuthRequest(mode authd.SessionMode, mTx pam.ModuleTran
 	var teaOpts []tea.ProgramOption
 
 	closeLogging, err := initLogging(parsedArgs, flags)
-	defer closeLogging()
 	defer func() {
 		log.Debugf(context.TODO(), "%s: exiting with error %v", mode, err)
+
+		// Wait a moment, before resetting as we may still receive bubbletea
+		// events that we could log in the wrong place.
+		<-time.After(time.Millisecond * 30)
+		closeLogging()
 	}()
 	if err != nil {
 		return err


### PR DESCRIPTION
When the PAM module is loaded by SSHd we may not want to expose broker
information to everyone that is connecting, so if the user is not known
by any broker we should just not give the ability to even select the
broker but to just auto-select the local broker instead

UDENG-3600