### PR TITLE
fix(pam/gdmmodel): Forward public AuthModeSelected to GDM

### DIFF
--- a/pam/internal/adapter/gdmmodel.go
+++ b/pam/internal/adapter/gdmmodel.go
@@ -107,9 +107,7 @@ func (m *gdmModel) pollGdm() tea.Cmd {
 	for _, result := range gdmPollResults {
 		switch res := result.Data.(type) {
 		case *gdm.EventData_UserSelected:
-			commands = append(commands, sendEvent(userSelected{
-				username: res.UserSelected.UserId,
-			}))
+			commands = append(commands, sendUserSelected(res.UserSelected.UserId))
 
 		case *gdm.EventData_BrokerSelected:
 			if res.BrokerSelected == nil {

--- a/pam/internal/adapter/gdmmodel.go
+++ b/pam/internal/adapter/gdmmodel.go
@@ -217,9 +217,9 @@ func (m gdmModel) Update(msg tea.Msg) (gdmModel, tea.Cmd) {
 			AuthModesReceived: &gdm.Events_AuthModesReceived{AuthModes: msg.authModes},
 		})
 
-	case authModeSelected:
+	case AuthModeSelected:
 		return m, m.emitEvent(&gdm.EventData_AuthModeSelected{
-			AuthModeSelected: &gdm.Events_AuthModeSelected{AuthModeId: msg.id},
+			AuthModeSelected: &gdm.Events_AuthModeSelected{AuthModeId: msg.ID},
 		})
 
 	case UILayoutReceived:

--- a/pam/internal/adapter/model.go
+++ b/pam/internal/adapter/model.go
@@ -269,14 +269,6 @@ func (m *UIModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			return m, nil
 		}
 
-		var modelCmd tea.Cmd
-		switch m.ClientType {
-		case Gdm:
-			m.gdmModel, modelCmd = m.gdmModel.Update(msg)
-		case Native:
-			m.nativeModel, modelCmd = m.nativeModel.Update(msg)
-		}
-
 		return m, tea.Sequence(
 			m.authenticationModel.Compose(
 				m.currentSession.brokerID,
@@ -284,7 +276,7 @@ func (m *UIModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				m.currentSession.encryptionKey,
 				msg.layout,
 			),
-			modelCmd,
+			m.updateClientModel(msg),
 		)
 
 	case SessionEnded:
@@ -305,16 +297,20 @@ func (m *UIModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	m.authenticationModel, cmd = m.authenticationModel.Update(msg)
 	cmds = append(cmds, cmd)
 
+	cmds = append(cmds, m.updateClientModel(msg))
+
+	return m, tea.Batch(cmds...)
+}
+
+func (m *UIModel) updateClientModel(msg tea.Msg) tea.Cmd {
+	var cmd tea.Cmd
 	switch m.ClientType {
 	case Gdm:
 		m.gdmModel, cmd = m.gdmModel.Update(msg)
-		cmds = append(cmds, cmd)
 	case Native:
 		m.nativeModel, cmd = m.nativeModel.Update(msg)
-		cmds = append(cmds, cmd)
 	}
-
-	return m, tea.Batch(cmds...)
+	return cmd
 }
 
 // View renders a text view of the whole UI.

--- a/pam/internal/adapter/model.go
+++ b/pam/internal/adapter/model.go
@@ -261,7 +261,10 @@ func (m *UIModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				msg:    "reselection of current auth mode without current ID",
 			})
 		}
-		return m, getLayout(m.Client, m.currentSession.sessionID, msg.ID)
+		return m, tea.Sequence(
+			m.updateClientModel(msg),
+			getLayout(m.Client, m.currentSession.sessionID, msg.ID),
+		)
 
 	case UILayoutReceived:
 		log.Debugf(context.TODO(), "%#v", msg)


### PR DESCRIPTION
authModeSelected event we were listening to is an event that may be
ignored or adjusted depending on authModeSelection model logic, so it's
what we should also expose to GDM.

We couldn't do that though since the event wasn't forwarded, so do it.

Also simplify user selection on GDM tests, by mimicking more what we really do.

It should help with flacky tests such as [1].

[1] https://github.com/ubuntu/authd/actions/runs/11802896113/job/32879602555?pr=583