### PR TITLE
Remove incorrect os.Exit(m.Run()) calls

### DIFF
--- a/cmd/authd/daemon/daemon_test.go
+++ b/cmd/authd/daemon/daemon_test.go
@@ -409,5 +409,5 @@ func TestMain(m *testing.M) {
 	}
 	defer cleanup()
 
-	os.Exit(m.Run())
+	m.Run()
 }

--- a/internal/brokers/manager_test.go
+++ b/internal/brokers/manager_test.go
@@ -396,5 +396,5 @@ func TestMain(m *testing.M) {
 	}
 	defer cleanup()
 
-	os.Exit(m.Run())
+	m.Run()
 }

--- a/internal/services/manager_test.go
+++ b/internal/services/manager_test.go
@@ -142,5 +142,5 @@ func TestMain(m *testing.M) {
 	}
 	defer cleanup()
 
-	os.Exit(m.Run())
+	m.Run()
 }

--- a/internal/services/nss/nss_test.go
+++ b/internal/services/nss/nss_test.go
@@ -424,5 +424,5 @@ func TestMain(m *testing.M) {
 	}
 	defer cleanup()
 
-	os.Exit(m.Run())
+	m.Run()
 }

--- a/internal/services/pam/pam_test.go
+++ b/internal/services/pam/pam_test.go
@@ -815,6 +815,41 @@ func startSession(t *testing.T, client authd.PAMClient, username string) string 
 	return sbResp.GetSessionId()
 }
 
+// setupGlobalBrokerMock creates and points to a test-wide system bus, registering the mock broker on it.
+func setupGlobalBrokerMock() (cleanup func(), err error) {
+	cleanup = func() {}
+
+	// Start system bus mock.
+	busCleanup, err := testutils.StartSystemBusMock()
+	if err != nil {
+		return cleanup, err
+	}
+	cleanup = busCleanup
+
+	// Start brokers mock over dbus.
+	brokersConfPath, brokerCleanup, err := initBrokers()
+	if err != nil {
+		return cleanup, err
+	}
+
+	cleanup = func() {
+		brokerCleanup()
+		busCleanup()
+	}
+
+	// Get manager shared across grpc services.
+	globalBrokerManager, err = brokers.NewManager(context.Background(), brokersConfPath, nil)
+	if err != nil {
+		return cleanup, err
+	}
+	mockBrokerGeneratedID, err = getMockBrokerGeneratedID(globalBrokerManager)
+	if err != nil {
+		return cleanup, err
+	}
+
+	return cleanup, nil
+}
+
 func TestMain(m *testing.M) {
 	if os.Getenv("GO_WANT_HELPER_PROCESS") != "" {
 		os.Exit(m.Run())
@@ -822,33 +857,13 @@ func TestMain(m *testing.M) {
 
 	slog.SetLogLoggerLevel(slog.LevelDebug)
 
-	// Start system bus mock.
-	busCleanup, err := testutils.StartSystemBusMock()
+	cleanup, err := setupGlobalBrokerMock()
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "%v\n", err)
-		os.Exit(1)
-	}
-	defer busCleanup()
-
-	// Start brokers mock over dbus.
-	brokersConfPath, cleanup, err := initBrokers()
-	if err != nil {
+		cleanup()
 		fmt.Fprintf(os.Stderr, "%v\n", err)
 		os.Exit(1)
 	}
 	defer cleanup()
-
-	// Get manager shared across grpc services.
-	globalBrokerManager, err = brokers.NewManager(context.Background(), brokersConfPath, nil)
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "%v\n", err)
-		os.Exit(1)
-	}
-	mockBrokerGeneratedID, err = getMockBrokerGeneratedID(globalBrokerManager)
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "%v\n", err)
-		os.Exit(1)
-	}
 
 	m.Run()
 }

--- a/internal/services/pam/pam_test.go
+++ b/internal/services/pam/pam_test.go
@@ -850,5 +850,5 @@ func TestMain(m *testing.M) {
 		os.Exit(1)
 	}
 
-	os.Exit(m.Run())
+	m.Run()
 }

--- a/internal/users/localgroups/localgroups_test.go
+++ b/internal/users/localgroups/localgroups_test.go
@@ -203,7 +203,3 @@ func TestCleanUserFromLocalGroups(t *testing.T) {
 func TestMockgpasswd(t *testing.T) {
 	localgroupstestutils.Mockgpasswd(t)
 }
-
-func TestMain(m *testing.M) {
-	os.Exit(m.Run())
-}

--- a/internal/users/manager_test.go
+++ b/internal/users/manager_test.go
@@ -636,7 +636,3 @@ func newManagerForTests(t *testing.T, cacheDir string) *users.Manager {
 func ptrUint32(v uint32) *uint32 {
 	return &v
 }
-
-func TestMain(m *testing.M) {
-	os.Exit(m.Run())
-}

--- a/nss/integration-tests/integration_test.go
+++ b/nss/integration-tests/integration_test.go
@@ -186,5 +186,5 @@ func TestMain(m *testing.M) {
 	defer cleanup()
 	daemonPath = execPath
 
-	os.Exit(m.Run())
+	m.Run()
 }

--- a/pam/integration-tests/cli-integration_test.go
+++ b/pam/integration-tests/cli-integration_test.go
@@ -24,5 +24,5 @@ func TestMain(m *testing.M) {
 	defer daemonCleanup()
 	daemonPath = execPath
 
-	os.Exit(m.Run())
+	m.Run()
 }

--- a/pam/internal/adapter/gdmmodel_test.go
+++ b/pam/internal/adapter/gdmmodel_test.go
@@ -7,7 +7,6 @@ import (
 	"encoding/base64"
 	"errors"
 	"fmt"
-	"os"
 	"slices"
 	"sync"
 	"testing"
@@ -2466,5 +2465,6 @@ func TestMain(m *testing.M) {
 		panic(fmt.Sprintf("could not create an valid rsa key: %v", err))
 	}
 	defer pam_test.MaybeDoLeakCheck()
-	os.Exit(m.Run())
+
+	m.Run()
 }

--- a/pam/internal/dbusmodule/transaction_test.go
+++ b/pam/internal/dbusmodule/transaction_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"os"
 	"sync"
 	"testing"
 
@@ -673,5 +672,6 @@ func prepareTestServer(t *testing.T, expectedReturns []methodReturn) (string, *t
 
 func TestMain(m *testing.M) {
 	log.SetLevel(log.DebugLevel)
-	os.Exit(m.Run())
+
+	m.Run()
 }

--- a/pam/internal/pam_test/pam-client-dummy_test.go
+++ b/pam/internal/pam_test/pam-client-dummy_test.go
@@ -9,7 +9,6 @@ import (
 	"encoding/base64"
 	"errors"
 	"fmt"
-	"os"
 	"testing"
 	"time"
 
@@ -1176,5 +1175,6 @@ func TestMain(m *testing.M) {
 	if err != nil {
 		panic(fmt.Sprintf("could not create an valid rsa key: %v", err))
 	}
-	os.Exit(m.Run())
+
+	m.Run()
 }


### PR DESCRIPTION
This is not needed since Go 1.15, where the test runtime registers the test result itself.
Also, os.Exit() would skip any defer() being called before, which might pollute the system running the tests.

Note that we only kept 2 occurences when subprocessing as a mock, as we shouldn't expect to have defer() beforehand in TestMain.

UDENG-5632