### PR TITLE
Ignore pam_unix_non_existent on getpwnam calls

### DIFF
--- a/nss/integration-tests/integration_test.go
+++ b/nss/integration-tests/integration_test.go
@@ -95,6 +95,9 @@ func TestIntegration(t *testing.T) {
 
 		"Error when getting passwd by id and daemon is not available": {db: "passwd", key: "1111", noDaemon: true, wantStatus: codeNotFound},
 		"Error when getting group by id and daemon is not available":  {db: "group", key: "11111", noDaemon: true, wantStatus: codeNotFound},
+
+		/* Special cases */
+		"Do not query the cache when user is pam_unix_non_existent": {db: "passwd", key: "pam_unix_non_existent:", cacheDB: "pam_unix_non_existent", wantStatus: codeNotFound},
 	}
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {

--- a/nss/integration-tests/testdata/db/pam_unix_non_existent.db.yaml
+++ b/nss/integration-tests/testdata/db/pam_unix_non_existent.db.yaml
@@ -1,0 +1,31 @@
+GroupByID:
+  "11111": '{"Name":"group1","GID":11111}'
+  "22222": '{"Name":"group2","GID":22222}'
+  "33333": '{"Name":"group3","GID":33333}'
+  "99999": '{"Name":"commongroup","GID":99999}'
+GroupByName:
+  commongroup: '{"Name":"commongroup","GID":99999}'
+  group1: '{"Name":"group1","GID":11111}'
+  group2: '{"Name":"group2","GID":22222}'
+  group3: '{"Name":"group3","GID":33333}'
+GroupToUsers:
+  "11111": '{"GID":11111,"UIDs":[1111]}'
+  "22222": '{"GID":22222,"UIDs":[2222]}'
+  "33333": '{"GID":33333,"UIDs":[3333]}'
+  "99999": '{"GID":99999,"UIDs":[2222,3333]}'
+UserByID:
+  "1111": '{"Name":"pam_unix_non_existent","UID":1111,"GID":11111,"Gecos":"pam_unix_non_existent gecos\nOn multiple lines","Dir":"/home/pam_unix_non_existent","Shell":"/bin/bash","LastPwdChange":-1,"MaxPwdAge":-1,"PwdWarnPeriod":-1,"PwdInactivity":-1,"MinPwdAge":-1,"ExpirationDate":-1,"LastLogin":"ABCDETIME"}'
+  "2222": '{"Name":"user2","UID":2222,"GID":22222,"Gecos":"User2","Dir":"/home/user2","Shell":"/bin/dash","LastPwdChange":-1,"MaxPwdAge":-1,"PwdWarnPeriod":-1,"PwdInactivity":-1,"MinPwdAge":-1,"ExpirationDate":-1,"LastLogin":"ABCDETIME"}'
+  "3333": '{"Name":"user3","UID":3333,"GID":33333,"Gecos":"User3","Dir":"/home/user3","Shell":"/bin/zsh","LastPwdChange":-1,"MaxPwdAge":-1,"PwdWarnPeriod":-1,"PwdInactivity":-1,"MinPwdAge":-1,"ExpirationDate":-1,"LastLogin":"ABCDETIME"}'
+UserByName:
+  pam_unix_non_existent: '{"Name":"pam_unix_non_existent","UID":1111,"GID":11111,"Gecos":"pam_unix_non_existent gecos\nOn multiple lines","Dir":"/home/pam_unix_non_existent","Shell":"/bin/bash","LastPwdChange":-1,"MaxPwdAge":-1,"PwdWarnPeriod":-1,"PwdInactivity":-1,"MinPwdAge":-1,"ExpirationDate":-1,"LastLogin":"ABCDETIME"}'
+  user2: '{"Name":"user2","UID":2222,"GID":22222,"Gecos":"User2","Dir":"/home/user2","Shell":"/bin/dash","LastPwdChange":-1,"MaxPwdAge":-1,"PwdWarnPeriod":-1,"PwdInactivity":-1,"MinPwdAge":-1,"ExpirationDate":-1,"LastLogin":"ABCDETIME"}'
+  user3: '{"Name":"user3","UID":3333,"GID":33333,"Gecos":"User3","Dir":"/home/user3","Shell":"/bin/zsh","LastPwdChange":-1,"MaxPwdAge":-1,"PwdWarnPeriod":-1,"PwdInactivity":-1,"MinPwdAge":-1,"ExpirationDate":-1,"LastLogin":"ABCDETIME"}'
+UserToGroups:
+  "1111": '{"UID":1111,"GIDs":[11111]}'
+  "2222": '{"UID":2222,"GIDs":[22222,99999]}'
+  "3333": '{"UID":3333,"GIDs":[33333,99999]}'
+UserToBroker:
+  "1111": '"ExampleBrokerID"'
+  "2222": '"ExampleBrokerID"'
+  "3333": '"ExampleBrokerID"'

--- a/nss/src/passwd/mod.rs
+++ b/nss/src/passwd/mod.rs
@@ -108,6 +108,12 @@ fn get_entry_by_name(name: String) -> Response<Passwd> {
             }
         };
 
+        // This is a fake call done by PAM to avoid attacks, so we need to special case it to avoid spamming
+        // logs with "Not Found" messages, as this call is done quite frequently.
+        if name == "pam_unix_non_existent:" {
+            return Response::NotFound;
+        }
+
         let mut req = Request::new(authd::GetPasswdByNameRequest {
             name: name.clone(),
             should_pre_check: should_pre_check(),


### PR DESCRIPTION
This is a common call done by PAM to prevent attacks. We need to special case it to avoid spamming the system logs with Not Found messages when the call happens.


Closes #468.
UDENG-3934