### PR TITLE
maint(pam/pwquality): Protect access to pwquality calls with a mutex

### DIFF
--- a/pam/internal/adapter/pwquality_c.go
+++ b/pam/internal/adapter/pwquality_c.go
@@ -8,11 +8,17 @@ import "C"
 import (
 	"errors"
 	"fmt"
+	"sync"
 	"unsafe"
 )
 
+var challengeQualityMu sync.Mutex
+
 // checkChallengeQuality checks the quality of the new password using the pwquality library.
 func checkChallengeQuality(old, new string) error {
+	challengeQualityMu.Lock()
+	defer challengeQualityMu.Unlock()
+
 	pwq := C.pwquality_default_settings()
 	if pwq == nil {
 		return errors.New("could not allocate pw quality default settings")


### PR DESCRIPTION
In some tests we are failing withe errors such as:
 - The password fails the dictionary check - error loading dictionary

This is likely due to the fact that we're accessing to the data from multiple threads, while the library doesn't seem to be thread-safe so add a mutex to ensure this