### PR TITLE
ci: Install git-delta for nicer diffs in error messages

### DIFF
--- a/.github/workflows/qa.yaml
+++ b/.github/workflows/qa.yaml
@@ -18,6 +18,7 @@ env:
   test_apt_deps: >-
     cracklib-runtime
     ffmpeg
+    git-delta
     openssh-client
     openssh-server
 


### PR DESCRIPTION
The diffs of mismatching golden files are passed through git-delta since https://github.com/ubuntu/authd/pull/645.