### PR TITLE
docs: Update README and SECURITY for docs migration

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,13 +30,11 @@ identity providers are under active development.
 
 ## Documentation
 
-Documentation for authd is currently available as a [wiki](https://github.com/ubuntu/authd/wiki/01---Get-started-with-authd) that includes how-to guides on:
+If you want to know more about using authd, refer to the
+[official authd documentation](https://canonical-authd.readthedocs-hosted.com/en/latest/).
 
-- [Installation](https://github.com/ubuntu/authd/wiki/02---How%E2%80%90to-install)
-- [Configuration](https://github.com/ubuntu/authd/wiki/03---How%E2%80%90to-configure)
-- Login through [GDM](https://github.com/ubuntu/authd/wiki/04---How%E2%80%90to-log-in-with-GDM) and [SSH](https://github.com/ubuntu/authd/wiki/05--How%E2%80%90to-log-in-over-SSH)
-
-A reference for [troubleshooting](https://github.com/ubuntu/authd/wiki/06--Troubleshooting-reference) is also provided along with an explanation of authd's [architecture](https://github.com/ubuntu/authd/wiki/07-Architecture-explanation).
+The documentation includes how-to guides on installing and configuring authd,
+in addition to information about authd architecture and troubleshooting.
 
 ## Brokers
 

--- a/README.md
+++ b/README.md
@@ -14,12 +14,16 @@
 [goreport-image]: https://goreportcard.com/badge/github.com/ubuntu/authd
 [goreport-url]: https://goreportcard.com/report/github.com/ubuntu/authd
 
+[docs-image]: https://readthedocs.com/projects/canonical-authd/badge/?version=latest
+[docs-url]: https://canonical-authd.readthedocs-hosted.com/en/latest/
+
 [![Code quality][actions-image]][actions-url]
 [![License][license-image]](COPYING)
 [![Code coverage][codecov-image]][codecov-url]
 [![Go Report Card][goreport-image]][goreport-url]
 [![Reference documentation][reference-documentation-image]][reference-documentation-url]
-[![Documentation Status](https://readthedocs.com/projects/canonical-authd/badge/?version=latest)](https://canonical-authd.readthedocs-hosted.com/en/latest/?badge=latest)
+
+[![Documentation Status][docs-image]][docs-url]
 
 authd is an authentication daemon for cloud-based identity providers. It helps
 ensure the secure management of identity and access for Ubuntu machines anywhere

--- a/README.md
+++ b/README.md
@@ -21,12 +21,12 @@
 [![Reference documentation][reference-documentation-image]][reference-documentation-url]
 [![Documentation Status](https://readthedocs.com/projects/canonical-authd/badge/?version=latest)](https://canonical-authd.readthedocs-hosted.com/en/latest/?badge=latest)
 
-Authd is an authentication daemon for cloud-based identity providers. It helps
-ensure the secure management of identity and access for Ubuntu machines
-anywhere in the world, on desktop and the server. Authd's modular design makes
-it a versatile authentication service that can integrate with multiple identity
-providers. MS Entra ID is currently supported and several other
-identity providers are under active development.
+authd is an authentication daemon for cloud-based identity providers. It helps
+ensure the secure management of identity and access for Ubuntu machines anywhere
+in the world, on desktop and the server. authd's modular design makes it a
+versatile authentication service that can integrate with multiple identity
+providers. MS Entra ID is currently supported and several other identity
+providers are under active development.
 
 ## Documentation
 
@@ -38,22 +38,35 @@ in addition to information about authd architecture and troubleshooting.
 
 ## Brokers
 
-Authd uses brokers to interface with cloud identity providers through a [DBus API](https://github.com/ubuntu/authd/blob/HEAD/examplebroker/com.ubuntu.auth.ExampleBroker.xml).
+authd uses brokers to interface with cloud identity providers through a
+[DBus API](https://github.com/ubuntu/authd/blob/HEAD/examplebroker/com.ubuntu.auth.ExampleBroker.xml).
 
-Currently [MS Entra ID](https://learn.microsoft.com/en-us/entra/fundamentals/whatis) is supported as an identity provider. 
-The [MS Entra ID broker](https://github.com/ubuntu/oidc-broker) allows you to authenticate against MS Entra ID using MFA and the device authentication flow.
+Currently [MS Entra ID](https://learn.microsoft.com/en-us/entra/fundamentals/whatis)
+is supported as an identity provider.
+The [MS Entra ID broker](https://github.com/ubuntu/oidc-broker) allows you to
+authenticate against MS Entra ID using MFA and the device authentication flow.
 
-For development purposes, authd also provides an [example broker](https://github.com/ubuntu/authd/tree/main/examplebroker) to help you develop your own.
+For development purposes, authd also provides an
+[example broker](https://github.com/ubuntu/authd/tree/main/examplebroker) 
+to help you develop your own.
 
 ## Get involved
 
-This is an [open source](COPYING) project and we warmly welcome community contributions, suggestions, and constructive feedback. If you're interested in contributing, please take a look at our [contribution guidelines](CONTRIBUTING.md) first.
+This is an [open source](COPYING) project and we warmly welcome community
+contributions, suggestions, and constructive feedback. If you're interested in
+contributing, please take a look at our [contribution guidelines](CONTRIBUTING.md)
+first.
 
-When reporting an issue you can [choose from several templates](https://github.com/ubuntu/authd/issues/new/choose):
+When reporting an issue you can
+[choose from several templates](https://github.com/ubuntu/authd/issues/new/choose):
 
-- To report an issue, please file a bug report against our repository, using the [report an issue](https://github.com/ubuntu/authd/issues/new?assignees=&labels=bug&projects=&template=bug_report.yml&title=Issue%3A+) template.
-- For suggestions and constructive feedback, report a feature request bug report, using the [request a feature](https://github.com/ubuntu/authd/issues/new?assignees=&labels=feature&projects=&template=feature_request.yml&title=Feature%3A+) template.
+- To report an issue, please file a bug report against our repository, using the
+  [report an issue](https://github.com/ubuntu/authd/issues/new?assignees=&labels=bug&projects=&template=bug_report.yml&title=Issue%3A+) template.
+- For suggestions and constructive feedback, report a feature request bug report, using the
+  [request a feature](https://github.com/ubuntu/authd/issues/new?assignees=&labels=feature&projects=&template=feature_request.yml&title=Feature%3A+) template.
 
 ## Get in touch
 
-We're friendly! You can find our community forum at [https://discourse.ubuntu.com](https://discourse.ubuntu.com) where we discuss feature plans, development news, issues, updates and troubleshooting.
+We're friendly! You can find our community forum at
+[https://discourse.ubuntu.com](https://discourse.ubuntu.com)
+where we discuss feature plans, development news, issues, updates and troubleshooting.

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@
 [![Code coverage][codecov-image]][codecov-url]
 [![Go Report Card][goreport-image]][goreport-url]
 [![Reference documentation][reference-documentation-image]][reference-documentation-url]
+[![Documentation Status](https://readthedocs.com/projects/canonical-authd/badge/?version=latest)](https://canonical-authd.readthedocs-hosted.com/en/latest/?badge=latest)
 
 Authd is an authentication daemon for cloud-based identity providers. It helps
 ensure the secure management of identity and access for Ubuntu machines

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ providers are under active development.
 ## Documentation
 
 If you want to know more about using authd, refer to the
-[official authd documentation](docs-url).
+[official authd documentation][docs-url].
 
 The documentation includes how-to guides on installing and configuring authd,
 in addition to information about authd architecture and troubleshooting.

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ providers are under active development.
 ## Documentation
 
 If you want to know more about using authd, refer to the
-[official authd documentation](https://canonical-authd.readthedocs-hosted.com/en/latest/).
+[official authd documentation](docs-url).
 
 The documentation includes how-to guides on installing and configuring authd,
 in addition to information about authd architecture and troubleshooting.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -37,6 +37,6 @@ The [Ubuntu Security disclosure and embargo policy](https://ubuntu.com/security/
 - [Canonical's Security Site](https://ubuntu.com/security)
 - [Ubuntu Security disclosure and embargo policy](https://ubuntu.com/security/disclosure-policy)
 - [Ubuntu Security Notices](https://ubuntu.com/security/notices)
-- [authd Documentation](https://github.com/ubuntu/authd/wiki/01---Get-started-with-authd)
+- [authd Documentation](https://canonical-authd.readthedocs-hosted.com/en/latest/)
 
 If you have any questions regarding security vulnerabilities, please reach out to the maintainers via the aforementioned channels.


### PR DESCRIPTION
The authd docs have been migrated from the GH wiki to Read the Docs.
This PR updates links to the documentation in the README.md and SECURITY.md .
In addition, a docs badge (build pass/fail) was added to the README.md.

Other minor changes:

- Removed capitalisation in first letter of authd for consistency of branding
- Reduced direct links to doc pages in README (maintenance issue at this stage in the docs development)
- Shortened line lengths in README (for source readability)

UDENG-5515