### PR TITLE
Change database dir from /var/cache/authd/ to /var/lib/authd/

### DIFF
--- a/cmd/authd/daemon/daemon.go
+++ b/cmd/authd/daemon/daemon.go
@@ -79,6 +79,10 @@ func New() *App {
 			setVerboseMode(a.config.Verbosity)
 			log.Debugf(context.Background(), "Verbosity: %d", a.config.Verbosity)
 
+			if err := migrateOldCacheDir(consts.OldCacheDir, a.config.Paths.Cache); err != nil {
+				return err
+			}
+
 			return nil
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/cmd/authd/daemon/migration.go
+++ b/cmd/authd/daemon/migration.go
@@ -1,0 +1,41 @@
+package daemon
+
+import (
+	"context"
+	"fmt"
+	"os"
+
+	"github.com/ubuntu/authd/internal/fileutils"
+	"github.com/ubuntu/authd/internal/log"
+)
+
+func migrateOldCacheDir(oldPath, newPath string) error {
+	exists, err := fileutils.FileExists(oldPath)
+	if err != nil {
+		// Let's not fail if we can't access the old database dir, but log a warning
+		log.Warningf(context.Background(), "Can't access old database directory %q: %v", oldPath, err)
+		return nil
+	}
+	if !exists {
+		return nil
+	}
+
+	exists, err = fileutils.FileExists(newPath)
+	if err != nil {
+		// We can't continue if we can't access the new database dir
+		return fmt.Errorf("can't access database directory %q: %w", newPath, err)
+	}
+	if exists {
+		// Both the old and the new database directories exist, so we can't migrate
+		log.Warningf(context.Background(), "Both old and new database directories exist, can't migrate %q to %q", oldPath, newPath)
+		return nil
+	}
+
+	if err := os.Rename(oldPath, newPath); err != nil {
+		return fmt.Errorf("can't migrate database directory from %q to %q: %w", oldPath, newPath, err)
+	}
+
+	log.Infof(context.Background(), "Migrated database directory from %q to %q", oldPath, newPath)
+
+	return nil
+}

--- a/cmd/authd/daemon/migration_test.go
+++ b/cmd/authd/daemon/migration_test.go
@@ -1,0 +1,116 @@
+package daemon
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/ubuntu/authd/internal/fileutils"
+)
+
+func TestMigrateOldCacheDir(t *testing.T) {
+	t.Parallel()
+
+	testCases := map[string]struct {
+		oldDirExists     bool
+		newDirExists     bool
+		oldDirUnreadable bool
+		newDirUnreadable bool
+		wantDbInNewDir   bool
+
+		wantedErr        error
+		wantOldDirExists bool
+		wantNewDirExists bool
+	}{
+		"Success if old dir does not exist": {oldDirExists: false, newDirExists: false},
+		"Success if old dir exists and new dir does not": {
+			oldDirExists:     true,
+			newDirExists:     false,
+			wantOldDirExists: false,
+			wantNewDirExists: true,
+			wantDbInNewDir:   true,
+		},
+		"Success if old dir exists and new dir exists": {
+			oldDirExists:     true,
+			newDirExists:     true,
+			wantOldDirExists: true,
+			wantNewDirExists: true,
+		},
+		"Success if old dir exists but is unreadable": {
+			oldDirExists:     true,
+			oldDirUnreadable: true,
+		},
+
+		"Error if new dir exists but is unreadable": {
+			oldDirExists:     true,
+			newDirExists:     true,
+			newDirUnreadable: true,
+			wantedErr:        os.ErrPermission,
+		},
+	}
+
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			oldParentDir := t.TempDir()
+			newParentDir := t.TempDir()
+			oldDir := filepath.Join(oldParentDir, "cache")
+			newDir := filepath.Join(newParentDir, "cache")
+			dbFilename := "authd.db"
+
+			if tc.oldDirExists {
+				err := os.Mkdir(oldDir, 0700)
+				require.NoError(t, err, "failed to create old dir")
+				err = fileutils.Touch(filepath.Join(oldDir, dbFilename))
+				require.NoError(t, err, "failed to create db file")
+			}
+
+			if tc.oldDirUnreadable {
+				err := os.Chmod(oldParentDir, 0000)
+				require.NoError(t, err, "failed to make old dir unreadable")
+				// Ensure that the directory is readable after the test, to avoid issues with cleanup
+				defer func() {
+					//nolint:gosec // G302 Permissions 0700 are not insecure for a directory
+					err := os.Chmod(oldParentDir, 0700)
+					require.NoError(t, err, "failed to make old dir readable")
+				}()
+			}
+
+			if tc.newDirExists {
+				err := os.Mkdir(newDir, 0700)
+				require.NoError(t, err, "failed to create new dir")
+			}
+
+			if tc.newDirUnreadable {
+				err := os.Chmod(newParentDir, 0000)
+				require.NoError(t, err, "failed to make new dir unreadable")
+				// Ensure that the directory is readable after the test, to avoid issues with cleanup
+				defer func() {
+					//nolint:gosec // G302 Permissions 0700 are not insecure for a directory
+					err := os.Chmod(newParentDir, 0700)
+					require.NoError(t, err, "failed to make new dir readable")
+				}()
+			}
+
+			err := migrateOldCacheDir(oldDir, newDir)
+			require.ErrorIs(t, err, tc.wantedErr)
+
+			if tc.wantOldDirExists {
+				_, err := os.Stat(oldDir)
+				require.NoError(t, err, "old dir does not exist")
+			}
+
+			if tc.wantNewDirExists {
+				_, err := os.Stat(newDir)
+				require.NoError(t, err, "new dir does not exist")
+			}
+
+			if tc.wantDbInNewDir {
+				_, err := os.Stat(filepath.Join(newDir, dbFilename))
+				require.NoError(t, err, "db file does not exist in new dir")
+			}
+		})
+	}
+}

--- a/debian/authd.service.in
+++ b/debian/authd.service.in
@@ -8,6 +8,10 @@ PartOf=authd.socket
 Type=notify
 ExecStart=@AUTHD_DAEMONS_PATH@/authd
 
+# Automatically create /var/lib/authd with the correct permissions
+StateDirectory=authd
+StateDirectoryMode=0700
+
 # Some daemon restrictions
 LockPersonality=yes
 MemoryDenyWriteExecute=yes

--- a/internal/consts/consts.go
+++ b/internal/consts/consts.go
@@ -21,6 +21,9 @@ const (
 	// DefaultBrokersConfPath is the default configuration directory for the brokers.
 	DefaultBrokersConfPath = "/etc/authd/brokers.d/"
 
-	// DefaultCacheDir is the default directory for the cache.
-	DefaultCacheDir = "/var/cache/authd/"
+	// OldCacheDir is the directory where the database was stored by default before 0.3.7.
+	OldCacheDir = "/var/cache/authd/"
+
+	// DefaultCacheDir is the default directory for the database.
+	DefaultCacheDir = "/var/lib/authd/"
 )

--- a/internal/fileutils/fileutils.go
+++ b/internal/fileutils/fileutils.go
@@ -1,0 +1,41 @@
+// Package fileutils provides utility functions for file operations.
+package fileutils
+
+import (
+	"errors"
+	"io"
+	"os"
+)
+
+// FileExists checks if a file exists at the given path.
+func FileExists(path string) (bool, error) {
+	_, err := os.Stat(path)
+	if err != nil && !errors.Is(err, os.ErrNotExist) {
+		return false, err
+	}
+	return !errors.Is(err, os.ErrNotExist), nil
+}
+
+// IsDirEmpty checks if the specified directory is empty.
+func IsDirEmpty(path string) (bool, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return false, err
+	}
+	defer f.Close()
+
+	_, err = f.Readdirnames(1)
+	if errors.Is(err, io.EOF) {
+		return true, nil
+	}
+	return false, err
+}
+
+// Touch creates an empty file at the given path, if it doesn't already exist.
+func Touch(path string) error {
+	file, err := os.OpenFile(path, os.O_RDONLY|os.O_CREATE, 0o600)
+	if err != nil && !errors.Is(err, os.ErrExist) {
+		return err
+	}
+	return file.Close()
+}

--- a/internal/fileutils/fileutils_test.go
+++ b/internal/fileutils/fileutils_test.go
@@ -1,0 +1,156 @@
+package fileutils_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/ubuntu/authd/internal/fileutils"
+)
+
+func TestFileExists(t *testing.T) {
+	t.Parallel()
+
+	tests := map[string]struct {
+		name            string
+		fileExists      bool
+		parentDirIsFile bool
+
+		wantExists bool
+		wantError  bool
+	}{
+		"Returns_true_when_file_exists":                      {fileExists: true, wantExists: true},
+		"Returns_false_when_file_does_not_exist":             {fileExists: false, wantExists: false},
+		"Returns_false_when_parent_directory_does_not_exist": {fileExists: false, wantExists: false},
+
+		"Error_when_parent_directory_is_a_file": {parentDirIsFile: true, wantError: true},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			tempDir := t.TempDir()
+			path := filepath.Join(tempDir, "file")
+			if tc.fileExists {
+				err := fileutils.Touch(path)
+				require.NoError(t, err, "Touch should not return an error")
+			}
+			if tc.parentDirIsFile {
+				path = filepath.Join(tempDir, "file", "file")
+				err := fileutils.Touch(filepath.Join(tempDir, "file"))
+				require.NoError(t, err, "Touch should not return an error")
+			}
+
+			exists, err := fileutils.FileExists(path)
+			if tc.wantError {
+				require.Error(t, err, "FileExists should return an error")
+			} else {
+				require.NoError(t, err, "FileExists should not return an error")
+			}
+			require.Equal(t, tc.wantExists, exists, "FileExists should return the expected result")
+		})
+	}
+}
+
+func TestIsDirEmpty(t *testing.T) {
+	t.Parallel()
+
+	tests := map[string]struct {
+		isEmpty      bool
+		isFile       bool
+		doesNotExist bool
+
+		wantEmpty bool
+		wantError bool
+	}{
+		"Returns_true_when_directory_is_empty":      {isEmpty: true, wantEmpty: true},
+		"Returns_false_when_directory_is_not_empty": {wantEmpty: false},
+
+		"Error_when_directory_does_not_exist": {doesNotExist: true, wantError: true},
+		"Error_when_directory_is_a_file":      {isFile: true, wantError: true},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			tempDir := t.TempDir()
+			path := filepath.Join(tempDir, "dir")
+
+			if !tc.doesNotExist {
+				err := os.Mkdir(path, 0o700)
+				require.NoError(t, err, "Mkdir should not return an error")
+			}
+
+			if !tc.isEmpty && !tc.doesNotExist && !tc.isFile {
+				err := fileutils.Touch(filepath.Join(tempDir, "dir", "file"))
+				require.NoError(t, err, "Touch should not return an error")
+			}
+			if tc.isFile {
+				path = filepath.Join(tempDir, "file")
+				err := fileutils.Touch(path)
+				require.NoError(t, err, "Touch should not return an error")
+			}
+
+			empty, err := fileutils.IsDirEmpty(path)
+			if tc.wantError {
+				require.Error(t, err, "IsDirEmpty should return an error")
+			} else {
+				require.NoError(t, err, "IsDirEmpty should not return an error")
+			}
+			require.Equal(t, tc.wantEmpty, empty, "IsDirEmpty should return the expected result")
+		})
+	}
+}
+
+func TestTouch(t *testing.T) {
+	t.Parallel()
+
+	tests := map[string]struct {
+		name               string
+		fileExists         bool
+		fileIsDir          bool
+		parentDoesNotExist bool
+
+		wantError bool
+	}{
+		"Creates_file_when_it_does_not_exist":            {fileExists: false},
+		"Does_not_return_error_when_file_already_exists": {fileExists: true},
+
+		"Returns_error_when_file_is_a_directory":             {fileIsDir: true, wantError: true},
+		"Returns_error_when_parent_directory_does_not_exist": {parentDoesNotExist: true, wantError: true},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			tempDir := t.TempDir()
+			path := filepath.Join(tempDir, "file")
+
+			if tc.fileExists && !tc.fileIsDir {
+				err := fileutils.Touch(path)
+				require.NoError(t, err, "Touch should not return an error")
+			}
+
+			if tc.fileIsDir {
+				path = filepath.Join(tempDir, "dir")
+				err := os.Mkdir(path, 0o700)
+				require.NoError(t, err, "Mkdir should not return an error")
+			}
+
+			if tc.parentDoesNotExist {
+				path = filepath.Join(tempDir, "dir", "file")
+			}
+
+			err := fileutils.Touch(path)
+			if tc.wantError {
+				require.Error(t, err, "Touch should return an error")
+				return
+			}
+
+			require.NoError(t, err, "Touch should not return an error")
+		})
+	}
+}


### PR DESCRIPTION
The database is not a cache, removing it has an impact on security because it allows users to be assigned the UID of a previous user.  

 We reflect that by storing the database in `/var/lib/authd/` instead of `/var/cache/authd/`. 