### PR TITLE
ci: Use gotestfmt to format go test output

### DIFF
--- a/.github/workflows/qa.yaml
+++ b/.github/workflows/qa.yaml
@@ -268,7 +268,18 @@ jobs:
           set +x
 
           # We're logging to a file, and this is useful for having artifacts, but we still may want to see it in logs:
-          cat "${AUTHD_TEST_ARTIFACTS_PATH}"/asan.log* || true
+          for f in "${AUTHD_TEST_ARTIFACTS_PATH}"/asan.log*; do
+            if ! [ -e "${f}" ]; then
+              continue
+            fi
+            if [ -s "${f}" ]; then
+              echo "::group::${f} ($(wc -l < "${f}") lines)"
+              cat "${f}"
+              echo "::endgroup::"
+            else
+              echo "${f}: empty"
+            fi
+          done
 
           exit ${exit_code}
 

--- a/.github/workflows/qa.yaml
+++ b/.github/workflows/qa.yaml
@@ -202,6 +202,9 @@ jobs:
           raw_cov_dir="${cov_dir}/raw"
           mkdir -p "${raw_cov_dir}" "${cod_cov_dir}"
 
+          # Print executed commands to ease debugging
+          set -x
+
           # Overriding the default coverage directory is not an exported flag of go test (yet), so
           # we need to override it using the test.gocoverdir flag instead.
           #TODO: Update when https://go-review.googlesource.com/c/go/+/456595 is merged.
@@ -239,6 +242,9 @@ jobs:
           # Use these flags to give ASAN a better time to unwind the stack trace
           GO_GC_FLAGS: -N -l
         run: |
+          # Print executed commands to ease debugging
+          set -x
+
           go test -C ./pam/internal -json -asan -gcflags=all="${GO_GC_FLAGS}" -timeout ${GO_TESTS_TIMEOUT} ./... | \
             ./tools/gotestfmt --logfile "${AUTHD_TEST_ARTIFACTS_PATH}/gotestfmt.pam-internal-asan.log" || exit_code=$?
           if [ -n "${exit_code:-}" ]; then
@@ -257,6 +263,9 @@ jobs:
             ../../tools/gotestfmt --logfile "${AUTHD_TEST_ARTIFACTS_PATH}/gotestfmt.pam-integration-tests-asan.log" || \
             exit_code=$?
           popd
+
+          # We don't need the xtrace output after this point
+          set +x
 
           # We're logging to a file, and this is useful for having artifacts, but we still may want to see it in logs:
           cat "${AUTHD_TEST_ARTIFACTS_PATH}"/asan.log* || true

--- a/.github/workflows/qa.yaml
+++ b/.github/workflows/qa.yaml
@@ -241,7 +241,7 @@ jobs:
         run: |
           go test -C ./pam/internal -json -asan -gcflags=all="${GO_GC_FLAGS}" -timeout ${GO_TESTS_TIMEOUT} ./... | \
             ./tools/gotestfmt --logfile "${AUTHD_TEST_ARTIFACTS_PATH}/gotestfmt.pam-internal-asan.log" || exit_code=$?
-          if [ "${exit_code}" -ne 0 ]; then
+          if [ -n "${exit_code:-}" ]; then
             cat "${AUTHD_TEST_ARTIFACTS_PATH}"/asan.log* || true
             exit ${exit_code}
           fi

--- a/.github/workflows/qa.yaml
+++ b/.github/workflows/qa.yaml
@@ -154,6 +154,10 @@ jobs:
       - uses: actions/setup-go@v5
         with:
           go-version-file: go.mod
+
+      - name: Install gotestfmt
+        run: go install github.com/gotesttools/gotestfmt/v2/cmd/gotestfmt@latest
+
       - name: Install VHS and ttyd for integration tests
         run: |
           set -eu
@@ -201,7 +205,8 @@ jobs:
           # Overriding the default coverage directory is not an exported flag of go test (yet), so
           # we need to override it using the test.gocoverdir flag instead.
           #TODO: Update when https://go-review.googlesource.com/c/go/+/456595 is merged.
-          go test -timeout ${GO_TESTS_TIMEOUT} -cover -covermode=set ./... -coverpkg=./... -shuffle=on -args -test.gocoverdir="${raw_cov_dir}"
+          go test -json -timeout ${GO_TESTS_TIMEOUT} -cover -covermode=set ./... -coverpkg=./... -shuffle=on -args -test.gocoverdir="${raw_cov_dir}" | \
+            ./tools/gotestfmt --logfile "${AUTHD_TEST_ARTIFACTS_PATH}/gotestfmt.cover.log"
 
           # Convert the raw coverage data into textfmt so we can merge the Rust one into it
           go tool covdata textfmt -i="${raw_cov_dir}" -o="${cov_dir}/coverage.out"
@@ -220,7 +225,8 @@ jobs:
         env:
           GO_TESTS_TIMEOUT: 35m
         run: |
-          go test -timeout ${GO_TESTS_TIMEOUT} -race ./...
+          go test -json -timeout ${GO_TESTS_TIMEOUT} -race ./... | \
+            ./tools/gotestfmt --logfile "${AUTHD_TEST_ARTIFACTS_PATH}/gotestfmt.race.log"
 
       - name: Run PAM tests (with Address Sanitizer)
         if: matrix.test == 'asan'
@@ -233,19 +239,23 @@ jobs:
           # Use these flags to give ASAN a better time to unwind the stack trace
           GO_GC_FLAGS: -N -l
         run: |
-          go test -C ./pam/internal -asan -gcflags=all="${GO_GC_FLAGS}" -timeout ${GO_TESTS_TIMEOUT} ./... || exit_code=$?
+          go test -C ./pam/internal -json -asan -gcflags=all="${GO_GC_FLAGS}" -timeout ${GO_TESTS_TIMEOUT} ./... | \
+            ./tools/gotestfmt --logfile "${AUTHD_TEST_ARTIFACTS_PATH}/gotestfmt.pam-internal-asan.log" || exit_code=$?
           if [ "${exit_code}" -ne 0 ]; then
             cat "${AUTHD_TEST_ARTIFACTS_PATH}"/asan.log* || true
             exit ${exit_code}
           fi
 
+          echo "Running PAM integration tests"
           pushd ./pam/integration-tests
           go test -asan -gcflags=all="${GO_GC_FLAGS}" -c
           # FIXME: Suppression may be removed with newer libpam, as the one we ship in ubuntu as some leaks
-          env LSAN_OPTIONS=suppressions=$(pwd)/lsan.supp \
-            ./integration-tests.test \
-              -test.timeout ${GO_TESTS_TIMEOUT} \
-            || exit_code=$?
+          LSAN_OPTIONS=suppressions=$(pwd)/lsan.supp \
+            go tool test2json -p pam/integrations-test ./integration-tests.test \
+              -test.v=test2json \
+              -test.timeout ${GO_TESTS_TIMEOUT} | \
+            ../../tools/gotestfmt --logfile "${AUTHD_TEST_ARTIFACTS_PATH}/gotestfmt.pam-integration-tests-asan.log" || \
+            exit_code=$?
           popd
 
           # We're logging to a file, and this is useful for having artifacts, but we still may want to see it in logs:
@@ -260,7 +270,7 @@ jobs:
           directory: ./coverage/codecov
           token: ${{ secrets.CODECOV_TOKEN }}
 
-      - name: Upload test failures artifacts
+      - name: Upload test artifacts
         if: failure()
         uses: actions/upload-artifact@v4
         with:

--- a/tools/gotestfmt
+++ b/tools/gotestfmt
@@ -1,0 +1,63 @@
+#!/bin/bash
+
+set -euo pipefail
+
+# This script is a wrapper around gotestfmt. It expects the output of `go test -json`
+# on stdin. The output of failed tests is written to stdout, while the full output
+# (including successful tests) is written to a logfile.
+
+usage(){
+    echo "Usage: $0 [--logfile <logfile>] [-h|--help]"
+}
+
+# Parse options
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --logfile)
+            LOGFILE="$2"
+            shift 2
+            ;;
+        -h|--help)
+            usage
+            exit 0
+            ;;
+        *)
+            echo "Unknown option: $1"
+            usage
+            exit 1
+            ;;
+    esac
+done
+
+LOGFILE="${LOGFILE:-$(mktemp -t gotestfmt.XXXXXX.log)}"
+echo >&2 "Logging to $LOGFILE"
+STDERR_FILE=${LOGFILE%.log}.stderr
+STDOUT_FILE=${LOGFILE%.log}.stdout
+
+strip_empty_coverage_lines() {
+    # This strips empty coverage lines from the output of `go test -cover -json`,
+    # which would otherwise be printed as error messages by gotestfmt.
+    jq -c 'select(.Output != null and (.Output | contains("coverage: 0.0%") | not))'
+}
+
+copy_to_logfile() {
+    # This copies the output of `go test -json` to the logfile. It also uses
+    # gotestfmt to format the output (but without GitHub Action workflow commands
+    # like `::group::` and `::endgroup::`) and removes ANSI color codes, to make
+    # the logfile more readable.
+    tee >(GITHUB_WORKFLOW='' gotestfmt -showteststatus | sed 's/\x1b\[[0-9;]*m//g' > "$LOGFILE")
+}
+
+copy_output() {
+    # Copy all output of `go test -json` unformatted to a file, for debugging purposes.
+    # This is useful if a jq format error occurs, to see the output that caused it.
+    tee "$STDOUT_FILE"
+}
+
+# Write stderr to a file which can be uploaded as an artifact
+copy_output | strip_empty_coverage_lines | copy_to_logfile | gotestfmt --hide all <&0 2> "$STDERR_FILE" || exitcode=$?
+
+# Print the stderr file to stderr
+cat >&2 "$STDERR_FILE"
+
+exit "${exitcode:-0}"


### PR DESCRIPTION
The output of go test is notoriously hard to read, especially when a lot of tests are executed and a lot of output is produced, which is the case in our CI.  This commit uses gotestfmt to format the go test output. It only prints the output of failed tests to stdout, because that's what we're usually interested in. In case we need the full test output, that's now uploaded as an artifact.

You can see an example of the produced output when a test fails in [this job](https://github.com/ubuntu/authd/actions/runs/11635771849/job/32405830353?pr=608). The produced artifacts for that job are available [here](https://github.com/ubuntu/authd/actions/runs/11635771849/artifacts/2134799888) or when you scroll down on the [summary page](https://github.com/ubuntu/authd/actions/runs/11635771849?pr=608) of that job.

UDENG-4788