### PR TITLE
cleanup(pam/integration-tests): Highlight PAM error messages better

### DIFF
--- a/pam/integration-tests/testdata/TestNativeAuthenticate/golden/authenticate_user_switching_auth_mode
+++ b/pam/integration-tests/testdata/TestNativeAuthenticate/golden/authenticate_user_switching_auth_mode
@@ -3108,7 +3108,7 @@ Select action: r
 7 - Use a QR code
 8 - Authentication code
 Select authentication mode: invalid-selection
-Provided input can't be parsed as integer value
+PAM Error Message: Provided input can't be parsed as integer value
 == Authentication mode selection (use 'r' to go back) ==
 1 - Password authentication
 2 - Send URL to user-integration-switch-mode@gmail.com
@@ -3265,7 +3265,7 @@ Select action: r
 7 - Use a QR code
 8 - Authentication code
 Select authentication mode: invalid-selection
-Provided input can't be parsed as integer value
+PAM Error Message: Provided input can't be parsed as integer value
 == Authentication mode selection (use 'r' to go back) ==
 1 - Password authentication
 2 - Send URL to user-integration-switch-mode@gmail.com
@@ -3276,7 +3276,7 @@ Provided input can't be parsed as integer value
 7 - Use a QR code
 8 - Authentication code
 Select authentication mode: -1
-Invalid entry. Try again or input 'r'.
+PAM Error Message: Invalid entry. Try again or input 'r'.
 == Authentication mode selection (use 'r' to go back) ==
 1 - Password authentication
 2 - Send URL to user-integration-switch-mode@gmail.com
@@ -3422,7 +3422,7 @@ Select action: r
 7 - Use a QR code
 8 - Authentication code
 Select authentication mode: invalid-selection
-Provided input can't be parsed as integer value
+PAM Error Message: Provided input can't be parsed as integer value
 == Authentication mode selection (use 'r' to go back) ==
 1 - Password authentication
 2 - Send URL to user-integration-switch-mode@gmail.com
@@ -3433,7 +3433,7 @@ Provided input can't be parsed as integer value
 7 - Use a QR code
 8 - Authentication code
 Select authentication mode: -1
-Invalid entry. Try again or input 'r'.
+PAM Error Message: Invalid entry. Try again or input 'r'.
 == Authentication mode selection (use 'r' to go back) ==
 1 - Password authentication
 2 - Send URL to user-integration-switch-mode@gmail.com
@@ -3579,7 +3579,7 @@ Select action: r
 7 - Use a QR code
 8 - Authentication code
 Select authentication mode: invalid-selection
-Provided input can't be parsed as integer value
+PAM Error Message: Provided input can't be parsed as integer value
 == Authentication mode selection (use 'r' to go back) ==
 1 - Password authentication
 2 - Send URL to user-integration-switch-mode@gmail.com
@@ -3590,7 +3590,7 @@ Provided input can't be parsed as integer value
 7 - Use a QR code
 8 - Authentication code
 Select authentication mode: -1
-Invalid entry. Try again or input 'r'.
+PAM Error Message: Invalid entry. Try again or input 'r'.
 == Authentication mode selection (use 'r' to go back) ==
 1 - Password authentication
 2 - Send URL to user-integration-switch-mode@gmail.com
@@ -3736,7 +3736,7 @@ Select action: r
 7 - Use a QR code
 8 - Authentication code
 Select authentication mode: invalid-selection
-Provided input can't be parsed as integer value
+PAM Error Message: Provided input can't be parsed as integer value
 == Authentication mode selection (use 'r' to go back) ==
 1 - Password authentication
 2 - Send URL to user-integration-switch-mode@gmail.com
@@ -3747,7 +3747,7 @@ Provided input can't be parsed as integer value
 7 - Use a QR code
 8 - Authentication code
 Select authentication mode: -1
-Invalid entry. Try again or input 'r'.
+PAM Error Message: Invalid entry. Try again or input 'r'.
 == Authentication mode selection (use 'r' to go back) ==
 1 - Password authentication
 2 - Send URL to user-integration-switch-mode@gmail.com

--- a/pam/integration-tests/testdata/TestNativeAuthenticate/golden/authenticate_user_switching_to_local_broker
+++ b/pam/integration-tests/testdata/TestNativeAuthenticate/golden/authenticate_user_switching_to_local_broker
@@ -260,7 +260,7 @@ Select authentication mode: r
 1 - local
 2 - ExampleBroker
 Select broker: invalid-ID
-Provided input can't be parsed as integer value
+PAM Error Message: Provided input can't be parsed as integer value
 == Broker selection (use 'r' to go back) ==
 1 - local
 2 - ExampleBroker
@@ -300,12 +300,12 @@ Select authentication mode: r
 1 - local
 2 - ExampleBroker
 Select broker: invalid-ID
-Provided input can't be parsed as integer value
+PAM Error Message: Provided input can't be parsed as integer value
 == Broker selection (use 'r' to go back) ==
 1 - local
 2 - ExampleBroker
 Select broker: 555
-Invalid entry. Try again or input 'r'.
+PAM Error Message: Invalid entry. Try again or input 'r'.
 == Broker selection (use 'r' to go back) ==
 1 - local
 2 - ExampleBroker
@@ -340,12 +340,12 @@ Select authentication mode: r
 1 - local
 2 - ExampleBroker
 Select broker: invalid-ID
-Provided input can't be parsed as integer value
+PAM Error Message: Provided input can't be parsed as integer value
 == Broker selection (use 'r' to go back) ==
 1 - local
 2 - ExampleBroker
 Select broker: 555
-Invalid entry. Try again or input 'r'.
+PAM Error Message: Invalid entry. Try again or input 'r'.
 == Broker selection (use 'r' to go back) ==
 1 - local
 2 - ExampleBroker
@@ -380,12 +380,12 @@ Select authentication mode: r
 1 - local
 2 - ExampleBroker
 Select broker: invalid-ID
-Provided input can't be parsed as integer value
+PAM Error Message: Provided input can't be parsed as integer value
 == Broker selection (use 'r' to go back) ==
 1 - local
 2 - ExampleBroker
 Select broker: 555
-Invalid entry. Try again or input 'r'.
+PAM Error Message: Invalid entry. Try again or input 'r'.
 == Broker selection (use 'r' to go back) ==
 1 - local
 2 - ExampleBroker

--- a/pam/integration-tests/testdata/TestNativeAuthenticate/golden/authenticate_user_with_mfa_and_reset_password_while_enforcing_policy
+++ b/pam/integration-tests/testdata/TestNativeAuthenticate/golden/authenticate_user_with_mfa_and_reset_password_while_enforcing_policy
@@ -311,7 +311,7 @@ Plug your fido device and press with your thumb:
 Select action: 1
 Insert 'r' to cancel the request and go back
 Enter your new password (3 days until mandatory):
-The password is the same as the old one
+PAM Error Message: The password is the same as the old one
 Insert 'r' to cancel the request and go back
 Enter your new password (3 days until mandatory):
 
@@ -344,10 +344,10 @@ Plug your fido device and press with your thumb:
 Select action: 1
 Insert 'r' to cancel the request and go back
 Enter your new password (3 days until mandatory):
-The password is the same as the old one
+PAM Error Message: The password is the same as the old one
 Insert 'r' to cancel the request and go back
 Enter your new password (3 days until mandatory):
-The password fails the dictionary check - it is based on a dictionary word
+PAM Error Message: The password fails the dictionary check - it is based on a dictionary word
 Insert 'r' to cancel the request and go back
 Enter your new password (3 days until mandatory):
 
@@ -377,51 +377,18 @@ Plug your fido device and press with your thumb:
 Select action: 1
 Insert 'r' to cancel the request and go back
 Enter your new password (3 days until mandatory):
-The password is the same as the old one
+PAM Error Message: The password is the same as the old one
 Insert 'r' to cancel the request and go back
 Enter your new password (3 days until mandatory):
-The password fails the dictionary check - it is based on a dictionary word
+PAM Error Message: The password fails the dictionary check - it is based on a dictionary word
 Insert 'r' to cancel the request and go back
 Enter your new password (3 days until mandatory):
-The password is the same as the old one
+PAM Error Message: The password is the same as the old one
 Insert 'r' to cancel the request and go back
 Enter your new password (3 days until mandatory):
 
 
 
-
-
-
-
-────────────────────────────────────────────────────────────────────────────────
-> ./pam_authd login socket=${AUTHD_TESTS_CLI_AUTHENTICATE_TESTS_SOCK} force_native_client=true
-Username: user-mfa-with-reset
-== Broker selection (use 'r' to go back) ==
-1 - local
-2 - ExampleBroker
-Select broker: 2
-Insert 'r' to cancel the request and go back
-Gimme your password:
-Leave the input field empty to wait for the authentication method or insert 'r' to go back
-Plug your fido device and press with your thumb:
-== Password Update (use 'r' to go back) ==
-1 - Proceed with password update
-2 - Skip
-Select action: 1
-Insert 'r' to cancel the request and go back
-Enter your new password (3 days until mandatory):
-The password is the same as the old one
-Insert 'r' to cancel the request and go back
-Enter your new password (3 days until mandatory):
-The password fails the dictionary check - it is based on a dictionary word
-Insert 'r' to cancel the request and go back
-Enter your new password (3 days until mandatory):
-The password is the same as the old one
-Insert 'r' to cancel the request and go back
-Enter your new password (3 days until mandatory):
-The password is shorter than 8 characters
-Insert 'r' to cancel the request and go back
-Enter your new password (3 days until mandatory):
 
 
 
@@ -443,16 +410,16 @@ Plug your fido device and press with your thumb:
 Select action: 1
 Insert 'r' to cancel the request and go back
 Enter your new password (3 days until mandatory):
-The password is the same as the old one
+PAM Error Message: The password is the same as the old one
 Insert 'r' to cancel the request and go back
 Enter your new password (3 days until mandatory):
-The password fails the dictionary check - it is based on a dictionary word
+PAM Error Message: The password fails the dictionary check - it is based on a dictionary word
 Insert 'r' to cancel the request and go back
 Enter your new password (3 days until mandatory):
-The password is the same as the old one
+PAM Error Message: The password is the same as the old one
 Insert 'r' to cancel the request and go back
 Enter your new password (3 days until mandatory):
-The password is shorter than 8 characters
+PAM Error Message: The password is shorter than 8 characters
 Insert 'r' to cancel the request and go back
 Enter your new password (3 days until mandatory):
 
@@ -476,16 +443,49 @@ Plug your fido device and press with your thumb:
 Select action: 1
 Insert 'r' to cancel the request and go back
 Enter your new password (3 days until mandatory):
-The password is the same as the old one
+PAM Error Message: The password is the same as the old one
 Insert 'r' to cancel the request and go back
 Enter your new password (3 days until mandatory):
-The password fails the dictionary check - it is based on a dictionary word
+PAM Error Message: The password fails the dictionary check - it is based on a dictionary word
 Insert 'r' to cancel the request and go back
 Enter your new password (3 days until mandatory):
-The password is the same as the old one
+PAM Error Message: The password is the same as the old one
 Insert 'r' to cancel the request and go back
 Enter your new password (3 days until mandatory):
-The password is shorter than 8 characters
+PAM Error Message: The password is shorter than 8 characters
+Insert 'r' to cancel the request and go back
+Enter your new password (3 days until mandatory):
+
+
+
+
+────────────────────────────────────────────────────────────────────────────────
+> ./pam_authd login socket=${AUTHD_TESTS_CLI_AUTHENTICATE_TESTS_SOCK} force_native_client=true
+Username: user-mfa-with-reset
+== Broker selection (use 'r' to go back) ==
+1 - local
+2 - ExampleBroker
+Select broker: 2
+Insert 'r' to cancel the request and go back
+Gimme your password:
+Leave the input field empty to wait for the authentication method or insert 'r' to go back
+Plug your fido device and press with your thumb:
+== Password Update (use 'r' to go back) ==
+1 - Proceed with password update
+2 - Skip
+Select action: 1
+Insert 'r' to cancel the request and go back
+Enter your new password (3 days until mandatory):
+PAM Error Message: The password is the same as the old one
+Insert 'r' to cancel the request and go back
+Enter your new password (3 days until mandatory):
+PAM Error Message: The password fails the dictionary check - it is based on a dictionary word
+Insert 'r' to cancel the request and go back
+Enter your new password (3 days until mandatory):
+PAM Error Message: The password is the same as the old one
+Insert 'r' to cancel the request and go back
+Enter your new password (3 days until mandatory):
+PAM Error Message: The password is shorter than 8 characters
 Insert 'r' to cancel the request and go back
 Enter your new password (3 days until mandatory):
 Repeat the previously inserted password or insert 'r' to cancel the request and go back
@@ -509,16 +509,16 @@ Plug your fido device and press with your thumb:
 Select action: 1
 Insert 'r' to cancel the request and go back
 Enter your new password (3 days until mandatory):
-The password is the same as the old one
+PAM Error Message: The password is the same as the old one
 Insert 'r' to cancel the request and go back
 Enter your new password (3 days until mandatory):
-The password fails the dictionary check - it is based on a dictionary word
+PAM Error Message: The password fails the dictionary check - it is based on a dictionary word
 Insert 'r' to cancel the request and go back
 Enter your new password (3 days until mandatory):
-The password is the same as the old one
+PAM Error Message: The password is the same as the old one
 Insert 'r' to cancel the request and go back
 Enter your new password (3 days until mandatory):
-The password is shorter than 8 characters
+PAM Error Message: The password is shorter than 8 characters
 Insert 'r' to cancel the request and go back
 Enter your new password (3 days until mandatory):
 Repeat the previously inserted password or insert 'r' to cancel the request and go back
@@ -542,16 +542,16 @@ Plug your fido device and press with your thumb:
 Select action: 1
 Insert 'r' to cancel the request and go back
 Enter your new password (3 days until mandatory):
-The password is the same as the old one
+PAM Error Message: The password is the same as the old one
 Insert 'r' to cancel the request and go back
 Enter your new password (3 days until mandatory):
-The password fails the dictionary check - it is based on a dictionary word
+PAM Error Message: The password fails the dictionary check - it is based on a dictionary word
 Insert 'r' to cancel the request and go back
 Enter your new password (3 days until mandatory):
-The password is the same as the old one
+PAM Error Message: The password is the same as the old one
 Insert 'r' to cancel the request and go back
 Enter your new password (3 days until mandatory):
-The password is shorter than 8 characters
+PAM Error Message: The password is shorter than 8 characters
 Insert 'r' to cancel the request and go back
 Enter your new password (3 days until mandatory):
 Repeat the previously inserted password or insert 'r' to cancel the request and go back
@@ -575,16 +575,16 @@ Plug your fido device and press with your thumb:
 Select action: 1
 Insert 'r' to cancel the request and go back
 Enter your new password (3 days until mandatory):
-The password is the same as the old one
+PAM Error Message: The password is the same as the old one
 Insert 'r' to cancel the request and go back
 Enter your new password (3 days until mandatory):
-The password fails the dictionary check - it is based on a dictionary word
+PAM Error Message: The password fails the dictionary check - it is based on a dictionary word
 Insert 'r' to cancel the request and go back
 Enter your new password (3 days until mandatory):
-The password is the same as the old one
+PAM Error Message: The password is the same as the old one
 Insert 'r' to cancel the request and go back
 Enter your new password (3 days until mandatory):
-The password is shorter than 8 characters
+PAM Error Message: The password is shorter than 8 characters
 Insert 'r' to cancel the request and go back
 Enter your new password (3 days until mandatory):
 Repeat the previously inserted password or insert 'r' to cancel the request and go back

--- a/pam/integration-tests/testdata/TestNativeAuthenticate/golden/deny_authentication_if_current_user_is_not_considered_as_root
+++ b/pam/integration-tests/testdata/TestNativeAuthenticate/golden/deny_authentication_if_current_user_is_not_considered_as_root
@@ -33,8 +33,8 @@ Username:
 ────────────────────────────────────────────────────────────────────────────────
 > ./pam_authd login socket=${AUTHD_TESTS_CLI_AUTHENTICATE_TESTS_SOCK} force_native_client=true
 Username:
-could not get current available brokers: permission denied: this action is only allowed for root
- users. Current user is XXXX
+PAM Error Message: could not get current available brokers: permission denied: this action is on
+ly allowed for root users. Current user is XXXX
 PAM Authenticate() for user "" exited with error (PAM exit code: 4): System error
 acct=incomplete
 PAM AcctMgmt() exited with error (PAM exit code: 25): The return value should be ignored by PAM
@@ -66,8 +66,8 @@ dispatch
 ────────────────────────────────────────────────────────────────────────────────
 > ./pam_authd login socket=${AUTHD_TESTS_CLI_AUTHENTICATE_TESTS_SOCK} force_native_client=true
 Username:
-could not get current available brokers: permission denied: this action is only allowed for root
- users. Current user is XXXX
+PAM Error Message: could not get current available brokers: permission denied: this action is on
+ly allowed for root users. Current user is XXXX
 PAM Authenticate() for user "" exited with error (PAM exit code: 4): System error
 acct=incomplete
 PAM AcctMgmt() exited with error (PAM exit code: 25): The return value should be ignored by PAM

--- a/pam/integration-tests/testdata/TestNativeAuthenticate/golden/deny_authentication_if_max_attempts_reached
+++ b/pam/integration-tests/testdata/TestNativeAuthenticate/golden/deny_authentication_if_max_attempts_reached
@@ -138,7 +138,7 @@ Username: user-integration-max-attempts
 Select broker: 2
 Insert 'r' to cancel the request and go back
 Gimme your password:
-invalid password 'wrongpass', should be 'goodpass'
+PAM Error Message: invalid password 'wrongpass', should be 'goodpass'
 Insert 'r' to cancel the request and go back
 Gimme your password:
 
@@ -171,10 +171,10 @@ Username: user-integration-max-attempts
 Select broker: 2
 Insert 'r' to cancel the request and go back
 Gimme your password:
-invalid password 'wrongpass', should be 'goodpass'
+PAM Error Message: invalid password 'wrongpass', should be 'goodpass'
 Insert 'r' to cancel the request and go back
 Gimme your password:
-invalid password 'wrongpass', should be 'goodpass'
+PAM Error Message: invalid password 'wrongpass', should be 'goodpass'
 Insert 'r' to cancel the request and go back
 Gimme your password:
 
@@ -204,13 +204,13 @@ Username: user-integration-max-attempts
 Select broker: 2
 Insert 'r' to cancel the request and go back
 Gimme your password:
-invalid password 'wrongpass', should be 'goodpass'
+PAM Error Message: invalid password 'wrongpass', should be 'goodpass'
 Insert 'r' to cancel the request and go back
 Gimme your password:
-invalid password 'wrongpass', should be 'goodpass'
+PAM Error Message: invalid password 'wrongpass', should be 'goodpass'
 Insert 'r' to cancel the request and go back
 Gimme your password:
-invalid password 'wrongpass', should be 'goodpass'
+PAM Error Message: invalid password 'wrongpass', should be 'goodpass'
 Insert 'r' to cancel the request and go back
 Gimme your password:
 
@@ -237,16 +237,16 @@ Username: user-integration-max-attempts
 Select broker: 2
 Insert 'r' to cancel the request and go back
 Gimme your password:
-invalid password 'wrongpass', should be 'goodpass'
+PAM Error Message: invalid password 'wrongpass', should be 'goodpass'
 Insert 'r' to cancel the request and go back
 Gimme your password:
-invalid password 'wrongpass', should be 'goodpass'
+PAM Error Message: invalid password 'wrongpass', should be 'goodpass'
 Insert 'r' to cancel the request and go back
 Gimme your password:
-invalid password 'wrongpass', should be 'goodpass'
+PAM Error Message: invalid password 'wrongpass', should be 'goodpass'
 Insert 'r' to cancel the request and go back
 Gimme your password:
-invalid password 'wrongpass', should be 'goodpass'
+PAM Error Message: invalid password 'wrongpass', should be 'goodpass'
 Insert 'r' to cancel the request and go back
 Gimme your password:
 
@@ -270,19 +270,19 @@ Username: user-integration-max-attempts
 Select broker: 2
 Insert 'r' to cancel the request and go back
 Gimme your password:
-invalid password 'wrongpass', should be 'goodpass'
+PAM Error Message: invalid password 'wrongpass', should be 'goodpass'
 Insert 'r' to cancel the request and go back
 Gimme your password:
-invalid password 'wrongpass', should be 'goodpass'
+PAM Error Message: invalid password 'wrongpass', should be 'goodpass'
 Insert 'r' to cancel the request and go back
 Gimme your password:
-invalid password 'wrongpass', should be 'goodpass'
+PAM Error Message: invalid password 'wrongpass', should be 'goodpass'
 Insert 'r' to cancel the request and go back
 Gimme your password:
-invalid password 'wrongpass', should be 'goodpass'
+PAM Error Message: invalid password 'wrongpass', should be 'goodpass'
 Insert 'r' to cancel the request and go back
 Gimme your password:
-invalid password 'wrongpass', should be 'goodpass'
+PAM Error Message: invalid password 'wrongpass', should be 'goodpass'
 PAM Authenticate() for user "user-integration-max-attempts" exited with error (PAM exit code: 7)
 : Authentication failure
 acct=incomplete
@@ -303,19 +303,19 @@ Username: user-integration-max-attempts
 Select broker: 2
 Insert 'r' to cancel the request and go back
 Gimme your password:
-invalid password 'wrongpass', should be 'goodpass'
+PAM Error Message: invalid password 'wrongpass', should be 'goodpass'
 Insert 'r' to cancel the request and go back
 Gimme your password:
-invalid password 'wrongpass', should be 'goodpass'
+PAM Error Message: invalid password 'wrongpass', should be 'goodpass'
 Insert 'r' to cancel the request and go back
 Gimme your password:
-invalid password 'wrongpass', should be 'goodpass'
+PAM Error Message: invalid password 'wrongpass', should be 'goodpass'
 Insert 'r' to cancel the request and go back
 Gimme your password:
-invalid password 'wrongpass', should be 'goodpass'
+PAM Error Message: invalid password 'wrongpass', should be 'goodpass'
 Insert 'r' to cancel the request and go back
 Gimme your password:
-invalid password 'wrongpass', should be 'goodpass'
+PAM Error Message: invalid password 'wrongpass', should be 'goodpass'
 PAM Authenticate() for user "user-integration-max-attempts" exited with error (PAM exit code: 7)
 : Authentication failure
 acct=incomplete

--- a/pam/integration-tests/testdata/TestNativeAuthenticate/golden/deny_authentication_if_newpassword_does_not_match_required_criteria
+++ b/pam/integration-tests/testdata/TestNativeAuthenticate/golden/deny_authentication_if_newpassword_does_not_match_required_criteria
@@ -193,7 +193,7 @@ Insert 'r' to cancel the request and go back
 Gimme your password:
 Insert 'r' to cancel the request and go back
 Enter your new password:
-No password supplied
+PAM Error Message: No password supplied
 Insert 'r' to cancel the request and go back
 Enter your new password:
 
@@ -230,10 +230,10 @@ Insert 'r' to cancel the request and go back
 Gimme your password:
 Insert 'r' to cancel the request and go back
 Enter your new password:
-No password supplied
+PAM Error Message: No password supplied
 Insert 'r' to cancel the request and go back
 Enter your new password:
-The password is shorter than 8 characters
+PAM Error Message: The password is shorter than 8 characters
 Insert 'r' to cancel the request and go back
 Enter your new password:
 
@@ -267,13 +267,13 @@ Insert 'r' to cancel the request and go back
 Gimme your password:
 Insert 'r' to cancel the request and go back
 Enter your new password:
-No password supplied
+PAM Error Message: No password supplied
 Insert 'r' to cancel the request and go back
 Enter your new password:
-The password is shorter than 8 characters
+PAM Error Message: The password is shorter than 8 characters
 Insert 'r' to cancel the request and go back
 Enter your new password:
-The password fails the dictionary check - it is too simplistic/systematic
+PAM Error Message: The password fails the dictionary check - it is too simplistic/systematic
 Insert 'r' to cancel the request and go back
 Enter your new password:
 
@@ -304,13 +304,13 @@ Insert 'r' to cancel the request and go back
 Gimme your password:
 Insert 'r' to cancel the request and go back
 Enter your new password:
-No password supplied
+PAM Error Message: No password supplied
 Insert 'r' to cancel the request and go back
 Enter your new password:
-The password is shorter than 8 characters
+PAM Error Message: The password is shorter than 8 characters
 Insert 'r' to cancel the request and go back
 Enter your new password:
-The password fails the dictionary check - it is too simplistic/systematic
+PAM Error Message: The password fails the dictionary check - it is too simplistic/systematic
 Insert 'r' to cancel the request and go back
 Enter your new password:
 Repeat the previously inserted password or insert 'r' to cancel the request and go back
@@ -341,18 +341,18 @@ Insert 'r' to cancel the request and go back
 Gimme your password:
 Insert 'r' to cancel the request and go back
 Enter your new password:
-No password supplied
+PAM Error Message: No password supplied
 Insert 'r' to cancel the request and go back
 Enter your new password:
-The password is shorter than 8 characters
+PAM Error Message: The password is shorter than 8 characters
 Insert 'r' to cancel the request and go back
 Enter your new password:
-The password fails the dictionary check - it is too simplistic/systematic
+PAM Error Message: The password fails the dictionary check - it is too simplistic/systematic
 Insert 'r' to cancel the request and go back
 Enter your new password:
 Repeat the previously inserted password or insert 'r' to cancel the request and go back
 Enter your new password:
-Password entries don't match
+PAM Error Message: Password entries don't match
 Insert 'r' to cancel the request and go back
 Enter your new password:
 
@@ -378,21 +378,21 @@ Insert 'r' to cancel the request and go back
 Gimme your password:
 Insert 'r' to cancel the request and go back
 Enter your new password:
-No password supplied
+PAM Error Message: No password supplied
 Insert 'r' to cancel the request and go back
 Enter your new password:
-The password is shorter than 8 characters
+PAM Error Message: The password is shorter than 8 characters
 Insert 'r' to cancel the request and go back
 Enter your new password:
-The password fails the dictionary check - it is too simplistic/systematic
+PAM Error Message: The password fails the dictionary check - it is too simplistic/systematic
 Insert 'r' to cancel the request and go back
 Enter your new password:
 Repeat the previously inserted password or insert 'r' to cancel the request and go back
 Enter your new password:
-Password entries don't match
+PAM Error Message: Password entries don't match
 Insert 'r' to cancel the request and go back
 Enter your new password:
-No password supplied
+PAM Error Message: No password supplied
 Insert 'r' to cancel the request and go back
 Enter your new password:
 
@@ -415,21 +415,21 @@ Insert 'r' to cancel the request and go back
 Gimme your password:
 Insert 'r' to cancel the request and go back
 Enter your new password:
-No password supplied
+PAM Error Message: No password supplied
 Insert 'r' to cancel the request and go back
 Enter your new password:
-The password is shorter than 8 characters
+PAM Error Message: The password is shorter than 8 characters
 Insert 'r' to cancel the request and go back
 Enter your new password:
-The password fails the dictionary check - it is too simplistic/systematic
+PAM Error Message: The password fails the dictionary check - it is too simplistic/systematic
 Insert 'r' to cancel the request and go back
 Enter your new password:
 Repeat the previously inserted password or insert 'r' to cancel the request and go back
 Enter your new password:
-Password entries don't match
+PAM Error Message: Password entries don't match
 Insert 'r' to cancel the request and go back
 Enter your new password:
-No password supplied
+PAM Error Message: No password supplied
 Insert 'r' to cancel the request and go back
 Enter your new password:
 Repeat the previously inserted password or insert 'r' to cancel the request and go back
@@ -452,21 +452,21 @@ Insert 'r' to cancel the request and go back
 Gimme your password:
 Insert 'r' to cancel the request and go back
 Enter your new password:
-No password supplied
+PAM Error Message: No password supplied
 Insert 'r' to cancel the request and go back
 Enter your new password:
-The password is shorter than 8 characters
+PAM Error Message: The password is shorter than 8 characters
 Insert 'r' to cancel the request and go back
 Enter your new password:
-The password fails the dictionary check - it is too simplistic/systematic
+PAM Error Message: The password fails the dictionary check - it is too simplistic/systematic
 Insert 'r' to cancel the request and go back
 Enter your new password:
 Repeat the previously inserted password or insert 'r' to cancel the request and go back
 Enter your new password:
-Password entries don't match
+PAM Error Message: Password entries don't match
 Insert 'r' to cancel the request and go back
 Enter your new password:
-No password supplied
+PAM Error Message: No password supplied
 Insert 'r' to cancel the request and go back
 Enter your new password:
 Repeat the previously inserted password or insert 'r' to cancel the request and go back
@@ -489,21 +489,21 @@ Insert 'r' to cancel the request and go back
 Gimme your password:
 Insert 'r' to cancel the request and go back
 Enter your new password:
-No password supplied
+PAM Error Message: No password supplied
 Insert 'r' to cancel the request and go back
 Enter your new password:
-The password is shorter than 8 characters
+PAM Error Message: The password is shorter than 8 characters
 Insert 'r' to cancel the request and go back
 Enter your new password:
-The password fails the dictionary check - it is too simplistic/systematic
+PAM Error Message: The password fails the dictionary check - it is too simplistic/systematic
 Insert 'r' to cancel the request and go back
 Enter your new password:
 Repeat the previously inserted password or insert 'r' to cancel the request and go back
 Enter your new password:
-Password entries don't match
+PAM Error Message: Password entries don't match
 Insert 'r' to cancel the request and go back
 Enter your new password:
-No password supplied
+PAM Error Message: No password supplied
 Insert 'r' to cancel the request and go back
 Enter your new password:
 Repeat the previously inserted password or insert 'r' to cancel the request and go back

--- a/pam/integration-tests/testdata/TestNativeAuthenticate/golden/deny_authentication_if_user_does_not_exist
+++ b/pam/integration-tests/testdata/TestNativeAuthenticate/golden/deny_authentication_if_user_does_not_exist
@@ -103,7 +103,7 @@ Username: user-unexistent
 1 - local
 2 - ExampleBroker
 Select broker: 2
-can't select broker: user "user-unexistent" does not exist
+PAM Error Message: can't select broker: user "user-unexistent" does not exist
 PAM Authenticate() for user "user-unexistent" exited with error (PAM exit code: 4): System error
 acct=incomplete
 PAM AcctMgmt() exited with error (PAM exit code: 25): The return value should be ignored by PAM
@@ -136,7 +136,7 @@ Username: user-unexistent
 1 - local
 2 - ExampleBroker
 Select broker: 2
-can't select broker: user "user-unexistent" does not exist
+PAM Error Message: can't select broker: user "user-unexistent" does not exist
 PAM Authenticate() for user "user-unexistent" exited with error (PAM exit code: 4): System error
 acct=incomplete
 PAM AcctMgmt() exited with error (PAM exit code: 25): The return value should be ignored by PAM

--- a/pam/integration-tests/testdata/TestNativeChangeAuthTok/golden/prevent_change_password_if_auth_fails
+++ b/pam/integration-tests/testdata/TestNativeChangeAuthTok/golden/prevent_change_password_if_auth_fails
@@ -138,7 +138,7 @@ Username: user-integration-max-attempts
 Select broker: 2
 Insert 'r' to cancel the request and go back
 Gimme your password:
-invalid password 'wrongpass', should be 'goodpass'
+PAM Error Message: invalid password 'wrongpass', should be 'goodpass'
 Insert 'r' to cancel the request and go back
 Gimme your password:
 
@@ -171,10 +171,10 @@ Username: user-integration-max-attempts
 Select broker: 2
 Insert 'r' to cancel the request and go back
 Gimme your password:
-invalid password 'wrongpass', should be 'goodpass'
+PAM Error Message: invalid password 'wrongpass', should be 'goodpass'
 Insert 'r' to cancel the request and go back
 Gimme your password:
-invalid password 'wrongpass', should be 'goodpass'
+PAM Error Message: invalid password 'wrongpass', should be 'goodpass'
 Insert 'r' to cancel the request and go back
 Gimme your password:
 
@@ -204,13 +204,13 @@ Username: user-integration-max-attempts
 Select broker: 2
 Insert 'r' to cancel the request and go back
 Gimme your password:
-invalid password 'wrongpass', should be 'goodpass'
+PAM Error Message: invalid password 'wrongpass', should be 'goodpass'
 Insert 'r' to cancel the request and go back
 Gimme your password:
-invalid password 'wrongpass', should be 'goodpass'
+PAM Error Message: invalid password 'wrongpass', should be 'goodpass'
 Insert 'r' to cancel the request and go back
 Gimme your password:
-invalid password 'wrongpass', should be 'goodpass'
+PAM Error Message: invalid password 'wrongpass', should be 'goodpass'
 Insert 'r' to cancel the request and go back
 Gimme your password:
 
@@ -237,16 +237,16 @@ Username: user-integration-max-attempts
 Select broker: 2
 Insert 'r' to cancel the request and go back
 Gimme your password:
-invalid password 'wrongpass', should be 'goodpass'
+PAM Error Message: invalid password 'wrongpass', should be 'goodpass'
 Insert 'r' to cancel the request and go back
 Gimme your password:
-invalid password 'wrongpass', should be 'goodpass'
+PAM Error Message: invalid password 'wrongpass', should be 'goodpass'
 Insert 'r' to cancel the request and go back
 Gimme your password:
-invalid password 'wrongpass', should be 'goodpass'
+PAM Error Message: invalid password 'wrongpass', should be 'goodpass'
 Insert 'r' to cancel the request and go back
 Gimme your password:
-invalid password 'wrongpass', should be 'goodpass'
+PAM Error Message: invalid password 'wrongpass', should be 'goodpass'
 Insert 'r' to cancel the request and go back
 Gimme your password:
 
@@ -270,19 +270,19 @@ Username: user-integration-max-attempts
 Select broker: 2
 Insert 'r' to cancel the request and go back
 Gimme your password:
-invalid password 'wrongpass', should be 'goodpass'
+PAM Error Message: invalid password 'wrongpass', should be 'goodpass'
 Insert 'r' to cancel the request and go back
 Gimme your password:
-invalid password 'wrongpass', should be 'goodpass'
+PAM Error Message: invalid password 'wrongpass', should be 'goodpass'
 Insert 'r' to cancel the request and go back
 Gimme your password:
-invalid password 'wrongpass', should be 'goodpass'
+PAM Error Message: invalid password 'wrongpass', should be 'goodpass'
 Insert 'r' to cancel the request and go back
 Gimme your password:
-invalid password 'wrongpass', should be 'goodpass'
+PAM Error Message: invalid password 'wrongpass', should be 'goodpass'
 Insert 'r' to cancel the request and go back
 Gimme your password:
-invalid password 'wrongpass', should be 'goodpass'
+PAM Error Message: invalid password 'wrongpass', should be 'goodpass'
 PAM ChangeAuthTok() for user "user-integration-max-attempts" exited with error (PAM exit code: 7
 ): Authentication failure
 acct=incomplete
@@ -303,19 +303,19 @@ Username: user-integration-max-attempts
 Select broker: 2
 Insert 'r' to cancel the request and go back
 Gimme your password:
-invalid password 'wrongpass', should be 'goodpass'
+PAM Error Message: invalid password 'wrongpass', should be 'goodpass'
 Insert 'r' to cancel the request and go back
 Gimme your password:
-invalid password 'wrongpass', should be 'goodpass'
+PAM Error Message: invalid password 'wrongpass', should be 'goodpass'
 Insert 'r' to cancel the request and go back
 Gimme your password:
-invalid password 'wrongpass', should be 'goodpass'
+PAM Error Message: invalid password 'wrongpass', should be 'goodpass'
 Insert 'r' to cancel the request and go back
 Gimme your password:
-invalid password 'wrongpass', should be 'goodpass'
+PAM Error Message: invalid password 'wrongpass', should be 'goodpass'
 Insert 'r' to cancel the request and go back
 Gimme your password:
-invalid password 'wrongpass', should be 'goodpass'
+PAM Error Message: invalid password 'wrongpass', should be 'goodpass'
 PAM ChangeAuthTok() for user "user-integration-max-attempts" exited with error (PAM exit code: 7
 ): Authentication failure
 acct=incomplete

--- a/pam/integration-tests/testdata/TestNativeChangeAuthTok/golden/prevent_change_password_if_current_user_is_not_root_as_can't_authenticate
+++ b/pam/integration-tests/testdata/TestNativeChangeAuthTok/golden/prevent_change_password_if_current_user_is_not_root_as_can't_authenticate
@@ -33,8 +33,8 @@ Username:
 ────────────────────────────────────────────────────────────────────────────────
 > ./pam_authd passwd socket=${AUTHD_TESTS_CLI_AUTHTOK_TESTS_SOCK} force_native_client=true
 Username:
-could not get current available brokers: permission denied: this action is only allowed for root
- users. Current user is XXXX
+PAM Error Message: could not get current available brokers: permission denied: this action is on
+ly allowed for root users. Current user is XXXX
 PAM ChangeAuthTok() for user "" exited with error (PAM exit code: 4): System error
 acct=incomplete
 PAM AcctMgmt() exited with error (PAM exit code: 25): The return value should be ignored by PAM
@@ -66,8 +66,8 @@ dispatch
 ────────────────────────────────────────────────────────────────────────────────
 > ./pam_authd passwd socket=${AUTHD_TESTS_CLI_AUTHTOK_TESTS_SOCK} force_native_client=true
 Username:
-could not get current available brokers: permission denied: this action is only allowed for root
- users. Current user is XXXX
+PAM Error Message: could not get current available brokers: permission denied: this action is on
+ly allowed for root users. Current user is XXXX
 PAM ChangeAuthTok() for user "" exited with error (PAM exit code: 4): System error
 acct=incomplete
 PAM AcctMgmt() exited with error (PAM exit code: 25): The return value should be ignored by PAM

--- a/pam/integration-tests/testdata/TestNativeChangeAuthTok/golden/prevent_change_password_if_user_does_not_exist
+++ b/pam/integration-tests/testdata/TestNativeChangeAuthTok/golden/prevent_change_password_if_user_does_not_exist
@@ -103,7 +103,7 @@ Username: user-unexistent
 1 - local
 2 - ExampleBroker
 Select broker: 2
-can't select broker: user "user-unexistent" does not exist
+PAM Error Message: can't select broker: user "user-unexistent" does not exist
 PAM ChangeAuthTok() for user "user-unexistent" exited with error (PAM exit code: 4): System erro
 r
 acct=incomplete
@@ -136,7 +136,7 @@ Username: user-unexistent
 1 - local
 2 - ExampleBroker
 Select broker: 2
-can't select broker: user "user-unexistent" does not exist
+PAM Error Message: can't select broker: user "user-unexistent" does not exist
 PAM ChangeAuthTok() for user "user-unexistent" exited with error (PAM exit code: 4): System erro
 r
 acct=incomplete

--- a/pam/integration-tests/testdata/TestNativeChangeAuthTok/golden/retry_if_new_password_does_not_match_quality_criteria
+++ b/pam/integration-tests/testdata/TestNativeChangeAuthTok/golden/retry_if_new_password_does_not_match_quality_criteria
@@ -193,7 +193,7 @@ Insert 'r' to cancel the request and go back
 Gimme your password:
 Insert 'r' to cancel the request and go back
 Enter your new password:
-No password supplied
+PAM Error Message: No password supplied
 Insert 'r' to cancel the request and go back
 Enter your new password:
 
@@ -230,10 +230,10 @@ Insert 'r' to cancel the request and go back
 Gimme your password:
 Insert 'r' to cancel the request and go back
 Enter your new password:
-No password supplied
+PAM Error Message: No password supplied
 Insert 'r' to cancel the request and go back
 Enter your new password:
-The password is shorter than 8 characters
+PAM Error Message: The password is shorter than 8 characters
 Insert 'r' to cancel the request and go back
 Enter your new password:
 
@@ -267,13 +267,13 @@ Insert 'r' to cancel the request and go back
 Gimme your password:
 Insert 'r' to cancel the request and go back
 Enter your new password:
-No password supplied
+PAM Error Message: No password supplied
 Insert 'r' to cancel the request and go back
 Enter your new password:
-The password is shorter than 8 characters
+PAM Error Message: The password is shorter than 8 characters
 Insert 'r' to cancel the request and go back
 Enter your new password:
-The password fails the dictionary check - it is too simplistic/systematic
+PAM Error Message: The password fails the dictionary check - it is too simplistic/systematic
 Insert 'r' to cancel the request and go back
 Enter your new password:
 
@@ -304,13 +304,13 @@ Insert 'r' to cancel the request and go back
 Gimme your password:
 Insert 'r' to cancel the request and go back
 Enter your new password:
-No password supplied
+PAM Error Message: No password supplied
 Insert 'r' to cancel the request and go back
 Enter your new password:
-The password is shorter than 8 characters
+PAM Error Message: The password is shorter than 8 characters
 Insert 'r' to cancel the request and go back
 Enter your new password:
-The password fails the dictionary check - it is too simplistic/systematic
+PAM Error Message: The password fails the dictionary check - it is too simplistic/systematic
 Insert 'r' to cancel the request and go back
 Enter your new password:
 Repeat the previously inserted password or insert 'r' to cancel the request and go back
@@ -341,18 +341,18 @@ Insert 'r' to cancel the request and go back
 Gimme your password:
 Insert 'r' to cancel the request and go back
 Enter your new password:
-No password supplied
+PAM Error Message: No password supplied
 Insert 'r' to cancel the request and go back
 Enter your new password:
-The password is shorter than 8 characters
+PAM Error Message: The password is shorter than 8 characters
 Insert 'r' to cancel the request and go back
 Enter your new password:
-The password fails the dictionary check - it is too simplistic/systematic
+PAM Error Message: The password fails the dictionary check - it is too simplistic/systematic
 Insert 'r' to cancel the request and go back
 Enter your new password:
 Repeat the previously inserted password or insert 'r' to cancel the request and go back
 Enter your new password:
-Password entries don't match
+PAM Error Message: Password entries don't match
 Insert 'r' to cancel the request and go back
 Enter your new password:
 
@@ -378,21 +378,21 @@ Insert 'r' to cancel the request and go back
 Gimme your password:
 Insert 'r' to cancel the request and go back
 Enter your new password:
-No password supplied
+PAM Error Message: No password supplied
 Insert 'r' to cancel the request and go back
 Enter your new password:
-The password is shorter than 8 characters
+PAM Error Message: The password is shorter than 8 characters
 Insert 'r' to cancel the request and go back
 Enter your new password:
-The password fails the dictionary check - it is too simplistic/systematic
+PAM Error Message: The password fails the dictionary check - it is too simplistic/systematic
 Insert 'r' to cancel the request and go back
 Enter your new password:
 Repeat the previously inserted password or insert 'r' to cancel the request and go back
 Enter your new password:
-Password entries don't match
+PAM Error Message: Password entries don't match
 Insert 'r' to cancel the request and go back
 Enter your new password:
-No password supplied
+PAM Error Message: No password supplied
 Insert 'r' to cancel the request and go back
 Enter your new password:
 
@@ -415,21 +415,21 @@ Insert 'r' to cancel the request and go back
 Gimme your password:
 Insert 'r' to cancel the request and go back
 Enter your new password:
-No password supplied
+PAM Error Message: No password supplied
 Insert 'r' to cancel the request and go back
 Enter your new password:
-The password is shorter than 8 characters
+PAM Error Message: The password is shorter than 8 characters
 Insert 'r' to cancel the request and go back
 Enter your new password:
-The password fails the dictionary check - it is too simplistic/systematic
+PAM Error Message: The password fails the dictionary check - it is too simplistic/systematic
 Insert 'r' to cancel the request and go back
 Enter your new password:
 Repeat the previously inserted password or insert 'r' to cancel the request and go back
 Enter your new password:
-Password entries don't match
+PAM Error Message: Password entries don't match
 Insert 'r' to cancel the request and go back
 Enter your new password:
-No password supplied
+PAM Error Message: No password supplied
 Insert 'r' to cancel the request and go back
 Enter your new password:
 Repeat the previously inserted password or insert 'r' to cancel the request and go back
@@ -452,21 +452,21 @@ Insert 'r' to cancel the request and go back
 Gimme your password:
 Insert 'r' to cancel the request and go back
 Enter your new password:
-No password supplied
+PAM Error Message: No password supplied
 Insert 'r' to cancel the request and go back
 Enter your new password:
-The password is shorter than 8 characters
+PAM Error Message: The password is shorter than 8 characters
 Insert 'r' to cancel the request and go back
 Enter your new password:
-The password fails the dictionary check - it is too simplistic/systematic
+PAM Error Message: The password fails the dictionary check - it is too simplistic/systematic
 Insert 'r' to cancel the request and go back
 Enter your new password:
 Repeat the previously inserted password or insert 'r' to cancel the request and go back
 Enter your new password:
-Password entries don't match
+PAM Error Message: Password entries don't match
 Insert 'r' to cancel the request and go back
 Enter your new password:
-No password supplied
+PAM Error Message: No password supplied
 Insert 'r' to cancel the request and go back
 Enter your new password:
 Repeat the previously inserted password or insert 'r' to cancel the request and go back
@@ -489,21 +489,21 @@ Insert 'r' to cancel the request and go back
 Gimme your password:
 Insert 'r' to cancel the request and go back
 Enter your new password:
-No password supplied
+PAM Error Message: No password supplied
 Insert 'r' to cancel the request and go back
 Enter your new password:
-The password is shorter than 8 characters
+PAM Error Message: The password is shorter than 8 characters
 Insert 'r' to cancel the request and go back
 Enter your new password:
-The password fails the dictionary check - it is too simplistic/systematic
+PAM Error Message: The password fails the dictionary check - it is too simplistic/systematic
 Insert 'r' to cancel the request and go back
 Enter your new password:
 Repeat the previously inserted password or insert 'r' to cancel the request and go back
 Enter your new password:
-Password entries don't match
+PAM Error Message: Password entries don't match
 Insert 'r' to cancel the request and go back
 Enter your new password:
-No password supplied
+PAM Error Message: No password supplied
 Insert 'r' to cancel the request and go back
 Enter your new password:
 Repeat the previously inserted password or insert 'r' to cancel the request and go back

--- a/pam/integration-tests/testdata/TestNativeChangeAuthTok/golden/retry_if_new_password_is_rejected_by_broker
+++ b/pam/integration-tests/testdata/TestNativeChangeAuthTok/golden/retry_if_new_password_is_rejected_by_broker
@@ -339,7 +339,7 @@ Insert 'r' to cancel the request and go back
 Enter your new password:
 Repeat the previously inserted password or insert 'r' to cancel the request and go back
 Enter your new password:
-new password does not match criteria: must be 'authd2404'
+PAM Error Message: new password does not match criteria: must be 'authd2404'
 Insert 'r' to cancel the request and go back
 Enter your new password:
 
@@ -386,7 +386,7 @@ Insert 'r' to cancel the request and go back
 Enter your new password:
 Repeat the previously inserted password or insert 'r' to cancel the request and go back
 Enter your new password:
-new password does not match criteria: must be 'authd2404'
+PAM Error Message: new password does not match criteria: must be 'authd2404'
 Insert 'r' to cancel the request and go back
 Enter your new password:
 Repeat the previously inserted password or insert 'r' to cancel the request and go back
@@ -433,7 +433,7 @@ Insert 'r' to cancel the request and go back
 Enter your new password:
 Repeat the previously inserted password or insert 'r' to cancel the request and go back
 Enter your new password:
-new password does not match criteria: must be 'authd2404'
+PAM Error Message: new password does not match criteria: must be 'authd2404'
 Insert 'r' to cancel the request and go back
 Enter your new password:
 Repeat the previously inserted password or insert 'r' to cancel the request and go back
@@ -480,7 +480,7 @@ Insert 'r' to cancel the request and go back
 Enter your new password:
 Repeat the previously inserted password or insert 'r' to cancel the request and go back
 Enter your new password:
-new password does not match criteria: must be 'authd2404'
+PAM Error Message: new password does not match criteria: must be 'authd2404'
 Insert 'r' to cancel the request and go back
 Enter your new password:
 Repeat the previously inserted password or insert 'r' to cancel the request and go back
@@ -527,7 +527,7 @@ Insert 'r' to cancel the request and go back
 Enter your new password:
 Repeat the previously inserted password or insert 'r' to cancel the request and go back
 Enter your new password:
-new password does not match criteria: must be 'authd2404'
+PAM Error Message: new password does not match criteria: must be 'authd2404'
 Insert 'r' to cancel the request and go back
 Enter your new password:
 Repeat the previously inserted password or insert 'r' to cancel the request and go back
@@ -574,7 +574,7 @@ Insert 'r' to cancel the request and go back
 Enter your new password:
 Repeat the previously inserted password or insert 'r' to cancel the request and go back
 Enter your new password:
-new password does not match criteria: must be 'authd2404'
+PAM Error Message: new password does not match criteria: must be 'authd2404'
 Insert 'r' to cancel the request and go back
 Enter your new password:
 Repeat the previously inserted password or insert 'r' to cancel the request and go back
@@ -621,7 +621,7 @@ Insert 'r' to cancel the request and go back
 Enter your new password:
 Repeat the previously inserted password or insert 'r' to cancel the request and go back
 Enter your new password:
-new password does not match criteria: must be 'authd2404'
+PAM Error Message: new password does not match criteria: must be 'authd2404'
 Insert 'r' to cancel the request and go back
 Enter your new password:
 Repeat the previously inserted password or insert 'r' to cancel the request and go back
@@ -668,7 +668,7 @@ Insert 'r' to cancel the request and go back
 Enter your new password:
 Repeat the previously inserted password or insert 'r' to cancel the request and go back
 Enter your new password:
-new password does not match criteria: must be 'authd2404'
+PAM Error Message: new password does not match criteria: must be 'authd2404'
 Insert 'r' to cancel the request and go back
 Enter your new password:
 Repeat the previously inserted password or insert 'r' to cancel the request and go back
@@ -715,7 +715,7 @@ Insert 'r' to cancel the request and go back
 Enter your new password:
 Repeat the previously inserted password or insert 'r' to cancel the request and go back
 Enter your new password:
-new password does not match criteria: must be 'authd2404'
+PAM Error Message: new password does not match criteria: must be 'authd2404'
 Insert 'r' to cancel the request and go back
 Enter your new password:
 Repeat the previously inserted password or insert 'r' to cancel the request and go back
@@ -762,7 +762,7 @@ Insert 'r' to cancel the request and go back
 Enter your new password:
 Repeat the previously inserted password or insert 'r' to cancel the request and go back
 Enter your new password:
-new password does not match criteria: must be 'authd2404'
+PAM Error Message: new password does not match criteria: must be 'authd2404'
 Insert 'r' to cancel the request and go back
 Enter your new password:
 Repeat the previously inserted password or insert 'r' to cancel the request and go back
@@ -809,7 +809,7 @@ Insert 'r' to cancel the request and go back
 Enter your new password:
 Repeat the previously inserted password or insert 'r' to cancel the request and go back
 Enter your new password:
-new password does not match criteria: must be 'authd2404'
+PAM Error Message: new password does not match criteria: must be 'authd2404'
 Insert 'r' to cancel the request and go back
 Enter your new password:
 Repeat the previously inserted password or insert 'r' to cancel the request and go back
@@ -856,7 +856,7 @@ Insert 'r' to cancel the request and go back
 Enter your new password:
 Repeat the previously inserted password or insert 'r' to cancel the request and go back
 Enter your new password:
-new password does not match criteria: must be 'authd2404'
+PAM Error Message: new password does not match criteria: must be 'authd2404'
 Insert 'r' to cancel the request and go back
 Enter your new password:
 Repeat the previously inserted password or insert 'r' to cancel the request and go back
@@ -872,7 +872,7 @@ Insert 'r' to cancel the request and go back
 Enter your new password:
 Repeat the previously inserted password or insert 'r' to cancel the request and go back
 Enter your new password:
-new password does not match criteria: must be 'goodpass'
+PAM Error Message: new password does not match criteria: must be 'goodpass'
 Insert 'r' to cancel the request and go back
 Enter your new password:
 
@@ -903,7 +903,7 @@ Insert 'r' to cancel the request and go back
 Enter your new password:
 Repeat the previously inserted password or insert 'r' to cancel the request and go back
 Enter your new password:
-new password does not match criteria: must be 'authd2404'
+PAM Error Message: new password does not match criteria: must be 'authd2404'
 Insert 'r' to cancel the request and go back
 Enter your new password:
 Repeat the previously inserted password or insert 'r' to cancel the request and go back
@@ -919,7 +919,7 @@ Insert 'r' to cancel the request and go back
 Enter your new password:
 Repeat the previously inserted password or insert 'r' to cancel the request and go back
 Enter your new password:
-new password does not match criteria: must be 'goodpass'
+PAM Error Message: new password does not match criteria: must be 'goodpass'
 Insert 'r' to cancel the request and go back
 Enter your new password:
 Repeat the previously inserted password or insert 'r' to cancel the request and go back
@@ -950,7 +950,7 @@ Insert 'r' to cancel the request and go back
 Enter your new password:
 Repeat the previously inserted password or insert 'r' to cancel the request and go back
 Enter your new password:
-new password does not match criteria: must be 'authd2404'
+PAM Error Message: new password does not match criteria: must be 'authd2404'
 Insert 'r' to cancel the request and go back
 Enter your new password:
 Repeat the previously inserted password or insert 'r' to cancel the request and go back
@@ -966,7 +966,7 @@ Insert 'r' to cancel the request and go back
 Enter your new password:
 Repeat the previously inserted password or insert 'r' to cancel the request and go back
 Enter your new password:
-new password does not match criteria: must be 'goodpass'
+PAM Error Message: new password does not match criteria: must be 'goodpass'
 Insert 'r' to cancel the request and go back
 Enter your new password:
 Repeat the previously inserted password or insert 'r' to cancel the request and go back
@@ -997,7 +997,7 @@ Insert 'r' to cancel the request and go back
 Enter your new password:
 Repeat the previously inserted password or insert 'r' to cancel the request and go back
 Enter your new password:
-new password does not match criteria: must be 'authd2404'
+PAM Error Message: new password does not match criteria: must be 'authd2404'
 Insert 'r' to cancel the request and go back
 Enter your new password:
 Repeat the previously inserted password or insert 'r' to cancel the request and go back
@@ -1013,7 +1013,7 @@ Insert 'r' to cancel the request and go back
 Enter your new password:
 Repeat the previously inserted password or insert 'r' to cancel the request and go back
 Enter your new password:
-new password does not match criteria: must be 'goodpass'
+PAM Error Message: new password does not match criteria: must be 'goodpass'
 Insert 'r' to cancel the request and go back
 Enter your new password:
 Repeat the previously inserted password or insert 'r' to cancel the request and go back
@@ -1044,7 +1044,7 @@ Insert 'r' to cancel the request and go back
 Enter your new password:
 Repeat the previously inserted password or insert 'r' to cancel the request and go back
 Enter your new password:
-new password does not match criteria: must be 'authd2404'
+PAM Error Message: new password does not match criteria: must be 'authd2404'
 Insert 'r' to cancel the request and go back
 Enter your new password:
 Repeat the previously inserted password or insert 'r' to cancel the request and go back
@@ -1060,7 +1060,7 @@ Insert 'r' to cancel the request and go back
 Enter your new password:
 Repeat the previously inserted password or insert 'r' to cancel the request and go back
 Enter your new password:
-new password does not match criteria: must be 'goodpass'
+PAM Error Message: new password does not match criteria: must be 'goodpass'
 Insert 'r' to cancel the request and go back
 Enter your new password:
 Repeat the previously inserted password or insert 'r' to cancel the request and go back

--- a/pam/integration-tests/testdata/TestNativeChangeAuthTok/golden/retry_if_new_password_is_same_of_previous
+++ b/pam/integration-tests/testdata/TestNativeChangeAuthTok/golden/retry_if_new_password_is_same_of_previous
@@ -206,7 +206,7 @@ Insert 'r' to cancel the request and go back
 Gimme your password:
 Insert 'r' to cancel the request and go back
 Enter your new password:
-The password is the same as the old one
+PAM Error Message: The password is the same as the old one
 Insert 'r' to cancel the request and go back
 Enter your new password:
 
@@ -239,7 +239,7 @@ Insert 'r' to cancel the request and go back
 Gimme your password:
 Insert 'r' to cancel the request and go back
 Enter your new password:
-The password is the same as the old one
+PAM Error Message: The password is the same as the old one
 Insert 'r' to cancel the request and go back
 Enter your new password:
 Repeat the previously inserted password or insert 'r' to cancel the request and go back
@@ -272,7 +272,7 @@ Insert 'r' to cancel the request and go back
 Gimme your password:
 Insert 'r' to cancel the request and go back
 Enter your new password:
-The password is the same as the old one
+PAM Error Message: The password is the same as the old one
 Insert 'r' to cancel the request and go back
 Enter your new password:
 Repeat the previously inserted password or insert 'r' to cancel the request and go back
@@ -305,7 +305,7 @@ Insert 'r' to cancel the request and go back
 Gimme your password:
 Insert 'r' to cancel the request and go back
 Enter your new password:
-The password is the same as the old one
+PAM Error Message: The password is the same as the old one
 Insert 'r' to cancel the request and go back
 Enter your new password:
 Repeat the previously inserted password or insert 'r' to cancel the request and go back
@@ -338,7 +338,7 @@ Insert 'r' to cancel the request and go back
 Gimme your password:
 Insert 'r' to cancel the request and go back
 Enter your new password:
-The password is the same as the old one
+PAM Error Message: The password is the same as the old one
 Insert 'r' to cancel the request and go back
 Enter your new password:
 Repeat the previously inserted password or insert 'r' to cancel the request and go back

--- a/pam/integration-tests/testdata/TestNativeChangeAuthTok/golden/retry_if_password_confirmation_is_not_the_same
+++ b/pam/integration-tests/testdata/TestNativeChangeAuthTok/golden/retry_if_password_confirmation_is_not_the_same
@@ -241,7 +241,7 @@ Insert 'r' to cancel the request and go back
 Enter your new password:
 Repeat the previously inserted password or insert 'r' to cancel the request and go back
 Enter your new password:
-Password entries don't match
+PAM Error Message: Password entries don't match
 Insert 'r' to cancel the request and go back
 Enter your new password:
 
@@ -274,7 +274,7 @@ Insert 'r' to cancel the request and go back
 Enter your new password:
 Repeat the previously inserted password or insert 'r' to cancel the request and go back
 Enter your new password:
-Password entries don't match
+PAM Error Message: Password entries don't match
 Insert 'r' to cancel the request and go back
 Enter your new password:
 Repeat the previously inserted password or insert 'r' to cancel the request and go back
@@ -307,7 +307,7 @@ Insert 'r' to cancel the request and go back
 Enter your new password:
 Repeat the previously inserted password or insert 'r' to cancel the request and go back
 Enter your new password:
-Password entries don't match
+PAM Error Message: Password entries don't match
 Insert 'r' to cancel the request and go back
 Enter your new password:
 Repeat the previously inserted password or insert 'r' to cancel the request and go back
@@ -340,7 +340,7 @@ Insert 'r' to cancel the request and go back
 Enter your new password:
 Repeat the previously inserted password or insert 'r' to cancel the request and go back
 Enter your new password:
-Password entries don't match
+PAM Error Message: Password entries don't match
 Insert 'r' to cancel the request and go back
 Enter your new password:
 Repeat the previously inserted password or insert 'r' to cancel the request and go back
@@ -373,7 +373,7 @@ Insert 'r' to cancel the request and go back
 Enter your new password:
 Repeat the previously inserted password or insert 'r' to cancel the request and go back
 Enter your new password:
-Password entries don't match
+PAM Error Message: Password entries don't match
 Insert 'r' to cancel the request and go back
 Enter your new password:
 Repeat the previously inserted password or insert 'r' to cancel the request and go back

--- a/pam/main-cli.go
+++ b/pam/main-cli.go
@@ -148,7 +148,7 @@ func simpleConversationHandler(style pam.Style, msg string) (string, error) {
 	case pam.TextInfo:
 		fmt.Println(msg)
 	case pam.ErrorMsg:
-		fmt.Fprintf(os.Stderr, "%s\n", msg)
+		return noConversationHandler(style, msg)
 	case pam.PromptEchoOn:
 		fmt.Print(msg)
 		line, err := bufio.NewReader(os.Stdin).ReadString('\n')


### PR DESCRIPTION
Ensure they're clearly marked as such so that we don't confuse them with simple info messages.