### PR TITLE
fix(pam/gdmmodel-test): Send authentication data only if in challenge stage

### DIFF
--- a/pam/internal/adapter/gdmmodel_test.go
+++ b/pam/internal/adapter/gdmmodel_test.go
@@ -10,7 +10,6 @@ import (
 	"os"
 	"slices"
 	"sync"
-	"sync/atomic"
 	"testing"
 	"time"
 
@@ -27,7 +26,6 @@ import (
 )
 
 var gdmTestPrivateKey *rsa.PrivateKey
-var gdmTestSequentialMessages atomic.Int64
 
 const gdmTestIgnoredMessage string = "<ignored>"
 

--- a/pam/internal/adapter/gdmmodel_test.go
+++ b/pam/internal/adapter/gdmmodel_test.go
@@ -472,9 +472,7 @@ func TestGdmModel(t *testing.T) {
 					Msg:    `{"message": "Hi GDM, it's a pleasure to let you change your password!"}`,
 				}, nil),
 			),
-			gdmEvents: []*gdm.EventData{
-				gdm_test.SelectUserEvent("gdm-selected-user-broker-and-auth-mode"),
-			},
+			pamUser: "pam-preset-user-with-daemon-selected-broker-and-auth-mode",
 			messages: []tea.Msg{
 				gdmTestWaitForStage{
 					stage: pam_proto.Stage_authModeSelection,
@@ -508,7 +506,6 @@ func TestGdmModel(t *testing.T) {
 				pam_test.FormUILayout(),
 				pam_test.NewPasswordUILayout(),
 			},
-			wantUsername:       "gdm-selected-user-broker-and-auth-mode",
 			wantSelectedBroker: firstBrokerInfo.Id,
 			wantGdmRequests: []gdm.RequestType{
 				gdm.RequestType_uiLayoutCapabilities,

--- a/pam/internal/adapter/gdmmodel_test.go
+++ b/pam/internal/adapter/gdmmodel_test.go
@@ -492,9 +492,16 @@ func TestGdmModel(t *testing.T) {
 										gdm_test.AuthModeSelectedEvent(newPasswordUILayoutID),
 									},
 									commands: []tea.Cmd{
-										sendEvent(gdmTestSendAuthDataWhenReady{&authd.IARequest_AuthenticationData_Challenge{
-											Challenge: "gdm-repeated-password",
-										}}),
+										sendEvent(gdmTestWaitForStage{
+											stage: pam_proto.Stage_challenge,
+											commands: []tea.Cmd{
+												sendEvent(gdmTestSendAuthDataWhenReady{
+													&authd.IARequest_AuthenticationData_Challenge{
+														Challenge: "gdm-repeated-password",
+													},
+												}),
+											},
+										}),
 									},
 								}),
 							},

--- a/pam/internal/adapter/gdmmodel_uimodel_test.go
+++ b/pam/internal/adapter/gdmmodel_uimodel_test.go
@@ -16,6 +16,8 @@ import (
 	"github.com/ubuntu/authd/pam/internal/proto"
 )
 
+var gdmTestSequentialMessages atomic.Int64
+
 // gdmTestUIModel is an override of [UIModel] used for testing the module with gdm.
 type gdmTestUIModel struct {
 	UIModel


### PR DESCRIPTION
Do not send the authentication data too early as we may not be in the
challenge stage yet.

Fixes races that we're seeing when optimizing constants: [1]

[1] https://github.com/ubuntu/authd/actions/runs/11835831306/attempts/1

UDENG-5261

