### PR TITLE
Revert "pam/integration-tests/ssh: Ignore SSH tests when running on u…

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -24,7 +24,6 @@ require (
 	google.golang.org/protobuf v1.35.2
 	gopkg.in/ini.v1 v1.67.0
 	gopkg.in/yaml.v3 v3.0.1
-	gorbe.io/go/osrelease v0.3.0
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -146,5 +146,3 @@ gopkg.in/ini.v1 v1.67.0/go.mod h1:pNLf8WUiyNEtQjuu5G5vTm06TEv9tsIgeAvK8hOrP4k=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
-gorbe.io/go/osrelease v0.3.0 h1:RqVqqfYMbe8AkTrCovTzE+FXYNolUFrhP/ne44za/xA=
-gorbe.io/go/osrelease v0.3.0/go.mod h1:kuAQu3QnfzxWIa2eppGpV3ZWAwa/7DP/m465/1I48oU=

--- a/pam/integration-tests/helpers_test.go
+++ b/pam/integration-tests/helpers_test.go
@@ -9,7 +9,6 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
-	"strconv"
 	"strings"
 	"sync"
 	"testing"
@@ -23,7 +22,6 @@ import (
 	"github.com/ubuntu/authd/pam/internal/pam_test"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
-	"gorbe.io/go/osrelease"
 )
 
 var (
@@ -243,26 +241,4 @@ func prepareGPasswdFiles(t *testing.T) (string, string) {
 	saveArtifactsForDebugOnCleanup(t, []string{gpasswdOutput, groupsFile})
 
 	return gpasswdOutput, groupsFile
-}
-
-func getUbuntuVersion(t *testing.T) int {
-	t.Helper()
-
-	err := osrelease.Parse()
-	require.NoError(t, err, "Can't parse os-release file %q: %v", osrelease.Path, err)
-
-	var versionID string
-	switch osrelease.Release.ID {
-	case "ubuntu":
-		versionID = strings.ReplaceAll(osrelease.Release.VersionID, ".", "")
-	case "ubuntu-core":
-		versionID = osrelease.Release.VersionID + "04"
-	default:
-		t.Logf("Not an ubuntu version: %q", osrelease.Release.ID)
-		return 0
-	}
-
-	v, err := strconv.Atoi(versionID)
-	require.NoError(t, err, "Can't parse version ID: %q", osrelease.Release.ID)
-	return v
 }

--- a/pam/integration-tests/ssh_test.go
+++ b/pam/integration-tests/ssh_test.go
@@ -48,12 +48,6 @@ func testSSHAuthenticate(t *testing.T, sharedSSHd bool) {
 		t.Skip("Skipping tests with external dependencies as requested")
 	}
 
-	if uv := getUbuntuVersion(t); uv == 0 || uv >= 2404 {
-		require.Empty(t, os.Getenv("GITHUB_REPOSITORY"),
-			"Golden files needs to be updated to ensure CI runs on Ubuntu %v")
-		t.Skipf("Skipping SSH tests since they require new golden files for Ubuntu %v", uv)
-	}
-
 	currentDir, err := os.Getwd()
 	require.NoError(t, err, "Setup: Could not get current directory for the tests")
 


### PR DESCRIPTION
…nsupported OS"

Not being able to update the golden files of these tests locally blocks many PRs.

This reverts commit 00f1a920760e64dda637e2b5266a5f59a2b7f826.