### PR TITLE
Fix artifacts not uploaded on failure

### DIFF
--- a/.github/workflows/qa.yaml
+++ b/.github/workflows/qa.yaml
@@ -293,6 +293,7 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
 
       - name: Upload test artifacts
+        if: always()
         uses: actions/upload-artifact@v4
         with:
           name: authd-${{ github.job }}-${{ matrix.test }}-artifacts-${{ github.run_attempt }}


### PR DESCRIPTION
If no `if` conditional is specified, a step is only executed if all previous succeeded (i.e. it defaults to `if success()`), see https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/evaluate-expressions-in-workflows-and-actions#status-check-functions