### PR TITLE
pam/gdm: Keep debugging all the events, sanitizing them if needed

### DIFF
--- a/pam/internal/adapter/gdmmodel.go
+++ b/pam/internal/adapter/gdmmodel.go
@@ -96,13 +96,15 @@ func (m *gdmModel) pollGdm() tea.Cmd {
 		})
 	}
 
-	for _, result := range gdmPollResults {
-		// Don't log EventData_IsAuthenticatedRequested because it contains
-		// the user password
-		if result.GetIsAuthenticatedRequested() != nil {
-			log.Debugf(context.TODO(), "GDM poll returned: IsAuthenticatedRequested")
-		} else {
-			log.Debugf(context.TODO(), "GDM poll returned: %s", result.Data)
+	if log.IsLevelEnabled(log.DebugLevel) {
+		for _, result := range gdmPollResults {
+			// Don't log EventData_IsAuthenticatedRequested because it contains
+			// the user password
+			if result.GetIsAuthenticatedRequested() != nil {
+				log.Debugf(context.TODO(), "GDM poll returned: IsAuthenticatedRequested")
+			} else {
+				log.Debugf(context.TODO(), "GDM poll returned: %s", result.Data)
+			}
 		}
 	}
 

--- a/pam/internal/adapter/gdmmodel.go
+++ b/pam/internal/adapter/gdmmodel.go
@@ -98,13 +98,7 @@ func (m *gdmModel) pollGdm() tea.Cmd {
 
 	if log.IsLevelEnabled(log.DebugLevel) {
 		for _, result := range gdmPollResults {
-			// Don't log EventData_IsAuthenticatedRequested because it contains
-			// the user password
-			if result.GetIsAuthenticatedRequested() != nil {
-				log.Debugf(context.TODO(), "GDM poll returned: IsAuthenticatedRequested")
-			} else {
-				log.Debugf(context.TODO(), "GDM poll returned: %s", result.Data)
-			}
+			log.Debugf(context.TODO(), "GDM poll response: %v", result.SafeString())
 		}
 	}
 

--- a/pam/internal/gdm/debug.go
+++ b/pam/internal/gdm/debug.go
@@ -5,4 +5,5 @@ package gdm
 func init() {
 	checkMembersFunc = checkMembersDebug
 	validateJSONFunc = validateJSONDebug
+	stringifyEventDataFunc = stringifyEventDataDebug
 }

--- a/pam/internal/gdm/export_test.go
+++ b/pam/internal/gdm/export_test.go
@@ -3,4 +3,5 @@ package gdm
 func init() {
 	checkMembersFunc = checkMembersDebug
 	validateJSONFunc = validateJSONDebug
+	stringifyEventDataFunc = stringifyEventDataDebug
 }


### PR DESCRIPTION
Instead of hiding the content authentication data completely, show the
whole challenge when `pam_gdm_debug` build tag is used, or when in
testing mode.

Otherwise, just show a sanitized challenge so that we don't miss the
fact that the event has happened.

In the same way, keep the conversation debugging alive so that we don't miss pieces of what we got from GDM if the content is relevant.

To sanitize the JSON I preferred to go wild and just replace the content, since it's still something happening only when debugging only, so not really something in production code.

Fixes: ca47562d3153, 40fa85db968ff