### PR TITLE
PAM: Support disabling qrcode rendering

### DIFF
--- a/examplebroker/broker.go
+++ b/examplebroker/broker.go
@@ -359,13 +359,19 @@ func getSupportedModes(sessionInfo sessionInfo, supportedUILayouts []map[string]
 
 		case "qrcode":
 			modeName := "qrcodewithtypo"
+			modeSelectionLabel := "Use a QR code"
 			modeLabel := "Enter the following code after flashing the address: "
 			if layout["code"] != "" {
 				modeName = "qrcodeandcodewithtypo"
 				modeLabel = "Scan the qrcode or enter the code in the login page"
 			}
+			if layout["content"] == "optional" {
+				modeName = "codewithtypo"
+				modeSelectionLabel = "Use a Login code"
+				modeLabel = "Enter the code in the login page"
+			}
 			allModes[modeName] = map[string]string{
-				"selection_label": "Use a QR code",
+				"selection_label": modeSelectionLabel,
 				"ui": mapToJSON(map[string]string{
 					"type":   "qrcode",
 					"label":  modeLabel,
@@ -468,7 +474,7 @@ func (b *Broker) SelectAuthenticationMode(ctx context.Context, sessionID, authen
 		// send request to sessionInfo.allModes[authenticationModeName]["phone"]
 	case "fidodevice1":
 		// start transaction with fido device
-	case "qrcodeandcodewithtypo":
+	case "qrcodeandcodewithtypo", "codewithtypo":
 		uiLayoutInfo["content"], uiLayoutInfo["code"] = qrcodeData(&sessionInfo)
 	case "qrcodewithtypo":
 		// generate the url and finish the prompt on the fly.
@@ -616,7 +622,7 @@ func (b *Broker) handleIsAuthenticated(ctx context.Context, sessionInfo sessionI
 			return AuthCancelled, "", nil
 		}
 
-	case "qrcodewithtypo", "qrcodeandcodewithtypo":
+	case "qrcodewithtypo", "qrcodeandcodewithtypo", "codewithtypo":
 		if authData["wait"] != "true" {
 			return AuthDenied, fmt.Sprintf(`{"message": "%s should have wait set to true"}`, sessionInfo.currentAuthMode), nil
 		}

--- a/pam/integration-tests/cli_test.go
+++ b/pam/integration-tests/cli_test.go
@@ -48,6 +48,7 @@ func TestCLIAuthenticate(t *testing.T) {
 		"Authenticate user with qr code in a TTY session":                      {tape: "qr_code", pamUser: "user-integration-qr-code-tty-session", termEnv: "xterm-256color", sessionEnv: "tty"},
 		"Authenticate user with qr code in screen":                             {tape: "qr_code", pamUser: "user-integration-qr-code-screen", termEnv: "screen"},
 		"Authenticate user with qr code after many regenerations":              {tape: "qr_code_quick_regenerate"},
+		"Authenticate user with login code":                                    {tape: "login_code"},
 		"Authenticate user and reset password while enforcing policy":          {tape: "mandatory_password_reset"},
 		"Authenticate user with mfa and reset password while enforcing policy": {tape: "mfa_reset_pwquality_auth"},
 		"Authenticate user and offer password reset":                           {tape: "optional_password_reset_skip"},

--- a/pam/integration-tests/native_test.go
+++ b/pam/integration-tests/native_test.go
@@ -45,6 +45,7 @@ func TestNativeAuthenticate(t *testing.T) {
 		"Authenticate user with qr code in a TTY session":                      {tape: "qr_code", pamUser: "user-integration-qr-code-tty-session", termEnv: "xterm-256color", sessionEnv: "tty"},
 		"Authenticate user with qr code in screen":                             {tape: "qr_code", pamUser: "user-integration-qr-code-screen", termEnv: "screen"},
 		"Authenticate user with qr code in polkit":                             {tape: "qr_code", pamUser: "user-integration-qr-code-screen", pamServiceName: "polkit-1"},
+		"Authenticate user with login code":                                    {tape: "login_code"},
 		"Authenticate user and reset password while enforcing policy":          {tape: "mandatory_password_reset"},
 		"Authenticate user with mfa and reset password while enforcing policy": {tape: "mfa_reset_pwquality_auth"},
 		"Authenticate user and offer password reset":                           {tape: "optional_password_reset_skip"},

--- a/pam/integration-tests/testdata/TestCLIAuthenticate/golden/authenticate_user_with_login_code
+++ b/pam/integration-tests/testdata/TestCLIAuthenticate/golden/authenticate_user_with_login_code
@@ -135,11 +135,11 @@ rue
   Select your authentication method
 
 > 1. Password authentication
-  2. Send URL to user-integration-login-code@gmail.com
-  3. Use your fido device foo
-  4. Use your phone +33…
-  5. Use your phone +1…
-  6. Use a QR code
+  2. Use a Login code
+  3. Send URL to user-integration-login-code@gmail.com
+  4. Use your fido device foo
+  5. Use your phone +33…
+  6. Use your phone +1…
   7. Authentication code
 
 
@@ -165,7 +165,7 @@ rue
 ────────────────────────────────────────────────────────────────────────────────
 > ./pam_authd login socket=${AUTHD_TESTS_CLI_AUTHENTICATE_TESTS_SOCK} disable_qrcode_rendering=t
 rue
-Scan the qrcode or enter the code in the login page
+Enter the code in the login page
 
 https://ubuntu.com
 1337
@@ -198,7 +198,7 @@ https://ubuntu.com
 ────────────────────────────────────────────────────────────────────────────────
 > ./pam_authd login socket=${AUTHD_TESTS_CLI_AUTHENTICATE_TESTS_SOCK} disable_qrcode_rendering=t
 rue
-Scan the qrcode or enter the code in the login page
+Enter the code in the login page
 
 https://ubuntu.com
 1337
@@ -231,7 +231,7 @@ https://ubuntu.com
 ────────────────────────────────────────────────────────────────────────────────
 > ./pam_authd login socket=${AUTHD_TESTS_CLI_AUTHENTICATE_TESTS_SOCK} disable_qrcode_rendering=t
 rue
-Scan the qrcode or enter the code in the login page
+Enter the code in the login page
 
 https://ubuntu.fr/
 1338
@@ -264,7 +264,7 @@ https://ubuntu.fr/
 ────────────────────────────────────────────────────────────────────────────────
 > ./pam_authd login socket=${AUTHD_TESTS_CLI_AUTHENTICATE_TESTS_SOCK} disable_qrcode_rendering=t
 rue
-Scan the qrcode or enter the code in the login page
+Enter the code in the login page
 
 https://ubuntu.fr/
 1338
@@ -297,7 +297,7 @@ PAM AcctMgmt() exited with success
 ────────────────────────────────────────────────────────────────────────────────
 > ./pam_authd login socket=${AUTHD_TESTS_CLI_AUTHENTICATE_TESTS_SOCK} disable_qrcode_rendering=t
 rue
-Scan the qrcode or enter the code in the login page
+Enter the code in the login page
 
 https://ubuntu.fr/
 1338

--- a/pam/integration-tests/testdata/TestCLIAuthenticate/golden/authenticate_user_with_login_code
+++ b/pam/integration-tests/testdata/TestCLIAuthenticate/golden/authenticate_user_with_login_code
@@ -1,0 +1,330 @@
+> ./pam_authd login socket=${AUTHD_TESTS_CLI_AUTHENTICATE_TESTS_SOCK} disable_qrcode_rendering=t
+rue
+Username: user name
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+────────────────────────────────────────────────────────────────────────────────
+> ./pam_authd login socket=${AUTHD_TESTS_CLI_AUTHENTICATE_TESTS_SOCK} disable_qrcode_rendering=t
+rue
+Username: user-integration-login-code
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+────────────────────────────────────────────────────────────────────────────────
+> ./pam_authd login socket=${AUTHD_TESTS_CLI_AUTHENTICATE_TESTS_SOCK} disable_qrcode_rendering=t
+rue
+  Select your provider
+
+> 1. local
+  2. ExampleBroker
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+────────────────────────────────────────────────────────────────────────────────
+> ./pam_authd login socket=${AUTHD_TESTS_CLI_AUTHENTICATE_TESTS_SOCK} disable_qrcode_rendering=t
+rue
+Gimme your password
+>
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+────────────────────────────────────────────────────────────────────────────────
+> ./pam_authd login socket=${AUTHD_TESTS_CLI_AUTHENTICATE_TESTS_SOCK} disable_qrcode_rendering=t
+rue
+  Select your authentication method
+
+> 1. Password authentication
+  2. Send URL to user-integration-login-code@gmail.com
+  3. Use your fido device foo
+  4. Use your phone +33…
+  5. Use your phone +1…
+  6. Use a QR code
+  7. Authentication code
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+────────────────────────────────────────────────────────────────────────────────
+> ./pam_authd login socket=${AUTHD_TESTS_CLI_AUTHENTICATE_TESTS_SOCK} disable_qrcode_rendering=t
+rue
+Scan the qrcode or enter the code in the login page
+
+https://ubuntu.com
+1337
+
+  [ Regenerate code ]
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+────────────────────────────────────────────────────────────────────────────────
+> ./pam_authd login socket=${AUTHD_TESTS_CLI_AUTHENTICATE_TESTS_SOCK} disable_qrcode_rendering=t
+rue
+Scan the qrcode or enter the code in the login page
+
+https://ubuntu.com
+1337
+
+  [ Regenerate code ]
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+────────────────────────────────────────────────────────────────────────────────
+> ./pam_authd login socket=${AUTHD_TESTS_CLI_AUTHENTICATE_TESTS_SOCK} disable_qrcode_rendering=t
+rue
+Scan the qrcode or enter the code in the login page
+
+https://ubuntu.fr/
+1338
+
+  [ Regenerate code ]
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+────────────────────────────────────────────────────────────────────────────────
+> ./pam_authd login socket=${AUTHD_TESTS_CLI_AUTHENTICATE_TESTS_SOCK} disable_qrcode_rendering=t
+rue
+Scan the qrcode or enter the code in the login page
+
+https://ubuntu.fr/
+1338
+
+PAM Authenticate() for user "user-integration-login-code" exited with success
+PAM AcctMgmt() exited with success
+>
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+────────────────────────────────────────────────────────────────────────────────
+> ./pam_authd login socket=${AUTHD_TESTS_CLI_AUTHENTICATE_TESTS_SOCK} disable_qrcode_rendering=t
+rue
+Scan the qrcode or enter the code in the login page
+
+https://ubuntu.fr/
+1338
+
+PAM Authenticate() for user "user-integration-login-code" exited with success
+PAM AcctMgmt() exited with success
+>
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+────────────────────────────────────────────────────────────────────────────────

--- a/pam/integration-tests/testdata/TestNativeAuthenticate/golden/authenticate_user_with_login_code
+++ b/pam/integration-tests/testdata/TestNativeAuthenticate/golden/authenticate_user_with_login_code
@@ -1,0 +1,910 @@
+> ./pam_authd login socket=${AUTHD_TESTS_CLI_AUTHENTICATE_TESTS_SOCK} force_native_client=true d
+isable_qrcode_rendering=true
+Username:
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+────────────────────────────────────────────────────────────────────────────────
+> ./pam_authd login socket=${AUTHD_TESTS_CLI_AUTHENTICATE_TESTS_SOCK} force_native_client=true d
+isable_qrcode_rendering=true
+Username: user-integration-login-code
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+────────────────────────────────────────────────────────────────────────────────
+> ./pam_authd login socket=${AUTHD_TESTS_CLI_AUTHENTICATE_TESTS_SOCK} force_native_client=true d
+isable_qrcode_rendering=true
+Username: user-integration-login-code
+== Broker selection (use 'r' to go back) ==
+1 - local
+2 - ExampleBroker
+Select broker:
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+────────────────────────────────────────────────────────────────────────────────
+> ./pam_authd login socket=${AUTHD_TESTS_CLI_AUTHENTICATE_TESTS_SOCK} force_native_client=true d
+isable_qrcode_rendering=true
+Username: user-integration-login-code
+== Broker selection (use 'r' to go back) ==
+1 - local
+2 - ExampleBroker
+Select broker: 2
+Insert 'r' to cancel the request and go back
+Gimme your password:
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+────────────────────────────────────────────────────────────────────────────────
+> ./pam_authd login socket=${AUTHD_TESTS_CLI_AUTHENTICATE_TESTS_SOCK} force_native_client=true d
+isable_qrcode_rendering=true
+Username: user-integration-login-code
+== Broker selection (use 'r' to go back) ==
+1 - local
+2 - ExampleBroker
+Select broker: 2
+Insert 'r' to cancel the request and go back
+Gimme your password:
+== Authentication mode selection (use 'r' to go back) ==
+1 - Password authentication
+2 - Use a Login code
+3 - Send URL to user-integration-login-code@gmail.com
+4 - Use your fido device foo
+5 - Use your phone +33…
+6 - Use your phone +1…
+7 - Pin code
+8 - Authentication code
+Select authentication mode:
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+────────────────────────────────────────────────────────────────────────────────
+> ./pam_authd login socket=${AUTHD_TESTS_CLI_AUTHENTICATE_TESTS_SOCK} force_native_client=true d
+isable_qrcode_rendering=true
+Username: user-integration-login-code
+== Broker selection (use 'r' to go back) ==
+1 - local
+2 - ExampleBroker
+Select broker: 2
+Insert 'r' to cancel the request and go back
+Gimme your password:
+== Authentication mode selection (use 'r' to go back) ==
+1 - Password authentication
+2 - Use a Login code
+3 - Send URL to user-integration-login-code@gmail.com
+4 - Use your fido device foo
+5 - Use your phone +33…
+6 - Use your phone +1…
+7 - Pin code
+8 - Authentication code
+Select authentication mode: 2
+Enter the code in the login page
+https://ubuntu.com
+       1337
+
+== Login Code authentication (use 'r' to go back) ==
+1 - Wait for the login code result
+2 - Regenerate code
+Select action:
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+────────────────────────────────────────────────────────────────────────────────
+> ./pam_authd login socket=${AUTHD_TESTS_CLI_AUTHENTICATE_TESTS_SOCK} force_native_client=true d
+isable_qrcode_rendering=true
+Username: user-integration-login-code
+== Broker selection (use 'r' to go back) ==
+1 - local
+2 - ExampleBroker
+Select broker: 2
+Insert 'r' to cancel the request and go back
+Gimme your password:
+== Authentication mode selection (use 'r' to go back) ==
+1 - Password authentication
+2 - Use a Login code
+3 - Send URL to user-integration-login-code@gmail.com
+4 - Use your fido device foo
+5 - Use your phone +33…
+6 - Use your phone +1…
+7 - Pin code
+8 - Authentication code
+Select authentication mode: 2
+Enter the code in the login page
+https://ubuntu.com
+       1337
+
+== Login Code authentication (use 'r' to go back) ==
+1 - Wait for the login code result
+2 - Regenerate code
+Select action: 2
+Enter the code in the login page
+https://ubuntu.fr/
+       1338
+
+== Login Code authentication (use 'r' to go back) ==
+1 - Wait for the login code result
+2 - Regenerate code
+Select action:
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+────────────────────────────────────────────────────────────────────────────────
+> ./pam_authd login socket=${AUTHD_TESTS_CLI_AUTHENTICATE_TESTS_SOCK} force_native_client=true d
+isable_qrcode_rendering=true
+Username: user-integration-login-code
+== Broker selection (use 'r' to go back) ==
+1 - local
+2 - ExampleBroker
+Select broker: 2
+Insert 'r' to cancel the request and go back
+Gimme your password:
+== Authentication mode selection (use 'r' to go back) ==
+1 - Password authentication
+2 - Use a Login code
+3 - Send URL to user-integration-login-code@gmail.com
+4 - Use your fido device foo
+5 - Use your phone +33…
+6 - Use your phone +1…
+7 - Pin code
+8 - Authentication code
+Select authentication mode: 2
+Enter the code in the login page
+https://ubuntu.com
+       1337
+
+== Login Code authentication (use 'r' to go back) ==
+1 - Wait for the login code result
+2 - Regenerate code
+Select action: 2
+Enter the code in the login page
+https://ubuntu.fr/
+       1338
+
+== Login Code authentication (use 'r' to go back) ==
+1 - Wait for the login code result
+2 - Regenerate code
+Select action: 2
+Enter the code in the login page
+https://ubuntuforum-br.org/
+           1339
+
+== Login Code authentication (use 'r' to go back) ==
+1 - Wait for the login code result
+2 - Regenerate code
+Select action:
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+────────────────────────────────────────────────────────────────────────────────
+> ./pam_authd login socket=${AUTHD_TESTS_CLI_AUTHENTICATE_TESTS_SOCK} force_native_client=true d
+isable_qrcode_rendering=true
+Username: user-integration-login-code
+== Broker selection (use 'r' to go back) ==
+1 - local
+2 - ExampleBroker
+Select broker: 2
+Insert 'r' to cancel the request and go back
+Gimme your password:
+== Authentication mode selection (use 'r' to go back) ==
+1 - Password authentication
+2 - Use a Login code
+3 - Send URL to user-integration-login-code@gmail.com
+4 - Use your fido device foo
+5 - Use your phone +33…
+6 - Use your phone +1…
+7 - Pin code
+8 - Authentication code
+Select authentication mode: 2
+Enter the code in the login page
+https://ubuntu.com
+       1337
+
+== Login Code authentication (use 'r' to go back) ==
+1 - Wait for the login code result
+2 - Regenerate code
+Select action: 2
+Enter the code in the login page
+https://ubuntu.fr/
+       1338
+
+== Login Code authentication (use 'r' to go back) ==
+1 - Wait for the login code result
+2 - Regenerate code
+Select action: 2
+Enter the code in the login page
+https://ubuntuforum-br.org/
+           1339
+
+== Login Code authentication (use 'r' to go back) ==
+1 - Wait for the login code result
+2 - Regenerate code
+Select action: 2
+Enter the code in the login page
+https://www.ubuntu-it.org/
+           1340
+
+== Login Code authentication (use 'r' to go back) ==
+1 - Wait for the login code result
+2 - Regenerate code
+Select action:
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+────────────────────────────────────────────────────────────────────────────────
+> ./pam_authd login socket=${AUTHD_TESTS_CLI_AUTHENTICATE_TESTS_SOCK} force_native_client=true d
+isable_qrcode_rendering=true
+Username: user-integration-login-code
+== Broker selection (use 'r' to go back) ==
+1 - local
+2 - ExampleBroker
+Select broker: 2
+Insert 'r' to cancel the request and go back
+Gimme your password:
+== Authentication mode selection (use 'r' to go back) ==
+1 - Password authentication
+2 - Use a Login code
+3 - Send URL to user-integration-login-code@gmail.com
+4 - Use your fido device foo
+5 - Use your phone +33…
+6 - Use your phone +1…
+7 - Pin code
+8 - Authentication code
+Select authentication mode: 2
+Enter the code in the login page
+https://ubuntu.com
+       1337
+
+== Login Code authentication (use 'r' to go back) ==
+1 - Wait for the login code result
+2 - Regenerate code
+Select action: 2
+Enter the code in the login page
+https://ubuntu.fr/
+       1338
+
+== Login Code authentication (use 'r' to go back) ==
+1 - Wait for the login code result
+2 - Regenerate code
+Select action: 2
+Enter the code in the login page
+https://ubuntuforum-br.org/
+           1339
+
+== Login Code authentication (use 'r' to go back) ==
+1 - Wait for the login code result
+2 - Regenerate code
+Select action: 2
+Enter the code in the login page
+https://www.ubuntu-it.org/
+           1340
+
+== Login Code authentication (use 'r' to go back) ==
+1 - Wait for the login code result
+2 - Regenerate code
+Select action: 2
+Enter the code in the login page
+https://ubuntu.com
+       1341
+
+== Login Code authentication (use 'r' to go back) ==
+1 - Wait for the login code result
+2 - Regenerate code
+Select action:
+
+
+
+
+
+
+
+
+
+
+────────────────────────────────────────────────────────────────────────────────
+> ./pam_authd login socket=${AUTHD_TESTS_CLI_AUTHENTICATE_TESTS_SOCK} force_native_client=true d
+isable_qrcode_rendering=true
+Username: user-integration-login-code
+== Broker selection (use 'r' to go back) ==
+1 - local
+2 - ExampleBroker
+Select broker: 2
+Insert 'r' to cancel the request and go back
+Gimme your password:
+== Authentication mode selection (use 'r' to go back) ==
+1 - Password authentication
+2 - Use a Login code
+3 - Send URL to user-integration-login-code@gmail.com
+4 - Use your fido device foo
+5 - Use your phone +33…
+6 - Use your phone +1…
+7 - Pin code
+8 - Authentication code
+Select authentication mode: 2
+Enter the code in the login page
+https://ubuntu.com
+       1337
+
+== Login Code authentication (use 'r' to go back) ==
+1 - Wait for the login code result
+2 - Regenerate code
+Select action: 2
+Enter the code in the login page
+https://ubuntu.fr/
+       1338
+
+== Login Code authentication (use 'r' to go back) ==
+1 - Wait for the login code result
+2 - Regenerate code
+Select action: 2
+Enter the code in the login page
+https://ubuntuforum-br.org/
+           1339
+
+== Login Code authentication (use 'r' to go back) ==
+1 - Wait for the login code result
+2 - Regenerate code
+Select action: 2
+Enter the code in the login page
+https://www.ubuntu-it.org/
+           1340
+
+== Login Code authentication (use 'r' to go back) ==
+1 - Wait for the login code result
+2 - Regenerate code
+Select action: 2
+Enter the code in the login page
+https://ubuntu.com
+       1341
+
+== Login Code authentication (use 'r' to go back) ==
+1 - Wait for the login code result
+2 - Regenerate code
+Select action: 1
+
+
+
+
+
+
+
+
+
+
+────────────────────────────────────────────────────────────────────────────────
+> ./pam_authd login socket=${AUTHD_TESTS_CLI_AUTHENTICATE_TESTS_SOCK} force_native_client=true d
+isable_qrcode_rendering=true
+Username: user-integration-login-code
+== Broker selection (use 'r' to go back) ==
+1 - local
+2 - ExampleBroker
+Select broker: 2
+Insert 'r' to cancel the request and go back
+Gimme your password:
+== Authentication mode selection (use 'r' to go back) ==
+1 - Password authentication
+2 - Use a Login code
+3 - Send URL to user-integration-login-code@gmail.com
+4 - Use your fido device foo
+5 - Use your phone +33…
+6 - Use your phone +1…
+7 - Pin code
+8 - Authentication code
+Select authentication mode: 2
+Enter the code in the login page
+https://ubuntu.com
+       1337
+
+== Login Code authentication (use 'r' to go back) ==
+1 - Wait for the login code result
+2 - Regenerate code
+Select action: 2
+Enter the code in the login page
+https://ubuntu.fr/
+       1338
+
+== Login Code authentication (use 'r' to go back) ==
+1 - Wait for the login code result
+2 - Regenerate code
+Select action: 2
+Enter the code in the login page
+https://ubuntuforum-br.org/
+           1339
+
+== Login Code authentication (use 'r' to go back) ==
+1 - Wait for the login code result
+2 - Regenerate code
+Select action: 2
+Enter the code in the login page
+https://www.ubuntu-it.org/
+           1340
+
+== Login Code authentication (use 'r' to go back) ==
+1 - Wait for the login code result
+2 - Regenerate code
+Select action: 2
+Enter the code in the login page
+https://ubuntu.com
+       1341
+
+== Login Code authentication (use 'r' to go back) ==
+1 - Wait for the login code result
+2 - Regenerate code
+Select action: 1
+PAM Authenticate() for user "user-integration-login-code" exited with success
+PAM AcctMgmt() exited with success
+>
+
+
+
+
+
+
+
+────────────────────────────────────────────────────────────────────────────────
+> ./pam_authd login socket=${AUTHD_TESTS_CLI_AUTHENTICATE_TESTS_SOCK} force_native_client=true d
+isable_qrcode_rendering=true
+Username: user-integration-login-code
+== Broker selection (use 'r' to go back) ==
+1 - local
+2 - ExampleBroker
+Select broker: 2
+Insert 'r' to cancel the request and go back
+Gimme your password:
+== Authentication mode selection (use 'r' to go back) ==
+1 - Password authentication
+2 - Use a Login code
+3 - Send URL to user-integration-login-code@gmail.com
+4 - Use your fido device foo
+5 - Use your phone +33…
+6 - Use your phone +1…
+7 - Pin code
+8 - Authentication code
+Select authentication mode: 2
+Enter the code in the login page
+https://ubuntu.com
+       1337
+
+== Login Code authentication (use 'r' to go back) ==
+1 - Wait for the login code result
+2 - Regenerate code
+Select action: 2
+Enter the code in the login page
+https://ubuntu.fr/
+       1338
+
+== Login Code authentication (use 'r' to go back) ==
+1 - Wait for the login code result
+2 - Regenerate code
+Select action: 2
+Enter the code in the login page
+https://ubuntuforum-br.org/
+           1339
+
+== Login Code authentication (use 'r' to go back) ==
+1 - Wait for the login code result
+2 - Regenerate code
+Select action: 2
+Enter the code in the login page
+https://www.ubuntu-it.org/
+           1340
+
+== Login Code authentication (use 'r' to go back) ==
+1 - Wait for the login code result
+2 - Regenerate code
+Select action: 2
+Enter the code in the login page
+https://ubuntu.com
+       1341
+
+== Login Code authentication (use 'r' to go back) ==
+1 - Wait for the login code result
+2 - Regenerate code
+Select action: 1
+PAM Authenticate() for user "user-integration-login-code" exited with success
+PAM AcctMgmt() exited with success
+>
+
+
+
+
+
+
+
+────────────────────────────────────────────────────────────────────────────────

--- a/pam/integration-tests/testdata/TestNativeAuthenticate/golden/authenticate_user_with_qr_code_in_polkit
+++ b/pam/integration-tests/testdata/TestNativeAuthenticate/golden/authenticate_user_with_qr_code_in_polkit
@@ -718,8 +718,8 @@ Scan the qrcode or enter the code in the login page
 https://ubuntu.com
        1337
 
-== Qr Code authentication (use 'r' to go back) ==
-1 - Wait for the QR code scan result
+== Login Code authentication (use 'r' to go back) ==
+1 - Wait for the login code result
 2 - Regenerate code
 Select action:
 
@@ -951,16 +951,16 @@ Scan the qrcode or enter the code in the login page
 https://ubuntu.com
        1337
 
-== Qr Code authentication (use 'r' to go back) ==
-1 - Wait for the QR code scan result
+== Login Code authentication (use 'r' to go back) ==
+1 - Wait for the login code result
 2 - Regenerate code
 Select action: 2
 Scan the qrcode or enter the code in the login page
 https://ubuntu.fr/
        1338
 
-== Qr Code authentication (use 'r' to go back) ==
-1 - Wait for the QR code scan result
+== Login Code authentication (use 'r' to go back) ==
+1 - Wait for the login code result
 2 - Regenerate code
 Select action:
 
@@ -1184,24 +1184,24 @@ Scan the qrcode or enter the code in the login page
 https://ubuntu.com
        1337
 
-== Qr Code authentication (use 'r' to go back) ==
-1 - Wait for the QR code scan result
+== Login Code authentication (use 'r' to go back) ==
+1 - Wait for the login code result
 2 - Regenerate code
 Select action: 2
 Scan the qrcode or enter the code in the login page
 https://ubuntu.fr/
        1338
 
-== Qr Code authentication (use 'r' to go back) ==
-1 - Wait for the QR code scan result
+== Login Code authentication (use 'r' to go back) ==
+1 - Wait for the login code result
 2 - Regenerate code
 Select action: 2
 Scan the qrcode or enter the code in the login page
 https://ubuntuforum-br.org/
            1339
 
-== Qr Code authentication (use 'r' to go back) ==
-1 - Wait for the QR code scan result
+== Login Code authentication (use 'r' to go back) ==
+1 - Wait for the login code result
 2 - Regenerate code
 Select action:
 
@@ -1417,32 +1417,32 @@ Scan the qrcode or enter the code in the login page
 https://ubuntu.com
        1337
 
-== Qr Code authentication (use 'r' to go back) ==
-1 - Wait for the QR code scan result
+== Login Code authentication (use 'r' to go back) ==
+1 - Wait for the login code result
 2 - Regenerate code
 Select action: 2
 Scan the qrcode or enter the code in the login page
 https://ubuntu.fr/
        1338
 
-== Qr Code authentication (use 'r' to go back) ==
-1 - Wait for the QR code scan result
+== Login Code authentication (use 'r' to go back) ==
+1 - Wait for the login code result
 2 - Regenerate code
 Select action: 2
 Scan the qrcode or enter the code in the login page
 https://ubuntuforum-br.org/
            1339
 
-== Qr Code authentication (use 'r' to go back) ==
-1 - Wait for the QR code scan result
+== Login Code authentication (use 'r' to go back) ==
+1 - Wait for the login code result
 2 - Regenerate code
 Select action: 2
 Scan the qrcode or enter the code in the login page
 https://www.ubuntu-it.org/
            1340
 
-== Qr Code authentication (use 'r' to go back) ==
-1 - Wait for the QR code scan result
+== Login Code authentication (use 'r' to go back) ==
+1 - Wait for the login code result
 2 - Regenerate code
 Select action:
 
@@ -1650,40 +1650,40 @@ Scan the qrcode or enter the code in the login page
 https://ubuntu.com
        1337
 
-== Qr Code authentication (use 'r' to go back) ==
-1 - Wait for the QR code scan result
+== Login Code authentication (use 'r' to go back) ==
+1 - Wait for the login code result
 2 - Regenerate code
 Select action: 2
 Scan the qrcode or enter the code in the login page
 https://ubuntu.fr/
        1338
 
-== Qr Code authentication (use 'r' to go back) ==
-1 - Wait for the QR code scan result
+== Login Code authentication (use 'r' to go back) ==
+1 - Wait for the login code result
 2 - Regenerate code
 Select action: 2
 Scan the qrcode or enter the code in the login page
 https://ubuntuforum-br.org/
            1339
 
-== Qr Code authentication (use 'r' to go back) ==
-1 - Wait for the QR code scan result
+== Login Code authentication (use 'r' to go back) ==
+1 - Wait for the login code result
 2 - Regenerate code
 Select action: 2
 Scan the qrcode or enter the code in the login page
 https://www.ubuntu-it.org/
            1340
 
-== Qr Code authentication (use 'r' to go back) ==
-1 - Wait for the QR code scan result
+== Login Code authentication (use 'r' to go back) ==
+1 - Wait for the login code result
 2 - Regenerate code
 Select action: 2
 Scan the qrcode or enter the code in the login page
 https://ubuntu.com
        1341
 
-== Qr Code authentication (use 'r' to go back) ==
-1 - Wait for the QR code scan result
+== Login Code authentication (use 'r' to go back) ==
+1 - Wait for the login code result
 2 - Regenerate code
 Select action:
 
@@ -1883,40 +1883,40 @@ Scan the qrcode or enter the code in the login page
 https://ubuntu.com
        1337
 
-== Qr Code authentication (use 'r' to go back) ==
-1 - Wait for the QR code scan result
+== Login Code authentication (use 'r' to go back) ==
+1 - Wait for the login code result
 2 - Regenerate code
 Select action: 2
 Scan the qrcode or enter the code in the login page
 https://ubuntu.fr/
        1338
 
-== Qr Code authentication (use 'r' to go back) ==
-1 - Wait for the QR code scan result
+== Login Code authentication (use 'r' to go back) ==
+1 - Wait for the login code result
 2 - Regenerate code
 Select action: 2
 Scan the qrcode or enter the code in the login page
 https://ubuntuforum-br.org/
            1339
 
-== Qr Code authentication (use 'r' to go back) ==
-1 - Wait for the QR code scan result
+== Login Code authentication (use 'r' to go back) ==
+1 - Wait for the login code result
 2 - Regenerate code
 Select action: 2
 Scan the qrcode or enter the code in the login page
 https://www.ubuntu-it.org/
            1340
 
-== Qr Code authentication (use 'r' to go back) ==
-1 - Wait for the QR code scan result
+== Login Code authentication (use 'r' to go back) ==
+1 - Wait for the login code result
 2 - Regenerate code
 Select action: 2
 Scan the qrcode or enter the code in the login page
 https://ubuntu.com
        1341
 
-== Qr Code authentication (use 'r' to go back) ==
-1 - Wait for the QR code scan result
+== Login Code authentication (use 'r' to go back) ==
+1 - Wait for the login code result
 2 - Regenerate code
 Select action: 1
 
@@ -2116,40 +2116,40 @@ Scan the qrcode or enter the code in the login page
 https://ubuntu.com
        1337
 
-== Qr Code authentication (use 'r' to go back) ==
-1 - Wait for the QR code scan result
+== Login Code authentication (use 'r' to go back) ==
+1 - Wait for the login code result
 2 - Regenerate code
 Select action: 2
 Scan the qrcode or enter the code in the login page
 https://ubuntu.fr/
        1338
 
-== Qr Code authentication (use 'r' to go back) ==
-1 - Wait for the QR code scan result
+== Login Code authentication (use 'r' to go back) ==
+1 - Wait for the login code result
 2 - Regenerate code
 Select action: 2
 Scan the qrcode or enter the code in the login page
 https://ubuntuforum-br.org/
            1339
 
-== Qr Code authentication (use 'r' to go back) ==
-1 - Wait for the QR code scan result
+== Login Code authentication (use 'r' to go back) ==
+1 - Wait for the login code result
 2 - Regenerate code
 Select action: 2
 Scan the qrcode or enter the code in the login page
 https://www.ubuntu-it.org/
            1340
 
-== Qr Code authentication (use 'r' to go back) ==
-1 - Wait for the QR code scan result
+== Login Code authentication (use 'r' to go back) ==
+1 - Wait for the login code result
 2 - Regenerate code
 Select action: 2
 Scan the qrcode or enter the code in the login page
 https://ubuntu.com
        1341
 
-== Qr Code authentication (use 'r' to go back) ==
-1 - Wait for the QR code scan result
+== Login Code authentication (use 'r' to go back) ==
+1 - Wait for the login code result
 2 - Regenerate code
 Select action: 1
 PAM Authenticate() for user "user-integration-qr-code-screen" exited with success
@@ -2349,40 +2349,40 @@ Scan the qrcode or enter the code in the login page
 https://ubuntu.com
        1337
 
-== Qr Code authentication (use 'r' to go back) ==
-1 - Wait for the QR code scan result
+== Login Code authentication (use 'r' to go back) ==
+1 - Wait for the login code result
 2 - Regenerate code
 Select action: 2
 Scan the qrcode or enter the code in the login page
 https://ubuntu.fr/
        1338
 
-== Qr Code authentication (use 'r' to go back) ==
-1 - Wait for the QR code scan result
+== Login Code authentication (use 'r' to go back) ==
+1 - Wait for the login code result
 2 - Regenerate code
 Select action: 2
 Scan the qrcode or enter the code in the login page
 https://ubuntuforum-br.org/
            1339
 
-== Qr Code authentication (use 'r' to go back) ==
-1 - Wait for the QR code scan result
+== Login Code authentication (use 'r' to go back) ==
+1 - Wait for the login code result
 2 - Regenerate code
 Select action: 2
 Scan the qrcode or enter the code in the login page
 https://www.ubuntu-it.org/
            1340
 
-== Qr Code authentication (use 'r' to go back) ==
-1 - Wait for the QR code scan result
+== Login Code authentication (use 'r' to go back) ==
+1 - Wait for the login code result
 2 - Regenerate code
 Select action: 2
 Scan the qrcode or enter the code in the login page
 https://ubuntu.com
        1341
 
-== Qr Code authentication (use 'r' to go back) ==
-1 - Wait for the QR code scan result
+== Login Code authentication (use 'r' to go back) ==
+1 - Wait for the login code result
 2 - Regenerate code
 Select action: 1
 PAM Authenticate() for user "user-integration-qr-code-screen" exited with success

--- a/pam/integration-tests/testdata/tapes/cli/login_code.tape
+++ b/pam/integration-tests/testdata/tapes/cli/login_code.tape
@@ -42,7 +42,7 @@ Sleep 300ms
 Show
 
 Hide
-Type "6"
+Type "2"
 Sleep 300ms
 Show
 

--- a/pam/integration-tests/testdata/tapes/cli/login_code.tape
+++ b/pam/integration-tests/testdata/tapes/cli/login_code.tape
@@ -1,0 +1,63 @@
+Output login_code.txt
+Output login_code.gif # If we don't specify a .gif output, it will create a default out.gif file.
+
+# Configuration header to standardize the output.
+# Does not work with the "Source" command.
+Set Width 800
+Set Height 500
+# TODO: Ideally, we should use Ubuntu Mono. However, the github runner is still on Jammy, which does not have it.
+# We should update this to use Ubuntu Mono once the runner is updated.
+Set FontFamily "Monospace"
+Set FontSize 13
+Set Padding 0
+Set Margin 0
+Set Shell bash
+
+Hide
+Type "./pam_authd login socket=${AUTHD_TESTS_CLI_AUTHENTICATE_TESTS_SOCK} disable_qrcode_rendering=true"
+Enter
+Sleep 300ms
+Show
+
+Hide
+Escape
+Backspace
+Type "user-integration-login-code"
+Sleep 300ms
+Show
+
+Hide
+Enter
+Sleep 300ms
+Show
+
+Hide
+Type "2"
+Sleep 300ms
+Show
+
+Hide
+Escape
+Sleep 300ms
+Show
+
+Hide
+Type "6"
+Sleep 300ms
+Show
+
+Hide
+Tab
+Sleep 300ms
+Show
+
+Hide
+Enter
+Sleep 1s
+Show
+
+Hide
+Sleep 5s
+Show
+
+Sleep 300ms

--- a/pam/integration-tests/testdata/tapes/native/login_code.tape
+++ b/pam/integration-tests/testdata/tapes/native/login_code.tape
@@ -1,0 +1,86 @@
+Output login_code.txt
+Output login_code.gif # If we don't specify a .gif output, it will create a default out.gif file.
+
+# Configuration header to standardize the output.
+# Does not work with the "Source" command.
+Set Width 800
+# We need high terminal view, as vhs doesn't scroll:
+#  https://github.com/charmbracelet/vhs/issues/404
+Set Height 1050
+# TODO: Ideally, we should use Ubuntu Mono. However, the github runner is still on Jammy, which does not have it.
+# We should update this to use Ubuntu Mono once the runner is updated.
+Set FontFamily "Monospace"
+Set FontSize 13
+Set Padding 0
+Set Margin 0
+Set Shell bash
+
+Hide
+Type "./pam_authd login socket=${AUTHD_TESTS_CLI_AUTHENTICATE_TESTS_SOCK} force_native_client=true disable_qrcode_rendering=true"
+Enter
+Sleep 300ms
+Show
+
+Hide
+Type "user-integration-login-code"
+Sleep 300ms
+Show
+
+Hide
+Enter
+Sleep 300ms
+Show
+
+Hide
+Type "2"
+Enter
+Sleep 500ms
+Show
+
+Hide
+Type "r"
+Enter
+Sleep 300ms
+Show
+
+Hide
+Type "2"
+Enter
+Sleep 300ms
+Show
+
+Hide
+Type "2"
+Enter
+Sleep 500ms
+Show
+
+Hide
+Type "2"
+Enter
+Sleep 500ms
+Show
+
+Hide
+Type "2"
+Enter
+Sleep 500ms
+Show
+
+Hide
+Type "2"
+Enter
+Sleep 500ms
+Show
+
+Hide
+Type "1"
+Enter
+Sleep 300ms
+Show
+
+Hide
+Sleep 3s
+Show
+
+Sleep 300ms

--- a/pam/internal/adapter/authentication.go
+++ b/pam/internal/adapter/authentication.go
@@ -370,7 +370,8 @@ func (m *authenticationModel) Blur() {
 
 // Compose initialize the authentication model to be used.
 // It creates and attaches the sub layout models based on UILayout.
-func (m *authenticationModel) Compose(brokerID, sessionID string, encryptionKey *rsa.PublicKey, layout *authd.UILayout) tea.Cmd {
+func (m *authenticationModel) Compose(brokerID, sessionID string,
+	encryptionKey *rsa.PublicKey, disableQrCodeRendering bool, layout *authd.UILayout) tea.Cmd {
 	m.currentBrokerID = brokerID
 	m.currentSessionID = sessionID
 	m.encryptionKey = encryptionKey
@@ -389,8 +390,9 @@ func (m *authenticationModel) Compose(brokerID, sessionID string, encryptionKey 
 		m.currentModel = form
 
 	case "qrcode":
-		qrcodeModel, err := newQRCodeModel(layout.GetContent(), layout.GetCode(),
-			layout.GetLabel(), layout.GetButton(), layout.GetWait() == "true")
+		qrcodeModel, err := newQRCodeModel(disableQrCodeRendering,
+			layout.GetContent(), layout.GetCode(), layout.GetLabel(),
+			layout.GetButton(), layout.GetWait() == "true")
 		if err != nil {
 			return sendEvent(pamError{status: pam.ErrSystem, msg: err.Error()})
 		}

--- a/pam/internal/adapter/authentication.go
+++ b/pam/internal/adapter/authentication.go
@@ -390,13 +390,9 @@ func (m *authenticationModel) Compose(brokerID, sessionID string,
 		m.currentModel = form
 
 	case "qrcode":
-		qrcodeModel, err := newQRCodeModel(disableQrCodeRendering,
+		m.currentModel = newQRCodeModel(disableQrCodeRendering,
 			layout.GetContent(), layout.GetCode(), layout.GetLabel(),
 			layout.GetButton(), layout.GetWait() == "true")
-		if err != nil {
-			return sendEvent(pamError{status: pam.ErrSystem, msg: err.Error()})
-		}
-		m.currentModel = qrcodeModel
 
 	case "newpassword":
 		newPasswordModel := newNewPasswordModel(layout.GetLabel(), layout.GetEntry(), layout.GetButton())

--- a/pam/internal/adapter/model.go
+++ b/pam/internal/adapter/model.go
@@ -49,6 +49,8 @@ type UIModel struct {
 	ClientType PamClientType
 	// SessionMode is the mode of the session invoked by the module.
 	SessionMode authd.SessionMode
+	// DisableQrCodeRendering is the flag to disable qrcode rendering
+	DisableQrCodeRendering bool
 
 	sessionStartingForBroker string
 	currentSession           *sessionInfo
@@ -272,6 +274,7 @@ func (m *UIModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				m.currentSession.brokerID,
 				m.currentSession.sessionID,
 				m.currentSession.encryptionKey,
+				m.DisableQrCodeRendering,
 				msg.layout,
 			),
 			modelCmd,

--- a/pam/internal/adapter/model.go
+++ b/pam/internal/adapter/model.go
@@ -112,7 +112,11 @@ func (m *UIModel) Init() tea.Cmd {
 		m.gdmModel = gdmModel{pamMTx: m.PamMTx}
 		cmds = append(cmds, m.gdmModel.Init())
 	case Native:
-		m.nativeModel = nativeModel{pamMTx: m.PamMTx, nssClient: m.NssClient}
+		m.nativeModel = nativeModel{
+			pamMTx:                 m.PamMTx,
+			nssClient:              m.NssClient,
+			disableQrCodeRendering: m.DisableQrCodeRendering,
+		}
 		cmds = append(cmds, m.nativeModel.Init())
 	}
 

--- a/pam/internal/adapter/model.go
+++ b/pam/internal/adapter/model.go
@@ -122,7 +122,7 @@ func (m *UIModel) Init() tea.Cmd {
 	m.brokerSelectionModel = newBrokerSelectionModel(m.Client, m.ClientType)
 	cmds = append(cmds, m.brokerSelectionModel.Init())
 
-	m.authModeSelectionModel = newAuthModeSelectionModel(m.ClientType)
+	m.authModeSelectionModel = newAuthModeSelectionModel(m.ClientType, m.DisableQrCodeRendering)
 	cmds = append(cmds, m.authModeSelectionModel.Init())
 
 	m.authenticationModel = newAuthenticationModel(m.Client, m.ClientType)

--- a/pam/internal/adapter/nativemodel.go
+++ b/pam/internal/adapter/nativemodel.go
@@ -24,6 +24,8 @@ type nativeModel struct {
 	pamMTx    pam.ModuleTransaction
 	nssClient authd.NSSClient
 
+	disableQrCodeRendering bool
+
 	availableBrokers []*authd.ABResponse_BrokerInfo
 	authModes        []*authd.GAMResponse_AuthenticationMode
 	selectedAuthMode string
@@ -81,6 +83,11 @@ func (m *nativeModel) Init() tea.Cmd {
 		requiredWithBooleans := "required:true,false"
 		optionalWithBooleans := "optional:true,false"
 
+		qrcodeContentSupportMode := required
+		if m.disableQrCodeRendering {
+			qrcodeContentSupportMode = optional
+		}
+
 		return supportedUILayoutsReceived{
 			layouts: []*authd.UILayout{
 				{
@@ -92,7 +99,7 @@ func (m *nativeModel) Init() tea.Cmd {
 				},
 				{
 					Type:    "qrcode",
-					Content: &required,
+					Content: &qrcodeContentSupportMode,
 					Code:    &optional,
 					Wait:    &requiredWithBooleans,
 					Label:   &optional,
@@ -694,6 +701,9 @@ func (m nativeModel) handleQrCode() tea.Cmd {
 }
 
 func (m nativeModel) isQrcodeRenderingSupported() bool {
+	if m.disableQrCodeRendering {
+		return false
+	}
 	switch m.serviceName {
 	case polkitServiceName:
 		return false

--- a/pam/internal/adapter/nativemodel.go
+++ b/pam/internal/adapter/nativemodel.go
@@ -659,14 +659,20 @@ func (m nativeModel) handleQrCode() tea.Cmd {
 		return cmd
 	}
 
+	authLabel := "Qr Code authentication"
+	choiceLabel := "Wait for the QR code scan result"
+	if !m.isQrcodeRenderingSupported() {
+		authLabel = "Login Code authentication"
+		choiceLabel = "Wait for the login code result"
+	}
 	choices := []choicePair{
-		{id: "wait", label: "Wait for the QR code scan result"},
+		{id: "wait", label: choiceLabel},
 	}
 	if buttonLabel := m.uiLayout.GetButton(); buttonLabel != "" {
 		choices = append(choices, choicePair{id: "button", label: buttonLabel})
 	}
 
-	id, err := m.promptForChoice("Qr Code authentication", choices, "Select action")
+	id, err := m.promptForChoice(authLabel, choices, "Select action")
 	if errors.Is(err, errGoBack) {
 		return sendEvent(nativeGoBack{})
 	}

--- a/pam/internal/adapter/qrcodemodel.go
+++ b/pam/internal/adapter/qrcodemodel.go
@@ -28,7 +28,7 @@ type qrcodeModel struct {
 }
 
 // newQRCodeModel initializes and return a new qrcodeModel.
-func newQRCodeModel(disableRendering bool, content, code, label, buttonLabel string, wait bool) (qrcodeModel, error) {
+func newQRCodeModel(disableRendering bool, content, code, label, buttonLabel string, wait bool) qrcodeModel {
 	var button *buttonModel
 	if buttonLabel != "" {
 		button = &buttonModel{label: buttonLabel}
@@ -50,7 +50,7 @@ func newQRCodeModel(disableRendering bool, content, code, label, buttonLabel str
 		code:        code,
 		qrCode:      qrCode,
 		wait:        wait,
-	}, nil
+	}
 }
 
 // Init initializes qrcodeModel.

--- a/pam/pam.go
+++ b/pam/pam.go
@@ -75,6 +75,7 @@ func parseArgs(args []string) (map[string]string, func()) {
 	}
 
 	return parsed, func() {
+		log.Debugf(context.TODO(), "Parsed PAM arguments %v", parsed)
 		for _, warn := range warnings {
 			log.Warning(context.TODO(), warn)
 		}

--- a/pam/pam.go
+++ b/pam/pam.go
@@ -49,12 +49,13 @@ const (
 )
 
 var supportedArgs = []string{
-	"debug",               // When this is set to "true", then debug logging is enabled.
-	"logfile",             // The path of the file that will be used for logging.
-	"disable_journal",     // Disable logging on systemd journal (this is implicit when `logfile` is set).
-	"socket",              // The authd socket to connect to.
-	"force_native_client", // Use native PAM client instead of custom UIs.
-	"force_reauth",        // Whether the authentication should be performed again even if it has been already completed.
+	"debug",                    // When this is set to "true", then debug logging is enabled.
+	"logfile",                  // The path of the file that will be used for logging.
+	"disable_journal",          // Disable logging on systemd journal (this is implicit when `logfile` is set).
+	"disable_qrcode_rendering", // Whether qrcode rendering should be disabled.
+	"socket",                   // The authd socket to connect to.
+	"force_native_client",      // Use native PAM client instead of custom UIs.
+	"force_reauth",             // Whether the authentication should be performed again even if it has been already completed.
 }
 
 // parseArgs parses the PAM arguments and returns a map of them and a function that logs the parsing issues.
@@ -314,10 +315,11 @@ func (h *pamModule) handleAuthRequest(mode authd.SessionMode, mTx pam.ModuleTran
 	defer closeConn()
 
 	appState := adapter.UIModel{
-		PamMTx:      mTx,
-		Client:      authd.NewPAMClient(conn),
-		ClientType:  pamClientType,
-		SessionMode: mode,
+		PamMTx:                 mTx,
+		Client:                 authd.NewPAMClient(conn),
+		ClientType:             pamClientType,
+		DisableQrCodeRendering: parsedArgs["disable_qrcode_rendering"] == "true",
+		SessionMode:            mode,
 	}
 
 	if pamClientType == adapter.Native && isSSHSession(mTx) {


### PR DESCRIPTION
Add PAM option to force disabling of qrcode rendering, by just writing the content URI.

The example broker shows a more generic information when `content` is `optional`, however maybe in this case we could also go back to my initial implementation of this (https://github.com/3v1n0/authd/commits/disable-qrcode-support) in which we didn't support the `content` at all. And in such case we should rely on the label to show the URI (not really nice).

@didrocks: Note for v2 we should generalize this kind of layout as simple "web-login" or something where the UI can have multiple way to render the URI.

This is based on what was done for https://github.com/ubuntu/authd/pull/387

UDENG-4362