### PR TITLE
fix(pam/integration-tests/gdm): Handle broker selection when on such stage

### DIFF
--- a/pam/integration-tests/gdm_test.go
+++ b/pam/integration-tests/gdm_test.go
@@ -640,6 +640,11 @@ func TestGdmModule(t *testing.T) {
 		},
 		"Error on missing user": {
 			pamUser: ptrValue(""),
+			eventPollResponses: map[gdm.EventType][]*gdm.EventData{
+				gdm.EventType_brokersReceived: {
+					gdm_test.SelectBrokerEvent(exampleBrokerName),
+				},
+			},
 			wantPamErrorMessages: []string{
 				"can't select broker: error InvalidArgument from server: can't start authentication transaction: rpc error: code = InvalidArgument desc = no user name provided",
 			},
@@ -656,13 +661,8 @@ func TestGdmModule(t *testing.T) {
 		},
 		"Error on unknown broker": {
 			brokerName: "Not a valid broker!",
-			eventPollResponses: map[gdm.EventType][]*gdm.EventData{
-				gdm.EventType_brokersReceived: {
-					gdm_test.SelectBrokerEvent("some-unknown-broker"),
-				},
-			},
 			wantPamErrorMessages: []string{
-				"Sending GDM event failed: Conversation error",
+				"Changing GDM stage failed: Conversation error",
 			},
 			wantError:       pam.ErrSystem,
 			wantAcctMgmtErr: pam_test.ErrIgnore,


### PR DESCRIPTION
We have some races in gdm tests caused by the fact we may send the
`brokerSelected` event too late, in particular when we received the
broker list, but at that point we may be have done other steps already.

Instead, handle the broker selection only when we're in broker selection
stage, and not too early or too late.