### PR TITLE
cleanup(pam): Use the same logic for the re-selection button event

### DIFF
--- a/examplebroker/broker.go
+++ b/examplebroker/broker.go
@@ -67,6 +67,7 @@ type sessionInfo struct {
 	firstSelectedMode string
 
 	qrcodeSelections int
+	totpSelections   int
 }
 
 type isAuthenticatedCtx struct {
@@ -506,6 +507,9 @@ func (b *Broker) SelectAuthenticationMode(ctx context.Context, sessionID, authen
 		// add a 0 to simulate new code generation.
 		authenticationMode["wantedCode"] = authenticationMode["wantedCode"] + "0"
 		sessionInfo.allModes[authenticationModeName] = authenticationMode
+		sessionInfo.totpSelections++
+		uiLayoutInfo["button"] = fmt.Sprintf("Resend SMS (%d sent)",
+			sessionInfo.totpSelections)
 	case "phoneack1", "phoneack2":
 		// send request to sessionInfo.allModes[authenticationModeName]["phone"]
 	case "fidodevice1":

--- a/pam/integration-tests/testdata/TestCLIAuthenticate/golden/authenticate_user_with_form_mode_with_button
+++ b/pam/integration-tests/testdata/TestCLIAuthenticate/golden/authenticate_user_with_form_mode_with_button
@@ -29,19 +29,19 @@ Gimme your password
 Enter your one time credential
 >
 
-  [ Resend sms ]
+  [ Resend SMS (1 sent) ]
 ────────────────────────────────────────────────────────────────────────────────
 > ./pam_authd login socket=${AUTHD_TESTS_CLI_AUTHENTICATE_TESTS_SOCK}
 Enter your one time credential
 >
 
-  [ Resend sms ]
+  [ Resend SMS (1 sent) ]
 ────────────────────────────────────────────────────────────────────────────────
 > ./pam_authd login socket=${AUTHD_TESTS_CLI_AUTHENTICATE_TESTS_SOCK}
 Enter your one time credential
 >
 
-  [ Resend sms ]
+  [ Resend SMS (2 sent) ]
 ────────────────────────────────────────────────────────────────────────────────
 > ./pam_authd login socket=${AUTHD_TESTS_CLI_AUTHENTICATE_TESTS_SOCK}
 PAM Authenticate()

--- a/pam/integration-tests/testdata/TestCLIAuthenticate/golden/remember_last_successful_broker_and_mode
+++ b/pam/integration-tests/testdata/TestCLIAuthenticate/golden/remember_last_successful_broker_and_mode
@@ -25,7 +25,7 @@ Username: user-integration-remember-mode
 Enter your one time credential
 >
 
-  [ Resend sms ]
+  [ Resend SMS (1 sent) ]
 ────────────────────────────────────────────────────────────────────────────────
 > ./pam_authd login socket=${AUTHD_TESTS_CLI_AUTHENTICATE_TESTS_SOCK}
 PAM Authenticate()
@@ -67,7 +67,7 @@ PAM AcctMgmt()
 Enter your one time credential
 >
 
-  [ Resend sms ]
+  [ Resend SMS (1 sent) ]
 ────────────────────────────────────────────────────────────────────────────────
 > ./pam_authd login socket=${AUTHD_TESTS_CLI_AUTHENTICATE_TESTS_SOCK}
 PAM Authenticate()

--- a/pam/integration-tests/testdata/TestNativeAuthenticate/golden/authenticate_user_switching_auth_mode
+++ b/pam/integration-tests/testdata/TestNativeAuthenticate/golden/authenticate_user_switching_auth_mode
@@ -1144,7 +1144,7 @@ Choose your authentication method:
 > 8
 == Authentication code ==
   1. Proceed with Authentication code
-  2. Resend sms
+  2. Resend SMS (1 sent)
 Or enter 'r' to go back to select the authentication method
 Choose action:
 >
@@ -1296,7 +1296,7 @@ Choose your authentication method:
 > 8
 == Authentication code ==
   1. Proceed with Authentication code
-  2. Resend sms
+  2. Resend SMS (1 sent)
 Or enter 'r' to go back to select the authentication method
 Choose action:
 > r
@@ -1460,7 +1460,7 @@ Choose your authentication method:
 > 8
 == Authentication code ==
   1. Proceed with Authentication code
-  2. Resend sms
+  2. Resend SMS (1 sent)
 Or enter 'r' to go back to select the authentication method
 Choose action:
 > r
@@ -1627,187 +1627,7 @@ Choose your authentication method:
 > 8
 == Authentication code ==
   1. Proceed with Authentication code
-  2. Resend sms
-Or enter 'r' to go back to select the authentication method
-Choose action:
-> r
-== Authentication method selection ==
-  1. Password authentication
-  2. Send URL to user-integration-switch-mode@gmail.com
-  3. Use your fido device foo
-  4. Use your phone +33...
-  5. Use your phone +1...
-  6. Pin code
-  7. Use a QR code
-  8. Authentication code
-Or enter 'r' to go back to choose the provider
-Choose your authentication method:
-> invalid-selection
-PAM Error Message: Unsupported input
-Choose your authentication method:
-> -1
-PAM Error Message: Invalid selection
-== Authentication method selection ==
-  1. Password authentication
-  2. Send URL to user-integration-switch-mode@gmail.com
-  3. Use your fido device foo
-  4. Use your phone +33...
-  5. Use your phone +1...
-  6. Pin code
-  7. Use a QR code
-  8. Authentication code
-Or enter 'r' to go back to choose the provider
-Choose your authentication method:
->
-────────────────────────────────────────────────────────────────────────────────
-> ./pam_authd login socket=${AUTHD_TESTS_CLI_AUTHENTICATE_TESTS_SOCK} force_native_client=true
-== Provider selection ==
-  1. local
-  2. ExampleBroker
-Choose your provider:
-> 2
-== Password authentication ==
-Enter 'r' to cancel the request and go back to select the authentication method
-Gimme your password:
->
-== Authentication method selection ==
-  1. Password authentication
-  2. Send URL to user-integration-switch-mode@gmail.com
-  3. Use your fido device foo
-  4. Use your phone +33...
-  5. Use your phone +1...
-  6. Pin code
-  7. Use a QR code
-  8. Authentication code
-Or enter 'r' to go back to choose the provider
-Choose your authentication method:
-> 2
-== Send URL to user-integration-switch-mode@gmail.com ==
-Leave the input field empty to wait for the alternative authentication method or enter 'r' to go
- back to select the authentication method
-Click on the link received at user-integration-switch-mode@gmail.com or enter the code:
-> r
-== Authentication method selection ==
-  1. Password authentication
-  2. Send URL to user-integration-switch-mode@gmail.com
-  3. Use your fido device foo
-  4. Use your phone +33...
-  5. Use your phone +1...
-  6. Pin code
-  7. Use a QR code
-  8. Authentication code
-Or enter 'r' to go back to choose the provider
-Choose your authentication method:
-> 3
-== Use your fido device foo ==
-Press Enter to wait for authentication or enter 'r' to go back to select the authentication meth
-od
-Plug your fido device and press with your thumb:
-> r
-== Authentication method selection ==
-  1. Password authentication
-  2. Send URL to user-integration-switch-mode@gmail.com
-  3. Use your fido device foo
-  4. Use your phone +33...
-  5. Use your phone +1...
-  6. Pin code
-  7. Use a QR code
-  8. Authentication code
-Or enter 'r' to go back to choose the provider
-Choose your authentication method:
-> 4
-== Use your phone +33... ==
-Press Enter to wait for authentication or enter 'r' to go back to select the authentication meth
-od
-Unlock your phone +33... or accept request on web interface:
-> r
-== Authentication method selection ==
-  1. Password authentication
-  2. Send URL to user-integration-switch-mode@gmail.com
-  3. Use your fido device foo
-  4. Use your phone +33...
-  5. Use your phone +1...
-  6. Pin code
-  7. Use a QR code
-  8. Authentication code
-Or enter 'r' to go back to choose the provider
-Choose your authentication method:
-> 5
-== Use your phone +1... ==
-Press Enter to wait for authentication or enter 'r' to go back to select the authentication meth
-od
-Unlock your phone +1... or accept request on web interface:
-> r
-== Authentication method selection ==
-  1. Password authentication
-  2. Send URL to user-integration-switch-mode@gmail.com
-  3. Use your fido device foo
-  4. Use your phone +33...
-  5. Use your phone +1...
-  6. Pin code
-  7. Use a QR code
-  8. Authentication code
-Or enter 'r' to go back to choose the provider
-Choose your authentication method:
-> 6
-== Pin code ==
-Enter 'r' to cancel the request and go back to select the authentication method
-Enter your pin code:
-> r
-== Authentication method selection ==
-  1. Password authentication
-  2. Send URL to user-integration-switch-mode@gmail.com
-  3. Use your fido device foo
-  4. Use your phone +33...
-  5. Use your phone +1...
-  6. Pin code
-  7. Use a QR code
-  8. Authentication code
-Or enter 'r' to go back to choose the provider
-Choose your authentication method:
-> 7
-== Qr Code authentication ==
-Scan the qrcode or enter the code in the login page
-█████████████████████████████████
-█████████████████████████████████
-████ ▄▄▄▄▄ █  ▀▀█▄██ █ ▄▄▄▄▄ ████
-████ █   █ █▀▄██ ▄▄▄██ █   █ ████
-████ █▄▄▄█ ██▄ █ ▄ ▄▄█ █▄▄▄█ ████
-████▄▄▄▄▄▄▄█ ▀▄▀▄▀ ▀▄█▄▄▄▄▄▄▄████
-████▄█ ▄█ ▄ ▀█▄▀▀▄▄█ █▄▀█▄█ ▄████
-█████▀█▀▄ ▄ ▄▀█▀▀▀ ▀█▄▀▄▄▀▀██████
-████▄  █▀█▄▄▄██ █▀█▀█▄   █▄▄ ████
-████▀▄  ▀▄▄█ ▄▄█ ▀▄▀▀ ▀▀ █▄▄▀████
-███████▄▄█▄█  ▀▄▀▀█▀ ▄▄▄ ▄ ▄ ████
-████ ▄▄▄▄▄ █  █▄ ██▀ █▄█ █▄  ████
-████ █   █ █▀▄ ▄  ▀▀▄  ▄  ▀▀▀████
-████ █▄▄▄█ █▄█▄▄▄▄█ █  █ █ ▄█████
-████▄▄▄▄▄▄▄█▄█▄█▄█▄████▄▄▄▄▄▄████
-█████████████████████████████████
-▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀
-       https://ubuntu.com
-              1337
-
-  1. Wait for the QR code scan result
-  2. Regenerate code
-Or enter 'r' to go back to select the authentication method
-Choose action:
-> r
-== Authentication method selection ==
-  1. Password authentication
-  2. Send URL to user-integration-switch-mode@gmail.com
-  3. Use your fido device foo
-  4. Use your phone +33...
-  5. Use your phone +1...
-  6. Pin code
-  7. Use a QR code
-  8. Authentication code
-Or enter 'r' to go back to choose the provider
-Choose your authentication method:
-> 8
-== Authentication code ==
-  1. Proceed with Authentication code
-  2. Resend sms
+  2. Resend SMS (1 sent)
 Or enter 'r' to go back to select the authentication method
 Choose action:
 > r
@@ -1838,6 +1658,186 @@ PAM Error Message: Invalid selection
   8. Authentication code
 Or enter 'r' to go back to choose the provider
 Choose your authentication method:
+>
+────────────────────────────────────────────────────────────────────────────────
+> ./pam_authd login socket=${AUTHD_TESTS_CLI_AUTHENTICATE_TESTS_SOCK} force_native_client=true
+== Provider selection ==
+  1. local
+  2. ExampleBroker
+Choose your provider:
+> 2
+== Password authentication ==
+Enter 'r' to cancel the request and go back to select the authentication method
+Gimme your password:
+>
+== Authentication method selection ==
+  1. Password authentication
+  2. Send URL to user-integration-switch-mode@gmail.com
+  3. Use your fido device foo
+  4. Use your phone +33...
+  5. Use your phone +1...
+  6. Pin code
+  7. Use a QR code
+  8. Authentication code
+Or enter 'r' to go back to choose the provider
+Choose your authentication method:
+> 2
+== Send URL to user-integration-switch-mode@gmail.com ==
+Leave the input field empty to wait for the alternative authentication method or enter 'r' to go
+ back to select the authentication method
+Click on the link received at user-integration-switch-mode@gmail.com or enter the code:
+> r
+== Authentication method selection ==
+  1. Password authentication
+  2. Send URL to user-integration-switch-mode@gmail.com
+  3. Use your fido device foo
+  4. Use your phone +33...
+  5. Use your phone +1...
+  6. Pin code
+  7. Use a QR code
+  8. Authentication code
+Or enter 'r' to go back to choose the provider
+Choose your authentication method:
+> 3
+== Use your fido device foo ==
+Press Enter to wait for authentication or enter 'r' to go back to select the authentication meth
+od
+Plug your fido device and press with your thumb:
+> r
+== Authentication method selection ==
+  1. Password authentication
+  2. Send URL to user-integration-switch-mode@gmail.com
+  3. Use your fido device foo
+  4. Use your phone +33...
+  5. Use your phone +1...
+  6. Pin code
+  7. Use a QR code
+  8. Authentication code
+Or enter 'r' to go back to choose the provider
+Choose your authentication method:
+> 4
+== Use your phone +33... ==
+Press Enter to wait for authentication or enter 'r' to go back to select the authentication meth
+od
+Unlock your phone +33... or accept request on web interface:
+> r
+== Authentication method selection ==
+  1. Password authentication
+  2. Send URL to user-integration-switch-mode@gmail.com
+  3. Use your fido device foo
+  4. Use your phone +33...
+  5. Use your phone +1...
+  6. Pin code
+  7. Use a QR code
+  8. Authentication code
+Or enter 'r' to go back to choose the provider
+Choose your authentication method:
+> 5
+== Use your phone +1... ==
+Press Enter to wait for authentication or enter 'r' to go back to select the authentication meth
+od
+Unlock your phone +1... or accept request on web interface:
+> r
+== Authentication method selection ==
+  1. Password authentication
+  2. Send URL to user-integration-switch-mode@gmail.com
+  3. Use your fido device foo
+  4. Use your phone +33...
+  5. Use your phone +1...
+  6. Pin code
+  7. Use a QR code
+  8. Authentication code
+Or enter 'r' to go back to choose the provider
+Choose your authentication method:
+> 6
+== Pin code ==
+Enter 'r' to cancel the request and go back to select the authentication method
+Enter your pin code:
+> r
+== Authentication method selection ==
+  1. Password authentication
+  2. Send URL to user-integration-switch-mode@gmail.com
+  3. Use your fido device foo
+  4. Use your phone +33...
+  5. Use your phone +1...
+  6. Pin code
+  7. Use a QR code
+  8. Authentication code
+Or enter 'r' to go back to choose the provider
+Choose your authentication method:
+> 7
+== Qr Code authentication ==
+Scan the qrcode or enter the code in the login page
+█████████████████████████████████
+█████████████████████████████████
+████ ▄▄▄▄▄ █  ▀▀█▄██ █ ▄▄▄▄▄ ████
+████ █   █ █▀▄██ ▄▄▄██ █   █ ████
+████ █▄▄▄█ ██▄ █ ▄ ▄▄█ █▄▄▄█ ████
+████▄▄▄▄▄▄▄█ ▀▄▀▄▀ ▀▄█▄▄▄▄▄▄▄████
+████▄█ ▄█ ▄ ▀█▄▀▀▄▄█ █▄▀█▄█ ▄████
+█████▀█▀▄ ▄ ▄▀█▀▀▀ ▀█▄▀▄▄▀▀██████
+████▄  █▀█▄▄▄██ █▀█▀█▄   █▄▄ ████
+████▀▄  ▀▄▄█ ▄▄█ ▀▄▀▀ ▀▀ █▄▄▀████
+███████▄▄█▄█  ▀▄▀▀█▀ ▄▄▄ ▄ ▄ ████
+████ ▄▄▄▄▄ █  █▄ ██▀ █▄█ █▄  ████
+████ █   █ █▀▄ ▄  ▀▀▄  ▄  ▀▀▀████
+████ █▄▄▄█ █▄█▄▄▄▄█ █  █ █ ▄█████
+████▄▄▄▄▄▄▄█▄█▄█▄█▄████▄▄▄▄▄▄████
+█████████████████████████████████
+▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀
+       https://ubuntu.com
+              1337
+
+  1. Wait for the QR code scan result
+  2. Regenerate code
+Or enter 'r' to go back to select the authentication method
+Choose action:
+> r
+== Authentication method selection ==
+  1. Password authentication
+  2. Send URL to user-integration-switch-mode@gmail.com
+  3. Use your fido device foo
+  4. Use your phone +33...
+  5. Use your phone +1...
+  6. Pin code
+  7. Use a QR code
+  8. Authentication code
+Or enter 'r' to go back to choose the provider
+Choose your authentication method:
+> 8
+== Authentication code ==
+  1. Proceed with Authentication code
+  2. Resend SMS (1 sent)
+Or enter 'r' to go back to select the authentication method
+Choose action:
+> r
+== Authentication method selection ==
+  1. Password authentication
+  2. Send URL to user-integration-switch-mode@gmail.com
+  3. Use your fido device foo
+  4. Use your phone +33...
+  5. Use your phone +1...
+  6. Pin code
+  7. Use a QR code
+  8. Authentication code
+Or enter 'r' to go back to choose the provider
+Choose your authentication method:
+> invalid-selection
+PAM Error Message: Unsupported input
+Choose your authentication method:
+> -1
+PAM Error Message: Invalid selection
+== Authentication method selection ==
+  1. Password authentication
+  2. Send URL to user-integration-switch-mode@gmail.com
+  3. Use your fido device foo
+  4. Use your phone +33...
+  5. Use your phone +1...
+  6. Pin code
+  7. Use a QR code
+  8. Authentication code
+Or enter 'r' to go back to choose the provider
+Choose your authentication method:
 > 6
 == Pin code ==
 Enter 'r' to cancel the request and go back to select the authentication method
@@ -1991,7 +1991,7 @@ Choose your authentication method:
 > 8
 == Authentication code ==
   1. Proceed with Authentication code
-  2. Resend sms
+  2. Resend SMS (1 sent)
 Or enter 'r' to go back to select the authentication method
 Choose action:
 > r
@@ -2182,7 +2182,7 @@ Choose your authentication method:
 > 8
 == Authentication code ==
   1. Proceed with Authentication code
-  2. Resend sms
+  2. Resend SMS (1 sent)
 Or enter 'r' to go back to select the authentication method
 Choose action:
 > r

--- a/pam/integration-tests/testdata/TestNativeAuthenticate/golden/authenticate_user_with_form_mode_with_button
+++ b/pam/integration-tests/testdata/TestNativeAuthenticate/golden/authenticate_user_with_form_mode_with_button
@@ -63,7 +63,7 @@ Choose your authentication method:
 > 8
 == Authentication code ==
   1. Proceed with Authentication code
-  2. Resend sms
+  2. Resend SMS (1 sent)
 Or enter 'r' to go back to select the authentication method
 Choose action:
 >
@@ -92,13 +92,13 @@ Choose your authentication method:
 > 8
 == Authentication code ==
   1. Proceed with Authentication code
-  2. Resend sms
+  2. Resend SMS (1 sent)
 Or enter 'r' to go back to select the authentication method
 Choose action:
 > 2
 == Authentication code ==
   1. Proceed with Authentication code
-  2. Resend sms
+  2. Resend SMS (2 sent)
 Or enter 'r' to go back to select the authentication method
 Choose action:
 >
@@ -127,13 +127,13 @@ Choose your authentication method:
 > 8
 == Authentication code ==
   1. Proceed with Authentication code
-  2. Resend sms
+  2. Resend SMS (1 sent)
 Or enter 'r' to go back to select the authentication method
 Choose action:
 > 2
 == Authentication code ==
   1. Proceed with Authentication code
-  2. Resend sms
+  2. Resend SMS (2 sent)
 Or enter 'r' to go back to select the authentication method
 Choose action:
 > 1
@@ -166,13 +166,13 @@ Choose your authentication method:
 > 8
 == Authentication code ==
   1. Proceed with Authentication code
-  2. Resend sms
+  2. Resend SMS (1 sent)
 Or enter 'r' to go back to select the authentication method
 Choose action:
 > 2
 == Authentication code ==
   1. Proceed with Authentication code
-  2. Resend sms
+  2. Resend SMS (2 sent)
 Or enter 'r' to go back to select the authentication method
 Choose action:
 > 1
@@ -212,13 +212,13 @@ Choose your authentication method:
 > 8
 == Authentication code ==
   1. Proceed with Authentication code
-  2. Resend sms
+  2. Resend SMS (1 sent)
 Or enter 'r' to go back to select the authentication method
 Choose action:
 > 2
 == Authentication code ==
   1. Proceed with Authentication code
-  2. Resend sms
+  2. Resend SMS (2 sent)
 Or enter 'r' to go back to select the authentication method
 Choose action:
 > 1

--- a/pam/integration-tests/testdata/TestNativeAuthenticate/golden/remember_last_successful_broker_and_mode
+++ b/pam/integration-tests/testdata/TestNativeAuthenticate/golden/remember_last_successful_broker_and_mode
@@ -63,7 +63,7 @@ Choose your authentication method:
 > 8
 == Authentication code ==
   1. Proceed with Authentication code
-  2. Resend sms
+  2. Resend SMS (1 sent)
 Or enter 'r' to go back to select the authentication method
 Choose action:
 >
@@ -92,7 +92,7 @@ Choose your authentication method:
 > 8
 == Authentication code ==
   1. Proceed with Authentication code
-  2. Resend sms
+  2. Resend SMS (1 sent)
 Or enter 'r' to go back to select the authentication method
 Choose action:
 > 1
@@ -125,7 +125,7 @@ Choose your authentication method:
 > 8
 == Authentication code ==
   1. Proceed with Authentication code
-  2. Resend sms
+  2. Resend SMS (1 sent)
 Or enter 'r' to go back to select the authentication method
 Choose action:
 > 1
@@ -165,7 +165,7 @@ Choose your authentication method:
 > 8
 == Authentication code ==
   1. Proceed with Authentication code
-  2. Resend sms
+  2. Resend SMS (1 sent)
 Or enter 'r' to go back to select the authentication method
 Choose action:
 > 1
@@ -182,7 +182,7 @@ PAM AcctMgmt()
 > ./pam_authd login socket=${AUTHD_TESTS_CLI_AUTHENTICATE_TESTS_SOCK} force_native_client=true
 == Authentication code ==
   1. Proceed with Authentication code
-  2. Resend sms
+  2. Resend SMS (1 sent)
 Or enter 'r' to go back to select the authentication method
 Choose action:
 >
@@ -211,7 +211,7 @@ Choose your authentication method:
 > 8
 == Authentication code ==
   1. Proceed with Authentication code
-  2. Resend sms
+  2. Resend SMS (1 sent)
 Or enter 'r' to go back to select the authentication method
 Choose action:
 > 1
@@ -228,7 +228,7 @@ PAM AcctMgmt()
 > ./pam_authd login socket=${AUTHD_TESTS_CLI_AUTHENTICATE_TESTS_SOCK} force_native_client=true
 == Authentication code ==
   1. Proceed with Authentication code
-  2. Resend sms
+  2. Resend SMS (1 sent)
 Or enter 'r' to go back to select the authentication method
 Choose action:
 > 1
@@ -261,7 +261,7 @@ Choose your authentication method:
 > 8
 == Authentication code ==
   1. Proceed with Authentication code
-  2. Resend sms
+  2. Resend SMS (1 sent)
 Or enter 'r' to go back to select the authentication method
 Choose action:
 > 1
@@ -278,7 +278,7 @@ PAM AcctMgmt()
 > ./pam_authd login socket=${AUTHD_TESTS_CLI_AUTHENTICATE_TESTS_SOCK} force_native_client=true
 == Authentication code ==
   1. Proceed with Authentication code
-  2. Resend sms
+  2. Resend SMS (1 sent)
 Or enter 'r' to go back to select the authentication method
 Choose action:
 > 1
@@ -314,7 +314,7 @@ Choose your authentication method:
 > 8
 == Authentication code ==
   1. Proceed with Authentication code
-  2. Resend sms
+  2. Resend SMS (1 sent)
 Or enter 'r' to go back to select the authentication method
 Choose action:
 > 1
@@ -331,7 +331,7 @@ PAM AcctMgmt()
 > ./pam_authd login socket=${AUTHD_TESTS_CLI_AUTHENTICATE_TESTS_SOCK} force_native_client=true
 == Authentication code ==
   1. Proceed with Authentication code
-  2. Resend sms
+  2. Resend SMS (1 sent)
 Or enter 'r' to go back to select the authentication method
 Choose action:
 > 1

--- a/pam/integration-tests/testdata/TestSSHAuthenticate/golden/authenticate_user_switching_auth_mode
+++ b/pam/integration-tests/testdata/TestSSHAuthenticate/golden/authenticate_user_switching_auth_mode
@@ -1278,7 +1278,7 @@ ication method:
 > 8
 == Authentication code ==
   1. Proceed with Authentication code
-  2. Resend sms
+  2. Resend SMS (1 sent)
 Or enter 'r' to go back to select the authentication method
 (user-integration-pre-check-authenticate-user-switching-auth-mode@localhost) Choose action:
 >
@@ -1428,7 +1428,7 @@ ication method:
 > 8
 == Authentication code ==
   1. Proceed with Authentication code
-  2. Resend sms
+  2. Resend SMS (1 sent)
 Or enter 'r' to go back to select the authentication method
 (user-integration-pre-check-authenticate-user-switching-auth-mode@localhost) Choose action:
 > r
@@ -1591,7 +1591,7 @@ ication method:
 > 8
 == Authentication code ==
   1. Proceed with Authentication code
-  2. Resend sms
+  2. Resend SMS (1 sent)
 Or enter 'r' to go back to select the authentication method
 (user-integration-pre-check-authenticate-user-switching-auth-mode@localhost) Choose action:
 > r
@@ -1758,188 +1758,7 @@ ication method:
 > 8
 == Authentication code ==
   1. Proceed with Authentication code
-  2. Resend sms
-Or enter 'r' to go back to select the authentication method
-(user-integration-pre-check-authenticate-user-switching-auth-mode@localhost) Choose action:
-> r
-== Authentication method selection ==
-  1. Password authentication
-  2. Use a Login code
-  3. Send URL to user-integration-pre-check-authenticate-user-switching-auth-mode@gmail.com
-  4. Use your fido device foo
-  5. Use your phone +33...
-  6. Use your phone +1...
-  7. Pin code
-  8. Authentication code
-Or enter 'r' to go back to choose the provider
-(user-integration-pre-check-authenticate-user-switching-auth-mode@localhost) Choose your authent
-ication method:
-> invalid-selection
-Unsupported input
-(user-integration-pre-check-authenticate-user-switching-auth-mode@localhost) Choose your authent
-ication method:
-> -1
-Invalid selection
-== Authentication method selection ==
-  1. Password authentication
-  2. Use a Login code
-  3. Send URL to user-integration-pre-check-authenticate-user-switching-auth-mode@gmail.com
-  4. Use your fido device foo
-  5. Use your phone +33...
-  6. Use your phone +1...
-  7. Pin code
-  8. Authentication code
-Or enter 'r' to go back to choose the provider
-(user-integration-pre-check-authenticate-user-switching-auth-mode@localhost) Choose your authent
-ication method:
->
-────────────────────────────────────────────────────────────────────────────────
-> ssh ${AUTHD_PAM_SSH_USER}@localhost ${AUTHD_PAM_SSH_ARGS}
-== Provider selection ==
-  1. local
-  2. ExampleBroker
-(user-integration-pre-check-authenticate-user-switching-auth-mode@localhost) Choose your provide
-r:
-> 2
-== Password authentication ==
-Enter 'r' to cancel the request and go back to select the authentication method
-(user-integration-pre-check-authenticate-user-switching-auth-mode@localhost) Gimme your password
-:
->
-== Authentication method selection ==
-  1. Password authentication
-  2. Use a Login code
-  3. Send URL to user-integration-pre-check-authenticate-user-switching-auth-mode@gmail.com
-  4. Use your fido device foo
-  5. Use your phone +33...
-  6. Use your phone +1...
-  7. Pin code
-  8. Authentication code
-Or enter 'r' to go back to choose the provider
-(user-integration-pre-check-authenticate-user-switching-auth-mode@localhost) Choose your authent
-ication method:
-> 2
-== Qr Code authentication ==
-Enter the code in the login page
-https://ubuntu.com
-       1337
-
-  1. Wait for the QR code scan result
-  2. Regenerate code
-Or enter 'r' to go back to select the authentication method
-(user-integration-pre-check-authenticate-user-switching-auth-mode@localhost) Choose action:
-> r
-== Authentication method selection ==
-  1. Password authentication
-  2. Use a Login code
-  3. Send URL to user-integration-pre-check-authenticate-user-switching-auth-mode@gmail.com
-  4. Use your fido device foo
-  5. Use your phone +33...
-  6. Use your phone +1...
-  7. Pin code
-  8. Authentication code
-Or enter 'r' to go back to choose the provider
-(user-integration-pre-check-authenticate-user-switching-auth-mode@localhost) Choose your authent
-ication method:
-> 3
-== Send URL to user-integration-pre-check-authenticate-user-switching-auth-mode@gmail.com ==
-Leave the input field empty to wait for the alternative authentication method or enter 'r' to go
- back to select the authentication method
-(user-integration-pre-check-authenticate-user-switching-auth-mode@localhost) Click on the link r
-eceived at user-integration-pre-check-authenticate-user-switching-auth-mode@gmail.com or enter t
-he code:
-> r
-== Authentication method selection ==
-  1. Password authentication
-  2. Use a Login code
-  3. Send URL to user-integration-pre-check-authenticate-user-switching-auth-mode@gmail.com
-  4. Use your fido device foo
-  5. Use your phone +33...
-  6. Use your phone +1...
-  7. Pin code
-  8. Authentication code
-Or enter 'r' to go back to choose the provider
-(user-integration-pre-check-authenticate-user-switching-auth-mode@localhost) Choose your authent
-ication method:
-> 4
-== Use your fido device foo ==
-Press Enter to wait for authentication or enter 'r' to go back to select the authentication meth
-od
-(user-integration-pre-check-authenticate-user-switching-auth-mode@localhost) Plug your fido devi
-ce and press with your thumb:
-> r
-== Authentication method selection ==
-  1. Password authentication
-  2. Use a Login code
-  3. Send URL to user-integration-pre-check-authenticate-user-switching-auth-mode@gmail.com
-  4. Use your fido device foo
-  5. Use your phone +33...
-  6. Use your phone +1...
-  7. Pin code
-  8. Authentication code
-Or enter 'r' to go back to choose the provider
-(user-integration-pre-check-authenticate-user-switching-auth-mode@localhost) Choose your authent
-ication method:
-> 5
-== Use your phone +33... ==
-Press Enter to wait for authentication or enter 'r' to go back to select the authentication meth
-od
-(user-integration-pre-check-authenticate-user-switching-auth-mode@localhost) Unlock your phone +
-33... or accept request on web interface:
-> r
-== Authentication method selection ==
-  1. Password authentication
-  2. Use a Login code
-  3. Send URL to user-integration-pre-check-authenticate-user-switching-auth-mode@gmail.com
-  4. Use your fido device foo
-  5. Use your phone +33...
-  6. Use your phone +1...
-  7. Pin code
-  8. Authentication code
-Or enter 'r' to go back to choose the provider
-(user-integration-pre-check-authenticate-user-switching-auth-mode@localhost) Choose your authent
-ication method:
-> 6
-== Use your phone +1... ==
-Press Enter to wait for authentication or enter 'r' to go back to select the authentication meth
-od
-(user-integration-pre-check-authenticate-user-switching-auth-mode@localhost) Unlock your phone +
-1... or accept request on web interface:
-> r
-== Authentication method selection ==
-  1. Password authentication
-  2. Use a Login code
-  3. Send URL to user-integration-pre-check-authenticate-user-switching-auth-mode@gmail.com
-  4. Use your fido device foo
-  5. Use your phone +33...
-  6. Use your phone +1...
-  7. Pin code
-  8. Authentication code
-Or enter 'r' to go back to choose the provider
-(user-integration-pre-check-authenticate-user-switching-auth-mode@localhost) Choose your authent
-ication method:
-> 7
-== Pin code ==
-Enter 'r' to cancel the request and go back to select the authentication method
-(user-integration-pre-check-authenticate-user-switching-auth-mode@localhost) Enter your pin code
-:
-> r
-== Authentication method selection ==
-  1. Password authentication
-  2. Use a Login code
-  3. Send URL to user-integration-pre-check-authenticate-user-switching-auth-mode@gmail.com
-  4. Use your fido device foo
-  5. Use your phone +33...
-  6. Use your phone +1...
-  7. Pin code
-  8. Authentication code
-Or enter 'r' to go back to choose the provider
-(user-integration-pre-check-authenticate-user-switching-auth-mode@localhost) Choose your authent
-ication method:
-> 8
-== Authentication code ==
-  1. Proceed with Authentication code
-  2. Resend sms
+  2. Resend SMS (1 sent)
 Or enter 'r' to go back to select the authentication method
 (user-integration-pre-check-authenticate-user-switching-auth-mode@localhost) Choose action:
 > r
@@ -1973,6 +1792,187 @@ Invalid selection
 Or enter 'r' to go back to choose the provider
 (user-integration-pre-check-authenticate-user-switching-auth-mode@localhost) Choose your authent
 ication method:
+>
+────────────────────────────────────────────────────────────────────────────────
+> ssh ${AUTHD_PAM_SSH_USER}@localhost ${AUTHD_PAM_SSH_ARGS}
+== Provider selection ==
+  1. local
+  2. ExampleBroker
+(user-integration-pre-check-authenticate-user-switching-auth-mode@localhost) Choose your provide
+r:
+> 2
+== Password authentication ==
+Enter 'r' to cancel the request and go back to select the authentication method
+(user-integration-pre-check-authenticate-user-switching-auth-mode@localhost) Gimme your password
+:
+>
+== Authentication method selection ==
+  1. Password authentication
+  2. Use a Login code
+  3. Send URL to user-integration-pre-check-authenticate-user-switching-auth-mode@gmail.com
+  4. Use your fido device foo
+  5. Use your phone +33...
+  6. Use your phone +1...
+  7. Pin code
+  8. Authentication code
+Or enter 'r' to go back to choose the provider
+(user-integration-pre-check-authenticate-user-switching-auth-mode@localhost) Choose your authent
+ication method:
+> 2
+== Qr Code authentication ==
+Enter the code in the login page
+https://ubuntu.com
+       1337
+
+  1. Wait for the QR code scan result
+  2. Regenerate code
+Or enter 'r' to go back to select the authentication method
+(user-integration-pre-check-authenticate-user-switching-auth-mode@localhost) Choose action:
+> r
+== Authentication method selection ==
+  1. Password authentication
+  2. Use a Login code
+  3. Send URL to user-integration-pre-check-authenticate-user-switching-auth-mode@gmail.com
+  4. Use your fido device foo
+  5. Use your phone +33...
+  6. Use your phone +1...
+  7. Pin code
+  8. Authentication code
+Or enter 'r' to go back to choose the provider
+(user-integration-pre-check-authenticate-user-switching-auth-mode@localhost) Choose your authent
+ication method:
+> 3
+== Send URL to user-integration-pre-check-authenticate-user-switching-auth-mode@gmail.com ==
+Leave the input field empty to wait for the alternative authentication method or enter 'r' to go
+ back to select the authentication method
+(user-integration-pre-check-authenticate-user-switching-auth-mode@localhost) Click on the link r
+eceived at user-integration-pre-check-authenticate-user-switching-auth-mode@gmail.com or enter t
+he code:
+> r
+== Authentication method selection ==
+  1. Password authentication
+  2. Use a Login code
+  3. Send URL to user-integration-pre-check-authenticate-user-switching-auth-mode@gmail.com
+  4. Use your fido device foo
+  5. Use your phone +33...
+  6. Use your phone +1...
+  7. Pin code
+  8. Authentication code
+Or enter 'r' to go back to choose the provider
+(user-integration-pre-check-authenticate-user-switching-auth-mode@localhost) Choose your authent
+ication method:
+> 4
+== Use your fido device foo ==
+Press Enter to wait for authentication or enter 'r' to go back to select the authentication meth
+od
+(user-integration-pre-check-authenticate-user-switching-auth-mode@localhost) Plug your fido devi
+ce and press with your thumb:
+> r
+== Authentication method selection ==
+  1. Password authentication
+  2. Use a Login code
+  3. Send URL to user-integration-pre-check-authenticate-user-switching-auth-mode@gmail.com
+  4. Use your fido device foo
+  5. Use your phone +33...
+  6. Use your phone +1...
+  7. Pin code
+  8. Authentication code
+Or enter 'r' to go back to choose the provider
+(user-integration-pre-check-authenticate-user-switching-auth-mode@localhost) Choose your authent
+ication method:
+> 5
+== Use your phone +33... ==
+Press Enter to wait for authentication or enter 'r' to go back to select the authentication meth
+od
+(user-integration-pre-check-authenticate-user-switching-auth-mode@localhost) Unlock your phone +
+33... or accept request on web interface:
+> r
+== Authentication method selection ==
+  1. Password authentication
+  2. Use a Login code
+  3. Send URL to user-integration-pre-check-authenticate-user-switching-auth-mode@gmail.com
+  4. Use your fido device foo
+  5. Use your phone +33...
+  6. Use your phone +1...
+  7. Pin code
+  8. Authentication code
+Or enter 'r' to go back to choose the provider
+(user-integration-pre-check-authenticate-user-switching-auth-mode@localhost) Choose your authent
+ication method:
+> 6
+== Use your phone +1... ==
+Press Enter to wait for authentication or enter 'r' to go back to select the authentication meth
+od
+(user-integration-pre-check-authenticate-user-switching-auth-mode@localhost) Unlock your phone +
+1... or accept request on web interface:
+> r
+== Authentication method selection ==
+  1. Password authentication
+  2. Use a Login code
+  3. Send URL to user-integration-pre-check-authenticate-user-switching-auth-mode@gmail.com
+  4. Use your fido device foo
+  5. Use your phone +33...
+  6. Use your phone +1...
+  7. Pin code
+  8. Authentication code
+Or enter 'r' to go back to choose the provider
+(user-integration-pre-check-authenticate-user-switching-auth-mode@localhost) Choose your authent
+ication method:
+> 7
+== Pin code ==
+Enter 'r' to cancel the request and go back to select the authentication method
+(user-integration-pre-check-authenticate-user-switching-auth-mode@localhost) Enter your pin code
+:
+> r
+== Authentication method selection ==
+  1. Password authentication
+  2. Use a Login code
+  3. Send URL to user-integration-pre-check-authenticate-user-switching-auth-mode@gmail.com
+  4. Use your fido device foo
+  5. Use your phone +33...
+  6. Use your phone +1...
+  7. Pin code
+  8. Authentication code
+Or enter 'r' to go back to choose the provider
+(user-integration-pre-check-authenticate-user-switching-auth-mode@localhost) Choose your authent
+ication method:
+> 8
+== Authentication code ==
+  1. Proceed with Authentication code
+  2. Resend SMS (1 sent)
+Or enter 'r' to go back to select the authentication method
+(user-integration-pre-check-authenticate-user-switching-auth-mode@localhost) Choose action:
+> r
+== Authentication method selection ==
+  1. Password authentication
+  2. Use a Login code
+  3. Send URL to user-integration-pre-check-authenticate-user-switching-auth-mode@gmail.com
+  4. Use your fido device foo
+  5. Use your phone +33...
+  6. Use your phone +1...
+  7. Pin code
+  8. Authentication code
+Or enter 'r' to go back to choose the provider
+(user-integration-pre-check-authenticate-user-switching-auth-mode@localhost) Choose your authent
+ication method:
+> invalid-selection
+Unsupported input
+(user-integration-pre-check-authenticate-user-switching-auth-mode@localhost) Choose your authent
+ication method:
+> -1
+Invalid selection
+== Authentication method selection ==
+  1. Password authentication
+  2. Use a Login code
+  3. Send URL to user-integration-pre-check-authenticate-user-switching-auth-mode@gmail.com
+  4. Use your fido device foo
+  5. Use your phone +33...
+  6. Use your phone +1...
+  7. Pin code
+  8. Authentication code
+Or enter 'r' to go back to choose the provider
+(user-integration-pre-check-authenticate-user-switching-auth-mode@localhost) Choose your authent
+ication method:
 > 7
 == Pin code ==
 Enter 'r' to cancel the request and go back to select the authentication method
@@ -2125,7 +2125,7 @@ ication method:
 > 8
 == Authentication code ==
   1. Proceed with Authentication code
-  2. Resend sms
+  2. Resend SMS (1 sent)
 Or enter 'r' to go back to select the authentication method
 (user-integration-pre-check-authenticate-user-switching-auth-mode@localhost) Choose action:
 > r
@@ -2325,7 +2325,7 @@ ication method:
 > 8
 == Authentication code ==
   1. Proceed with Authentication code
-  2. Resend sms
+  2. Resend SMS (1 sent)
 Or enter 'r' to go back to select the authentication method
 (user-integration-pre-check-authenticate-user-switching-auth-mode@localhost) Choose action:
 > r

--- a/pam/integration-tests/testdata/TestSSHAuthenticate/golden/authenticate_user_switching_auth_mode_on_shared_sshd
+++ b/pam/integration-tests/testdata/TestSSHAuthenticate/golden/authenticate_user_switching_auth_mode_on_shared_sshd
@@ -1358,7 +1358,7 @@ se your authentication method:
 > 8
 == Authentication code ==
   1. Proceed with Authentication code
-  2. Resend sms
+  2. Resend SMS (1 sent)
 Or enter 'r' to go back to select the authentication method
 (user-integration-pre-check-authenticate-user-switching-auth-mode-on-shared-sshd@localhost) Choo
 se action:
@@ -1518,7 +1518,7 @@ se your authentication method:
 > 8
 == Authentication code ==
   1. Proceed with Authentication code
-  2. Resend sms
+  2. Resend SMS (1 sent)
 Or enter 'r' to go back to select the authentication method
 (user-integration-pre-check-authenticate-user-switching-auth-mode-on-shared-sshd@localhost) Choo
 se action:
@@ -1692,7 +1692,7 @@ se your authentication method:
 > 8
 == Authentication code ==
   1. Proceed with Authentication code
-  2. Resend sms
+  2. Resend SMS (1 sent)
 Or enter 'r' to go back to select the authentication method
 (user-integration-pre-check-authenticate-user-switching-auth-mode-on-shared-sshd@localhost) Choo
 se action:
@@ -1870,200 +1870,7 @@ se your authentication method:
 > 8
 == Authentication code ==
   1. Proceed with Authentication code
-  2. Resend sms
-Or enter 'r' to go back to select the authentication method
-(user-integration-pre-check-authenticate-user-switching-auth-mode-on-shared-sshd@localhost) Choo
-se action:
-> r
-== Authentication method selection ==
-  1. Password authentication
-  2. Use a Login code
-  3. Send URL to user-integration-pre-check-authenticate-user-switching-auth-mode-on-shared-sshd
-@gmail.com
-  4. Use your fido device foo
-  5. Use your phone +33...
-  6. Use your phone +1...
-  7. Pin code
-  8. Authentication code
-Or enter 'r' to go back to choose the provider
-(user-integration-pre-check-authenticate-user-switching-auth-mode-on-shared-sshd@localhost) Choo
-se your authentication method:
-> invalid-selection
-Unsupported input
-(user-integration-pre-check-authenticate-user-switching-auth-mode-on-shared-sshd@localhost) Choo
-se your authentication method:
-> -1
-Invalid selection
-== Authentication method selection ==
-  1. Password authentication
-  2. Use a Login code
-  3. Send URL to user-integration-pre-check-authenticate-user-switching-auth-mode-on-shared-sshd
-@gmail.com
-  4. Use your fido device foo
-  5. Use your phone +33...
-  6. Use your phone +1...
-  7. Pin code
-  8. Authentication code
-Or enter 'r' to go back to choose the provider
-(user-integration-pre-check-authenticate-user-switching-auth-mode-on-shared-sshd@localhost) Choo
-se your authentication method:
->
-────────────────────────────────────────────────────────────────────────────────
-> ssh ${AUTHD_PAM_SSH_USER}@localhost ${AUTHD_PAM_SSH_ARGS}
-== Provider selection ==
-  1. local
-  2. ExampleBroker
-(user-integration-pre-check-authenticate-user-switching-auth-mode-on-shared-sshd@localhost) Choo
-se your provider:
-> 2
-== Password authentication ==
-Enter 'r' to cancel the request and go back to select the authentication method
-(user-integration-pre-check-authenticate-user-switching-auth-mode-on-shared-sshd@localhost) Gimm
-e your password:
->
-== Authentication method selection ==
-  1. Password authentication
-  2. Use a Login code
-  3. Send URL to user-integration-pre-check-authenticate-user-switching-auth-mode-on-shared-sshd
-@gmail.com
-  4. Use your fido device foo
-  5. Use your phone +33...
-  6. Use your phone +1...
-  7. Pin code
-  8. Authentication code
-Or enter 'r' to go back to choose the provider
-(user-integration-pre-check-authenticate-user-switching-auth-mode-on-shared-sshd@localhost) Choo
-se your authentication method:
-> 2
-== Qr Code authentication ==
-Enter the code in the login page
-https://ubuntu.com
-       1337
-
-  1. Wait for the QR code scan result
-  2. Regenerate code
-Or enter 'r' to go back to select the authentication method
-(user-integration-pre-check-authenticate-user-switching-auth-mode-on-shared-sshd@localhost) Choo
-se action:
-> r
-== Authentication method selection ==
-  1. Password authentication
-  2. Use a Login code
-  3. Send URL to user-integration-pre-check-authenticate-user-switching-auth-mode-on-shared-sshd
-@gmail.com
-  4. Use your fido device foo
-  5. Use your phone +33...
-  6. Use your phone +1...
-  7. Pin code
-  8. Authentication code
-Or enter 'r' to go back to choose the provider
-(user-integration-pre-check-authenticate-user-switching-auth-mode-on-shared-sshd@localhost) Choo
-se your authentication method:
-> 3
-== Send URL to user-integration-pre-check-authenticate-user-switching-auth-mode-on-shared-sshd@g
-mail.com ==
-Leave the input field empty to wait for the alternative authentication method or enter 'r' to go
- back to select the authentication method
-(user-integration-pre-check-authenticate-user-switching-auth-mode-on-shared-sshd@localhost) Clic
-k on the link received at user-integration-pre-check-authenticate-user-switching-auth-mode-on-sh
-ared-sshd@gmail.com or enter the code:
-> r
-== Authentication method selection ==
-  1. Password authentication
-  2. Use a Login code
-  3. Send URL to user-integration-pre-check-authenticate-user-switching-auth-mode-on-shared-sshd
-@gmail.com
-  4. Use your fido device foo
-  5. Use your phone +33...
-  6. Use your phone +1...
-  7. Pin code
-  8. Authentication code
-Or enter 'r' to go back to choose the provider
-(user-integration-pre-check-authenticate-user-switching-auth-mode-on-shared-sshd@localhost) Choo
-se your authentication method:
-> 4
-== Use your fido device foo ==
-Press Enter to wait for authentication or enter 'r' to go back to select the authentication meth
-od
-(user-integration-pre-check-authenticate-user-switching-auth-mode-on-shared-sshd@localhost) Plug
- your fido device and press with your thumb:
-> r
-== Authentication method selection ==
-  1. Password authentication
-  2. Use a Login code
-  3. Send URL to user-integration-pre-check-authenticate-user-switching-auth-mode-on-shared-sshd
-@gmail.com
-  4. Use your fido device foo
-  5. Use your phone +33...
-  6. Use your phone +1...
-  7. Pin code
-  8. Authentication code
-Or enter 'r' to go back to choose the provider
-(user-integration-pre-check-authenticate-user-switching-auth-mode-on-shared-sshd@localhost) Choo
-se your authentication method:
-> 5
-== Use your phone +33... ==
-Press Enter to wait for authentication or enter 'r' to go back to select the authentication meth
-od
-(user-integration-pre-check-authenticate-user-switching-auth-mode-on-shared-sshd@localhost) Unlo
-ck your phone +33... or accept request on web interface:
-> r
-== Authentication method selection ==
-  1. Password authentication
-  2. Use a Login code
-  3. Send URL to user-integration-pre-check-authenticate-user-switching-auth-mode-on-shared-sshd
-@gmail.com
-  4. Use your fido device foo
-  5. Use your phone +33...
-  6. Use your phone +1...
-  7. Pin code
-  8. Authentication code
-Or enter 'r' to go back to choose the provider
-(user-integration-pre-check-authenticate-user-switching-auth-mode-on-shared-sshd@localhost) Choo
-se your authentication method:
-> 6
-== Use your phone +1... ==
-Press Enter to wait for authentication or enter 'r' to go back to select the authentication meth
-od
-(user-integration-pre-check-authenticate-user-switching-auth-mode-on-shared-sshd@localhost) Unlo
-ck your phone +1... or accept request on web interface:
-> r
-== Authentication method selection ==
-  1. Password authentication
-  2. Use a Login code
-  3. Send URL to user-integration-pre-check-authenticate-user-switching-auth-mode-on-shared-sshd
-@gmail.com
-  4. Use your fido device foo
-  5. Use your phone +33...
-  6. Use your phone +1...
-  7. Pin code
-  8. Authentication code
-Or enter 'r' to go back to choose the provider
-(user-integration-pre-check-authenticate-user-switching-auth-mode-on-shared-sshd@localhost) Choo
-se your authentication method:
-> 7
-== Pin code ==
-Enter 'r' to cancel the request and go back to select the authentication method
-(user-integration-pre-check-authenticate-user-switching-auth-mode-on-shared-sshd@localhost) Ente
-r your pin code:
-> r
-== Authentication method selection ==
-  1. Password authentication
-  2. Use a Login code
-  3. Send URL to user-integration-pre-check-authenticate-user-switching-auth-mode-on-shared-sshd
-@gmail.com
-  4. Use your fido device foo
-  5. Use your phone +33...
-  6. Use your phone +1...
-  7. Pin code
-  8. Authentication code
-Or enter 'r' to go back to choose the provider
-(user-integration-pre-check-authenticate-user-switching-auth-mode-on-shared-sshd@localhost) Choo
-se your authentication method:
-> 8
-== Authentication code ==
-  1. Proceed with Authentication code
-  2. Resend sms
+  2. Resend SMS (1 sent)
 Or enter 'r' to go back to select the authentication method
 (user-integration-pre-check-authenticate-user-switching-auth-mode-on-shared-sshd@localhost) Choo
 se action:
@@ -2100,6 +1907,199 @@ Invalid selection
 Or enter 'r' to go back to choose the provider
 (user-integration-pre-check-authenticate-user-switching-auth-mode-on-shared-sshd@localhost) Choo
 se your authentication method:
+>
+────────────────────────────────────────────────────────────────────────────────
+> ssh ${AUTHD_PAM_SSH_USER}@localhost ${AUTHD_PAM_SSH_ARGS}
+== Provider selection ==
+  1. local
+  2. ExampleBroker
+(user-integration-pre-check-authenticate-user-switching-auth-mode-on-shared-sshd@localhost) Choo
+se your provider:
+> 2
+== Password authentication ==
+Enter 'r' to cancel the request and go back to select the authentication method
+(user-integration-pre-check-authenticate-user-switching-auth-mode-on-shared-sshd@localhost) Gimm
+e your password:
+>
+== Authentication method selection ==
+  1. Password authentication
+  2. Use a Login code
+  3. Send URL to user-integration-pre-check-authenticate-user-switching-auth-mode-on-shared-sshd
+@gmail.com
+  4. Use your fido device foo
+  5. Use your phone +33...
+  6. Use your phone +1...
+  7. Pin code
+  8. Authentication code
+Or enter 'r' to go back to choose the provider
+(user-integration-pre-check-authenticate-user-switching-auth-mode-on-shared-sshd@localhost) Choo
+se your authentication method:
+> 2
+== Qr Code authentication ==
+Enter the code in the login page
+https://ubuntu.com
+       1337
+
+  1. Wait for the QR code scan result
+  2. Regenerate code
+Or enter 'r' to go back to select the authentication method
+(user-integration-pre-check-authenticate-user-switching-auth-mode-on-shared-sshd@localhost) Choo
+se action:
+> r
+== Authentication method selection ==
+  1. Password authentication
+  2. Use a Login code
+  3. Send URL to user-integration-pre-check-authenticate-user-switching-auth-mode-on-shared-sshd
+@gmail.com
+  4. Use your fido device foo
+  5. Use your phone +33...
+  6. Use your phone +1...
+  7. Pin code
+  8. Authentication code
+Or enter 'r' to go back to choose the provider
+(user-integration-pre-check-authenticate-user-switching-auth-mode-on-shared-sshd@localhost) Choo
+se your authentication method:
+> 3
+== Send URL to user-integration-pre-check-authenticate-user-switching-auth-mode-on-shared-sshd@g
+mail.com ==
+Leave the input field empty to wait for the alternative authentication method or enter 'r' to go
+ back to select the authentication method
+(user-integration-pre-check-authenticate-user-switching-auth-mode-on-shared-sshd@localhost) Clic
+k on the link received at user-integration-pre-check-authenticate-user-switching-auth-mode-on-sh
+ared-sshd@gmail.com or enter the code:
+> r
+== Authentication method selection ==
+  1. Password authentication
+  2. Use a Login code
+  3. Send URL to user-integration-pre-check-authenticate-user-switching-auth-mode-on-shared-sshd
+@gmail.com
+  4. Use your fido device foo
+  5. Use your phone +33...
+  6. Use your phone +1...
+  7. Pin code
+  8. Authentication code
+Or enter 'r' to go back to choose the provider
+(user-integration-pre-check-authenticate-user-switching-auth-mode-on-shared-sshd@localhost) Choo
+se your authentication method:
+> 4
+== Use your fido device foo ==
+Press Enter to wait for authentication or enter 'r' to go back to select the authentication meth
+od
+(user-integration-pre-check-authenticate-user-switching-auth-mode-on-shared-sshd@localhost) Plug
+ your fido device and press with your thumb:
+> r
+== Authentication method selection ==
+  1. Password authentication
+  2. Use a Login code
+  3. Send URL to user-integration-pre-check-authenticate-user-switching-auth-mode-on-shared-sshd
+@gmail.com
+  4. Use your fido device foo
+  5. Use your phone +33...
+  6. Use your phone +1...
+  7. Pin code
+  8. Authentication code
+Or enter 'r' to go back to choose the provider
+(user-integration-pre-check-authenticate-user-switching-auth-mode-on-shared-sshd@localhost) Choo
+se your authentication method:
+> 5
+== Use your phone +33... ==
+Press Enter to wait for authentication or enter 'r' to go back to select the authentication meth
+od
+(user-integration-pre-check-authenticate-user-switching-auth-mode-on-shared-sshd@localhost) Unlo
+ck your phone +33... or accept request on web interface:
+> r
+== Authentication method selection ==
+  1. Password authentication
+  2. Use a Login code
+  3. Send URL to user-integration-pre-check-authenticate-user-switching-auth-mode-on-shared-sshd
+@gmail.com
+  4. Use your fido device foo
+  5. Use your phone +33...
+  6. Use your phone +1...
+  7. Pin code
+  8. Authentication code
+Or enter 'r' to go back to choose the provider
+(user-integration-pre-check-authenticate-user-switching-auth-mode-on-shared-sshd@localhost) Choo
+se your authentication method:
+> 6
+== Use your phone +1... ==
+Press Enter to wait for authentication or enter 'r' to go back to select the authentication meth
+od
+(user-integration-pre-check-authenticate-user-switching-auth-mode-on-shared-sshd@localhost) Unlo
+ck your phone +1... or accept request on web interface:
+> r
+== Authentication method selection ==
+  1. Password authentication
+  2. Use a Login code
+  3. Send URL to user-integration-pre-check-authenticate-user-switching-auth-mode-on-shared-sshd
+@gmail.com
+  4. Use your fido device foo
+  5. Use your phone +33...
+  6. Use your phone +1...
+  7. Pin code
+  8. Authentication code
+Or enter 'r' to go back to choose the provider
+(user-integration-pre-check-authenticate-user-switching-auth-mode-on-shared-sshd@localhost) Choo
+se your authentication method:
+> 7
+== Pin code ==
+Enter 'r' to cancel the request and go back to select the authentication method
+(user-integration-pre-check-authenticate-user-switching-auth-mode-on-shared-sshd@localhost) Ente
+r your pin code:
+> r
+== Authentication method selection ==
+  1. Password authentication
+  2. Use a Login code
+  3. Send URL to user-integration-pre-check-authenticate-user-switching-auth-mode-on-shared-sshd
+@gmail.com
+  4. Use your fido device foo
+  5. Use your phone +33...
+  6. Use your phone +1...
+  7. Pin code
+  8. Authentication code
+Or enter 'r' to go back to choose the provider
+(user-integration-pre-check-authenticate-user-switching-auth-mode-on-shared-sshd@localhost) Choo
+se your authentication method:
+> 8
+== Authentication code ==
+  1. Proceed with Authentication code
+  2. Resend SMS (1 sent)
+Or enter 'r' to go back to select the authentication method
+(user-integration-pre-check-authenticate-user-switching-auth-mode-on-shared-sshd@localhost) Choo
+se action:
+> r
+== Authentication method selection ==
+  1. Password authentication
+  2. Use a Login code
+  3. Send URL to user-integration-pre-check-authenticate-user-switching-auth-mode-on-shared-sshd
+@gmail.com
+  4. Use your fido device foo
+  5. Use your phone +33...
+  6. Use your phone +1...
+  7. Pin code
+  8. Authentication code
+Or enter 'r' to go back to choose the provider
+(user-integration-pre-check-authenticate-user-switching-auth-mode-on-shared-sshd@localhost) Choo
+se your authentication method:
+> invalid-selection
+Unsupported input
+(user-integration-pre-check-authenticate-user-switching-auth-mode-on-shared-sshd@localhost) Choo
+se your authentication method:
+> -1
+Invalid selection
+== Authentication method selection ==
+  1. Password authentication
+  2. Use a Login code
+  3. Send URL to user-integration-pre-check-authenticate-user-switching-auth-mode-on-shared-sshd
+@gmail.com
+  4. Use your fido device foo
+  5. Use your phone +33...
+  6. Use your phone +1...
+  7. Pin code
+  8. Authentication code
+Or enter 'r' to go back to choose the provider
+(user-integration-pre-check-authenticate-user-switching-auth-mode-on-shared-sshd@localhost) Choo
+se your authentication method:
 > 7
 == Pin code ==
 Enter 'r' to cancel the request and go back to select the authentication method
@@ -2261,7 +2261,7 @@ se your authentication method:
 > 8
 == Authentication code ==
   1. Proceed with Authentication code
-  2. Resend sms
+  2. Resend SMS (1 sent)
 Or enter 'r' to go back to select the authentication method
 (user-integration-pre-check-authenticate-user-switching-auth-mode-on-shared-sshd@localhost) Choo
 se action:
@@ -2472,7 +2472,7 @@ se your authentication method:
 > 8
 == Authentication code ==
   1. Proceed with Authentication code
-  2. Resend sms
+  2. Resend SMS (1 sent)
 Or enter 'r' to go back to select the authentication method
 (user-integration-pre-check-authenticate-user-switching-auth-mode-on-shared-sshd@localhost) Choo
 se action:

--- a/pam/integration-tests/testdata/TestSSHAuthenticate/golden/authenticate_user_with_form_mode_with_button
+++ b/pam/integration-tests/testdata/TestSSHAuthenticate/golden/authenticate_user_with_form_mode_with_button
@@ -74,7 +74,7 @@ authentication method:
 > 8
 == Authentication code ==
   1. Proceed with Authentication code
-  2. Resend sms
+  2. Resend SMS (1 sent)
 Or enter 'r' to go back to select the authentication method
 (user-integration-pre-check-authenticate-user-with-form-mode-with-button@localhost) Choose actio
 n:
@@ -108,14 +108,14 @@ authentication method:
 > 8
 == Authentication code ==
   1. Proceed with Authentication code
-  2. Resend sms
+  2. Resend SMS (1 sent)
 Or enter 'r' to go back to select the authentication method
 (user-integration-pre-check-authenticate-user-with-form-mode-with-button@localhost) Choose actio
 n:
 > 2
 == Authentication code ==
   1. Proceed with Authentication code
-  2. Resend sms
+  2. Resend SMS (2 sent)
 Or enter 'r' to go back to select the authentication method
 (user-integration-pre-check-authenticate-user-with-form-mode-with-button@localhost) Choose actio
 n:
@@ -149,14 +149,14 @@ authentication method:
 > 8
 == Authentication code ==
   1. Proceed with Authentication code
-  2. Resend sms
+  2. Resend SMS (1 sent)
 Or enter 'r' to go back to select the authentication method
 (user-integration-pre-check-authenticate-user-with-form-mode-with-button@localhost) Choose actio
 n:
 > 2
 == Authentication code ==
   1. Proceed with Authentication code
-  2. Resend sms
+  2. Resend SMS (2 sent)
 Or enter 'r' to go back to select the authentication method
 (user-integration-pre-check-authenticate-user-with-form-mode-with-button@localhost) Choose actio
 n:
@@ -195,14 +195,14 @@ authentication method:
 > 8
 == Authentication code ==
   1. Proceed with Authentication code
-  2. Resend sms
+  2. Resend SMS (1 sent)
 Or enter 'r' to go back to select the authentication method
 (user-integration-pre-check-authenticate-user-with-form-mode-with-button@localhost) Choose actio
 n:
 > 2
 == Authentication code ==
   1. Proceed with Authentication code
-  2. Resend sms
+  2. Resend SMS (2 sent)
 Or enter 'r' to go back to select the authentication method
 (user-integration-pre-check-authenticate-user-with-form-mode-with-button@localhost) Choose actio
 n:
@@ -255,14 +255,14 @@ authentication method:
 > 8
 == Authentication code ==
   1. Proceed with Authentication code
-  2. Resend sms
+  2. Resend SMS (1 sent)
 Or enter 'r' to go back to select the authentication method
 (user-integration-pre-check-authenticate-user-with-form-mode-with-button@localhost) Choose actio
 n:
 > 2
 == Authentication code ==
   1. Proceed with Authentication code
-  2. Resend sms
+  2. Resend SMS (2 sent)
 Or enter 'r' to go back to select the authentication method
 (user-integration-pre-check-authenticate-user-with-form-mode-with-button@localhost) Choose actio
 n:

--- a/pam/integration-tests/testdata/TestSSHAuthenticate/golden/authenticate_user_with_form_mode_with_button_on_shared_sshd
+++ b/pam/integration-tests/testdata/TestSSHAuthenticate/golden/authenticate_user_with_form_mode_with_button_on_shared_sshd
@@ -74,7 +74,7 @@ t) Choose your authentication method:
 > 8
 == Authentication code ==
   1. Proceed with Authentication code
-  2. Resend sms
+  2. Resend SMS (1 sent)
 Or enter 'r' to go back to select the authentication method
 (user-integration-pre-check-authenticate-user-with-form-mode-with-button-on-shared-sshd@localhos
 t) Choose action:
@@ -108,14 +108,14 @@ t) Choose your authentication method:
 > 8
 == Authentication code ==
   1. Proceed with Authentication code
-  2. Resend sms
+  2. Resend SMS (1 sent)
 Or enter 'r' to go back to select the authentication method
 (user-integration-pre-check-authenticate-user-with-form-mode-with-button-on-shared-sshd@localhos
 t) Choose action:
 > 2
 == Authentication code ==
   1. Proceed with Authentication code
-  2. Resend sms
+  2. Resend SMS (2 sent)
 Or enter 'r' to go back to select the authentication method
 (user-integration-pre-check-authenticate-user-with-form-mode-with-button-on-shared-sshd@localhos
 t) Choose action:
@@ -149,14 +149,14 @@ t) Choose your authentication method:
 > 8
 == Authentication code ==
   1. Proceed with Authentication code
-  2. Resend sms
+  2. Resend SMS (1 sent)
 Or enter 'r' to go back to select the authentication method
 (user-integration-pre-check-authenticate-user-with-form-mode-with-button-on-shared-sshd@localhos
 t) Choose action:
 > 2
 == Authentication code ==
   1. Proceed with Authentication code
-  2. Resend sms
+  2. Resend SMS (2 sent)
 Or enter 'r' to go back to select the authentication method
 (user-integration-pre-check-authenticate-user-with-form-mode-with-button-on-shared-sshd@localhos
 t) Choose action:
@@ -195,14 +195,14 @@ t) Choose your authentication method:
 > 8
 == Authentication code ==
   1. Proceed with Authentication code
-  2. Resend sms
+  2. Resend SMS (1 sent)
 Or enter 'r' to go back to select the authentication method
 (user-integration-pre-check-authenticate-user-with-form-mode-with-button-on-shared-sshd@localhos
 t) Choose action:
 > 2
 == Authentication code ==
   1. Proceed with Authentication code
-  2. Resend sms
+  2. Resend SMS (2 sent)
 Or enter 'r' to go back to select the authentication method
 (user-integration-pre-check-authenticate-user-with-form-mode-with-button-on-shared-sshd@localhos
 t) Choose action:
@@ -254,14 +254,14 @@ t) Choose your authentication method:
 > 8
 == Authentication code ==
   1. Proceed with Authentication code
-  2. Resend sms
+  2. Resend SMS (1 sent)
 Or enter 'r' to go back to select the authentication method
 (user-integration-pre-check-authenticate-user-with-form-mode-with-button-on-shared-sshd@localhos
 t) Choose action:
 > 2
 == Authentication code ==
   1. Proceed with Authentication code
-  2. Resend sms
+  2. Resend SMS (2 sent)
 Or enter 'r' to go back to select the authentication method
 (user-integration-pre-check-authenticate-user-with-form-mode-with-button-on-shared-sshd@localhos
 t) Choose action:

--- a/pam/integration-tests/testdata/TestSSHAuthenticate/golden/remember_last_successful_broker_and_mode
+++ b/pam/integration-tests/testdata/TestSSHAuthenticate/golden/remember_last_successful_broker_and_mode
@@ -72,7 +72,7 @@ entication method:
 > 8
 == Authentication code ==
   1. Proceed with Authentication code
-  2. Resend sms
+  2. Resend SMS (1 sent)
 Or enter 'r' to go back to select the authentication method
 (user-integration-pre-check-remember-last-successful-broker-and-mode@localhost) Choose action:
 >
@@ -104,7 +104,7 @@ entication method:
 > 8
 == Authentication code ==
   1. Proceed with Authentication code
-  2. Resend sms
+  2. Resend SMS (1 sent)
 Or enter 'r' to go back to select the authentication method
 (user-integration-pre-check-remember-last-successful-broker-and-mode@localhost) Choose action:
 > 1
@@ -141,7 +141,7 @@ entication method:
 > 8
 == Authentication code ==
   1. Proceed with Authentication code
-  2. Resend sms
+  2. Resend SMS (1 sent)
 Or enter 'r' to go back to select the authentication method
 (user-integration-pre-check-remember-last-successful-broker-and-mode@localhost) Choose action:
 > 1
@@ -192,7 +192,7 @@ entication method:
 > 8
 == Authentication code ==
   1. Proceed with Authentication code
-  2. Resend sms
+  2. Resend SMS (1 sent)
 Or enter 'r' to go back to select the authentication method
 (user-integration-pre-check-remember-last-successful-broker-and-mode@localhost) Choose action:
 > 1
@@ -217,7 +217,7 @@ Connection to localhost closed.
 > ssh ${AUTHD_PAM_SSH_USER}@localhost ${AUTHD_PAM_SSH_ARGS}
 == Authentication code ==
   1. Proceed with Authentication code
-  2. Resend sms
+  2. Resend SMS (1 sent)
 Or enter 'r' to go back to select the authentication method
 (user-integration-pre-check-remember-last-successful-broker-and-mode@localhost) Choose action:
 >
@@ -249,7 +249,7 @@ entication method:
 > 8
 == Authentication code ==
   1. Proceed with Authentication code
-  2. Resend sms
+  2. Resend SMS (1 sent)
 Or enter 'r' to go back to select the authentication method
 (user-integration-pre-check-remember-last-successful-broker-and-mode@localhost) Choose action:
 > 1
@@ -274,7 +274,7 @@ Connection to localhost closed.
 > ssh ${AUTHD_PAM_SSH_USER}@localhost ${AUTHD_PAM_SSH_ARGS}
 == Authentication code ==
   1. Proceed with Authentication code
-  2. Resend sms
+  2. Resend SMS (1 sent)
 Or enter 'r' to go back to select the authentication method
 (user-integration-pre-check-remember-last-successful-broker-and-mode@localhost) Choose action:
 > 1
@@ -311,7 +311,7 @@ entication method:
 > 8
 == Authentication code ==
   1. Proceed with Authentication code
-  2. Resend sms
+  2. Resend SMS (1 sent)
 Or enter 'r' to go back to select the authentication method
 (user-integration-pre-check-remember-last-successful-broker-and-mode@localhost) Choose action:
 > 1
@@ -336,7 +336,7 @@ Connection to localhost closed.
 > ssh ${AUTHD_PAM_SSH_USER}@localhost ${AUTHD_PAM_SSH_ARGS}
 == Authentication code ==
   1. Proceed with Authentication code
-  2. Resend sms
+  2. Resend SMS (1 sent)
 Or enter 'r' to go back to select the authentication method
 (user-integration-pre-check-remember-last-successful-broker-and-mode@localhost) Choose action:
 > 1
@@ -387,7 +387,7 @@ entication method:
 > 8
 == Authentication code ==
   1. Proceed with Authentication code
-  2. Resend sms
+  2. Resend SMS (1 sent)
 Or enter 'r' to go back to select the authentication method
 (user-integration-pre-check-remember-last-successful-broker-and-mode@localhost) Choose action:
 > 1
@@ -412,7 +412,7 @@ Connection to localhost closed.
 > ssh ${AUTHD_PAM_SSH_USER}@localhost ${AUTHD_PAM_SSH_ARGS}
 == Authentication code ==
   1. Proceed with Authentication code
-  2. Resend sms
+  2. Resend SMS (1 sent)
 Or enter 'r' to go back to select the authentication method
 (user-integration-pre-check-remember-last-successful-broker-and-mode@localhost) Choose action:
 > 1

--- a/pam/integration-tests/testdata/TestSSHAuthenticate/golden/remember_last_successful_broker_and_mode_on_shared_sshd
+++ b/pam/integration-tests/testdata/TestSSHAuthenticate/golden/remember_last_successful_broker_and_mode_on_shared_sshd
@@ -74,7 +74,7 @@ hoose your authentication method:
 > 8
 == Authentication code ==
   1. Proceed with Authentication code
-  2. Resend sms
+  2. Resend SMS (1 sent)
 Or enter 'r' to go back to select the authentication method
 (user-integration-pre-check-remember-last-successful-broker-and-mode-on-shared-sshd@localhost) C
 hoose action:
@@ -108,7 +108,7 @@ hoose your authentication method:
 > 8
 == Authentication code ==
   1. Proceed with Authentication code
-  2. Resend sms
+  2. Resend SMS (1 sent)
 Or enter 'r' to go back to select the authentication method
 (user-integration-pre-check-remember-last-successful-broker-and-mode-on-shared-sshd@localhost) C
 hoose action:
@@ -147,7 +147,7 @@ hoose your authentication method:
 > 8
 == Authentication code ==
   1. Proceed with Authentication code
-  2. Resend sms
+  2. Resend SMS (1 sent)
 Or enter 'r' to go back to select the authentication method
 (user-integration-pre-check-remember-last-successful-broker-and-mode-on-shared-sshd@localhost) C
 hoose action:
@@ -199,7 +199,7 @@ hoose your authentication method:
 > 8
 == Authentication code ==
   1. Proceed with Authentication code
-  2. Resend sms
+  2. Resend SMS (1 sent)
 Or enter 'r' to go back to select the authentication method
 (user-integration-pre-check-remember-last-successful-broker-and-mode-on-shared-sshd@localhost) C
 hoose action:
@@ -224,7 +224,7 @@ Connection to localhost closed.
 > ssh ${AUTHD_PAM_SSH_USER}@localhost ${AUTHD_PAM_SSH_ARGS}
 == Authentication code ==
   1. Proceed with Authentication code
-  2. Resend sms
+  2. Resend SMS (1 sent)
 Or enter 'r' to go back to select the authentication method
 (user-integration-pre-check-remember-last-successful-broker-and-mode-on-shared-sshd@localhost) C
 hoose action:
@@ -258,7 +258,7 @@ hoose your authentication method:
 > 8
 == Authentication code ==
   1. Proceed with Authentication code
-  2. Resend sms
+  2. Resend SMS (1 sent)
 Or enter 'r' to go back to select the authentication method
 (user-integration-pre-check-remember-last-successful-broker-and-mode-on-shared-sshd@localhost) C
 hoose action:
@@ -283,7 +283,7 @@ Connection to localhost closed.
 > ssh ${AUTHD_PAM_SSH_USER}@localhost ${AUTHD_PAM_SSH_ARGS}
 == Authentication code ==
   1. Proceed with Authentication code
-  2. Resend sms
+  2. Resend SMS (1 sent)
 Or enter 'r' to go back to select the authentication method
 (user-integration-pre-check-remember-last-successful-broker-and-mode-on-shared-sshd@localhost) C
 hoose action:
@@ -322,7 +322,7 @@ hoose your authentication method:
 > 8
 == Authentication code ==
   1. Proceed with Authentication code
-  2. Resend sms
+  2. Resend SMS (1 sent)
 Or enter 'r' to go back to select the authentication method
 (user-integration-pre-check-remember-last-successful-broker-and-mode-on-shared-sshd@localhost) C
 hoose action:
@@ -347,7 +347,7 @@ Connection to localhost closed.
 > ssh ${AUTHD_PAM_SSH_USER}@localhost ${AUTHD_PAM_SSH_ARGS}
 == Authentication code ==
   1. Proceed with Authentication code
-  2. Resend sms
+  2. Resend SMS (1 sent)
 Or enter 'r' to go back to select the authentication method
 (user-integration-pre-check-remember-last-successful-broker-and-mode-on-shared-sshd@localhost) C
 hoose action:
@@ -399,7 +399,7 @@ hoose your authentication method:
 > 8
 == Authentication code ==
   1. Proceed with Authentication code
-  2. Resend sms
+  2. Resend SMS (1 sent)
 Or enter 'r' to go back to select the authentication method
 (user-integration-pre-check-remember-last-successful-broker-and-mode-on-shared-sshd@localhost) C
 hoose action:
@@ -424,7 +424,7 @@ Connection to localhost closed.
 > ssh ${AUTHD_PAM_SSH_USER}@localhost ${AUTHD_PAM_SSH_ARGS}
 == Authentication code ==
   1. Proceed with Authentication code
-  2. Resend sms
+  2. Resend SMS (1 sent)
 Or enter 'r' to go back to select the authentication method
 (user-integration-pre-check-remember-last-successful-broker-and-mode-on-shared-sshd@localhost) C
 hoose action:

--- a/pam/internal/adapter/authentication.go
+++ b/pam/internal/adapter/authentication.go
@@ -410,7 +410,9 @@ func (m *authenticationModel) Compose(brokerID, sessionID string, encryptionKey 
 		})
 	}
 
-	return tea.Sequence(sendEvent(ChangeStage{pam_proto.Stage_challenge}),
+	return tea.Sequence(
+		m.currentModel.Init(),
+		sendEvent(ChangeStage{pam_proto.Stage_challenge}),
 		sendEvent(startAuthentication{}))
 }
 

--- a/pam/internal/adapter/formmodel.go
+++ b/pam/internal/adapter/formmodel.go
@@ -41,7 +41,11 @@ func newFormModel(label, entryType, buttonLabel string, wait bool) formModel {
 
 // Init initializes formModel.
 func (m formModel) Init() tea.Cmd {
-	return nil
+	var commands []tea.Cmd
+	for _, c := range m.focusableModels {
+		commands = append(commands, c.Init())
+	}
+	return tea.Batch(commands...)
 }
 
 // Update handles events and actions.

--- a/pam/internal/adapter/formmodel.go
+++ b/pam/internal/adapter/formmodel.go
@@ -27,7 +27,7 @@ func newFormModel(label, entryType, buttonLabel string, wait bool) formModel {
 		focusableModels = append(focusableModels, &entry)
 	}
 	if buttonLabel != "" {
-		button := &buttonModel{label: buttonLabel}
+		button := newAuthReselectionButtonModel(buttonLabel)
 		focusableModels = append(focusableModels, button)
 	}
 
@@ -84,11 +84,7 @@ func (m formModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 						Challenge: entry.Value(),
 					},
 				})
-			case *buttonModel:
-				return m, sendEvent(reselectAuthMode{})
 			}
-
-			return m, nil
 
 		case "tab":
 			m.focusIndex++

--- a/pam/internal/adapter/newpasswordmodel.go
+++ b/pam/internal/adapter/newpasswordmodel.go
@@ -53,7 +53,14 @@ func newNewPasswordModel(label, entryType, buttonLabel string) newPasswordModel 
 
 // Init initializes newPasswordModel.
 func (m newPasswordModel) Init() tea.Cmd {
-	return nil
+	var commands []tea.Cmd
+	for _, c := range m.focusableModels {
+		commands = append(commands, c.Init())
+	}
+	for _, c := range m.passwordEntries {
+		commands = append(commands, c.Init())
+	}
+	return tea.Batch(commands...)
 }
 
 // Update handles events and actions.

--- a/pam/internal/adapter/newpasswordmodel.go
+++ b/pam/internal/adapter/newpasswordmodel.go
@@ -68,7 +68,7 @@ func (m newPasswordModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	switch msg := msg.(type) {
 	case startAuthentication:
 		m.Clear()
-		return m, nil
+		return m, m.updateFocusModel(msg)
 
 	case newPasswordCheckResult:
 		if msg.msg != "" {
@@ -139,17 +139,17 @@ func (m newPasswordModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 	}
 
-	var cmd tea.Cmd
-	for i, fm := range m.focusableModels {
-		if i != m.focusIndex {
-			continue
-		}
-		var model tea.Model
-		model, cmd = fm.Update(msg)
-		m.focusableModels[i] = convertTo[authenticationComponent](model)
-	}
+	return m, m.updateFocusModel(msg)
+}
 
-	return m, cmd
+func (m *newPasswordModel) updateFocusModel(msg tea.Msg) tea.Cmd {
+	if m.focusIndex >= len(m.focusableModels) {
+		return nil
+	}
+	model, cmd := m.focusableModels[m.focusIndex].Update(msg)
+	m.focusableModels[m.focusIndex] = convertTo[authenticationComponent](model)
+
+	return cmd
 }
 
 // View renders a text view of the form.

--- a/pam/internal/adapter/newpasswordmodel.go
+++ b/pam/internal/adapter/newpasswordmodel.go
@@ -78,6 +78,14 @@ func (m newPasswordModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 		return m, tea.Batch(sendEvent(errMsgToDisplay{}), m.focusNextField())
 
+	case buttonSelectionEvent:
+		if m.focusIndex < len(m.focusableModels) &&
+			msg.model == m.focusableModels[m.focusIndex] {
+			return m, sendEvent(isAuthenticatedRequested{
+				item: &authd.IARequest_AuthenticationData_Skip{Skip: "true"},
+			})
+		}
+
 	case tea.KeyMsg: // Key presses
 		switch msg.String() {
 		case "tab", "shift+tab":
@@ -124,14 +132,7 @@ func (m newPasswordModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				return m, sendEvent(isAuthenticatedRequested{
 					item: &authd.IARequest_AuthenticationData_Challenge{Challenge: entry.Value()},
 				})
-
-			case *buttonModel:
-				return m, sendEvent(isAuthenticatedRequested{
-					item: &authd.IARequest_AuthenticationData_Skip{Skip: "true"},
-				})
 			}
-
-			return m, nil
 
 		default:
 			m.errorMsg = ""

--- a/pam/internal/adapter/qrcodemodel.go
+++ b/pam/internal/adapter/qrcodemodel.go
@@ -1,30 +1,23 @@
 package adapter
 
 import (
-	"context"
 	"fmt"
 	"os"
 	"strings"
-	"time"
 
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
 	"github.com/muesli/termenv"
 	"github.com/skip2/go-qrcode"
 	"github.com/ubuntu/authd"
-	"github.com/ubuntu/authd/internal/log"
 )
 
 var centeredStyle = lipgloss.NewStyle().Align(lipgloss.Center, lipgloss.Top)
 
-// reselectionWaitTime is the amount of time that we wait before regenerating the qrcode.
-const reselectionWaitTime time.Duration = 300 * time.Millisecond
-
 // qrcodeModel is the form layout type to allow authenticating and return a challenge.
 type qrcodeModel struct {
-	label         string
-	buttonModel   *buttonModel
-	selectionTime time.Time
+	label       string
+	buttonModel *authReselectButtonModel
 
 	content string
 	code    string
@@ -35,9 +28,9 @@ type qrcodeModel struct {
 
 // newQRCodeModel initializes and return a new qrcodeModel.
 func newQRCodeModel(content, code, label, buttonLabel string, wait bool) (qrcodeModel, error) {
-	var button *buttonModel
+	var button *authReselectButtonModel
 	if buttonLabel != "" {
-		button = &buttonModel{label: buttonLabel}
+		button = newAuthReselectionButtonModel(buttonLabel)
 	}
 
 	qrCode, err := qrcode.New(content, qrcode.Medium)
@@ -46,13 +39,12 @@ func newQRCodeModel(content, code, label, buttonLabel string, wait bool) (qrcode
 	}
 
 	return qrcodeModel{
-		label:         label,
-		buttonModel:   button,
-		selectionTime: time.Now(),
-		content:       content,
-		code:          code,
-		qrCode:        qrCode,
-		wait:          wait,
+		label:       label,
+		buttonModel: button,
+		content:     content,
+		code:        code,
+		qrCode:      qrCode,
+		wait:        wait,
 	}, nil
 }
 
@@ -73,26 +65,8 @@ func (m qrcodeModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		})
 	}
 
-	switch msg := msg.(type) {
-	// Key presses
-	case tea.KeyMsg:
-		switch msg.String() {
-		case "enter":
-			if m.buttonModel == nil {
-				return m, nil
-			}
-			now := time.Now()
-			if now.Sub(m.selectionTime) < reselectionWaitTime {
-				log.Debug(context.TODO(), "Button press ignored, too fast!")
-				return m, nil
-			}
-			m.selectionTime = now
-			return m, sendEvent(reselectAuthMode{})
-		}
-	}
-
 	model, cmd := m.buttonModel.Update(msg)
-	m.buttonModel = convertTo[*buttonModel](model)
+	m.buttonModel = convertTo[*authReselectButtonModel](model)
 
 	return m, cmd
 }

--- a/pam/internal/adapter/qrcodemodel.go
+++ b/pam/internal/adapter/qrcodemodel.go
@@ -58,7 +58,7 @@ func newQRCodeModel(content, code, label, buttonLabel string, wait bool) (qrcode
 
 // Init initializes qrcodeModel.
 func (m qrcodeModel) Init() tea.Cmd {
-	return nil
+	return m.buttonModel.Init()
 }
 
 // Update handles events and actions.

--- a/pam/internal/adapter/reselectbuttonmodel.go
+++ b/pam/internal/adapter/reselectbuttonmodel.go
@@ -1,0 +1,47 @@
+package adapter
+
+import (
+	"context"
+	"time"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/ubuntu/authd/internal/log"
+)
+
+type authReselectButtonModel struct {
+	*buttonModel
+}
+
+func newAuthReselectionButtonModel(label string) *authReselectButtonModel {
+	return &authReselectButtonModel{
+		buttonModel: &buttonModel{
+			selectionTime: time.Now(),
+			label:         label,
+		},
+	}
+}
+
+// Init initializes the [reselectionButtonModel].
+func (b authReselectButtonModel) Init() tea.Cmd {
+	return b.buttonModel.Init()
+}
+
+// Update handles events and actions.
+func (b *authReselectButtonModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+	switch msg := msg.(type) {
+	case startAuthentication:
+		b.buttonModel.selectionTime = time.Now()
+		return b, nil
+
+	case buttonSelectionEvent:
+		log.Debugf(context.TODO(), "%#v: %#v", b, msg)
+		if msg.model == b.buttonModel {
+			return b, sendEvent(reselectAuthMode{})
+		}
+	}
+
+	model, cmd := b.buttonModel.Update(msg)
+	b.buttonModel = convertTo[*buttonModel](model)
+
+	return b, cmd
+}


### PR DESCRIPTION
Prevent the user to do too-many auth mode reselections that may lead to break the broker.

Cleans up https://github.com/ubuntu/authd/pull/513 by adapting the same logic to the other models too.

UDENG-5520