### PR TITLE
debian: Also insert authd as NSS source on reinstall

### DIFF
--- a/debian/postinst
+++ b/debian/postinst
@@ -32,11 +32,5 @@ action="$1"
 
 if [ configure = "$action" ]; then
     pam-auth-update --package
-
-    if [ -z "$2" ]; then
-        log "First installation detected..."
-        # first install: setup the recommended configuration (unless
-        # nsswitch.conf already contains authd entries)
-        insert_nss_entry
-    fi
+    insert_nss_entry
 fi


### PR DESCRIPTION
The debian/postrm script removes authd as a source from /etc/nsswitch.conf, but the debian/postinst script only added it when the package was installed for the fist time. That led to NSS not using authd as a source when the package was reinstalled.

We now ensure that authd is always added as a source to the `passwd`, `group` and `shadow` databases in /etc/nsswitch.conf when the authd package is installed.

UDENG-3906