### PR TITLE
pam/gdmmodel-test: Ignore brokers checks on PAM errors

### DIFF
--- a/pam/internal/adapter/gdmmodel_test.go
+++ b/pam/internal/adapter/gdmmodel_test.go
@@ -39,10 +39,7 @@ func TestGdmModel(t *testing.T) {
 	// However we do return a PAM error in such case because that's what we're
 	// going to return to the PAM stack in case authentication process has not
 	// been completed fully.
-	gdmTestEarlyStopExitStatus := pamError{
-		status: pam.ErrSystem,
-		msg:    "model did not return anything",
-	}
+	gdmTestEarlyStopExitStatus := errNoExitStatus
 
 	gdmTestIgnoreStage := pam_proto.Stage(-1)
 
@@ -2515,9 +2512,10 @@ func TestGdmModel(t *testing.T) {
 				// is matching what we expect.
 				switch r.Status() {
 				case pam.ErrIgnore, pam.ErrAuth:
-				case gdmTestEarlyStopExitStatus.Status():
 				default:
-					return
+					if r != gdmTestEarlyStopExitStatus {
+						return
+					}
 				}
 			}
 

--- a/pam/internal/adapter/gdmmodel_test.go
+++ b/pam/internal/adapter/gdmmodel_test.go
@@ -2516,6 +2516,10 @@ func TestGdmModel(t *testing.T) {
 					if r != gdmTestEarlyStopExitStatus {
 						return
 					}
+					if slices.Contains(tc.messages, tea.Quit()) {
+						// Test required to quit, so we can't be reliable on what the status is.
+						return
+					}
 				}
 			}
 

--- a/pam/internal/adapter/model.go
+++ b/pam/internal/adapter/model.go
@@ -418,10 +418,12 @@ func (m *UIModel) MsgFilter(model tea.Model, msg tea.Msg) tea.Msg {
 	return msg
 }
 
+var errNoExitStatus = pamError{status: pam.ErrSystem, msg: "model did not return anything"}
+
 // ExitStatus exposes the [PamReturnStatus] externally.
 func (m *UIModel) ExitStatus() PamReturnStatus {
 	if m.exitStatus == nil {
-		return pamError{status: pam.ErrSystem, msg: "model did not return anything"}
+		return errNoExitStatus
 	}
 	return m.exitStatus
 }


### PR DESCRIPTION
We didn't care about checking broker details on error, but we where just
ignoring all the Pam.ErrSystem's instead of only the ones due to a test
early stop request.

So fix this, fixing various test races:
-  https://github.com/ubuntu/authd/actions/runs/11332985482/job/31516241957
- https://github.com/ubuntu/authd/actions/runs/11332985482/job/31517065552 