### PR TITLE
Replace logrus with slog

### DIFF
--- a/cmd/authd/daemon/config.go
+++ b/cmd/authd/daemon/config.go
@@ -87,18 +87,13 @@ func installConfigFlag(cmd *cobra.Command) *string {
 
 // SetVerboseMode change ErrorFormat and logs between very, middly and non verbose.
 func setVerboseMode(level int) {
-	var reportCaller bool
 	switch level {
 	case 0:
 		log.SetLevel(consts.DefaultLogLevel)
 	case 1:
 		log.SetLevel(log.InfoLevel)
-	case 3:
-		reportCaller = true
-		fallthrough
 	default:
 		log.SetLevel(log.DebugLevel)
 		slog.SetLogLoggerLevel(slog.LevelDebug)
 	}
-	log.SetReportCaller(reportCaller)
 }

--- a/cmd/authd/main.go
+++ b/cmd/authd/main.go
@@ -32,15 +32,6 @@ type app interface {
 func run(a app) int {
 	defer installSignalHandler(a)()
 
-	log.SetFormatter(&log.TextFormatter{
-		DisableLevelTruncation: true,
-		DisableTimestamp:       true,
-
-		// ForceColors is necessary on Windows, not only to have colors but to
-		// prevent logrus from falling back to structured logs.
-		ForceColors: true,
-	})
-
 	if err := a.Run(); err != nil {
 		log.Error(context.Background(), err)
 

--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,6 @@ require (
 	github.com/google/uuid v1.6.0
 	github.com/msteinert/pam/v2 v2.0.0
 	github.com/muesli/termenv v0.15.2
-	github.com/sirupsen/logrus v1.9.3
 	github.com/skip2/go-qrcode v0.0.0-20200617195104-da1b6568686e
 	github.com/spf13/cobra v1.8.1
 	github.com/spf13/viper v1.19.0
@@ -51,6 +50,7 @@ require (
 	github.com/sagikazarmark/locafero v0.4.0 // indirect
 	github.com/sagikazarmark/slog-shim v0.1.0 // indirect
 	github.com/sahilm/fuzzy v0.1.1 // indirect
+	github.com/sirupsen/logrus v1.9.3 // indirect
 	github.com/sourcegraph/conc v0.3.0 // indirect
 	github.com/spf13/afero v1.11.0 // indirect
 	github.com/spf13/cast v1.6.0 // indirect

--- a/internal/consts/consts.go
+++ b/internal/consts/consts.go
@@ -1,7 +1,7 @@
 // Package consts defines the constants used by the project
 package consts
 
-import log "github.com/sirupsen/logrus"
+import log "github.com/ubuntu/authd/internal/log"
 
 var (
 	// Version is the version of the executable.

--- a/internal/log/log_test.go
+++ b/internal/log/log_test.go
@@ -10,10 +10,10 @@ import (
 )
 
 var supportedLevels = []log.Level{
-	log.ErrorLevel,
-	log.WarnLevel,
-	log.InfoLevel,
 	log.DebugLevel,
+	log.InfoLevel,
+	log.WarnLevel,
+	log.ErrorLevel,
 }
 
 func TestLevelEnabled(t *testing.T) {
@@ -146,17 +146,22 @@ func TestSetHandler(t *testing.T) {
 		require.Equal(t, wantLevel, l, "Log level should match %v", l)
 		require.Equal(t, fmt.Sprint(wantArgs...), format, "Format should match")
 	})
-	for _, level := range supportedLevels {
+	for idx, level := range supportedLevels {
 		t.Run(fmt.Sprintf("Set log handler, testing level %s", level), func(t *testing.T) {})
 
 		wantLevel = level
 		handlerCalled = false
 		log.SetLevel(level)
+		fmt.Println("Logging at level", level)
 		callLogHandler(wantCtx, level, wantArgs...)
 		require.True(t, handlerCalled, "Handler should have been called")
 
 		handlerCalled = false
-		log.SetLevel(level - 1)
+		nextLevel := level + 1
+		if idx < len(supportedLevels)-1 {
+			nextLevel = supportedLevels[idx+1]
+		}
+		log.SetLevel(nextLevel)
 		callLogHandler(wantCtx, level, wantArgs...)
 		require.False(t, handlerCalled, "Handler should not have been called")
 	}
@@ -180,7 +185,7 @@ func TestSetHandler(t *testing.T) {
 		require.Equal(t, wantFormat, format, "Format should match")
 		require.Equal(t, wantArgs, args, "Arguments should match")
 	})
-	for _, level := range supportedLevels {
+	for idx, level := range supportedLevels {
 		t.Run(fmt.Sprintf("Set log handler, testing level %s", level), func(t *testing.T) {})
 
 		wantLevel = level
@@ -190,7 +195,11 @@ func TestSetHandler(t *testing.T) {
 		require.True(t, handlerCalled, "Handler should have been called")
 
 		handlerCalled = false
-		log.SetLevel(level - 1)
+		nextLevel := level + 1
+		if idx < len(supportedLevels)-1 {
+			nextLevel = supportedLevels[idx+1]
+		}
+		log.SetLevel(nextLevel)
 		callLogHandlerf(wantCtx, level, wantFormat, wantArgs...)
 		require.False(t, handlerCalled, "Handler should not have been called")
 	}

--- a/internal/services/errmessages/redactor.go
+++ b/internal/services/errmessages/redactor.go
@@ -5,8 +5,8 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"log/slog"
 
+	"github.com/ubuntu/authd/internal/log"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -18,7 +18,7 @@ import (
 func RedactErrorInterceptor(ctx context.Context, req any, _ *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (any, error) {
 	m, err := handler(ctx, req)
 	if err != nil {
-		slog.Warn(err.Error())
+		log.Warning(context.TODO(), err.Error())
 		var redactedError ErrToDisplay
 		if !errors.As(err, &redactedError) {
 			return m, err

--- a/internal/services/manager.go
+++ b/internal/services/manager.go
@@ -3,7 +3,6 @@ package services
 
 import (
 	"context"
-	"log/slog"
 
 	"github.com/ubuntu/authd"
 	"github.com/ubuntu/authd/internal/brokers"
@@ -69,7 +68,7 @@ func (m Manager) RegisterGRPCServices(ctx context.Context) *grpc.Server {
 
 // stop stops the underlying cache.
 func (m *Manager) stop() error {
-	slog.Debug("Closing grpc manager and cache")
+	log.Debug(context.TODO(), "Closing grpc manager and cache")
 
 	return m.userManager.Stop()
 }

--- a/internal/users/cache/delete.go
+++ b/internal/users/cache/delete.go
@@ -119,7 +119,7 @@ func deleteOrphanedUsers(db *bbolt.DB) error {
 		return buckets[userByIDBucketName].ForEach(func(k, v []byte) error {
 			var user UserDB
 			if err := json.Unmarshal(v, &user); err != nil {
-				log.Warningf(context.TODO(), "Error loading user record {%s: %s}: %v", string(k), string(v), err)
+				log.Warningf(context.TODO(), "Error loading user record {%s: %s}: %v", k, v, err)
 				return nil
 			}
 

--- a/internal/users/cache/update.go
+++ b/internal/users/cache/update.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"log/slog"
 	"slices"
 	"strconv"
 	"time"
@@ -66,13 +65,13 @@ func updateUser(buckets map[string]bucketWithName, userContent userDB) error {
 
 	// If a user with the same UID exists, we need to ensure that it's the same user or fail the update otherwise.
 	if existingUser.Name != "" && existingUser.Name != userContent.Name {
-		slog.Error(fmt.Sprintf("UID for user %q already in use by user %q", userContent.Name, existingUser.Name))
+		log.Errorf(context.TODO(), "UID for user %q already in use by user %q", userContent.Name, existingUser.Name)
 		return errors.New("UID already in use by a different user")
 	}
 
 	// Ensure that we use the same homedir as the one we have in cache.
 	if existingUser.Dir != "" && existingUser.Dir != userContent.Dir {
-		slog.Warn(fmt.Sprintf("User %q already has a homedir. The existing %q one will be kept instead of %q", userContent.Name, existingUser.Dir, userContent.Dir))
+		log.Warningf(context.TODO(), "User %q already has a homedir. The existing %q one will be kept instead of %q", userContent.Name, existingUser.Dir, userContent.Dir)
 		userContent.Dir = existingUser.Dir
 	}
 
@@ -94,7 +93,7 @@ func updateGroups(buckets map[string]bucketWithName, groupContents []GroupDB) er
 
 		// If a group with the same GID exists, we need to ensure that it's the same group or fail the update otherwise.
 		if existingGroup.Name != "" && existingGroup.Name != groupContent.Name {
-			slog.Error(fmt.Sprintf("GID %d for group %q already in use by group %q", groupContent.GID, groupContent.Name, existingGroup.Name))
+			log.Errorf(context.TODO(), "GID %d for group %q already in use by group %q", groupContent.GID, groupContent.Name, existingGroup.Name)
 			return fmt.Errorf("GID for group %q already in use by a different group", groupContent.Name)
 		}
 

--- a/internal/users/localgroups/localgroups.go
+++ b/internal/users/localgroups/localgroups.go
@@ -3,15 +3,16 @@ package localgroups
 
 import (
 	"bufio"
+	"context"
 	"errors"
 	"fmt"
-	"log/slog"
 	"os"
 	"os/exec"
 	"slices"
 	"strings"
 	"sync"
 
+	"github.com/ubuntu/authd/internal/log"
 	"github.com/ubuntu/decorate"
 )
 
@@ -248,7 +249,7 @@ func runGPasswd(cmdName string, args ...string) error {
 	out, err := cmd.CombinedOutput()
 	if err != nil {
 		if cmd.ProcessState.ExitCode() == 3 {
-			slog.Info(fmt.Sprintf("ignoring gpasswd error: %s", out))
+			log.Infof(context.TODO(), "ignoring gpasswd error: %s", out)
 			return nil
 		}
 		return fmt.Errorf("%q returned: %v\nOutput: %s", strings.Join(cmd.Args, " "), err, out)

--- a/internal/users/manager.go
+++ b/internal/users/manager.go
@@ -2,15 +2,16 @@
 package users
 
 import (
+	"context"
 	"crypto/sha256"
 	"encoding/binary"
 	"errors"
 	"fmt"
-	"log/slog"
 	"os"
 	"strings"
 	"syscall"
 
+	"github.com/ubuntu/authd/internal/log"
 	"github.com/ubuntu/authd/internal/users/cache"
 	"github.com/ubuntu/authd/internal/users/localgroups"
 	"github.com/ubuntu/decorate"
@@ -40,7 +41,7 @@ type Manager struct {
 
 // NewManager creates a new user manager.
 func NewManager(config Config, cacheDir string) (m *Manager, err error) {
-	slog.Debug(fmt.Sprintf("Creating user manager with config: %+v", config))
+	log.Debugf(context.TODO(), "Creating user manager with config: %+v", config)
 
 	// Check that the ID ranges are valid.
 	if config.UIDMin >= config.UIDMax {
@@ -173,10 +174,10 @@ func checkHomeDirOwnership(u UserInfo) error {
 
 	// Check if the home directory is owned by the user.
 	if oldUID != newUID {
-		slog.Warn(fmt.Sprintf("Home directory %q is not owned by UID %d. To fix this, run `sudo chown -R --from=%d %d %s`.", u.Dir, oldUID, oldUID, newUID, u.Dir))
+		log.Warningf(context.TODO(), "Home directory %q is not owned by UID %d. To fix this, run `sudo chown -R --from=%d %d %s`.", u.Dir, oldUID, oldUID, newUID, u.Dir)
 	}
 	if oldGID != newGID {
-		slog.Warn(fmt.Sprintf("Home directory %q is not owned by GID %d. To fix this, run `sudo chown -R --from=:%d :%d %s`.", u.Dir, oldGID, oldGID, newGID, u.Dir))
+		log.Warningf(context.TODO(), "Home directory %q is not owned by GID %d. To fix this, run `sudo chown -R --from=:%d :%d %s`.", u.Dir, oldGID, oldGID, newGID, u.Dir)
 	}
 
 	return nil


### PR DESCRIPTION
Currently, we use both our own github.com/ubuntu/authd/internal/log package (with logrus as the backend) and log/slog in authd. We want to use slog as the backend for out custom log package and consistently use that (instead of mixing uses of the custom log package and direct uses of slog).

UDENG-4622
