### PR TITLE
Fix golangci-lint complaint

### DIFF
--- a/internal/users/localgroups/testutils/gpasswd.go
+++ b/internal/users/localgroups/testutils/gpasswd.go
@@ -1,7 +1,5 @@
 package localgrouptestutils
 
-//nolint:gci // We import unsafe as it is needed for go:linkname, but the nolint comment confuses gofmt and it adds
-// a blank space between the imports, which creates problems with gci so we need to ignore it.
 import (
 	"fmt"
 	"os"


### PR DESCRIPTION
I'm not sure why, but since 48eb235d845ff4c717eea6111153b44048239bc4 golangci-lint fails with:

    internal/users/localgroups/testutils/gpasswd.go:3:1: directive `//nolint:gci // We import unsafe as it is needed for go:linkname, but the nolint comment confuses gofmt and it adds` is unused for linter "gci" (nolintlint)

Removing that line fixes it.