### PR TITLE
pam/userselection: Do not draw the model when not enabled

### DIFF
--- a/pam/internal/adapter/userselection.go
+++ b/pam/internal/adapter/userselection.go
@@ -158,3 +158,11 @@ func (m *userSelectionModel) Focus() tea.Cmd {
 	m.selected = false
 	return m.Model.Focus()
 }
+
+// View renders a text view of the user selection UI.
+func (m userSelectionModel) View() string {
+	if !m.enabled {
+		return ""
+	}
+	return m.Model.View()
+}


### PR DESCRIPTION
When the model is not enabled we may still have it focused, since it's the default initial model that we have in the CLI mode.

This may cause to a visual issue (not a security one, since the input is disabled for this):
 - login with the UI using a preset user
 - while the client is connecting to the server we may show a "frozen" user selection view with the pre-selected  user written in.

This is not really something we need to show, so do not draw anything until we've something to show.

This can be replicated easily by applying:

```diff
diff --git a/pam/internal/adapter/brokerselection.go b/pam/internal/adapter/brokerselection.go
index 54725222..31c56f7b 100644
--- a/pam/internal/adapter/brokerselection.go
+++ b/pam/internal/adapter/brokerselection.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io"
 	"strconv"
+	"time"
 
 	"github.com/charmbracelet/bubbles/list"
 	tea "github.com/charmbracelet/bubbletea"
@@ -254,6 +255,7 @@ func (d itemLayout) Render(w io.Writer, m list.Model, index int, item list.Item)
 // getAvailableBrokers returns available broker list from authd.
 func getAvailableBrokers(client authd.PAMClient) tea.Cmd {
 	return func() tea.Msg {
+		time.Sleep(5 * time.Second)
 		brokersInfo, err := client.AvailableBrokers(context.TODO(), &authd.Empty{})
 		if err != nil {
 			return pamError{
```

And then running `env AUTHD_PAM_RUNNER_USER=user@foo.bar go run -tags=withpamrunner ./pam/tools/pam-client login`

UDENG-5166