### PR TITLE
maint: Remove false positive linters

### DIFF
--- a/cmd/authd/daemon/export_test.go
+++ b/cmd/authd/daemon/export_test.go
@@ -58,8 +58,6 @@ func GenerateTestConfig(t *testing.T, origConf *daemonConfig) string {
 }
 
 // Config returns a DaemonConfig for tests.
-//
-//nolint:revive // DaemonConfig is a type alias for tests
 func (a App) Config() DaemonConfig {
 	return a.config
 }

--- a/internal/services/permissions/export_test.go
+++ b/internal/services/permissions/export_test.go
@@ -2,7 +2,6 @@ package permissions
 
 type PeerCredsInfo = peerCredsInfo
 
-//nolint:revive // This is a false positive as we returned a typed alias and not the private type.
 func NewTestPeerCredsInfo(uid uint32, pid int32) PeerCredsInfo {
 	return PeerCredsInfo{uid: uid, pid: pid}
 }

--- a/internal/services/permissions/testutils/permissions.go
+++ b/internal/services/permissions/testutils/permissions.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"strings"
 
-	//nolint:revive,nolintlint // needed for go:linkname, but only used in tests. nolintlint as false positive then.
 	_ "unsafe"
 
 	"github.com/ubuntu/authd/internal/services/permissions"


### PR DESCRIPTION
It seems they are now fixed in current golangci-lint.