### PR TITLE
qrcodemodel: Rate limit the emission of reselect auth mode events

### DIFF
--- a/pam/integration-tests/testdata/tapes/cli/qr_code.tape
+++ b/pam/integration-tests/testdata/tapes/cli/qr_code.tape
@@ -22,7 +22,7 @@ Show
 Hide
 Type "./pam_authd login socket=${AUTHD_TESTS_CLI_AUTHENTICATE_TESTS_SOCK}"
 Enter
-Sleep 300ms
+Sleep 800ms
 Show
 
 Hide
@@ -47,17 +47,17 @@ Show
 
 Hide
 Enter
-Sleep 300ms
+Sleep 800ms
 Show
 
 Hide
 Enter
-Sleep 300ms
+Sleep 800ms
 Show
 
 Hide
 Enter
-Sleep 300ms
+Sleep 800ms
 Show
 
 Hide

--- a/pam/integration-tests/testdata/tapes/cli/qr_code_quick_regenerate.tape
+++ b/pam/integration-tests/testdata/tapes/cli/qr_code_quick_regenerate.tape
@@ -48,12 +48,12 @@ Show
 
 Hide
 Tab
-Sleep 300ms
+Sleep 500ms
 Show
 
 Hide
-Enter@1ms 50
-Sleep 10s
+Enter@1ms 500
+Sleep 15s
 Show
 
 Sleep 300ms


### PR DESCRIPTION
When hitting the Enter key for a while, bubbletea sends lots of events and we may imply sending reselectAuthMode{} events faster than we can actually handle the cancellation/reauthModeSelection in the whole stack.

This never happened (ever) when using the example broker, but it may actually happen in a real world scenario where the broker may not cancel the requests quickly enough.

Do this instead of avoiding the handling of the reselectAuthMode event because it's better to prevent bubbletea to break our (fragile) system.

The change is already tested by `authenticate_user_with_qr_code_after_many_regenerations` test.

UDENG-4091