### PR TITLE
Don't try to get passwd entry for UIDs which we know are orphaned

### DIFF
--- a/internal/users/cache/db.go
+++ b/internal/users/cache/db.go
@@ -155,7 +155,7 @@ func openAndInitDB(path string) (*bbolt.DB, error) {
 }
 
 // CleanExpiredUsers removes from the cache any user that exceeded the maximum amount of days without authentication.
-func (c *Cache) CleanExpiredUsers(activeUsers map[string]struct{}, expirationDate time.Time) (cleanedUsers []string, err error) {
+func (c *Cache) CleanExpiredUsers(activeUIDs map[uint32]struct{}, expirationDate time.Time) (cleanedUsers []string, err error) {
 	defer decorate.OnError(&err, "could not clean up database")
 
 	c.mu.RLock()
@@ -176,7 +176,9 @@ func (c *Cache) CleanExpiredUsers(activeUsers map[string]struct{}, expirationDat
 				return nil
 			}
 
-			if _, active := activeUsers[u.Name]; !active && u.LastLogin.Before(expirationDate) {
+			//nolint:gosec // This conversion is safe because UIDs can't be larger than a uint32.
+			uid := uint32(u.UID)
+			if _, active := activeUIDs[uid]; !active && u.LastLogin.Before(expirationDate) {
 				expiredUsers = append(expiredUsers, u)
 			}
 			return nil

--- a/internal/users/cache/db_test.go
+++ b/internal/users/cache/db_test.go
@@ -507,13 +507,6 @@ func TestClear(t *testing.T) {
 func TestCleanExpiredUsers(t *testing.T) {
 	t.Parallel()
 
-	username := "root"
-	currentUser, err := user.Current()
-	require.NoError(t, err, "Setup: should be able to get current user")
-	if currentUser.Name != "" {
-		username = currentUser.Name
-	}
-
 	tests := map[string]struct {
 		dbFile string
 
@@ -539,8 +532,10 @@ func TestCleanExpiredUsers(t *testing.T) {
 			expirationDate, err := time.Parse(time.DateOnly, tc.expirationDate)
 			require.NoError(t, err, "Setup: should be able to parse expiration date")
 
-			activeUsers := map[string]struct{}{username: {}}
-			cleanedUsers, err := c.CleanExpiredUsers(activeUsers, expirationDate)
+			//nolint:gosec // This conversion is safe because UIDs can't be larger than a uint32.
+			uid := uint32(os.Geteuid())
+			activeUIDs := map[uint32]struct{}{uid: {}}
+			cleanedUsers, err := c.CleanExpiredUsers(activeUIDs, expirationDate)
 			require.NoError(t, err, "CleanExpiredUsers should not return an error")
 
 			gotDump, err := cachetestutils.DumpToYaml(c)

--- a/internal/users/cache/testdata/TestCleanExpiredUsers/golden/do_not_clean_active_user
+++ b/internal/users/cache/testdata/TestCleanExpiredUsers/golden/do_not_clean_active_user
@@ -8,9 +8,9 @@ GroupByName:
 GroupToUsers:
     "11111": '{"GID":11111,"UIDs":[1111]}'
 UserByID:
-    "1111": '{"Name":"ACTIVE_USER","UID":1111,"GID":11111,"Gecos":"ACTIVE_USER gecos\nOn multiple lines","Dir":"/home/ACTIVE_USER","Shell":"/bin/bash","LastPwdChange":-1,"MaxPwdAge":-1,"PwdWarnPeriod":-1,"PwdInactivity":-1,"MinPwdAge":-1,"ExpirationDate":-1,"LastLogin":"AAAAATIME"}'
+    '{{CURRENT_UID}}': '{"Name":"user1","UID":{{CURRENT_UID}},"GID":11111,"Gecos":"ACTIVE_USER gecos\nOn multiple lines","Dir":"/home/ACTIVE_USER","Shell":"/bin/bash","LastPwdChange":-1,"MaxPwdAge":-1,"PwdWarnPeriod":-1,"PwdInactivity":-1,"MinPwdAge":-1,"ExpirationDate":-1,"LastLogin":"AAAAATIME"}'
 UserByName:
-    ACTIVE_USER: '{"Name":"ACTIVE_USER","UID":1111,"GID":11111,"Gecos":"ACTIVE_USER gecos\nOn multiple lines","Dir":"/home/ACTIVE_USER","Shell":"/bin/bash","LastPwdChange":-1,"MaxPwdAge":-1,"PwdWarnPeriod":-1,"PwdInactivity":-1,"MinPwdAge":-1,"ExpirationDate":-1,"LastLogin":"AAAAATIME"}'
+    user1: '{"Name":"user1","UID":{{CURRENT_UID}},"GID":11111,"Gecos":"ACTIVE_USER gecos\nOn multiple lines","Dir":"/home/ACTIVE_USER","Shell":"/bin/bash","LastPwdChange":-1,"MaxPwdAge":-1,"PwdWarnPeriod":-1,"PwdInactivity":-1,"MinPwdAge":-1,"ExpirationDate":-1,"LastLogin":"AAAAATIME"}'
 UserToBroker:
     "1111": '"broker-id"'
 UserToGroups:

--- a/internal/users/cache/testdata/active_user.db.yaml
+++ b/internal/users/cache/testdata/active_user.db.yaml
@@ -5,9 +5,9 @@ GroupByName:
 GroupToUsers:
   "11111": '{"GID":11111,"UIDs":[1111]}'
 UserByID:
-  "1111": '{"Name":"ACTIVE_USER","UID":1111,"GID":11111,"Gecos":"ACTIVE_USER gecos\nOn multiple lines","Dir":"/home/ACTIVE_USER","Shell":"/bin/bash","LastPwdChange":-1,"MaxPwdAge":-1,"PwdWarnPeriod":-1,"PwdInactivity":-1,"MinPwdAge":-1,"ExpirationDate":-1,"LastLogin":"AAAAATIME"}'
+  "{{CURRENT_UID}}": '{"Name":"user1","UID":{{CURRENT_UID}},"GID":11111,"Gecos":"ACTIVE_USER gecos\nOn multiple lines","Dir":"/home/ACTIVE_USER","Shell":"/bin/bash","LastPwdChange":-1,"MaxPwdAge":-1,"PwdWarnPeriod":-1,"PwdInactivity":-1,"MinPwdAge":-1,"ExpirationDate":-1,"LastLogin":"AAAAATIME"}'
 UserByName:
-  ACTIVE_USER: '{"Name":"ACTIVE_USER","UID":1111,"GID":11111,"Gecos":"ACTIVE_USER gecos\nOn multiple lines","Dir":"/home/ACTIVE_USER","Shell":"/bin/bash","LastPwdChange":-1,"MaxPwdAge":-1,"PwdWarnPeriod":-1,"PwdInactivity":-1,"MinPwdAge":-1,"ExpirationDate":-1,"LastLogin":"AAAAATIME"}'
+  "user1": '{"Name":"user1","UID":{{CURRENT_UID}},"GID":11111,"Gecos":"ACTIVE_USER gecos\nOn multiple lines","Dir":"/home/ACTIVE_USER","Shell":"/bin/bash","LastPwdChange":-1,"MaxPwdAge":-1,"PwdWarnPeriod":-1,"PwdInactivity":-1,"MinPwdAge":-1,"ExpirationDate":-1,"LastLogin":"AAAAATIME"}'
 UserToGroups:
   "1111": '{"UID":1111,"GIDs":[11111]}'
 UserToBroker:

--- a/internal/users/manager.go
+++ b/internal/users/manager.go
@@ -10,7 +10,6 @@ import (
 	"log/slog"
 	"math"
 	"os"
-	"os/user"
 	"path/filepath"
 	"strconv"
 	"strings"
@@ -356,12 +355,12 @@ func (m *Manager) clear(cacheDir string) error {
 
 // cleanExpiredUserData cleans up the data belonging to expired users.
 func (m *Manager) cleanExpiredUserData(opts *options) error {
-	activeUsers, err := getActiveUsers(opts.procDir)
+	activeUIDs, err := getUIDsOfRunningProcesses(opts.procDir)
 	if err != nil {
 		return fmt.Errorf("could not get list of active users: %v", err)
 	}
 
-	cleanedUsers, err := m.cache.CleanExpiredUsers(activeUsers, opts.expirationDate)
+	cleanedUsers, err := m.cache.CleanExpiredUsers(activeUIDs, opts.expirationDate)
 	if err != nil {
 		return fmt.Errorf("could not clean database of expired users: %v", err)
 	}
@@ -375,18 +374,16 @@ func (m *Manager) cleanExpiredUserData(opts *options) error {
 	return err
 }
 
-// getActiveUsers walks through procDir and returns a map with the usernames of the owners of all active processes.
-func getActiveUsers(procDir string) (activeUsers map[string]struct{}, err error) {
-	defer decorate.OnError(&err, "could not get list of active users")
+// getUIDsOfRunningProcesses walks through procDir and returns a map with the UIDs of the running processes.
+func getUIDsOfRunningProcesses(procDir string) (uids map[uint32]struct{}, err error) {
+	defer decorate.OnError(&err, "could not get UIDs of running processes")
 
-	activeUsers = make(map[string]struct{})
+	uids = make(map[uint32]struct{})
 
 	dirEntries, err := os.ReadDir(procDir)
 	if err != nil {
 		return nil, err
 	}
-
-	orphanedUIDs := make(map[uint32]struct{})
 
 	for _, dirEntry := range dirEntries {
 		// Checks if the dirEntry represents a process dir (i.e. /proc/<pid>/)
@@ -407,22 +404,9 @@ func getActiveUsers(procDir string) (activeUsers map[string]struct{}, err error)
 		if !ok {
 			return nil, fmt.Errorf("could not get ownership of file %q", info.Name())
 		}
-
-		if _, ok := orphanedUIDs[stats.Uid]; ok {
-			continue
-		}
-
-		u, err := user.LookupId(strconv.Itoa(int(stats.Uid)))
-		if err != nil {
-			// Possibly a ghost/orphaned UID - no reason to error out. Just warn the user and continue.
-			slog.Warn(fmt.Sprintf("Could not map active user ID to an actual user: %v", err))
-			orphanedUIDs[stats.Uid] = struct{}{}
-			continue
-		}
-
-		activeUsers[u.Name] = struct{}{}
+		uids[stats.Uid] = struct{}{}
 	}
-	return activeUsers, nil
+	return uids, nil
 }
 
 // GenerateID deterministically generates an ID between from the given string, ignoring case. The ID is in the range


### PR DESCRIPTION
I've encountered a case where each `getpwuid` call took 5 seconds, and because there were a lot of active processes from an orphaned user, we issued so many `getpwuid` calls that the start operation of the authd.service timed out. 

Closes #542
UDENG-4628