### PR TITLE
pam: Always Honor PAM_TTY if set

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/charmbracelet/bubbles v0.20.0
 	github.com/charmbracelet/bubbletea v1.2.4
 	github.com/charmbracelet/lipgloss v1.0.0
+	github.com/charmbracelet/x/term v0.2.1
 	github.com/coreos/go-systemd/v22 v22.5.0
 	github.com/godbus/dbus/v5 v5.1.0
 	github.com/google/uuid v1.6.0
@@ -33,7 +34,6 @@ require (
 	github.com/atotto/clipboard v0.1.4 // indirect
 	github.com/aymanbagabas/go-osc52/v2 v2.0.1 // indirect
 	github.com/charmbracelet/x/ansi v0.4.5 // indirect
-	github.com/charmbracelet/x/term v0.2.1 // indirect
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
 	github.com/erikgeiser/coninput v0.0.0-20211004153227-1c3628e74d0f // indirect
 	github.com/fsnotify/fsnotify v1.7.0 // indirect

--- a/pam/internal/adapter/utils.go
+++ b/pam/internal/adapter/utils.go
@@ -1,17 +1,25 @@
 package adapter
 
 import (
+	"context"
 	"errors"
+	"fmt"
+	"math"
 	"os"
 	"sync"
 
 	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/x/term"
 	"github.com/msteinert/pam/v2"
+	"github.com/ubuntu/authd/log"
 )
 
 var (
 	isSSHSessionValue bool
 	isSSHSessionOnce  sync.Once
+
+	isTerminalTTYValue bool
+	isTerminalTTYOnce  sync.Once
 )
 
 // convertTo converts an interface I value to T. It will panic (progamming error) if this is not the case.
@@ -63,6 +71,48 @@ func isSSHSessionFunc(mTx pam.ModuleTransaction) bool {
 func isSSHSession(mTx pam.ModuleTransaction) bool {
 	isSSHSessionOnce.Do(func() { isSSHSessionValue = isSSHSessionFunc(mTx) })
 	return isSSHSessionValue
+}
+
+func getPamTTY(mTx pam.ModuleTransaction) (*os.File, func(), error) {
+	pamTTY, err := mTx.GetItem(pam.Tty)
+	if err != nil {
+		return nil, nil, err
+	}
+	if pamTTY == "" {
+		return nil, func() {}, nil
+	}
+
+	tty, err := os.OpenFile(pamTTY, os.O_RDWR, 0600)
+	if err != nil {
+		return nil, nil, err
+	}
+	cleanup := func() { tty.Close() }
+
+	// We check the fd could be passed to x/term to decide if we should fallback to stdin
+	if tty.Fd() > math.MaxInt {
+		defer cleanup()
+		return nil, nil, fmt.Errorf("unexpected large PAM TTY fd: %d", tty.Fd())
+	}
+
+	return tty, cleanup, nil
+}
+
+// IsTerminalTTY returns whether the [pam.Tty] or the [os.Stdin] is a terminal TTY.
+func IsTerminalTTY(mTx pam.ModuleTransaction) bool {
+	isTerminalTTYOnce.Do(func() {
+		tty, cleanup, err := getPamTTY(mTx)
+		if err != nil {
+			log.Warningf(context.TODO(), "Failed to open PAM TTY: %s", err)
+		}
+		if tty == nil {
+			tty = os.Stdin
+		}
+		if cleanup != nil {
+			defer cleanup()
+		}
+		isTerminalTTYValue = term.IsTerminal(tty.Fd())
+	})
+	return isTerminalTTYValue
 }
 
 func maybeSendPamError(err error) tea.Cmd {

--- a/pam/pam.go
+++ b/pam/pam.go
@@ -123,7 +123,7 @@ func sendReturnMessageToPam(mTx pam.ModuleTransaction, retStatus adapter.PamRetu
 // initLogging initializes the logging given the passed parameters.
 // It returns a function that should be called in order to reset the logging to
 // the default and potentially close the opened resources.
-func initLogging(args map[string]string, flags pam.Flags) (func(), error) {
+func initLogging(mTx pam.ModuleTransaction, args map[string]string, flags pam.Flags) (func(), error) {
 	log.SetLevel(log.InfoLevel)
 	resetFunc := func() {}
 	if args["debug"] == "true" {
@@ -163,7 +163,7 @@ func initLogging(args map[string]string, flags pam.Flags) (func(), error) {
 		if log.IsLevelEnabled(log.DebugLevel) {
 			return
 		}
-		if term.IsTerminal(int(os.Stdin.Fd())) {
+		if adapter.IsTerminalTTY(mTx) {
 			return
 		}
 		log.SetLevel(log.WarnLevel)
@@ -226,7 +226,7 @@ func (h *pamModule) handleAuthRequest(mode authd.SessionMode, mTx pam.ModuleTran
 	var pamClientType adapter.PamClientType
 	var teaOpts []tea.ProgramOption
 
-	closeLogging, err := initLogging(parsedArgs, flags)
+	closeLogging, err := initLogging(mTx, parsedArgs, flags)
 	defer func() {
 		log.Debugf(context.TODO(), "%s: exiting with error %v", mode, err)
 
@@ -349,7 +349,7 @@ func (h *pamModule) handleAuthRequest(mode authd.SessionMode, mTx pam.ModuleTran
 // AcctMgmt sets any used brokerID as default for the user.
 func (h *pamModule) AcctMgmt(mTx pam.ModuleTransaction, flags pam.Flags, args []string) (err error) {
 	parsedArgs, logArgsIssues := parseArgs(args)
-	closeLogging, err := initLogging(parsedArgs, flags)
+	closeLogging, err := initLogging(mTx, parsedArgs, flags)
 	defer closeLogging()
 	defer func() {
 		log.Debugf(context.TODO(), "AcctMgmt: exiting with error %v", err)


### PR DESCRIPTION
In case a PAM tty is used, we should do our terminal checks against that
instead of the stdin value, since they may differ.

Do this check also to ensure that we can run the interactive CLI UI.

A follow-up of https://github.com/ubuntu/authd/pull/720#discussion_r1910410356

UDENG-5760