### PR TITLE
fix(pam/integration-tests): Fix potential failures depending on pam arguments

### DIFF
--- a/.github/workflows/qa.yaml
+++ b/.github/workflows/qa.yaml
@@ -9,6 +9,7 @@ on:
 
 env:
   DEBIAN_FRONTEND: noninteractive
+  GO_TESTS_TIMEOUT: 20m
   apt_deps: >-
     libpam-dev
     libglib2.0-dev
@@ -192,7 +193,7 @@ jobs:
           # Overriding the default coverage directory is not an exported flag of go test (yet), so
           # we need to override it using the test.gocoverdir flag instead.
           #TODO: Update when https://go-review.googlesource.com/c/go/+/456595 is merged.
-          go test -cover -covermode=set ./... -coverpkg=./... -shuffle=on -args -test.gocoverdir="${raw_cov_dir}"
+          go test -timeout ${GO_TESTS_TIMEOUT} -cover -covermode=set ./... -coverpkg=./... -shuffle=on -args -test.gocoverdir="${raw_cov_dir}"
 
           # Convert the raw coverage data into textfmt so we can merge the Rust one into it
           go tool covdata textfmt -i="${raw_cov_dir}" -o="${cov_dir}/coverage.out"
@@ -208,7 +209,7 @@ jobs:
 
       - name: Run tests (with race detector)
         run: |
-          go test -race ./...
+          go test -timeout ${GO_TESTS_TIMEOUT} -race ./...
 
       - name: Run PAM tests (with Address Sanitizer)
         env:
@@ -218,10 +219,10 @@ jobs:
           G_DEBUG: "fatal-criticals"
         run: |
           # Use `-dwarflocationlists` to give ASAN a better time to unwind the stack trace
-          go test -C ./pam/internal -asan -gcflags="-dwarflocationlists=true" ./...
+          go test -C ./pam/internal -asan -gcflags="-dwarflocationlists=true" -timeout ${GO_TESTS_TIMEOUT} ./...
 
           pushd ./pam/integration-tests
-          go test -asan -gcflags="-dwarflocationlists=true" -c
+          go test -asan -gcflags="-dwarflocationlists=true" -timeout ${GO_TESTS_TIMEOUT} -c
           # FIXME: Suppression may be removed with newer libpam, as the one we ship in ubuntu as some leaks
           env LSAN_OPTIONS=suppressions=$(pwd)/lsan.supp \
             ./integration-tests.test \

--- a/pam/integration-tests/cmd/exec-client/client.go
+++ b/pam/integration-tests/cmd/exec-client/client.go
@@ -11,6 +11,7 @@ import (
 	"os"
 	"reflect"
 	"regexp"
+	"strings"
 
 	"github.com/godbus/dbus/v5"
 	"github.com/msteinert/pam/v2"
@@ -23,6 +24,7 @@ var (
 	pamFlags      = flag.Int64("flags", 0, "pam flags")
 	serverAddress = flag.String("server-address", "", "the dbus connection address to use to communicate with module")
 	logFile       = flag.String("client-log", "", "the file where to save logs")
+	argsFile      = flag.String("client-args-file", "", "the file where arguments are saved")
 )
 
 func main() {
@@ -76,6 +78,15 @@ func mainFunc() error {
 			return err
 		}
 		log.SetOutput(f)
+	}
+
+	if argsFile != nil && *argsFile != "" {
+		log.Debug(context.TODO(), "Reading arguments from %s", *argsFile)
+		ca, err := os.ReadFile(*argsFile)
+		if err != nil {
+			return err
+		}
+		args = append(args, strings.Split(string(ca), "\t")...)
 	}
 
 	actionFlags := pam.Flags(0)

--- a/pam/integration-tests/gdm_test.go
+++ b/pam/integration-tests/gdm_test.go
@@ -673,11 +673,11 @@ func TestGdmModule(t *testing.T) {
 			moduleArgs := []string{"socket=" + socketPath}
 
 			gdmLog := prepareFileLogging(t, "authd-pam-gdm.log")
-			t.Cleanup(func() { saveArtifactsForDebug(t, []string{gdmLog}) })
+			saveArtifactsForDebugOnCleanup(t, []string{gdmLog})
 			moduleArgs = append(moduleArgs, "debug=true", "logfile="+gdmLog)
 
-			serviceFile := createServiceFile(t, "gdm-authd", libPath,
-				moduleArgs)
+			serviceFile := createServiceFile(t, "gdm-authd", libPath, moduleArgs)
+			saveArtifactsForDebugOnCleanup(t, []string{serviceFile})
 
 			pamUser := "user-integration-" + strings.ReplaceAll(filepath.Base(t.Name()), "_", "-")
 			if tc.pamUser != nil {
@@ -788,10 +788,11 @@ func TestGdmModuleAuthenticateWithoutGdmExtension(t *testing.T) {
 	moduleArgs = append(moduleArgs, "socket="+socketPath)
 
 	gdmLog := prepareFileLogging(t, "authd-pam-gdm.log")
-	t.Cleanup(func() { saveArtifactsForDebug(t, []string{gdmLog}) })
+	saveArtifactsForDebugOnCleanup(t, []string{gdmLog})
 	moduleArgs = append(moduleArgs, "debug=true", "logfile="+gdmLog)
 
 	serviceFile := createServiceFile(t, "gdm-authd", libPath, moduleArgs)
+	saveArtifactsForDebugOnCleanup(t, []string{serviceFile})
 	pamUser := "user-integration-auth-no-gdm-extension"
 	gh := newGdmTestModuleHandler(t, serviceFile, pamUser)
 	t.Cleanup(func() { require.NoError(t, gh.tx.End(), "PAM: can't end transaction") })
@@ -830,10 +831,11 @@ func TestGdmModuleAcctMgmtWithoutGdmExtension(t *testing.T) {
 	moduleArgs = append(moduleArgs, "socket="+socketPath)
 
 	gdmLog := prepareFileLogging(t, "authd-pam-gdm.log")
-	t.Cleanup(func() { saveArtifactsForDebug(t, []string{gdmLog}) })
+	saveArtifactsForDebugOnCleanup(t, []string{gdmLog})
 	moduleArgs = append(moduleArgs, "debug=true", "logfile="+gdmLog)
 
 	serviceFile := createServiceFile(t, "gdm-authd", libPath, moduleArgs)
+	saveArtifactsForDebugOnCleanup(t, []string{serviceFile})
 	pamUser := "user-integration-acctmgmt-no-gdm-extension"
 	gh := newGdmTestModuleHandler(t, serviceFile, pamUser)
 	t.Cleanup(func() { require.NoError(t, gh.tx.End(), "PAM: can't end transaction") })

--- a/pam/integration-tests/helpers_test.go
+++ b/pam/integration-tests/helpers_test.go
@@ -51,3 +51,8 @@ func requirePreviousBrokerForUser(t *testing.T, socketPath string, brokerName st
 	}
 	require.Equal(t, prevBroker.PreviousBroker, prevBrokerID)
 }
+
+func saveArtifactsForDebugOnCleanup(t *testing.T, artifacts []string) {
+	t.Helper()
+	t.Cleanup(func() { saveArtifactsForDebug(t, artifacts) })
+}


### PR DESCRIPTION
Passing lots arguments to a pam library via the service file is not very much supported by older libpam libraries as the one we've in CI, so avoid failing on that by passing the same arguments to the exec-test client through a file when required.

---

This was already approved

UDENG-4793