### PR TITLE
fix(pam/model): Initialize user only after we've got the brokers list

### DIFF
--- a/pam/integration-tests/testdata/TestNativeAuthenticate/golden/deny_authentication_if_current_user_is_not_considered_as_root
+++ b/pam/integration-tests/testdata/TestNativeAuthenticate/golden/deny_authentication_if_current_user_is_not_considered_as_root
@@ -1,8 +1,4 @@
 > ./pam_authd login socket=${AUTHD_TESTS_CLI_AUTHENTICATE_TESTS_SOCK} force_native_client=true
-Username:
-────────────────────────────────────────────────────────────────────────────────
-> ./pam_authd login socket=${AUTHD_TESTS_CLI_AUTHENTICATE_TESTS_SOCK} force_native_client=true
-Username:
 PAM Error Message: could not get current available brokers: permission denied: this action is on
 ly allowed for root users. Current user is XXXX
 PAM Authenticate() for user "" exited with error (PAM exit code: 4): System error
@@ -12,12 +8,22 @@ dispatch
 >
 ────────────────────────────────────────────────────────────────────────────────
 > ./pam_authd login socket=${AUTHD_TESTS_CLI_AUTHENTICATE_TESTS_SOCK} force_native_client=true
-Username:
 PAM Error Message: could not get current available brokers: permission denied: this action is on
 ly allowed for root users. Current user is XXXX
 PAM Authenticate() for user "" exited with error (PAM exit code: 4): System error
 acct=incomplete
 PAM AcctMgmt() exited with error (PAM exit code: 25): The return value should be ignored by PAM
 dispatch
+>
+>
+────────────────────────────────────────────────────────────────────────────────
+> ./pam_authd login socket=${AUTHD_TESTS_CLI_AUTHENTICATE_TESTS_SOCK} force_native_client=true
+PAM Error Message: could not get current available brokers: permission denied: this action is on
+ly allowed for root users. Current user is XXXX
+PAM Authenticate() for user "" exited with error (PAM exit code: 4): System error
+acct=incomplete
+PAM AcctMgmt() exited with error (PAM exit code: 25): The return value should be ignored by PAM
+dispatch
+>
 >
 ────────────────────────────────────────────────────────────────────────────────

--- a/pam/integration-tests/testdata/TestNativeAuthenticate/golden/deny_authentication_if_current_user_is_not_considered_as_root
+++ b/pam/integration-tests/testdata/TestNativeAuthenticate/golden/deny_authentication_if_current_user_is_not_considered_as_root
@@ -15,15 +15,4 @@ acct=incomplete
 PAM AcctMgmt() exited with error (PAM exit code: 25): The return value should be ignored by PAM
 dispatch
 >
->
-────────────────────────────────────────────────────────────────────────────────
-> ./pam_authd login socket=${AUTHD_TESTS_CLI_AUTHENTICATE_TESTS_SOCK} force_native_client=true
-PAM Error Message: could not get current available brokers: permission denied: this action is on
-ly allowed for root users. Current user is XXXX
-PAM Authenticate() for user "" exited with error (PAM exit code: 4): System error
-acct=incomplete
-PAM AcctMgmt() exited with error (PAM exit code: 25): The return value should be ignored by PAM
-dispatch
->
->
 ────────────────────────────────────────────────────────────────────────────────

--- a/pam/integration-tests/testdata/TestNativeChangeAuthTok/golden/prevent_change_password_if_current_user_is_not_root_as_can't_authenticate
+++ b/pam/integration-tests/testdata/TestNativeChangeAuthTok/golden/prevent_change_password_if_current_user_is_not_root_as_can't_authenticate
@@ -1,8 +1,4 @@
 > ./pam_authd passwd socket=${AUTHD_TESTS_CLI_AUTHTOK_TESTS_SOCK} force_native_client=true
-Username:
-────────────────────────────────────────────────────────────────────────────────
-> ./pam_authd passwd socket=${AUTHD_TESTS_CLI_AUTHTOK_TESTS_SOCK} force_native_client=true
-Username:
 PAM Error Message: could not get current available brokers: permission denied: this action is on
 ly allowed for root users. Current user is XXXX
 PAM ChangeAuthTok() for user "" exited with error (PAM exit code: 4): System error
@@ -12,12 +8,22 @@ dispatch
 >
 ────────────────────────────────────────────────────────────────────────────────
 > ./pam_authd passwd socket=${AUTHD_TESTS_CLI_AUTHTOK_TESTS_SOCK} force_native_client=true
-Username:
 PAM Error Message: could not get current available brokers: permission denied: this action is on
 ly allowed for root users. Current user is XXXX
 PAM ChangeAuthTok() for user "" exited with error (PAM exit code: 4): System error
 acct=incomplete
 PAM AcctMgmt() exited with error (PAM exit code: 25): The return value should be ignored by PAM
 dispatch
+>
+>
+────────────────────────────────────────────────────────────────────────────────
+> ./pam_authd passwd socket=${AUTHD_TESTS_CLI_AUTHTOK_TESTS_SOCK} force_native_client=true
+PAM Error Message: could not get current available brokers: permission denied: this action is on
+ly allowed for root users. Current user is XXXX
+PAM ChangeAuthTok() for user "" exited with error (PAM exit code: 4): System error
+acct=incomplete
+PAM AcctMgmt() exited with error (PAM exit code: 25): The return value should be ignored by PAM
+dispatch
+>
 >
 ────────────────────────────────────────────────────────────────────────────────

--- a/pam/integration-tests/testdata/TestNativeChangeAuthTok/golden/prevent_change_password_if_current_user_is_not_root_as_can't_authenticate
+++ b/pam/integration-tests/testdata/TestNativeChangeAuthTok/golden/prevent_change_password_if_current_user_is_not_root_as_can't_authenticate
@@ -15,15 +15,4 @@ acct=incomplete
 PAM AcctMgmt() exited with error (PAM exit code: 25): The return value should be ignored by PAM
 dispatch
 >
->
-────────────────────────────────────────────────────────────────────────────────
-> ./pam_authd passwd socket=${AUTHD_TESTS_CLI_AUTHTOK_TESTS_SOCK} force_native_client=true
-PAM Error Message: could not get current available brokers: permission denied: this action is on
-ly allowed for root users. Current user is XXXX
-PAM ChangeAuthTok() for user "" exited with error (PAM exit code: 4): System error
-acct=incomplete
-PAM AcctMgmt() exited with error (PAM exit code: 25): The return value should be ignored by PAM
-dispatch
->
->
 ────────────────────────────────────────────────────────────────────────────────

--- a/pam/integration-tests/testdata/tapes/native/not_root.tape
+++ b/pam/integration-tests/testdata/tapes/native/not_root.tape
@@ -1,12 +1,7 @@
 Hide
 Type "./pam_authd login socket=${AUTHD_TESTS_CLI_AUTHENTICATE_TESTS_SOCK} force_native_client=true"
 Enter
-Sleep ${AUTHD_SLEEP_DEFAULT}
-Show
-
-Hide
-Enter
-Sleep ${AUTHD_SLEEP_LONG} * 2
+Sleep ${AUTHD_SLEEP_DEFAULT} * 3
 Show
 
 Sleep ${AUTHD_SLEEP_DEFAULT}

--- a/pam/integration-tests/testdata/tapes/native/passwd_not_root.tape
+++ b/pam/integration-tests/testdata/tapes/native/passwd_not_root.tape
@@ -1,12 +1,7 @@
 Hide
 Type "./pam_authd passwd socket=${AUTHD_TESTS_CLI_AUTHTOK_TESTS_SOCK} force_native_client=true"
 Enter
-Sleep ${AUTHD_SLEEP_DEFAULT}
-Show
-
-Hide
-Enter
-Sleep ${AUTHD_SLEEP_LONG} * 2
+Sleep ${AUTHD_SLEEP_DEFAULT} * 3
 Show
 
 Sleep ${AUTHD_SLEEP_DEFAULT}

--- a/pam/internal/adapter/brokerselection.go
+++ b/pam/internal/adapter/brokerselection.go
@@ -97,7 +97,7 @@ func (m brokerSelectionModel) Update(msg tea.Msg) (brokerSelectionModel, tea.Cmd
 		}
 		var cmds []tea.Cmd
 		cmds = append(cmds, m.SetItems(allBrokers))
-		cmds = append(cmds, sendEvent(UsernameOrBrokerListReceived{}))
+		cmds = append(cmds, sendEvent(BrokerListReceived{}))
 
 		return m, tea.Batch(cmds...)
 

--- a/pam/internal/adapter/model.go
+++ b/pam/internal/adapter/model.go
@@ -68,8 +68,8 @@ type UIModel struct {
 // BrokerListReceived is received when we got the broker list.
 type BrokerListReceived struct{}
 
-// UsernameAndBrokerListReceived is received either when the user name is filled (pam or manually) and we got the broker list.
-type UsernameAndBrokerListReceived struct{}
+// UsernameSelected is received when the user name is filled (from pam or manually).
+type UsernameSelected struct{}
 
 // BrokerSelected signifies that the broker has been chosen.
 type BrokerSelected struct {
@@ -180,12 +180,9 @@ func (m *UIModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 		return m, m.userSelectionModel.SelectUser()
 
-	case UsernameAndBrokerListReceived:
-		log.Debugf(context.TODO(), "%#v, user: %q, brokers: %#v", msg, m.username(), m.availableBrokers())
+	case UsernameSelected:
+		log.Debugf(context.TODO(), "%#v, user: %q", msg, m.username())
 		if m.username() == "" {
-			return m, nil
-		}
-		if m.availableBrokers() == nil {
 			return m, nil
 		}
 

--- a/pam/internal/adapter/model.go
+++ b/pam/internal/adapter/model.go
@@ -65,8 +65,11 @@ type UIModel struct {
 
 /* global events */
 
-// UsernameOrBrokerListReceived is received either when the user name is filled (pam or manually) and we got the broker list.
-type UsernameOrBrokerListReceived struct{}
+// BrokerListReceived is received when we got the broker list.
+type BrokerListReceived struct{}
+
+// UsernameAndBrokerListReceived is received either when the user name is filled (pam or manually) and we got the broker list.
+type UsernameAndBrokerListReceived struct{}
 
 // BrokerSelected signifies that the broker has been chosen.
 type BrokerSelected struct {
@@ -170,7 +173,14 @@ func (m *UIModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m, m.quit()
 
 	// Events
-	case UsernameOrBrokerListReceived:
+	case BrokerListReceived:
+		log.Debugf(context.TODO(), "%#v, brokers: %#v", msg, m.availableBrokers())
+		if m.availableBrokers() == nil {
+			return m, nil
+		}
+		return m, m.userSelectionModel.SelectUser()
+
+	case UsernameAndBrokerListReceived:
 		log.Debugf(context.TODO(), "%#v, user: %q, brokers: %#v", msg, m.username(), m.availableBrokers())
 		if m.username() == "" {
 			return m, nil

--- a/pam/internal/adapter/userselection.go
+++ b/pam/internal/adapter/userselection.go
@@ -57,8 +57,13 @@ func newUserSelectionModel(pamMTx pam.ModuleTransaction, clientType PamClientTyp
 	}
 }
 
-// Init initializes userSelectionModel, by getting it from PAM if prefilled.
+// Init initializes userSelectionModel.
 func (m *userSelectionModel) Init() tea.Cmd {
+	return nil
+}
+
+// SelectUser selects the user name to be used, by getting it from PAM if prefilled.
+func (m userSelectionModel) SelectUser() tea.Cmd {
 	pamUser, err := m.pamMTx.GetItem(pam.User)
 	if cmd := maybeSendPamError(err); cmd != nil {
 		return cmd
@@ -98,7 +103,7 @@ func (m userSelectionModel) Update(msg tea.Msg) (userSelectionModel, tea.Cmd) {
 		if !m.selected {
 			return m, nil
 		}
-		return m, sendEvent(UsernameOrBrokerListReceived{})
+		return m, sendEvent(UsernameAndBrokerListReceived{})
 
 	case userRequired:
 		log.Debugf(context.TODO(), "%#v", msg)

--- a/pam/internal/adapter/userselection.go
+++ b/pam/internal/adapter/userselection.go
@@ -103,7 +103,7 @@ func (m userSelectionModel) Update(msg tea.Msg) (userSelectionModel, tea.Cmd) {
 		if !m.selected {
 			return m, nil
 		}
-		return m, sendEvent(UsernameAndBrokerListReceived{})
+		return m, sendEvent(UsernameSelected{})
 
 	case userRequired:
 		log.Debugf(context.TODO(), "%#v", msg)


### PR DESCRIPTION
One of the races we were facing (mostly in native model) is that we
could end up in a situation in which we receive an authd error on
getting the brokers list *after* that the user selection view is already
shown, leading to racy golden files ordering.

This is because what it could happen is:
 - We start in parallel:
   -> User selection
   -> UI Layouts -> Available brokers fetching

Now let's "imagine" that the brokers fetching fails (as when we've not
the permissions to read it, as for being not root).

If the user selection result arrives first, then we end up showing the
user selection UI (that is blocking in the native model) and only then
we handle the AvailableBrokers result (the error).

If the broker selection arrives first, we show first the error instead.

Now, this kind of approach made sense when we had no errors during this
phases, to get the user name as early as possible, but since we're now
doing various permissions checks in the broker, it's better to always go
in order instead of performing such operations in parallel, so now:
 - UI Layouts -> Available brokers fetching
 - User selection starts

Blocking as soon as we've a failure, as highlighted by the new golden
files.

You can see an example of this failure in this CI job:
 - https://github.com/ubuntu/authd/actions/runs/11708304677/job/32609750206?pr=619

UDENG-5161