### PR TITLE
fix(pam/nativemodel): Do not report the authentication denied PAM error twice

### DIFF
--- a/pam/integration-tests/testdata/TestNativeAuthenticate/golden/deny_authentication_if_max_attempts_reached
+++ b/pam/integration-tests/testdata/TestNativeAuthenticate/golden/deny_authentication_if_max_attempts_reached
@@ -283,13 +283,13 @@ invalid password 'wrongpass', should be 'goodpass'
 Insert 'r' to cancel the request and go back
 Gimme your password:
 invalid password 'wrongpass', should be 'goodpass'
-invalid password 'wrongpass', should be 'goodpass'
 PAM Authenticate() for user "user-integration-max-attempts" exited with error (PAM exit code: 7)
 : Authentication failure
 acct=incomplete
 PAM AcctMgmt() exited with error (PAM exit code: 25): The return value should be ignored by PAM
 dispatch
 >
+
 
 
 
@@ -316,13 +316,13 @@ invalid password 'wrongpass', should be 'goodpass'
 Insert 'r' to cancel the request and go back
 Gimme your password:
 invalid password 'wrongpass', should be 'goodpass'
-invalid password 'wrongpass', should be 'goodpass'
 PAM Authenticate() for user "user-integration-max-attempts" exited with error (PAM exit code: 7)
 : Authentication failure
 acct=incomplete
 PAM AcctMgmt() exited with error (PAM exit code: 25): The return value should be ignored by PAM
 dispatch
 >
+
 
 
 

--- a/pam/integration-tests/testdata/TestNativeChangeAuthTok/golden/prevent_change_password_if_auth_fails
+++ b/pam/integration-tests/testdata/TestNativeChangeAuthTok/golden/prevent_change_password_if_auth_fails
@@ -283,13 +283,13 @@ invalid password 'wrongpass', should be 'goodpass'
 Insert 'r' to cancel the request and go back
 Gimme your password:
 invalid password 'wrongpass', should be 'goodpass'
-invalid password 'wrongpass', should be 'goodpass'
 PAM ChangeAuthTok() for user "user-integration-max-attempts" exited with error (PAM exit code: 7
 ): Authentication failure
 acct=incomplete
 PAM AcctMgmt() exited with error (PAM exit code: 25): The return value should be ignored by PAM
 dispatch
 >
+
 
 
 
@@ -316,13 +316,13 @@ invalid password 'wrongpass', should be 'goodpass'
 Insert 'r' to cancel the request and go back
 Gimme your password:
 invalid password 'wrongpass', should be 'goodpass'
-invalid password 'wrongpass', should be 'goodpass'
 PAM ChangeAuthTok() for user "user-integration-max-attempts" exited with error (PAM exit code: 7
 ): Authentication failure
 acct=incomplete
 PAM AcctMgmt() exited with error (PAM exit code: 25): The return value should be ignored by PAM
 dispatch
 >
+
 
 
 

--- a/pam/internal/adapter/nativemodel.go
+++ b/pam/internal/adapter/nativemodel.go
@@ -272,8 +272,11 @@ func (m nativeModel) Update(msg tea.Msg) (nativeModel, tea.Cmd) {
 		case brokers.AuthNext:
 			m.uiLayout = nil
 			return m, maybeSendPamError(m.sendInfo(authMsg))
-		case brokers.AuthDenied, brokers.AuthRetry:
+		case brokers.AuthRetry:
 			return m, maybeSendPamError(m.sendError(authMsg))
+		case brokers.AuthDenied:
+			// This is handled by the main authentication model
+			return m, nil
 		case brokers.AuthCancelled:
 			return m, sendEvent(isAuthenticatedCancelled{})
 		default:


### PR DESCRIPTION
In case that the authentication failed, the authentication model sends a pamError that includes the error message and that our pam module will eventually write.

So, there's no need to handle the error again in the native module or we'd duplicate such error string

UDENG-4763