### PR TITLE
pam: Block until the connection with the daemon is ready

### DIFF
--- a/debian/authd.gdm-authd.pam
+++ b/debian/authd.gdm-authd.pam
@@ -1,6 +1,6 @@
 #%PAM-1.0
 auth    [success=ok user_unknown=ignore default=bad] pam_succeed_if.so user != root quiet_success
-auth    [success=1 ignore=ignore default=die] pam_authd.so
+auth    [success=1 ignore=ignore default=die authinfo_unavail=ignore] pam_authd.so
 # If authd ignored the request => local broker is selected,
 # then we continue with normal stack
 auth    substack        common-auth

--- a/debian/authd.gdm-authd.pam
+++ b/debian/authd.gdm-authd.pam
@@ -8,7 +8,7 @@ auth    substack        common-auth
 auth    requisite       pam_nologin.so
 auth    optional        pam_gnome_keyring.so
 
-account [default=ignore success=ok user_unknown=ignore]	pam_authd.so
+account [default=ignore success=ok]	pam_authd.so
 # This is potentially loading pam_authd.again but we've checks in AcctMgmt() to
 # prevent this to happen when the gdm-authd service is used without GDM extensions.
 # Plus the model used by the services is different, so there's no risk for this to happen.

--- a/debian/pam-configs/authd.in
+++ b/debian/pam-configs/authd.in
@@ -7,7 +7,7 @@ Auth:
 	[success=end ignore=ignore default=die authinfo_unavail=ignore]	pam_authd_exec.so @AUTHD_DAEMONS_PATH@/authd-pam
 Account-Type: Additional
 Account:
-	[default=ignore success=ok user_unknown=ignore authinfo_unavail=ignore]	pam_authd_exec.so @AUTHD_DAEMONS_PATH@/authd-pam
+	[default=ignore success=ok]	pam_authd_exec.so @AUTHD_DAEMONS_PATH@/authd-pam
 Password-Type: Primary
 Password:
 	[success=end ignore=ignore default=die authinfo_unavail=ignore]	pam_authd_exec.so @AUTHD_DAEMONS_PATH@/authd-pam

--- a/internal/consts/consts.go
+++ b/internal/consts/consts.go
@@ -26,4 +26,7 @@ const (
 
 	// DefaultCacheDir is the default directory for the database.
 	DefaultCacheDir = "/var/lib/authd/"
+
+	// ServiceName is the authd service name for health check purposes.
+	ServiceName = "com.ubuntu.authd"
 )

--- a/internal/daemon/daemon_test.go
+++ b/internal/daemon/daemon_test.go
@@ -11,12 +11,16 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/require"
+	"github.com/ubuntu/authd/internal/consts"
 	"github.com/ubuntu/authd/internal/daemon"
 	"github.com/ubuntu/authd/internal/daemon/testdata/grpctestservice"
 	"github.com/ubuntu/authd/internal/grpcutils"
 	"github.com/ubuntu/authd/internal/services/errmessages"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/health"
+	healthgrpc "google.golang.org/grpc/health/grpc_health_v1"
+	healthpb "google.golang.org/grpc/health/grpc_health_v1"
 )
 
 func TestNew(t *testing.T) {
@@ -220,6 +224,9 @@ func TestQuit(t *testing.T) {
 			registerGRPC := func(context.Context) *grpc.Server {
 				var service testGRPCService
 				grpctestservice.RegisterTestServiceServer(grpcServer, service)
+				hc := health.NewServer()
+				hc.SetServingStatus(consts.ServiceName, healthpb.HealthCheckResponse_SERVING)
+				healthgrpc.RegisterHealthServer(grpcServer, hc)
 				return grpcServer
 			}
 			systemdNotifier := func(unsetEnvironment bool, state string) (bool, error) {

--- a/internal/daemon/daemon_test.go
+++ b/internal/daemon/daemon_test.go
@@ -13,9 +13,9 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/ubuntu/authd/internal/daemon"
 	"github.com/ubuntu/authd/internal/daemon/testdata/grpctestservice"
+	"github.com/ubuntu/authd/internal/grpcutils"
 	"github.com/ubuntu/authd/internal/services/errmessages"
 	"google.golang.org/grpc"
-	"google.golang.org/grpc/connectivity"
 	"google.golang.org/grpc/credentials/insecure"
 )
 
@@ -245,7 +245,6 @@ func TestQuit(t *testing.T) {
 				var connected bool
 				connected, disconnectClient = createClientConnection(t, socketPath)
 				require.True(t, connected, "new connection should be made allowed")
-				defer disconnectClient()
 			}
 
 			// Request quitting.
@@ -290,26 +289,15 @@ func createClientConnection(t *testing.T, socketPath string) (success bool, disc
 	t.Helper()
 
 	ctx, disconnect := context.WithCancel(context.Background())
+	t.Cleanup(disconnect)
 
-	var conn *grpc.ClientConn
-	connected := make(chan struct{})
-	go func() {
-		defer close(connected)
-		var err error
-		conn, err = grpc.NewClient("unix://"+socketPath, grpc.WithTransportCredentials(insecure.NewCredentials()), grpc.WithUnaryInterceptor(errmessages.FormatErrorMessage))
-		require.NoError(t, err, "Could not connect to grpc server")
+	conn, err := grpc.NewClient("unix://"+socketPath, grpc.WithTransportCredentials(insecure.NewCredentials()), grpc.WithUnaryInterceptor(errmessages.FormatErrorMessage))
+	require.NoError(t, err, "Could not connect to grpc server")
 
-		// The daemon tests require an active connection, so we need to block here until the connection is ready.
-		conn.Connect()
-		for conn.GetState() != connectivity.Ready {
-			conn.WaitForStateChange(context.Background(), conn.GetState())
-		}
-	}()
-	select {
-	case <-connected:
-	case <-time.After(5 * time.Second):
-		disconnect()
-		return false, func() {}
+	// The daemon tests require an active connection, so we need to block here until the connection is ready.
+	if err := grpcutils.WaitForConnection(ctx, conn, 5*time.Second); err != nil {
+		t.Logf("Client connection failed: %v", err)
+		return false, nil
 	}
 
 	client := grpctestservice.NewTestServiceClient(conn)

--- a/internal/grpcutils/grpcutils.go
+++ b/internal/grpcutils/grpcutils.go
@@ -1,0 +1,36 @@
+// Package grpcutils provides utility functions for GRPC operations.
+package grpcutils
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/ubuntu/authd/internal/log"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/connectivity"
+)
+
+// WaitForConnection synchronously waits for a [grpc.ClientConn] connection to be established.
+func WaitForConnection(ctx context.Context, conn *grpc.ClientConn, timeout time.Duration) (err error) {
+	// Block for connection to be started.
+	waitCtx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+
+	log.Debugf(ctx, "Connecting to %s", conn.Target())
+	conn.Connect()
+
+	for {
+		switch state := conn.GetState(); state {
+		// In case of connectivity.TransientFailure we can't fail early since we may
+		// still connect in time for the timeout, so we have to be conservative here.
+		case connectivity.Ready:
+			return nil
+		}
+
+		conn.WaitForStateChange(waitCtx, conn.GetState())
+		if err := waitCtx.Err(); err != nil {
+			return fmt.Errorf("could not connect to %v: %w", conn.Target(), err)
+		}
+	}
+}

--- a/internal/services/testdata/golden/TestRegisterGRPCServices
+++ b/internal/services/testdata/golden/TestRegisterGRPCServices
@@ -52,3 +52,12 @@ authd.PAM:
           isclientstream: false
           isserverstream: false
     metadata: authd.proto
+grpc.health.v1.Health:
+    methods:
+        - name: Check
+          isclientstream: false
+          isserverstream: false
+        - name: Watch
+          isclientstream: false
+          isserverstream: true
+    metadata: grpc/health/v1/health.proto

--- a/pam/integration-tests/cli_test.go
+++ b/pam/integration-tests/cli_test.go
@@ -35,6 +35,7 @@ func TestCLIAuthenticate(t *testing.T) {
 		tapeSettings []tapeSetting
 
 		clientOptions      clientOptions
+		socketPath         string
 		currentUserNotRoot bool
 		wantLocalGroups    bool
 	}{
@@ -154,6 +155,11 @@ func TestCLIAuthenticate(t *testing.T) {
 		"Exit authd if user sigints": {
 			tape: "sigint",
 		},
+
+		"Error if cannot connect to authd": {
+			tape:       "connection_error",
+			socketPath: "/some-path/not-existent-socket",
+		},
 	}
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
@@ -174,6 +180,9 @@ func TestCLIAuthenticate(t *testing.T) {
 				var groupsFile string
 				gpasswdOutput, groupsFile = prepareGPasswdFiles(t)
 				socketPath = runAuthd(t, gpasswdOutput, groupsFile, !tc.currentUserNotRoot)
+			}
+			if tc.socketPath != "" {
+				socketPath = tc.socketPath
 			}
 
 			td := newTapeData(tc.tape, tc.tapeSettings...)
@@ -313,7 +322,7 @@ func TestPamCLIRunStandalone(t *testing.T) {
 	outStr := string(out)
 	t.Log(outStr)
 
-	require.Contains(t, outStr, pam.ErrSystem.Error())
+	require.Contains(t, outStr, pam.ErrAuthinfoUnavail.Error())
 	require.Contains(t, outStr, pam.ErrIgnore.Error())
 }
 

--- a/pam/integration-tests/gdm_test.go
+++ b/pam/integration-tests/gdm_test.go
@@ -643,7 +643,7 @@ func TestGdmModule(t *testing.T) {
 		"Error on connection failure": {
 			moduleArgs: []string{fmt.Sprintf("socket=%s_invalid", socketPath)},
 			wantPamErrorMessages: []string{
-				fmt.Sprintf("could not connect to unix://%s_invalid: context deadline exceeded", socketPath),
+				fmt.Sprintf("could not connect to unix://%s_invalid: service took too long to respond. Disconnecting client", socketPath),
 			},
 			wantError:       pam.ErrAuthinfoUnavail,
 			wantAcctMgmtErr: pam_test.ErrIgnore,

--- a/pam/integration-tests/gdm_test.go
+++ b/pam/integration-tests/gdm_test.go
@@ -153,6 +153,16 @@ func TestGdmModule(t *testing.T) {
 				},
 			},
 		},
+		"Authenticates user with invalid connection timeout": {
+			moduleArgs: []string{"connection_timeout=invalid"},
+			eventPollResponses: map[gdm.EventType][]*gdm.EventData{
+				gdm.EventType_startAuthentication: {
+					gdm_test.IsAuthenticatedEvent(&authd.IARequest_AuthenticationData_Challenge{
+						Challenge: "goodpass",
+					}),
+				},
+			},
+		},
 		"Authenticates user with multiple retries": {
 			wantAuthModeIDs: []string{passwordAuthID, passwordAuthID, passwordAuthID},
 			eventPollResponses: map[gdm.EventType][]*gdm.EventData{

--- a/pam/integration-tests/gdm_test.go
+++ b/pam/integration-tests/gdm_test.go
@@ -134,6 +134,7 @@ func TestGdmModule(t *testing.T) {
 		protoVersion       uint32
 		brokerName         string
 		eventPollResponses map[gdm.EventType][]*gdm.EventData
+		moduleArgs         []string
 
 		wantError            error
 		wantAuthModeIDs      []string
@@ -639,6 +640,14 @@ func TestGdmModule(t *testing.T) {
 			wantError:       pam.ErrCredUnavail,
 			wantAcctMgmtErr: pam_test.ErrIgnore,
 		},
+		"Error on connection failure": {
+			moduleArgs: []string{fmt.Sprintf("socket=%s_invalid", socketPath)},
+			wantPamErrorMessages: []string{
+				fmt.Sprintf("could not connect to unix://%s_invalid: context deadline exceeded", socketPath),
+			},
+			wantError:       pam.ErrAuthinfoUnavail,
+			wantAcctMgmtErr: pam_test.ErrIgnore,
+		},
 		"Error on missing user": {
 			pamUser: ptrValue(""),
 			eventPollResponses: map[gdm.EventType][]*gdm.EventData{
@@ -794,6 +803,7 @@ func TestGdmModule(t *testing.T) {
 
 			gdmLog := prepareFileLogging(t, "authd-pam-gdm.log")
 			moduleArgs = append(moduleArgs, "debug=true", "logfile="+gdmLog)
+			moduleArgs = append(moduleArgs, tc.moduleArgs...)
 
 			serviceFile := createServiceFile(t, "gdm-authd", libPath, moduleArgs)
 			saveArtifactsForDebugOnCleanup(t, []string{serviceFile})

--- a/pam/integration-tests/helpers_test.go
+++ b/pam/integration-tests/helpers_test.go
@@ -16,6 +16,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/require"
+	"github.com/ubuntu/authd/internal/grpcutils"
 	"github.com/ubuntu/authd/internal/proto/authd"
 	"github.com/ubuntu/authd/internal/services/errmessages"
 	"github.com/ubuntu/authd/internal/testutils"
@@ -148,6 +149,8 @@ func requirePreviousBrokerForUser(t *testing.T, socketPath string, brokerName st
 	require.NoError(t, err, "Can't connect to authd socket")
 
 	t.Cleanup(func() { conn.Close() })
+	require.NoError(t, grpcutils.WaitForConnection(context.TODO(), conn,
+		sleepDuration(30*time.Second)))
 	pamClient := authd.NewPAMClient(conn)
 	brokers, err := pamClient.AvailableBrokers(context.TODO(), nil)
 	require.NoError(t, err, "Can't get available brokers")

--- a/pam/integration-tests/native_test.go
+++ b/pam/integration-tests/native_test.go
@@ -36,6 +36,7 @@ func TestNativeAuthenticate(t *testing.T) {
 		currentUserNotRoot bool
 		wantLocalGroups    bool
 		skipRunnerCheck    bool
+		socketPath         string
 	}{
 		"Authenticate user successfully": {
 			tape:          "simple_auth",
@@ -271,6 +272,11 @@ func TestNativeAuthenticate(t *testing.T) {
 			clientOptions:   clientOptions{PamUser: "user-integration-sigint"},
 			skipRunnerCheck: true,
 		},
+
+		"Error if cannot connect to authd": {
+			tape:       "connection_error",
+			socketPath: "/some-path/not-existent-socket",
+		},
 	}
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
@@ -291,6 +297,9 @@ func TestNativeAuthenticate(t *testing.T) {
 				var groupsFile string
 				gpasswdOutput, groupsFile = prepareGPasswdFiles(t)
 				socketPath = runAuthd(t, gpasswdOutput, groupsFile, !tc.currentUserNotRoot)
+			}
+			if tc.socketPath != "" {
+				socketPath = tc.socketPath
 			}
 
 			if tc.tapeCommand == "" {

--- a/pam/integration-tests/native_test.go
+++ b/pam/integration-tests/native_test.go
@@ -45,6 +45,13 @@ func TestNativeAuthenticate(t *testing.T) {
 		"Authenticate user successfully with user selection": {
 			tape: "simple_auth_with_user_selection",
 		},
+		"Authenticate user successfully with invalid connection timeout": {
+			tape: "simple_auth",
+			clientOptions: clientOptions{
+				PamUser:    "user-integration-simple-auth-invalid-timeout",
+				PamTimeout: "invalid",
+			},
+		},
 		"Authenticate user with mfa": {
 			tape:          "mfa_auth",
 			tapeSettings:  []tapeSetting{{vhsHeight, 1200}},

--- a/pam/integration-tests/ssh_test.go
+++ b/pam/integration-tests/ssh_test.go
@@ -341,6 +341,7 @@ func createSshdServiceFile(t *testing.T, module, execChild, socketPath string) s
 	moduleArgs := []string{
 		execChild,
 		"socket=" + socketPath,
+		fmt.Sprintf("connection_timeout=%d", defaultConnectionTimeout),
 		"debug=true",
 		"logfile=" + os.Stderr.Name(),
 		"--exec-debug",

--- a/pam/integration-tests/testdata/golden/TestCLIAuthenticate/Authenticate_user_successfully_with_invalid_connection_timeout
+++ b/pam/integration-tests/testdata/golden/TestCLIAuthenticate/Authenticate_user_successfully_with_invalid_connection_timeout
@@ -1,0 +1,29 @@
+> ./pam_authd login socket=${AUTHD_TESTS_CLI_AUTHENTICATE_TESTS_SOCK}
+Username: user name
+────────────────────────────────────────────────────────────────────────────────
+> ./pam_authd login socket=${AUTHD_TESTS_CLI_AUTHENTICATE_TESTS_SOCK}
+Username: user-integration-invalid-timeout
+────────────────────────────────────────────────────────────────────────────────
+> ./pam_authd login socket=${AUTHD_TESTS_CLI_AUTHENTICATE_TESTS_SOCK}
+  Select your provider
+
+> 1. local
+  2. ExampleBroker
+────────────────────────────────────────────────────────────────────────────────
+> ./pam_authd login socket=${AUTHD_TESTS_CLI_AUTHENTICATE_TESTS_SOCK}
+Gimme your password:
+>
+────────────────────────────────────────────────────────────────────────────────
+> ./pam_authd login socket=${AUTHD_TESTS_CLI_AUTHENTICATE_TESTS_SOCK}
+Gimme your password:
+> ********
+────────────────────────────────────────────────────────────────────────────────
+> ./pam_authd login socket=${AUTHD_TESTS_CLI_AUTHENTICATE_TESTS_SOCK}
+PAM Authenticate()
+  User: "user-integration-invalid-timeout"
+  Result: success
+PAM AcctMgmt()
+  User: "user-integration-invalid-timeout"
+  Result: success
+>
+────────────────────────────────────────────────────────────────────────────────

--- a/pam/integration-tests/testdata/golden/TestCLIAuthenticate/Error_if_cannot_connect_to_authd
+++ b/pam/integration-tests/testdata/golden/TestCLIAuthenticate/Error_if_cannot_connect_to_authd
@@ -1,0 +1,16 @@
+> ./pam_authd login socket=${AUTHD_TESTS_CLI_AUTHENTICATE_TESTS_SOCK}
+────────────────────────────────────────────────────────────────────────────────
+> ./pam_authd login socket=${AUTHD_TESTS_CLI_AUTHENTICATE_TESTS_SOCK}
+PAM Error Message: could not connect to unix:///some-path/not-existent-socket: context deadline
+exceeded
+PAM Authenticate()
+  User: "<unset>"
+  Result: error: PAM exit code: 9
+    Authentication service cannot retrieve authentication info
+PAM Info Message: acct=incomplete
+PAM AcctMgmt()
+  User: "<unset>"
+  Result: error: PAM exit code: 25
+    The return value should be ignored by PAM dispatch
+>
+────────────────────────────────────────────────────────────────────────────────

--- a/pam/integration-tests/testdata/golden/TestCLIAuthenticate/Error_if_cannot_connect_to_authd
+++ b/pam/integration-tests/testdata/golden/TestCLIAuthenticate/Error_if_cannot_connect_to_authd
@@ -1,8 +1,8 @@
 > ./pam_authd login socket=${AUTHD_TESTS_CLI_AUTHENTICATE_TESTS_SOCK}
 ────────────────────────────────────────────────────────────────────────────────
 > ./pam_authd login socket=${AUTHD_TESTS_CLI_AUTHENTICATE_TESTS_SOCK}
-PAM Error Message: could not connect to unix:///some-path/not-existent-socket: context deadline
-exceeded
+PAM Error Message: could not connect to unix:///some-path/not-existent-socket: service took too
+long to respond. Disconnecting client
 PAM Authenticate()
   User: "<unset>"
   Result: error: PAM exit code: 9

--- a/pam/integration-tests/testdata/golden/TestCLIAuthenticate/Exit_if_authd_is_stopped
+++ b/pam/integration-tests/testdata/golden/TestCLIAuthenticate/Exit_if_authd_is_stopped
@@ -1,0 +1,16 @@
+> ./pam_authd login socket=${AUTHD_TESTS_CLI_AUTHENTICATE_TESTS_SOCK}
+Username: user name
+────────────────────────────────────────────────────────────────────────────────
+> ./pam_authd login socket=${AUTHD_TESTS_CLI_AUTHENTICATE_TESTS_SOCK}
+PAM Error Message: unix:///authd/test_socket.sock stopped serving
+PAM Authenticate()
+  User: "<unset>"
+  Result: error: PAM exit code: 4
+    System error
+PAM Info Message: acct=incomplete
+PAM AcctMgmt()
+  User: "<unset>"
+  Result: error: PAM exit code: 25
+    The return value should be ignored by PAM dispatch
+>
+────────────────────────────────────────────────────────────────────────────────

--- a/pam/integration-tests/testdata/golden/TestNativeAuthenticate/Authenticate_user_successfully_with_invalid_connection_timeout
+++ b/pam/integration-tests/testdata/golden/TestNativeAuthenticate/Authenticate_user_successfully_with_invalid_connection_timeout
@@ -1,0 +1,43 @@
+> ./pam_authd login socket=${AUTHD_TESTS_CLI_AUTHENTICATE_TESTS_SOCK} force_native_client=true
+== Provider selection ==
+  1. local
+  2. ExampleBroker
+Choose your provider:
+>
+────────────────────────────────────────────────────────────────────────────────
+> ./pam_authd login socket=${AUTHD_TESTS_CLI_AUTHENTICATE_TESTS_SOCK} force_native_client=true
+== Provider selection ==
+  1. local
+  2. ExampleBroker
+Choose your provider:
+> 2
+────────────────────────────────────────────────────────────────────────────────
+> ./pam_authd login socket=${AUTHD_TESTS_CLI_AUTHENTICATE_TESTS_SOCK} force_native_client=true
+== Provider selection ==
+  1. local
+  2. ExampleBroker
+Choose your provider:
+> 2
+== Password authentication ==
+Enter 'r' to cancel the request and go back to select the authentication method
+Gimme your password:
+>
+────────────────────────────────────────────────────────────────────────────────
+> ./pam_authd login socket=${AUTHD_TESTS_CLI_AUTHENTICATE_TESTS_SOCK} force_native_client=true
+== Provider selection ==
+  1. local
+  2. ExampleBroker
+Choose your provider:
+> 2
+== Password authentication ==
+Enter 'r' to cancel the request and go back to select the authentication method
+Gimme your password:
+>
+PAM Authenticate()
+  User: "user-integration-simple-auth-invalid-timeout"
+  Result: success
+PAM AcctMgmt()
+  User: "user-integration-simple-auth-invalid-timeout"
+  Result: success
+>
+────────────────────────────────────────────────────────────────────────────────

--- a/pam/integration-tests/testdata/golden/TestNativeAuthenticate/Error_if_cannot_connect_to_authd
+++ b/pam/integration-tests/testdata/golden/TestNativeAuthenticate/Error_if_cannot_connect_to_authd
@@ -1,8 +1,8 @@
 > ./pam_authd login socket=${AUTHD_TESTS_CLI_AUTHENTICATE_TESTS_SOCK} force_native_client=true
 ────────────────────────────────────────────────────────────────────────────────
 > ./pam_authd login socket=${AUTHD_TESTS_CLI_AUTHENTICATE_TESTS_SOCK} force_native_client=true
-PAM Error Message: could not connect to unix:///some-path/not-existent-socket: context deadline
-exceeded
+PAM Error Message: could not connect to unix:///some-path/not-existent-socket: service took too
+long to respond. Disconnecting client
 PAM Authenticate()
   User: "<unset>"
   Result: error: PAM exit code: 9

--- a/pam/integration-tests/testdata/golden/TestNativeAuthenticate/Error_if_cannot_connect_to_authd
+++ b/pam/integration-tests/testdata/golden/TestNativeAuthenticate/Error_if_cannot_connect_to_authd
@@ -1,0 +1,16 @@
+> ./pam_authd login socket=${AUTHD_TESTS_CLI_AUTHENTICATE_TESTS_SOCK} force_native_client=true
+────────────────────────────────────────────────────────────────────────────────
+> ./pam_authd login socket=${AUTHD_TESTS_CLI_AUTHENTICATE_TESTS_SOCK} force_native_client=true
+PAM Error Message: could not connect to unix:///some-path/not-existent-socket: context deadline
+exceeded
+PAM Authenticate()
+  User: "<unset>"
+  Result: error: PAM exit code: 9
+    Authentication service cannot retrieve authentication info
+acct=incomplete
+PAM AcctMgmt()
+  User: "<unset>"
+  Result: error: PAM exit code: 25
+    The return value should be ignored by PAM dispatch
+>
+────────────────────────────────────────────────────────────────────────────────

--- a/pam/integration-tests/testdata/golden/TestNativeAuthenticate/Exit_if_authd_is_stopped
+++ b/pam/integration-tests/testdata/golden/TestNativeAuthenticate/Exit_if_authd_is_stopped
@@ -1,0 +1,25 @@
+> ./pam_authd login socket=${AUTHD_TESTS_CLI_AUTHENTICATE_TESTS_SOCK} force_native_client=true
+== Provider selection ==
+  1. local
+  2. ExampleBroker
+Choose your provider:
+>
+────────────────────────────────────────────────────────────────────────────────
+> ./pam_authd login socket=${AUTHD_TESTS_CLI_AUTHENTICATE_TESTS_SOCK} force_native_client=true
+== Provider selection ==
+  1. local
+  2. ExampleBroker
+Choose your provider:
+>
+PAM Error Message: unix:///authd/test_socket.sock stopped serving
+PAM Authenticate()
+  User: "user-integration-authd-stopped"
+  Result: error: PAM exit code: 4
+    System error
+acct=incomplete
+PAM AcctMgmt()
+  User: "user-integration-authd-stopped"
+  Result: error: PAM exit code: 25
+    The return value should be ignored by PAM dispatch
+>
+────────────────────────────────────────────────────────────────────────────────

--- a/pam/integration-tests/testdata/golden/TestSSHAuthenticate/Deny_authentication_if_max_attempts_reached
+++ b/pam/integration-tests/testdata/golden/TestSSHAuthenticate/Deny_authentication_if_max_attempts_reached
@@ -148,9 +148,7 @@ Enter 'r' to cancel the request and go back to select the authentication method
 (user-integration-pre-check-deny-authentication-if-max-attempts-reached@localhost) Gimme your password:
 >
 invalid password 'wrongpass', should be 'goodpass'
-== Provider selection ==
-  1. local
-  2. ExampleBroker
-(user-integration-pre-check-deny-authentication-if-max-attempts-reached@localhost) Choose your provider:
+Received disconnect from ${SSH_HOST} port ${SSH_PORT} Too many authentication failures
+Disconnected from ${SSH_HOST} port ${SSH_PORT}
 >
 ────────────────────────────────────────────────────────────────────────────────

--- a/pam/integration-tests/testdata/golden/TestSSHAuthenticate/Deny_authentication_if_max_attempts_reached_on_shared_SSHd
+++ b/pam/integration-tests/testdata/golden/TestSSHAuthenticate/Deny_authentication_if_max_attempts_reached_on_shared_SSHd
@@ -148,9 +148,7 @@ Enter 'r' to cancel the request and go back to select the authentication method
 (user-integration-pre-check-deny-authentication-if-max-attempts-reached-on-shared-sshd@localhost) Gimme your password:
 >
 invalid password 'wrongpass', should be 'goodpass'
-== Provider selection ==
-  1. local
-  2. ExampleBroker
-(user-integration-pre-check-deny-authentication-if-max-attempts-reached-on-shared-sshd@localhost) Choose your provider:
+Received disconnect from ${SSH_HOST} port ${SSH_PORT} Too many authentication failures
+Disconnected from ${SSH_HOST} port ${SSH_PORT}
 >
 ────────────────────────────────────────────────────────────────────────────────

--- a/pam/integration-tests/testdata/golden/TestSSHAuthenticate/Error_if_cannot_connect_to_authd
+++ b/pam/integration-tests/testdata/golden/TestSSHAuthenticate/Error_if_cannot_connect_to_authd
@@ -1,0 +1,8 @@
+> ssh ${AUTHD_PAM_SSH_USER}@localhost ${AUTHD_PAM_SSH_ARGS}
+────────────────────────────────────────────────────────────────────────────────
+> ssh ${AUTHD_PAM_SSH_USER}@localhost ${AUTHD_PAM_SSH_ARGS}
+could not connect to unix:///some-path/not-existent-socket: context deadline exceeded
+Received disconnect from ${SSH_HOST} port ${SSH_PORT} Too many authentication failures
+Disconnected from ${SSH_HOST} port ${SSH_PORT}
+>
+────────────────────────────────────────────────────────────────────────────────

--- a/pam/integration-tests/testdata/golden/TestSSHAuthenticate/Error_if_cannot_connect_to_authd
+++ b/pam/integration-tests/testdata/golden/TestSSHAuthenticate/Error_if_cannot_connect_to_authd
@@ -1,7 +1,7 @@
 > ssh ${AUTHD_PAM_SSH_USER}@localhost ${AUTHD_PAM_SSH_ARGS}
 ────────────────────────────────────────────────────────────────────────────────
 > ssh ${AUTHD_PAM_SSH_USER}@localhost ${AUTHD_PAM_SSH_ARGS}
-could not connect to unix:///some-path/not-existent-socket: context deadline exceeded
+could not connect to unix:///some-path/not-existent-socket: service took too long to respond. Disconnecting client
 Received disconnect from ${SSH_HOST} port ${SSH_PORT} Too many authentication failures
 Disconnected from ${SSH_HOST} port ${SSH_PORT}
 >

--- a/pam/integration-tests/testdata/golden/TestSSHAuthenticate/Error_if_cannot_connect_to_authd_on_shared_SSHd
+++ b/pam/integration-tests/testdata/golden/TestSSHAuthenticate/Error_if_cannot_connect_to_authd_on_shared_SSHd
@@ -1,0 +1,8 @@
+> ssh ${AUTHD_PAM_SSH_USER}@localhost ${AUTHD_PAM_SSH_ARGS}
+────────────────────────────────────────────────────────────────────────────────
+> ssh ${AUTHD_PAM_SSH_USER}@localhost ${AUTHD_PAM_SSH_ARGS}
+could not connect to unix:///some-path/not-existent-socket: context deadline exceeded
+Received disconnect from ${SSH_HOST} port ${SSH_PORT} Too many authentication failures
+Disconnected from ${SSH_HOST} port ${SSH_PORT}
+>
+────────────────────────────────────────────────────────────────────────────────

--- a/pam/integration-tests/testdata/golden/TestSSHAuthenticate/Error_if_cannot_connect_to_authd_on_shared_SSHd
+++ b/pam/integration-tests/testdata/golden/TestSSHAuthenticate/Error_if_cannot_connect_to_authd_on_shared_SSHd
@@ -1,7 +1,7 @@
 > ssh ${AUTHD_PAM_SSH_USER}@localhost ${AUTHD_PAM_SSH_ARGS}
 ────────────────────────────────────────────────────────────────────────────────
 > ssh ${AUTHD_PAM_SSH_USER}@localhost ${AUTHD_PAM_SSH_ARGS}
-could not connect to unix:///some-path/not-existent-socket: context deadline exceeded
+could not connect to unix:///some-path/not-existent-socket: service took too long to respond. Disconnecting client
 Received disconnect from ${SSH_HOST} port ${SSH_PORT} Too many authentication failures
 Disconnected from ${SSH_HOST} port ${SSH_PORT}
 >

--- a/pam/integration-tests/testdata/tapes/cli/authd_stopped.tape
+++ b/pam/integration-tests/testdata/tapes/cli/authd_stopped.tape
@@ -1,0 +1,11 @@
+Hide
+Wait
+Type "${AUTHD_TEST_TAPE_COMMAND}"
+Enter
+Wait /Username: user name\n/
+Show
+
+Hide
+Wait+Screen /unix:[^\n]+ stopped serving/
+Wait
+Show

--- a/pam/integration-tests/testdata/tapes/cli/connection_error.tape
+++ b/pam/integration-tests/testdata/tapes/cli/connection_error.tape
@@ -1,0 +1,1 @@
+../native/connection_error.tape

--- a/pam/integration-tests/testdata/tapes/cli/simple_auth.tape
+++ b/pam/integration-tests/testdata/tapes/cli/simple_auth.tape
@@ -6,7 +6,7 @@ Wait /Username: user name\n/
 Show
 
 Hide
-TypeUsername "user1"
+TypeUsername "${AUTHD_SIMPLE_AUTH_TAPE_USER}"
 Show
 
 Hide

--- a/pam/integration-tests/testdata/tapes/native/authd_stopped.tape
+++ b/pam/integration-tests/testdata/tapes/native/authd_stopped.tape
@@ -1,0 +1,13 @@
+Hide
+Wait
+Type "${AUTHD_TEST_TAPE_COMMAND}"
+Enter
+Wait+Prompt /Choose your provider/
+Show
+
+Hide
+Sleep ${AUTHD_SLEEP_LONG} * 5
+Enter
+Wait+Screen /unix:[^\n]+ stopped serving/
+Wait
+Show

--- a/pam/integration-tests/testdata/tapes/native/connection_error.tape
+++ b/pam/integration-tests/testdata/tapes/native/connection_error.tape
@@ -1,0 +1,9 @@
+Hide
+Type "${AUTHD_TEST_TAPE_COMMAND}"
+Show
+
+Hide
+Enter
+Wait+Screen /could not connect to unix:[^\n]+/
+Wait
+Show

--- a/pam/integration-tests/testdata/tapes/ssh/connection_error.tape
+++ b/pam/integration-tests/testdata/tapes/ssh/connection_error.tape
@@ -1,0 +1,1 @@
+../native/connection_error.tape

--- a/pam/integration-tests/vhs-helpers_test.go
+++ b/pam/integration-tests/vhs-helpers_test.go
@@ -112,6 +112,8 @@ var (
 	vhsSleepRegex = regexp.MustCompile(
 		`(?m)\$\{?(AUTHD_SLEEP_[A-Z_]+)\}?(\s?([*/]+)\s?([\d.]+))?(.*)$`)
 	vhsEmptyTrailingLinesRegex = regexp.MustCompile(`(?m)\s+\z`)
+	vhsUnixTargetRegex         = regexp.MustCompile(fmt.Sprintf(`unix://%s/(\S*)\b`,
+		regexp.QuoteMeta(os.TempDir())))
 
 	// vhsWaitRegex catches Wait(@timeout)? /Pattern/ commands to re-implement default vhs
 	// Wait /Pattern/ command with full context on errors.
@@ -349,6 +351,9 @@ func (td tapeData) ExpectedOutput(t *testing.T, outputDir string) string {
 		frames[i] = vhsEmptyTrailingLinesRegex.ReplaceAllString(f, "\n")
 	}
 	got = strings.Join(frames, framesSeparator)
+
+	// Drop all the socket references.
+	got = vhsUnixTargetRegex.ReplaceAllLiteralString(got, "unix:///authd/test_socket.sock")
 
 	// Save the sanitized result on cleanup
 	t.Cleanup(func() {

--- a/pam/integration-tests/vhs-helpers_test.go
+++ b/pam/integration-tests/vhs-helpers_test.go
@@ -107,6 +107,8 @@ var (
 		authdSleepQrCodeReselection: 700 * time.Millisecond,
 	}
 
+	defaultConnectionTimeout = sleepDuration(3*time.Second) / time.Millisecond
+
 	vhsSleepRegex = regexp.MustCompile(
 		`(?m)\$\{?(AUTHD_SLEEP_[A-Z_]+)\}?(\s?([*/]+)\s?([\d.]+))?(.*)$`)
 	vhsEmptyTrailingLinesRegex = regexp.MustCompile(`(?m)\s+\z`)
@@ -184,6 +186,7 @@ type clientOptions struct {
 	PamUser        string
 	PamEnv         []string
 	PamServiceName string
+	PamTimeout     string
 	Term           string
 	SessionType    string
 }
@@ -203,6 +206,12 @@ func (td *tapeData) AddClientOptions(t *testing.T, opts clientOptions) {
 	}
 	if opts.PamServiceName != "" {
 		td.Env[pam_test.RunnerEnvService] = opts.PamServiceName
+	}
+	if opts.PamTimeout != "" {
+		td.Env[pam_test.RunnerEnvConnectionTimeout] = opts.PamTimeout
+	}
+	if _, ok := td.Env[pam_test.RunnerEnvConnectionTimeout]; !ok {
+		td.Env[pam_test.RunnerEnvConnectionTimeout] = fmt.Sprintf("%d", defaultConnectionTimeout)
 	}
 	if opts.Term != "" {
 		td.Env["AUTHD_PAM_CLI_TERM"] = opts.Term

--- a/pam/internal/adapter/commands.go
+++ b/pam/internal/adapter/commands.go
@@ -102,7 +102,7 @@ func (m *UIModel) quit() tea.Cmd {
 	if m.currentSession == nil {
 		return tea.Quit
 	}
-	return tea.Sequence(endSession(m.Client, m.currentSession), tea.Quit)
+	return tea.Sequence(endSession(m.client, m.currentSession), tea.Quit)
 }
 
 // endSession requests the broker to end the session.

--- a/pam/internal/adapter/gdmmodel_test.go
+++ b/pam/internal/adapter/gdmmodel_test.go
@@ -2241,7 +2241,7 @@ func TestGdmModel(t *testing.T) {
 			uiModel := UIModel{
 				PamMTx:     pam_test.NewModuleTransactionDummy(gdmHandler),
 				ClientType: Gdm,
-				Client:     tc.client,
+				client:     tc.client,
 			}
 			appState := gdmTestUIModel{
 				UIModel:             uiModel,
@@ -2447,7 +2447,7 @@ func TestGdmModel(t *testing.T) {
 
 			wantBrokers := []*authd.ABResponse_BrokerInfo(nil)
 			if !tc.wantNoBrokers {
-				availableBrokers, err := appState.Client.AvailableBrokers(context.TODO(), nil)
+				availableBrokers, err := appState.client.AvailableBrokers(context.TODO(), nil)
 				require.NoError(t, err)
 				wantBrokers = availableBrokers.GetBrokersInfos()
 			}

--- a/pam/internal/adapter/nativemodel.go
+++ b/pam/internal/adapter/nativemodel.go
@@ -90,7 +90,7 @@ func (m *nativeModel) Init() tea.Cmd {
 		log.Errorf(context.TODO(), "failed to get the PAM service: %v", err)
 	}
 
-	m.interactive = IsSSHSession(m.pamMTx) || m.isTerminalTty()
+	m.interactive = isSSHSession(m.pamMTx) || m.isTerminalTty()
 	rendersQrCode := m.isQrcodeRenderingSupported()
 
 	return func() tea.Msg {
@@ -779,7 +779,7 @@ func (m nativeModel) isQrcodeRenderingSupported() bool {
 	case polkitServiceName:
 		return false
 	default:
-		if IsSSHSession(m.pamMTx) {
+		if isSSHSession(m.pamMTx) {
 			return false
 		}
 		return m.isTerminalTty()

--- a/pam/internal/adapter/utils.go
+++ b/pam/internal/adapter/utils.go
@@ -10,8 +10,8 @@ import (
 )
 
 var (
-	isSSHSession     bool
-	isSSHSessionOnce sync.Once
+	isSSHSessionValue bool
+	isSSHSessionOnce  sync.Once
 )
 
 // convertTo converts an interface I value to T. It will panic (progamming error) if this is not the case.
@@ -59,10 +59,10 @@ func isSSHSessionFunc(mTx pam.ModuleTransaction) bool {
 	return false
 }
 
-// IsSSHSession checks if the module transaction is currently handling a SSH session.
-func IsSSHSession(mTx pam.ModuleTransaction) bool {
-	isSSHSessionOnce.Do(func() { isSSHSession = isSSHSessionFunc(mTx) })
-	return isSSHSession
+// isSSHSession checks if the module transaction is currently handling a SSH session.
+func isSSHSession(mTx pam.ModuleTransaction) bool {
+	isSSHSessionOnce.Do(func() { isSSHSessionValue = isSSHSessionFunc(mTx) })
+	return isSSHSessionValue
 }
 
 func maybeSendPamError(err error) tea.Cmd {

--- a/pam/internal/pam_test/runner-utils.go
+++ b/pam/internal/pam_test/runner-utils.go
@@ -21,6 +21,8 @@ const (
 	RunnerEnvTestName = "AUTHD_PAM_RUNNER_TEST_NAME"
 	// RunnerEnvUser is the environment variable used by the test client to set the PAM user to use.
 	RunnerEnvUser = "AUTHD_PAM_RUNNER_USER"
+	// RunnerEnvConnectionTimeout is the environment variable used by the test client to set the PAM connection timeout.
+	RunnerEnvConnectionTimeout = "AUTHD_PAM_CONNECTION_TIMEOUT"
 	// RunnerEnvEnvs is the environment variable used by the test client to set the PAM child environment variables.
 	RunnerEnvEnvs = "AUTHD_PAM_RUNNER_ENVS"
 	// RunnerEnvService is the environment variable used by the test client to set the PAM service name.

--- a/pam/pam.go
+++ b/pam/pam.go
@@ -324,13 +324,9 @@ func (h *pamModule) handleAuthRequest(mode authd.SessionMode, mTx pam.ModuleTran
 
 	appState := adapter.UIModel{
 		PamMTx:      mTx,
-		Client:      authd.NewPAMClient(conn),
+		Conn:        conn,
 		ClientType:  pamClientType,
 		SessionMode: mode,
-	}
-
-	if pamClientType == adapter.Native && adapter.IsSSHSession(mTx) {
-		appState.NssClient = authd.NewNSSClient(conn)
 	}
 
 	if err := mTx.SetData(authenticationBrokerIDKey, nil); err != nil {

--- a/pam/pam.go
+++ b/pam/pam.go
@@ -312,7 +312,7 @@ func (h *pamModule) handleAuthRequest(mode authd.SessionMode, mTx pam.ModuleTran
 		if err := showPamMessage(mTx, pam.ErrorMsg, err.Error()); err != nil {
 			log.Warningf(context.TODO(), "Impossible to show PAM message: %v", err)
 		}
-		return errors.Join(err, pam.ErrAuthinfoUnavail)
+		return fmt.Errorf("%w: %w", pam.ErrAuthinfoUnavail, err)
 	}
 	defer closeConn()
 

--- a/pam/pam.go
+++ b/pam/pam.go
@@ -309,7 +309,6 @@ func (h *pamModule) handleAuthRequest(mode authd.SessionMode, mTx pam.ModuleTran
 
 	conn, closeConn, err := newClientConnection(parsedArgs)
 	if err != nil {
-		log.Debug(context.TODO(), err)
 		if err := showPamMessage(mTx, pam.ErrorMsg, err.Error()); err != nil {
 			log.Warningf(context.TODO(), "Impossible to show PAM message: %v", err)
 		}

--- a/pam/tools/pam-runner/pam-runner.go
+++ b/pam/tools/pam-runner/pam-runner.go
@@ -27,6 +27,7 @@ func main() {
 	pamUser := os.Getenv(pam_test.RunnerEnvUser)
 	pamEnvs := os.Getenv(pam_test.RunnerEnvEnvs)
 	pamService := os.Getenv(pam_test.RunnerEnvService)
+	timeoutDuration := os.Getenv(pam_test.RunnerEnvConnectionTimeout)
 
 	tmpDir, err := os.MkdirTemp(os.TempDir(), "pam-cli-tester-")
 	if err != nil {
@@ -48,7 +49,11 @@ func main() {
 		}
 	}
 
-	defaultArgs := []string{execChildPath, "debug=true"}
+	defaultArgs := []string{
+		execChildPath,
+		"debug=true",
+		"connection_timeout=" + timeoutDuration,
+	}
 	if logFile != "" {
 		defaultArgs = append(defaultArgs, "logfile="+logFile)
 		defaultArgs = append(defaultArgs, "--exec-debug", "--exec-log", logFile)


### PR DESCRIPTION
An authd instance running is a strong prerequisite for for the authd PAM
module too, so instead of failing at the first grpc method invocation
with a system error, let's just try to connect first and in case of
failure, we just fail (as expected) with pam.ErrAuthinfoUnavail so that
the service files can decide what to do with it (normally: ignore it).

Add tests.

A followup of #273, to make sure we're actually returning the expected error on connection failures.

Closes #535
UDENG-4695
UDENG-5639