### PR TITLE
pam: Do not save or check for local broker ID in module data and drop PamIgnore

### DIFF
--- a/pam/internal/adapter/commands.go
+++ b/pam/internal/adapter/commands.go
@@ -24,7 +24,7 @@ func sendEvent(msg tea.Msg) tea.Cmd {
 func startBrokerSession(client authd.PAMClient, brokerID, username string, mode authd.SessionMode) tea.Cmd {
 	return func() tea.Msg {
 		if brokerID == brokers.LocalBrokerName {
-			return PamIgnore{LocalBrokerID: brokerID}
+			return pamError{status: pam.ErrIgnore}
 		}
 
 		// Start a transaction for this user with the broker.

--- a/pam/internal/adapter/return.go
+++ b/pam/internal/adapter/return.go
@@ -28,22 +28,6 @@ func (p PamSuccess) Message() string {
 	return p.msg
 }
 
-// PamIgnore signals PAM module to return pam.Ignore and Quit tea.Model.
-type PamIgnore struct {
-	LocalBrokerID string // Only set for local broker to store it globally.
-	msg           string
-}
-
-// Status returns [pam.ErrIgnore].
-func (p PamIgnore) Status() pam.Error {
-	return pam.ErrIgnore
-}
-
-// Message returns the message that should be sent to pam as info message.
-func (p PamIgnore) Message() string {
-	return p.msg
-}
-
 // pamError signals PAM module to return the provided error message and Quit tea.Model.
 type pamError struct {
 	status pam.Error
@@ -59,6 +43,9 @@ func (p pamError) Status() pam.Error {
 func (p pamError) Message() string {
 	if p.msg != "" {
 		return p.msg
+	}
+	if p.status == pam.ErrIgnore {
+		return ""
 	}
 	return p.status.Error()
 }

--- a/pam/internal/adapter/return.go
+++ b/pam/internal/adapter/return.go
@@ -44,7 +44,7 @@ func (p PamIgnore) Message() string {
 	return p.msg
 }
 
-// pamIgnore signals PAM module to return the provided error message and Quit tea.Model.
+// pamError signals PAM module to return the provided error message and Quit tea.Model.
 type pamError struct {
 	status pam.Error
 	msg    string

--- a/pam/pam.go
+++ b/pam/pam.go
@@ -350,9 +350,10 @@ func (h *pamModule) handleAuthRequest(mode authd.SessionMode, mTx pam.ModuleTran
 
 	case adapter.PamReturnError:
 		return fmt.Errorf("%w: %s", exitStatus.Status(), exitStatus.Message())
-	}
 
-	return fmt.Errorf("%w: unknown exit code", pam.ErrSystem)
+	default:
+		return fmt.Errorf("%w: unknown exit code: %#v", pam.ErrSystem, exitStatus)
+	}
 }
 
 // AcctMgmt sets any used brokerID as default for the user.

--- a/pam/pam.go
+++ b/pam/pam.go
@@ -100,9 +100,13 @@ func sendReturnMessageToPam(mTx pam.ModuleTransaction, retStatus adapter.PamRetu
 	}
 
 	style := pam.ErrorMsg
-	switch retStatus.(type) {
-	case adapter.PamIgnore, adapter.PamSuccess:
+	switch rs := retStatus.(type) {
+	case adapter.PamSuccess:
 		style = pam.TextInfo
+	case adapter.PamReturnError:
+		if rs.Status() == pam.ErrIgnore {
+			style = pam.TextInfo
+		}
 	}
 
 	if err := showPamMessage(mTx, style, msg); err != nil {
@@ -343,9 +347,6 @@ func (h *pamModule) handleAuthRequest(mode authd.SessionMode, mTx pam.ModuleTran
 			return err
 		}
 		return nil
-
-	case adapter.PamIgnore:
-		return fmt.Errorf("%w: %s", exitStatus.Status(), exitStatus.Message())
 
 	case adapter.PamReturnError:
 		return fmt.Errorf("%w: %s", exitStatus.Status(), exitStatus.Message())

--- a/pam/pam.go
+++ b/pam/pam.go
@@ -345,10 +345,6 @@ func (h *pamModule) handleAuthRequest(mode authd.SessionMode, mTx pam.ModuleTran
 		return nil
 
 	case adapter.PamIgnore:
-		// localBrokerID is only set on pamIgnore if the user has chosen local broker.
-		if err := mTx.SetData(authenticationBrokerIDKey, exitStatus.LocalBrokerID); err != nil {
-			return err
-		}
 		return fmt.Errorf("%w: %s", exitStatus.Status(), exitStatus.Message())
 
 	case adapter.PamReturnError:
@@ -426,11 +422,6 @@ func (h *pamModule) AcctMgmt(mTx pam.ModuleTransaction, flags pam.Flags, args []
 		return pam.ErrAuthinfoUnavail
 	}
 	defer closeConn()
-
-	if brokerIDUsedToAuthenticate == brokers.LocalBrokerName {
-		// Don't set the default broker to the local broker.
-		return pam.ErrIgnore
-	}
 
 	req := authd.SDBFURequest{
 		BrokerId: brokerIDUsedToAuthenticate,


### PR DESCRIPTION
As per commit 4fd03a407e69 we're just not storing if the local broker
has been used, as per this we don't even care about saving it in the
module since we'd just return with pam.ErrIgnore anyways if the broker
authentication ID isn't stored or is null

Thus we don't need to return anymore the ID of the local broker if we
want to be used, so we can also remove the complexity of
PamIgnore, by just considering it a particular case of pamError

UDENG-5576