### PR TITLE
ci: Cache grcov installed via cargo install

### DIFF
--- a/.github/workflows/qa.yaml
+++ b/.github/workflows/qa.yaml
@@ -174,9 +174,9 @@ jobs:
           components: llvm-tools-preview
       - name: Install grcov
         if: matrix.test == 'coverage'
-        run: |
-          set -eu
-          cargo install grcov
+        uses: baptiste0928/cargo-install@v3
+        with:
+          crate: grcov
       - name: Prepare tests artifacts path
         run: |
           set -eu


### PR DESCRIPTION
Use a GitHub Action which caches the grcov binary installed via cargo install.