### PR TITLE
refactor: Rename DumpToYaml -> DumpNormalizedYAML

### DIFF
--- a/internal/services/pam/pam_test.go
+++ b/internal/services/pam/pam_test.go
@@ -530,7 +530,7 @@ func TestIsAuthenticated(t *testing.T) {
 			require.Equal(t, want, got, "IsAuthenticated should return the expected combined data, but did not")
 
 			// Check that cache has been updated too.
-			gotDB, err := cachetestutils.DumpToYaml(userstestutils.GetManagerCache(m))
+			gotDB, err := cachetestutils.DumpNormalizedYAML(userstestutils.GetManagerCache(m))
 			require.NoError(t, err, "Setup: failed to dump database for comparing")
 			wantDB := testutils.LoadWithUpdateFromGolden(t, gotDB, testutils.WithGoldenPath(filepath.Join(testutils.GoldenPath(t), "cache.db")))
 			require.Equal(t, wantDB, gotDB, "IsAuthenticated should update the cache database as expected")
@@ -571,7 +571,7 @@ func TestIDGeneration(t *testing.T) {
 			require.NoError(t, err, "Setup: could not authenticate user")
 			require.Equal(t, "granted", resp.GetAccess(), "Setup: authentication should be granted")
 
-			gotDB, err := cachetestutils.DumpToYaml(userstestutils.GetManagerCache(m))
+			gotDB, err := cachetestutils.DumpNormalizedYAML(userstestutils.GetManagerCache(m))
 			require.NoError(t, err, "Setup: failed to dump database for comparing")
 			wantDB := testutils.LoadWithUpdateFromGolden(t, gotDB, testutils.WithGoldenPath(filepath.Join(testutils.GoldenPath(t), "cache.db")))
 			require.Equal(t, wantDB, gotDB, "IsAuthenticated should update the cache database as expected")
@@ -631,7 +631,7 @@ func TestSetDefaultBrokerForUser(t *testing.T) {
 			require.Equal(t, tc.brokerID, gpbResp.GetPreviousBroker(), "SetDefaultBrokerForUser should set the default broker as expected")
 
 			// Check that cache has been updated too.
-			gotDB, err := cachetestutils.DumpToYaml(userstestutils.GetManagerCache(m))
+			gotDB, err := cachetestutils.DumpNormalizedYAML(userstestutils.GetManagerCache(m))
 			require.NoError(t, err, "Setup: failed to dump database for comparing")
 			wantDB := testutils.LoadWithUpdateFromGolden(t, gotDB, testutils.WithGoldenPath(filepath.Join(testutils.GoldenPath(t), "cache.db")))
 			require.Equal(t, wantDB, gotDB, "SetDefaultBrokerForUser should update the cache database as expected")

--- a/internal/users/cache/db_test.go
+++ b/internal/users/cache/db_test.go
@@ -75,7 +75,7 @@ func TestNew(t *testing.T) {
 			require.NoError(t, err)
 			defer c.Close()
 
-			got, err := cachetestutils.DumpToYaml(c)
+			got, err := cachetestutils.DumpNormalizedYAML(c)
 			require.NoError(t, err, "Created database should be valid yaml content")
 
 			want := testutils.LoadWithUpdateFromGolden(t, got)
@@ -226,7 +226,7 @@ func TestUpdateUserEntry(t *testing.T) {
 			}
 			require.NoError(t, err)
 
-			got, err := cachetestutils.DumpToYaml(c)
+			got, err := cachetestutils.DumpNormalizedYAML(c)
 			require.NoError(t, err, "Created database should be valid yaml content")
 
 			want := testutils.LoadWithUpdateFromGolden(t, got)
@@ -480,7 +480,7 @@ func TestDeleteUser(t *testing.T) {
 			}
 			require.NoError(t, err)
 
-			got, err := cachetestutils.DumpToYaml(c)
+			got, err := cachetestutils.DumpNormalizedYAML(c)
 			require.NoError(t, err, "Created database should be valid yaml content")
 			want := testutils.LoadWithUpdateFromGolden(t, got)
 			require.Equal(t, want, got, "Did not get expected database content")

--- a/internal/users/cache/testutils.go
+++ b/internal/users/cache/testutils.go
@@ -61,10 +61,11 @@ func redactTime(line string) string {
 	return line
 }
 
-// dumpToYaml deserializes the cache database as a string in yaml format.
+// dumpNormalizedYAML gets the content of the database, normalizes it (so that
+// it can be compared with a golden file) and returns it as a YAML string.
 //
 //nolint:unused // This is used for tests, with go linking. Not part of exported API.
-func (c *Cache) dumpToYaml() (string, error) {
+func (c *Cache) dumpNormalizedYAML() (string, error) {
 	testsdetection.MustBeTesting()
 
 	d := make(map[string]map[string]string)

--- a/internal/users/cache/testutils/serialization.go
+++ b/internal/users/cache/testutils/serialization.go
@@ -24,10 +24,11 @@ var (
 	DbName string
 )
 
-// DumpToYaml deserializes the cache database as a string in yaml format.
+// DumpNormalizedYAML gets the content of the database, normalizes it (so that
+// it can be compared with a golden file) and returns it as a YAML string.
 //
-//go:linkname DumpToYaml github.com/ubuntu/authd/internal/users/cache.(*Cache).dumpToYaml
-func DumpToYaml(c *cache.Cache) (string, error)
+//go:linkname DumpNormalizedYAML github.com/ubuntu/authd/internal/users/cache.(*Cache).dumpNormalizedYAML
+func DumpNormalizedYAML(c *cache.Cache) (string, error)
 
 // DbfromYAML loads a yaml formatted of the buckets from a reader and dump it into destDir, with its dbname.
 //

--- a/internal/users/manager_test.go
+++ b/internal/users/manager_test.go
@@ -76,7 +76,7 @@ func TestNewManager(t *testing.T) {
 			}
 			require.NoError(t, err, "NewManager should not return an error, but did")
 
-			got, err := cachetestutils.DumpToYaml(userstestutils.GetManagerCache(m))
+			got, err := cachetestutils.DumpNormalizedYAML(userstestutils.GetManagerCache(m))
 			require.NoError(t, err, "Created database should be valid yaml content")
 
 			want := testutils.LoadWithUpdateFromGolden(t, got)
@@ -231,7 +231,7 @@ func TestUpdateUser(t *testing.T) {
 				require.Equal(t, oldUID, newUser.UID, "UID should not have changed")
 			}
 
-			got, err := cachetestutils.DumpToYaml(userstestutils.GetManagerCache(m))
+			got, err := cachetestutils.DumpNormalizedYAML(userstestutils.GetManagerCache(m))
 			require.NoError(t, err, "Created database should be valid yaml content")
 
 			want := testutils.LoadWithUpdateFromGoldenYAML(t, got)
@@ -315,7 +315,7 @@ func TestUpdateBrokerForUser(t *testing.T) {
 				return
 			}
 
-			got, err := cachetestutils.DumpToYaml(userstestutils.GetManagerCache(m))
+			got, err := cachetestutils.DumpNormalizedYAML(userstestutils.GetManagerCache(m))
 			require.NoError(t, err, "Created database should be valid yaml content")
 
 			want := testutils.LoadWithUpdateFromGoldenYAML(t, got)


### PR DESCRIPTION
I was surprised that "DumpToYaml" modifies some values in the returned YAML. The new name should be less surprising.

It also contains the acronym YAML in uppercase, as recommended by the Go Code Review Comments: https://go.dev/wiki/CodeReviewComments#initialisms

Also improves the doc comment of the function.

UDENG-5450