### PR TITLE
pam/native-model: Do not render qr code in SSH sessions at all

### DIFF
--- a/pam/integration-tests/native_test.go
+++ b/pam/integration-tests/native_test.go
@@ -45,6 +45,7 @@ func TestNativeAuthenticate(t *testing.T) {
 		"Authenticate user with qr code in a TTY session":                      {tape: "qr_code", pamUser: "user-integration-qr-code-tty-session", termEnv: "xterm-256color", sessionEnv: "tty"},
 		"Authenticate user with qr code in screen":                             {tape: "qr_code", pamUser: "user-integration-qr-code-screen", termEnv: "screen"},
 		"Authenticate user with qr code in polkit":                             {tape: "qr_code", pamUser: "user-integration-qr-code-screen", pamServiceName: "polkit-1"},
+		"Authenticate user with qr code in ssh":                                {tape: "qr_code", pamUser: "user-integration-pre-check-ssh-service-qr-code", pamServiceName: "sshd"},
 		"Authenticate user and reset password while enforcing policy":          {tape: "mandatory_password_reset"},
 		"Authenticate user with mfa and reset password while enforcing policy": {tape: "mfa_reset_pwquality_auth"},
 		"Authenticate user and offer password reset":                           {tape: "optional_password_reset_skip"},

--- a/pam/integration-tests/testdata/TestNativeAuthenticate/golden/authenticate_user_with_qr_code_in_ssh
+++ b/pam/integration-tests/testdata/TestNativeAuthenticate/golden/authenticate_user_with_qr_code_in_ssh
@@ -1,0 +1,2562 @@
+> ./pam_authd login socket=${AUTHD_TESTS_CLI_AUTHENTICATE_TESTS_SOCK} force_native_client=true
+== Broker selection (use 'r' to go back) ==
+1 - local
+2 - ExampleBroker
+Select broker:
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+────────────────────────────────────────────────────────────────────────────────
+> if [ -v AUTHD_PAM_CLI_TERM ]; then export TERM=${AUTHD_PAM_CLI_TERM}; fi
+> ./pam_authd login socket=${AUTHD_TESTS_CLI_AUTHENTICATE_TESTS_SOCK} force_native_client=true
+== Broker selection (use 'r' to go back) ==
+1 - local
+2 - ExampleBroker
+Select broker: 2
+Insert 'r' to cancel the request and go back
+Gimme your password:
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+────────────────────────────────────────────────────────────────────────────────
+> if [ -v AUTHD_PAM_CLI_TERM ]; then export TERM=${AUTHD_PAM_CLI_TERM}; fi
+> ./pam_authd login socket=${AUTHD_TESTS_CLI_AUTHENTICATE_TESTS_SOCK} force_native_client=true
+== Broker selection (use 'r' to go back) ==
+1 - local
+2 - ExampleBroker
+Select broker: 2
+Insert 'r' to cancel the request and go back
+Gimme your password:
+== Authentication mode selection (use 'r' to go back) ==
+1 - Password authentication
+2 - Send URL to user-integration-pre-check-ssh-service-qr-code@gmail.com
+3 - Use your fido device foo
+4 - Use your phone +33…
+5 - Use your phone +1…
+6 - Pin code
+7 - Use a QR code
+8 - Authentication code
+Select authentication mode:
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+────────────────────────────────────────────────────────────────────────────────
+> if [ -v AUTHD_PAM_CLI_TERM ]; then export TERM=${AUTHD_PAM_CLI_TERM}; fi
+> ./pam_authd login socket=${AUTHD_TESTS_CLI_AUTHENTICATE_TESTS_SOCK} force_native_client=true
+== Broker selection (use 'r' to go back) ==
+1 - local
+2 - ExampleBroker
+Select broker: 2
+Insert 'r' to cancel the request and go back
+Gimme your password:
+== Authentication mode selection (use 'r' to go back) ==
+1 - Password authentication
+2 - Send URL to user-integration-pre-check-ssh-service-qr-code@gmail.com
+3 - Use your fido device foo
+4 - Use your phone +33…
+5 - Use your phone +1…
+6 - Pin code
+7 - Use a QR code
+8 - Authentication code
+Select authentication mode: 7
+Scan the qrcode or enter the code in the login page
+https://ubuntu.com
+       1337
+
+== Qr Code authentication (use 'r' to go back) ==
+1 - Wait for the QR code scan result
+2 - Regenerate code
+Select action:
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+────────────────────────────────────────────────────────────────────────────────
+> if [ -v AUTHD_PAM_CLI_TERM ]; then export TERM=${AUTHD_PAM_CLI_TERM}; fi
+> ./pam_authd login socket=${AUTHD_TESTS_CLI_AUTHENTICATE_TESTS_SOCK} force_native_client=true
+== Broker selection (use 'r' to go back) ==
+1 - local
+2 - ExampleBroker
+Select broker: 2
+Insert 'r' to cancel the request and go back
+Gimme your password:
+== Authentication mode selection (use 'r' to go back) ==
+1 - Password authentication
+2 - Send URL to user-integration-pre-check-ssh-service-qr-code@gmail.com
+3 - Use your fido device foo
+4 - Use your phone +33…
+5 - Use your phone +1…
+6 - Pin code
+7 - Use a QR code
+8 - Authentication code
+Select authentication mode: 7
+Scan the qrcode or enter the code in the login page
+https://ubuntu.com
+       1337
+
+== Qr Code authentication (use 'r' to go back) ==
+1 - Wait for the QR code scan result
+2 - Regenerate code
+Select action: 2
+Scan the qrcode or enter the code in the login page
+https://ubuntu.fr/
+       1338
+
+== Qr Code authentication (use 'r' to go back) ==
+1 - Wait for the QR code scan result
+2 - Regenerate code
+Select action:
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+────────────────────────────────────────────────────────────────────────────────
+> if [ -v AUTHD_PAM_CLI_TERM ]; then export TERM=${AUTHD_PAM_CLI_TERM}; fi
+> ./pam_authd login socket=${AUTHD_TESTS_CLI_AUTHENTICATE_TESTS_SOCK} force_native_client=true
+== Broker selection (use 'r' to go back) ==
+1 - local
+2 - ExampleBroker
+Select broker: 2
+Insert 'r' to cancel the request and go back
+Gimme your password:
+== Authentication mode selection (use 'r' to go back) ==
+1 - Password authentication
+2 - Send URL to user-integration-pre-check-ssh-service-qr-code@gmail.com
+3 - Use your fido device foo
+4 - Use your phone +33…
+5 - Use your phone +1…
+6 - Pin code
+7 - Use a QR code
+8 - Authentication code
+Select authentication mode: 7
+Scan the qrcode or enter the code in the login page
+https://ubuntu.com
+       1337
+
+== Qr Code authentication (use 'r' to go back) ==
+1 - Wait for the QR code scan result
+2 - Regenerate code
+Select action: 2
+Scan the qrcode or enter the code in the login page
+https://ubuntu.fr/
+       1338
+
+== Qr Code authentication (use 'r' to go back) ==
+1 - Wait for the QR code scan result
+2 - Regenerate code
+Select action: 2
+Scan the qrcode or enter the code in the login page
+https://ubuntuforum-br.org/
+           1339
+
+== Qr Code authentication (use 'r' to go back) ==
+1 - Wait for the QR code scan result
+2 - Regenerate code
+Select action:
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+────────────────────────────────────────────────────────────────────────────────
+> if [ -v AUTHD_PAM_CLI_TERM ]; then export TERM=${AUTHD_PAM_CLI_TERM}; fi
+> ./pam_authd login socket=${AUTHD_TESTS_CLI_AUTHENTICATE_TESTS_SOCK} force_native_client=true
+== Broker selection (use 'r' to go back) ==
+1 - local
+2 - ExampleBroker
+Select broker: 2
+Insert 'r' to cancel the request and go back
+Gimme your password:
+== Authentication mode selection (use 'r' to go back) ==
+1 - Password authentication
+2 - Send URL to user-integration-pre-check-ssh-service-qr-code@gmail.com
+3 - Use your fido device foo
+4 - Use your phone +33…
+5 - Use your phone +1…
+6 - Pin code
+7 - Use a QR code
+8 - Authentication code
+Select authentication mode: 7
+Scan the qrcode or enter the code in the login page
+https://ubuntu.com
+       1337
+
+== Qr Code authentication (use 'r' to go back) ==
+1 - Wait for the QR code scan result
+2 - Regenerate code
+Select action: 2
+Scan the qrcode or enter the code in the login page
+https://ubuntu.fr/
+       1338
+
+== Qr Code authentication (use 'r' to go back) ==
+1 - Wait for the QR code scan result
+2 - Regenerate code
+Select action: 2
+Scan the qrcode or enter the code in the login page
+https://ubuntuforum-br.org/
+           1339
+
+== Qr Code authentication (use 'r' to go back) ==
+1 - Wait for the QR code scan result
+2 - Regenerate code
+Select action: 2
+Scan the qrcode or enter the code in the login page
+https://www.ubuntu-it.org/
+           1340
+
+== Qr Code authentication (use 'r' to go back) ==
+1 - Wait for the QR code scan result
+2 - Regenerate code
+Select action:
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+────────────────────────────────────────────────────────────────────────────────
+> if [ -v AUTHD_PAM_CLI_TERM ]; then export TERM=${AUTHD_PAM_CLI_TERM}; fi
+> ./pam_authd login socket=${AUTHD_TESTS_CLI_AUTHENTICATE_TESTS_SOCK} force_native_client=true
+== Broker selection (use 'r' to go back) ==
+1 - local
+2 - ExampleBroker
+Select broker: 2
+Insert 'r' to cancel the request and go back
+Gimme your password:
+== Authentication mode selection (use 'r' to go back) ==
+1 - Password authentication
+2 - Send URL to user-integration-pre-check-ssh-service-qr-code@gmail.com
+3 - Use your fido device foo
+4 - Use your phone +33…
+5 - Use your phone +1…
+6 - Pin code
+7 - Use a QR code
+8 - Authentication code
+Select authentication mode: 7
+Scan the qrcode or enter the code in the login page
+https://ubuntu.com
+       1337
+
+== Qr Code authentication (use 'r' to go back) ==
+1 - Wait for the QR code scan result
+2 - Regenerate code
+Select action: 2
+Scan the qrcode or enter the code in the login page
+https://ubuntu.fr/
+       1338
+
+== Qr Code authentication (use 'r' to go back) ==
+1 - Wait for the QR code scan result
+2 - Regenerate code
+Select action: 2
+Scan the qrcode or enter the code in the login page
+https://ubuntuforum-br.org/
+           1339
+
+== Qr Code authentication (use 'r' to go back) ==
+1 - Wait for the QR code scan result
+2 - Regenerate code
+Select action: 2
+Scan the qrcode or enter the code in the login page
+https://www.ubuntu-it.org/
+           1340
+
+== Qr Code authentication (use 'r' to go back) ==
+1 - Wait for the QR code scan result
+2 - Regenerate code
+Select action: 2
+Scan the qrcode or enter the code in the login page
+https://ubuntu.com
+       1341
+
+== Qr Code authentication (use 'r' to go back) ==
+1 - Wait for the QR code scan result
+2 - Regenerate code
+Select action:
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+────────────────────────────────────────────────────────────────────────────────
+> if [ -v AUTHD_PAM_CLI_TERM ]; then export TERM=${AUTHD_PAM_CLI_TERM}; fi
+> ./pam_authd login socket=${AUTHD_TESTS_CLI_AUTHENTICATE_TESTS_SOCK} force_native_client=true
+== Broker selection (use 'r' to go back) ==
+1 - local
+2 - ExampleBroker
+Select broker: 2
+Insert 'r' to cancel the request and go back
+Gimme your password:
+== Authentication mode selection (use 'r' to go back) ==
+1 - Password authentication
+2 - Send URL to user-integration-pre-check-ssh-service-qr-code@gmail.com
+3 - Use your fido device foo
+4 - Use your phone +33…
+5 - Use your phone +1…
+6 - Pin code
+7 - Use a QR code
+8 - Authentication code
+Select authentication mode: 7
+Scan the qrcode or enter the code in the login page
+https://ubuntu.com
+       1337
+
+== Qr Code authentication (use 'r' to go back) ==
+1 - Wait for the QR code scan result
+2 - Regenerate code
+Select action: 2
+Scan the qrcode or enter the code in the login page
+https://ubuntu.fr/
+       1338
+
+== Qr Code authentication (use 'r' to go back) ==
+1 - Wait for the QR code scan result
+2 - Regenerate code
+Select action: 2
+Scan the qrcode or enter the code in the login page
+https://ubuntuforum-br.org/
+           1339
+
+== Qr Code authentication (use 'r' to go back) ==
+1 - Wait for the QR code scan result
+2 - Regenerate code
+Select action: 2
+Scan the qrcode or enter the code in the login page
+https://www.ubuntu-it.org/
+           1340
+
+== Qr Code authentication (use 'r' to go back) ==
+1 - Wait for the QR code scan result
+2 - Regenerate code
+Select action: 2
+Scan the qrcode or enter the code in the login page
+https://ubuntu.com
+       1341
+
+== Qr Code authentication (use 'r' to go back) ==
+1 - Wait for the QR code scan result
+2 - Regenerate code
+Select action: 1
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+────────────────────────────────────────────────────────────────────────────────
+> if [ -v AUTHD_PAM_CLI_TERM ]; then export TERM=${AUTHD_PAM_CLI_TERM}; fi
+> ./pam_authd login socket=${AUTHD_TESTS_CLI_AUTHENTICATE_TESTS_SOCK} force_native_client=true
+== Broker selection (use 'r' to go back) ==
+1 - local
+2 - ExampleBroker
+Select broker: 2
+Insert 'r' to cancel the request and go back
+Gimme your password:
+== Authentication mode selection (use 'r' to go back) ==
+1 - Password authentication
+2 - Send URL to user-integration-pre-check-ssh-service-qr-code@gmail.com
+3 - Use your fido device foo
+4 - Use your phone +33…
+5 - Use your phone +1…
+6 - Pin code
+7 - Use a QR code
+8 - Authentication code
+Select authentication mode: 7
+Scan the qrcode or enter the code in the login page
+https://ubuntu.com
+       1337
+
+== Qr Code authentication (use 'r' to go back) ==
+1 - Wait for the QR code scan result
+2 - Regenerate code
+Select action: 2
+Scan the qrcode or enter the code in the login page
+https://ubuntu.fr/
+       1338
+
+== Qr Code authentication (use 'r' to go back) ==
+1 - Wait for the QR code scan result
+2 - Regenerate code
+Select action: 2
+Scan the qrcode or enter the code in the login page
+https://ubuntuforum-br.org/
+           1339
+
+== Qr Code authentication (use 'r' to go back) ==
+1 - Wait for the QR code scan result
+2 - Regenerate code
+Select action: 2
+Scan the qrcode or enter the code in the login page
+https://www.ubuntu-it.org/
+           1340
+
+== Qr Code authentication (use 'r' to go back) ==
+1 - Wait for the QR code scan result
+2 - Regenerate code
+Select action: 2
+Scan the qrcode or enter the code in the login page
+https://ubuntu.com
+       1341
+
+== Qr Code authentication (use 'r' to go back) ==
+1 - Wait for the QR code scan result
+2 - Regenerate code
+Select action: 1
+PAM Authenticate() for user "user-integration-pre-check-ssh-service-qr-code" exited with success
+PAM AcctMgmt() exited with success
+>
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+────────────────────────────────────────────────────────────────────────────────
+> if [ -v AUTHD_PAM_CLI_TERM ]; then export TERM=${AUTHD_PAM_CLI_TERM}; fi
+> ./pam_authd login socket=${AUTHD_TESTS_CLI_AUTHENTICATE_TESTS_SOCK} force_native_client=true
+== Broker selection (use 'r' to go back) ==
+1 - local
+2 - ExampleBroker
+Select broker: 2
+Insert 'r' to cancel the request and go back
+Gimme your password:
+== Authentication mode selection (use 'r' to go back) ==
+1 - Password authentication
+2 - Send URL to user-integration-pre-check-ssh-service-qr-code@gmail.com
+3 - Use your fido device foo
+4 - Use your phone +33…
+5 - Use your phone +1…
+6 - Pin code
+7 - Use a QR code
+8 - Authentication code
+Select authentication mode: 7
+Scan the qrcode or enter the code in the login page
+https://ubuntu.com
+       1337
+
+== Qr Code authentication (use 'r' to go back) ==
+1 - Wait for the QR code scan result
+2 - Regenerate code
+Select action: 2
+Scan the qrcode or enter the code in the login page
+https://ubuntu.fr/
+       1338
+
+== Qr Code authentication (use 'r' to go back) ==
+1 - Wait for the QR code scan result
+2 - Regenerate code
+Select action: 2
+Scan the qrcode or enter the code in the login page
+https://ubuntuforum-br.org/
+           1339
+
+== Qr Code authentication (use 'r' to go back) ==
+1 - Wait for the QR code scan result
+2 - Regenerate code
+Select action: 2
+Scan the qrcode or enter the code in the login page
+https://www.ubuntu-it.org/
+           1340
+
+== Qr Code authentication (use 'r' to go back) ==
+1 - Wait for the QR code scan result
+2 - Regenerate code
+Select action: 2
+Scan the qrcode or enter the code in the login page
+https://ubuntu.com
+       1341
+
+== Qr Code authentication (use 'r' to go back) ==
+1 - Wait for the QR code scan result
+2 - Regenerate code
+Select action: 1
+PAM Authenticate() for user "user-integration-pre-check-ssh-service-qr-code" exited with success
+PAM AcctMgmt() exited with success
+>
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+────────────────────────────────────────────────────────────────────────────────

--- a/pam/internal/adapter/nativemodel.go
+++ b/pam/internal/adapter/nativemodel.go
@@ -699,7 +699,7 @@ func (m nativeModel) isQrcodeRenderingSupported() bool {
 	case polkitServiceName:
 		return false
 	default:
-		return true
+		return !IsSSHSession(m.pamMTx)
 	}
 }
 

--- a/pam/internal/adapter/utils.go
+++ b/pam/internal/adapter/utils.go
@@ -33,3 +33,23 @@ func TeaHeadlessOptions() ([]tea.ProgramOption, error) {
 		tea.WithOutput(devNull),
 	}, nil
 }
+
+// IsSSHSession checks if the module transaction is currently handling a SSH session.
+func IsSSHSession(mTx pam.ModuleTransaction) bool {
+	service, _ := mTx.GetItem(pam.Service)
+	if service == "sshd" {
+		return true
+	}
+
+	envs, err := mTx.GetEnvList()
+	if err != nil {
+		return false
+	}
+	if _, ok := envs["SSH_CONNECTION"]; ok {
+		return true
+	}
+	if _, ok := envs["SSH_AUTH_INFO_0"]; ok {
+		return true
+	}
+	return false
+}

--- a/pam/pam.go
+++ b/pam/pam.go
@@ -320,7 +320,7 @@ func (h *pamModule) handleAuthRequest(mode authd.SessionMode, mTx pam.ModuleTran
 		SessionMode: mode,
 	}
 
-	if pamClientType == adapter.Native && isSSHSession(mTx) {
+	if pamClientType == adapter.Native && adapter.IsSSHSession(mTx) {
 		appState.NssClient = authd.NewNSSClient(conn)
 	}
 
@@ -468,25 +468,6 @@ func getSocketPath(args map[string]string) string {
 		return val
 	}
 	return consts.DefaultSocketPath
-}
-
-func isSSHSession(mTx pam.ModuleTransaction) bool {
-	service, _ := mTx.GetItem(pam.Service)
-	if service == "sshd" {
-		return true
-	}
-
-	envs, err := mTx.GetEnvList()
-	if err != nil {
-		return false
-	}
-	if _, ok := envs["SSH_CONNECTION"]; ok {
-		return true
-	}
-	if _, ok := envs["SSH_AUTH_INFO_0"]; ok {
-		return true
-	}
-	return false
 }
 
 // SetCred is the method that is invoked during pam_setcred request.


### PR DESCRIPTION
Do not renderer qrcode in SSH at all, the only clients supporting it are putty and `ssh` provided by ubuntu (>= 24.04), and it's not possible (yet) to detect this from PAM level, so let's just ignore it for now.

And add an integration test covering this case.

Closes: #497 

UDENG-4279