### PR TITLE
pam/integration-tests/native: Check that the user 'r' is accepted

### DIFF
--- a/pam/integration-tests/native_test.go
+++ b/pam/integration-tests/native_test.go
@@ -67,6 +67,7 @@ func TestNativeAuthenticate(t *testing.T) {
 
 		"Deny authentication if max attempts reached":                         {tape: "max_attempts"},
 		"Deny authentication if user does not exist":                          {tape: "unexistent_user"},
+		"Deny authentication if user does not exist and matches cancel key":   {tape: "cancel_key_user"},
 		"Deny authentication if newpassword does not match required criteria": {tape: "bad_password"},
 
 		"Exit authd if local broker is selected":                                    {tape: "local_broker"},

--- a/pam/integration-tests/testdata/TestNativeAuthenticate/golden/deny_authentication_if_user_does_not_exist_and_matches_cancel_key
+++ b/pam/integration-tests/testdata/TestNativeAuthenticate/golden/deny_authentication_if_user_does_not_exist_and_matches_cancel_key
@@ -1,0 +1,198 @@
+> ./pam_authd login socket=${AUTHD_TESTS_CLI_AUTHENTICATE_TESTS_SOCK} force_native_client=true
+Username:
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+────────────────────────────────────────────────────────────────────────────────
+> ./pam_authd login socket=${AUTHD_TESTS_CLI_AUTHENTICATE_TESTS_SOCK} force_native_client=true
+Username: r
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+────────────────────────────────────────────────────────────────────────────────
+> ./pam_authd login socket=${AUTHD_TESTS_CLI_AUTHENTICATE_TESTS_SOCK} force_native_client=true
+Username: r
+== Broker selection (use 'r' to go back) ==
+1 - local
+2 - ExampleBroker
+Select broker:
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+────────────────────────────────────────────────────────────────────────────────
+> ./pam_authd login socket=${AUTHD_TESTS_CLI_AUTHENTICATE_TESTS_SOCK} force_native_client=true
+Username: r
+== Broker selection (use 'r' to go back) ==
+1 - local
+2 - ExampleBroker
+Select broker: 2
+Insert 'r' to cancel the request and go back
+Gimme your password:
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+────────────────────────────────────────────────────────────────────────────────
+> ./pam_authd login socket=${AUTHD_TESTS_CLI_AUTHENTICATE_TESTS_SOCK} force_native_client=true
+Username: r
+== Broker selection (use 'r' to go back) ==
+1 - local
+2 - ExampleBroker
+Select broker: 2
+Insert 'r' to cancel the request and go back
+Gimme your password:
+PAM Error Message: user not found
+PAM Authenticate() for user "r" exited with error (PAM exit code: 7): Authentication failure
+acct=incomplete
+PAM AcctMgmt() exited with error (PAM exit code: 25): The return value should be ignored by PAM
+dispatch
+>
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+────────────────────────────────────────────────────────────────────────────────
+> ./pam_authd login socket=${AUTHD_TESTS_CLI_AUTHENTICATE_TESTS_SOCK} force_native_client=true
+Username: r
+== Broker selection (use 'r' to go back) ==
+1 - local
+2 - ExampleBroker
+Select broker: 2
+Insert 'r' to cancel the request and go back
+Gimme your password:
+PAM Error Message: user not found
+PAM Authenticate() for user "r" exited with error (PAM exit code: 7): Authentication failure
+acct=incomplete
+PAM AcctMgmt() exited with error (PAM exit code: 25): The return value should be ignored by PAM
+dispatch
+>
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+────────────────────────────────────────────────────────────────────────────────

--- a/pam/integration-tests/testdata/tapes/native/cancel_key_user.tape
+++ b/pam/integration-tests/testdata/tapes/native/cancel_key_user.tape
@@ -1,0 +1,43 @@
+Output cancel_key_user.txt
+Output cancel_key_user.gif # If we don't specify a .gif output, it will create a default out.gif file.
+
+# Configuration header to standardize the output.
+# Does not work with the "Source" command.
+Set Width 800
+Set Height 500
+# TODO: Ideally, we should use Ubuntu Mono. However, the github runner is still on Jammy, which does not have it.
+# We should update this to use Ubuntu Mono once the runner is updated.
+Set FontFamily "Monospace"
+Set FontSize 13
+Set Padding 0
+Set Margin 0
+Set Shell bash
+
+Hide
+Type "./pam_authd login socket=${AUTHD_TESTS_CLI_AUTHENTICATE_TESTS_SOCK} force_native_client=true"
+Enter
+Sleep 300ms
+Show
+
+Hide
+Type "r"
+Sleep 300ms
+Show
+
+Hide
+Enter
+Sleep 300ms
+Show
+
+Hide
+Type "2"
+Enter
+Sleep 500ms
+Show
+
+Hide
+Enter
+Sleep 500ms
+Show
+
+Sleep 300ms


### PR DESCRIPTION
This is something that was already manually tested, but since 'r' is a special string in the native model, let's add an explicit check, ensuring that a such user can work properly.

And no, we won't support a 'r' secret, even though we could just wait for a broker refusal before using it as a "go back" command, but at the date there's not a real requirement for that to increase the model complexity.