### PR TITLE
maint(pam/integration-tests/gdm): Use unique authd instance for gdm tests

### DIFF
--- a/pam/integration-tests/cli_test.go
+++ b/pam/integration-tests/cli_test.go
@@ -167,14 +167,8 @@ func TestCLIChangeAuthTok(t *testing.T) {
 	outDir := t.TempDir()
 	cliEnv := preparePamRunnerTest(t, outDir)
 
-	// we don't care about the output of gpasswd for this test, but we still need to mock it.
-	err := os.MkdirAll(filepath.Join(outDir, "gpasswd"), 0700)
-	require.NoError(t, err, "Setup: Could not create gpasswd output directory")
-	gpasswdOutput := filepath.Join(outDir, "gpasswd", "chauthtok.output")
-	groupsFile := filepath.Join(testutils.TestFamilyPath(t), "gpasswd.group")
-
 	const socketPathEnv = "AUTHD_TESTS_CLI_AUTHTOK_TESTS_SOCK"
-	defaultSocketPath := runAuthd(t, gpasswdOutput, groupsFile, true)
+	defaultSocketPath := runAuthd(t, os.DevNull, os.DevNull, true)
 
 	tests := map[string]struct {
 		tape         string
@@ -226,7 +220,7 @@ func TestCLIChangeAuthTok(t *testing.T) {
 
 			socketPath := defaultSocketPath
 			if tc.currentUserNotRoot {
-				socketPath = runAuthd(t, gpasswdOutput, groupsFile, false)
+				socketPath = runAuthd(t, os.DevNull, os.DevNull, false)
 			}
 
 			td := newTapeData(tc.tape, tc.tapeSettings...)

--- a/pam/integration-tests/gdm_test.go
+++ b/pam/integration-tests/gdm_test.go
@@ -101,9 +101,7 @@ func TestGdmModule(t *testing.T) {
 		"PAM does not support binary protocol")
 
 	libPath := buildPAMModule(t)
-	gpasswdOutput := filepath.Join(t.TempDir(), "gpasswd.output")
-	groupsFile := filepath.Join(testutils.TestFamilyPath(t), "gpasswd.group")
-	socketPath := runAuthd(t, gpasswdOutput, groupsFile, true)
+	socketPath := runAuthd(t, os.DevNull, os.DevNull, true)
 
 	testCases := map[string]struct {
 		supportedLayouts   []*authd.UILayout
@@ -764,9 +762,7 @@ func TestGdmModuleAuthenticateWithoutGdmExtension(t *testing.T) {
 	libPath := buildPAMModule(t)
 	moduleArgs := []string{libPath}
 
-	gpasswdOutput := filepath.Join(t.TempDir(), "gpasswd.output")
-	groupsFile := filepath.Join(testutils.TestFamilyPath(t), "gpasswd.group")
-	socketPath := runAuthd(t, gpasswdOutput, groupsFile, true)
+	socketPath := runAuthd(t, os.DevNull, os.DevNull, true)
 	moduleArgs = append(moduleArgs, "socket="+socketPath)
 
 	gdmLog := prepareFileLogging(t, "authd-pam-gdm.log")
@@ -800,9 +796,7 @@ func TestGdmModuleAcctMgmtWithoutGdmExtension(t *testing.T) {
 	libPath := buildPAMModule(t)
 	moduleArgs := []string{libPath}
 
-	gpasswdOutput := filepath.Join(t.TempDir(), "gpasswd.output")
-	groupsFile := filepath.Join(testutils.TestFamilyPath(t), "gpasswd.group")
-	socketPath := runAuthd(t, gpasswdOutput, groupsFile, true)
+	socketPath := runAuthd(t, os.DevNull, os.DevNull, true)
 	moduleArgs = append(moduleArgs, "socket="+socketPath)
 
 	gdmLog := prepareFileLogging(t, "authd-pam-gdm.log")

--- a/pam/integration-tests/gdm_test.go
+++ b/pam/integration-tests/gdm_test.go
@@ -1,7 +1,6 @@
 package main_test
 
 import (
-	"context"
 	"fmt"
 	"os"
 	"os/exec"
@@ -15,7 +14,6 @@ import (
 	"github.com/ubuntu/authd"
 	"github.com/ubuntu/authd/internal/brokers"
 	"github.com/ubuntu/authd/internal/testutils"
-	localgroupstestutils "github.com/ubuntu/authd/internal/users/localgroups/testutils"
 	"github.com/ubuntu/authd/pam/internal/gdm"
 	"github.com/ubuntu/authd/pam/internal/gdm_test"
 	"github.com/ubuntu/authd/pam/internal/pam_test"
@@ -663,13 +661,7 @@ func TestGdmModule(t *testing.T) {
 			// We run a daemon for each test, because here we don't want to
 			// make assumptions whether the state of the broker and each test
 			// should run in parallel and work the same way in any order is ran.
-			ctx, cancel := context.WithCancel(context.Background())
-			env := append(localgroupstestutils.AuthdIntegrationTestsEnvWithGpasswdMock(t, gpasswdOutput, groupsFile), authdCurrentUserRootEnvVariableContent)
-			socketPath, stopped := testutils.RunDaemon(ctx, t, daemonPath, testutils.WithEnvironment(env...))
-			t.Cleanup(func() {
-				cancel()
-				<-stopped
-			})
+			socketPath := runAuthd(t, gpasswdOutput, groupsFile, true)
 			moduleArgs := []string{"socket=" + socketPath}
 
 			gdmLog := prepareFileLogging(t, "authd-pam-gdm.log")
@@ -777,13 +769,7 @@ func TestGdmModuleAuthenticateWithoutGdmExtension(t *testing.T) {
 
 	gpasswdOutput := filepath.Join(t.TempDir(), "gpasswd.output")
 	groupsFile := filepath.Join(testutils.TestFamilyPath(t), "gpasswd.group")
-	ctx, cancel := context.WithCancel(context.Background())
-	env := append(localgroupstestutils.AuthdIntegrationTestsEnvWithGpasswdMock(t, gpasswdOutput, groupsFile), authdCurrentUserRootEnvVariableContent)
-	socketPath, stopped := testutils.RunDaemon(ctx, t, daemonPath, testutils.WithEnvironment(env...))
-	t.Cleanup(func() {
-		cancel()
-		<-stopped
-	})
+	socketPath := runAuthd(t, gpasswdOutput, groupsFile, true)
 	moduleArgs = append(moduleArgs, "socket="+socketPath)
 
 	gdmLog := prepareFileLogging(t, "authd-pam-gdm.log")
@@ -819,13 +805,7 @@ func TestGdmModuleAcctMgmtWithoutGdmExtension(t *testing.T) {
 
 	gpasswdOutput := filepath.Join(t.TempDir(), "gpasswd.output")
 	groupsFile := filepath.Join(testutils.TestFamilyPath(t), "gpasswd.group")
-	ctx, cancel := context.WithCancel(context.Background())
-	env := append(localgroupstestutils.AuthdIntegrationTestsEnvWithGpasswdMock(t, gpasswdOutput, groupsFile), authdCurrentUserRootEnvVariableContent)
-	socketPath, stopped := testutils.RunDaemon(ctx, t, daemonPath, testutils.WithEnvironment(env...))
-	t.Cleanup(func() {
-		cancel()
-		<-stopped
-	})
+	socketPath := runAuthd(t, gpasswdOutput, groupsFile, true)
 	moduleArgs = append(moduleArgs, "socket="+socketPath)
 
 	gdmLog := prepareFileLogging(t, "authd-pam-gdm.log")

--- a/pam/integration-tests/native_test.go
+++ b/pam/integration-tests/native_test.go
@@ -233,14 +233,8 @@ func TestNativeChangeAuthTok(t *testing.T) {
 	outDir := t.TempDir()
 	cliEnv := preparePamRunnerTest(t, outDir)
 
-	// we don't care about the output of gpasswd for this test, but we still need to mock it.
-	err := os.MkdirAll(filepath.Join(outDir, "gpasswd"), 0700)
-	require.NoError(t, err, "Setup: Could not create gpasswd output directory")
-	gpasswdOutput := filepath.Join(outDir, "gpasswd", "chauthtok.output")
-	groupsFile := filepath.Join(testutils.TestFamilyPath(t), "gpasswd.group")
-
 	const socketPathEnv = "AUTHD_TESTS_CLI_AUTHTOK_TESTS_SOCK"
-	defaultSocketPath := runAuthd(t, gpasswdOutput, groupsFile, true)
+	defaultSocketPath := runAuthd(t, os.DevNull, os.DevNull, true)
 
 	tests := map[string]struct {
 		tape         string
@@ -295,7 +289,7 @@ func TestNativeChangeAuthTok(t *testing.T) {
 
 			socketPath := defaultSocketPath
 			if tc.currentUserNotRoot {
-				socketPath = runAuthd(t, gpasswdOutput, groupsFile, false)
+				socketPath = runAuthd(t, os.DevNull, os.DevNull, false)
 			}
 
 			td := newTapeData(tc.tape, tc.tapeSettings...)


### PR DESCRIPTION
We were running a new authd instance for each gdm test, but this is not
needed anymore as we're using unique user names (since commit 7a77d331),
so let's just add more concurrency to the game, ensuring that authd is
still behaving well when multiple requests are happening concurrently
with gdm too