### PR TITLE
Fix broken db migration because new db dir always exists

### DIFF
--- a/debian/authd.service.in
+++ b/debian/authd.service.in
@@ -8,10 +8,6 @@ PartOf=authd.socket
 Type=notify
 ExecStart=@AUTHD_DAEMONS_PATH@/authd
 
-# Automatically create /var/lib/authd with the correct permissions
-StateDirectory=authd
-StateDirectoryMode=0700
-
 # Some daemon restrictions
 LockPersonality=yes
 MemoryDenyWriteExecute=yes


### PR DESCRIPTION
We only migrate the old database directory if the new one doesn't exist, so we shouldn't let systemd automatically create it.

This reverts commit f68935530c130a249dbdc340d475907728ed2d57.