### PR TITLE
Fix local broker being used after local user was removed

### DIFF
--- a/internal/brokers/manager.go
+++ b/internal/brokers/manager.go
@@ -190,6 +190,14 @@ func (m *Manager) EndSession(sessionID string) error {
 	return nil
 }
 
+// BrokerExists returns true if the brokerID is known by the manager. It can
+// happen that a broker which was stored in the database is not available anymore
+// because the user removed the configuration file.
+func (m *Manager) BrokerExists(brokerID string) bool {
+	_, exists := m.brokers[brokerID]
+	return exists
+}
+
 // brokerFromID returns the broker matching this brokerID.
 func (m *Manager) brokerFromID(id string) (broker *Broker, err error) {
 	broker, exists := m.brokers[id]

--- a/internal/services/pam/pam.go
+++ b/internal/services/pam/pam.go
@@ -98,9 +98,19 @@ func (s Service) GetPreviousBroker(ctx context.Context, req *authd.GPBRequest) (
 		return &authd.GPBResponse{}, nil
 	}
 
-	// Updates manager memory to stop needing to query the database for the broker.
+	if !s.brokerManager.BrokerExists(brokerID) {
+		log.Warningf(ctx, "Last used broker %q is not available for user %q, letting the user select a new one", brokerID, req.GetUsername())
+		return &authd.GPBResponse{}, nil
+	}
+
+	// Cache the broker which should be used for the user, so that we don't have to query the database again next time -
+	// except if the broker is the local broker, because then the decision to use the local broker should be made each
+	// time the user tries to log in, based on whether the user is provided by any other NSS service.
+	if brokerID == brokers.LocalBrokerName {
+		return &authd.GPBResponse{PreviousBroker: brokerID}, nil
+	}
 	if err = s.brokerManager.SetDefaultBrokerForUser(brokerID, req.GetUsername()); err != nil {
-		log.Warningf(ctx, "Last broker used by %q is not available, letting the user selecting one: %v", req.GetUsername(), err)
+		log.Warningf(ctx, "Could not set default broker %q for user %q: %v", brokerID, req.GetUsername(), err)
 		return &authd.GPBResponse{}, nil
 	}
 
@@ -276,12 +286,14 @@ func (s Service) SetDefaultBrokerForUser(ctx context.Context, req *authd.SDBFURe
 		return nil, status.Error(codes.InvalidArgument, "no user name given")
 	}
 
-	if err = s.brokerManager.SetDefaultBrokerForUser(req.GetBrokerId(), req.GetUsername()); err != nil {
-		return &authd.Empty{}, err
+	// Don't allow setting the default broker to the local broker, because the decision to use the local broker should
+	// be made each time the user tries to log in, based on whether the user is provided by any other NSS service.
+	if req.GetBrokerId() == brokers.LocalBrokerName {
+		return nil, status.Error(codes.InvalidArgument, "can't set local broker as default")
 	}
 
-	if req.GetBrokerId() == brokers.LocalBrokerName {
-		return &authd.Empty{}, nil
+	if err = s.brokerManager.SetDefaultBrokerForUser(req.GetBrokerId(), req.GetUsername()); err != nil {
+		return &authd.Empty{}, err
 	}
 
 	if err = s.userManager.UpdateBrokerForUser(req.GetUsername(), req.GetBrokerId()); err != nil {

--- a/internal/services/pam/pam.go
+++ b/internal/services/pam/pam.go
@@ -78,7 +78,7 @@ func (s Service) GetPreviousBroker(ctx context.Context, req *authd.GPBRequest) (
 			return &authd.GPBResponse{PreviousBroker: brokers.LocalBrokerName}, nil
 		}
 
-		// User not acccessible through NSS, first time login or no valid user. Anyway, no broker selected.
+		// User not accessible through NSS, first time login or no valid user. Anyway, no broker selected.
 		if _, err := user.Lookup(req.GetUsername()); err != nil {
 			log.Debugf(ctx, "User %q is unknown", req.GetUsername())
 			return &authd.GPBResponse{}, nil

--- a/internal/services/pam/pam_test.go
+++ b/internal/services/pam/pam_test.go
@@ -594,12 +594,12 @@ func TestSetDefaultBrokerForUser(t *testing.T) {
 	}{
 		"Set default broker for existing user with no broker":   {username: "usersetbroker"},
 		"Update default broker for existing user with a broker": {username: "userupdatebroker"},
-		"Setting local broker as default should not save on DB": {username: "userlocalbroker", brokerID: brokers.LocalBrokerName},
 
-		"Error when not root":              {username: "usersetbroker", currentUserNotRoot: true, wantErr: true},
-		"Error when username is empty":     {wantErr: true},
-		"Error when user does not exist ":  {username: "doesnotexist", wantErr: true},
-		"Error when broker does not exist": {username: "userwithbroker", brokerID: "does not exist", wantErr: true},
+		"Error when setting default broker to local broker": {username: "userlocalbroker", brokerID: brokers.LocalBrokerName, wantErr: true},
+		"Error when not root":                               {username: "usersetbroker", currentUserNotRoot: true, wantErr: true},
+		"Error when username is empty":                      {wantErr: true},
+		"Error when user does not exist ":                   {username: "doesnotexist", wantErr: true},
+		"Error when broker does not exist":                  {username: "userwithbroker", brokerID: "does not exist", wantErr: true},
 	}
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {

--- a/pam/pam.go
+++ b/pam/pam.go
@@ -427,6 +427,11 @@ func (h *pamModule) AcctMgmt(mTx pam.ModuleTransaction, flags pam.Flags, args []
 	}
 	defer closeConn()
 
+	if brokerIDUsedToAuthenticate == brokers.LocalBrokerName {
+		// Don't set the default broker to the local broker.
+		return pam.ErrIgnore
+	}
+
 	req := authd.SDBFURequest{
 		BrokerId: brokerIDUsedToAuthenticate,
 		Username: user,


### PR DESCRIPTION
The decision whether to use the local broker or not should be made on each login request, based on whether the user exists locally or not. If we cache that decision, the local broker is used even when the local user was removed.

UDENG-5338