### PR TITLE
fix(pam): Avoid duplicate auth-mode selection race

### DIFF
--- a/pam/internal/adapter/authmodeselection.go
+++ b/pam/internal/adapter/authmodeselection.go
@@ -31,6 +31,9 @@ type supportedUILayoutsReceived struct {
 	layouts []*authd.UILayout
 }
 
+// supportedUILayoutsSet is the event signalling that the current supported ui layout in the context have been set.
+type supportedUILayoutsSet struct{}
+
 // authModesReceived is the internal event signalling that the supported authentication modes have been received.
 type authModesReceived struct {
 	authModes []*authd.GAMResponse_AuthenticationMode
@@ -132,7 +135,7 @@ func (m authModeSelectionModel) Update(msg tea.Msg) (authModeSelectionModel, tea
 		m.supportedUILayoutsMu.Lock()
 		m.supportedUILayouts = msg.layouts
 		m.supportedUILayoutsMu.Unlock()
-		return m, nil
+		return m, sendEvent(supportedUILayoutsSet{})
 
 	case authModesReceived:
 		log.Debugf(context.TODO(), "%#v", msg)

--- a/pam/internal/adapter/authmodeselection.go
+++ b/pam/internal/adapter/authmodeselection.go
@@ -132,7 +132,7 @@ func (m authModeSelectionModel) Update(msg tea.Msg) (authModeSelectionModel, tea
 		m.supportedUILayoutsMu.Lock()
 		m.supportedUILayouts = msg.layouts
 		m.supportedUILayoutsMu.Unlock()
-		return m, sendEvent(GetAuthenticationModesRequested{})
+		return m, nil
 
 	case authModesReceived:
 		log.Debugf(context.TODO(), "%#v", msg)

--- a/pam/internal/adapter/brokerselection.go
+++ b/pam/internal/adapter/brokerselection.go
@@ -69,12 +69,15 @@ func newBrokerSelectionModel(client authd.PAMClient, clientType PamClientType) b
 
 // Init initializes brokerSelectionModel by requesting the available brokers.
 func (m brokerSelectionModel) Init() tea.Cmd {
-	return getAvailableBrokers(m.client)
+	return nil
 }
 
 // Update handles events and actions.
 func (m brokerSelectionModel) Update(msg tea.Msg) (brokerSelectionModel, tea.Cmd) {
 	switch msg := msg.(type) {
+	case supportedUILayoutsSet:
+		return m, getAvailableBrokers(m.client)
+
 	case brokersListReceived:
 		log.Debugf(context.TODO(), "%#v", msg)
 		if len(msg.brokers) == 0 {

--- a/pam/internal/adapter/gdmmodel_test.go
+++ b/pam/internal/adapter/gdmmodel_test.go
@@ -1546,8 +1546,8 @@ func TestGdmModel(t *testing.T) {
 			),
 			supportedLayouts: []*authd.UILayout{},
 			wantGdmRequests:  []gdm.RequestType{gdm.RequestType_uiLayoutCapabilities},
-			wantGdmEvents:    []gdm.EventType{gdm.EventType_brokersReceived},
 			wantNoGdmEvents: []gdm.EventType{
+				gdm.EventType_brokersReceived,
 				gdm.EventType_userSelected,
 			},
 			wantExitStatus: pamError{
@@ -2281,6 +2281,7 @@ func TestGdmModel(t *testing.T) {
 					},
 				}): errors.New("this is an UI capabilities request error"),
 			},
+			wantNoBrokers: true,
 			wantExitStatus: pamError{
 				status: pam.ErrSystem,
 				msg:    "Sending GDM UI capabilities Request failed: Conversation error: this is an UI capabilities request error",

--- a/pam/internal/adapter/model.go
+++ b/pam/internal/adapter/model.go
@@ -229,7 +229,7 @@ func (m *UIModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 	case GetAuthenticationModesRequested:
 		log.Debugf(context.TODO(), "%#v", msg)
-		if m.currentSession == nil || !m.authModeSelectionModel.IsReady() {
+		if m.currentSession == nil {
 			return m, nil
 		}
 


### PR DESCRIPTION
See each commit for details, but this comes up to fix races such as https://github.com/ubuntu/authd/actions/runs/11325604248/job/31492851219 where we may end up doing duplicate requests to `GetAuthenticationModes` that eventually lead to two `selectAuthMode(firstAuthModeID)` which may break our "go-back" requests.

Also simplify the handling of `supportedUILayouts` so that it's following more the ELM architecture.

This implies that no broker requests is done until we've the supported UI defined now, but it's definitely a prerequisite to continue, so making this more explicit looks cleaner to me.

UDENG-4943