### PR TITLE
Revert removal of groups in example broker

### DIFF
--- a/examplebroker/broker.go
+++ b/examplebroker/broker.go
@@ -930,11 +930,12 @@ func userInfoFromName(name string) string {
 		Groups []groupJSONInfo
 		Gecos  string
 	}{
-		Name:  name,
-		UUID:  "uuid-" + name,
-		Home:  "/home/" + name,
-		Shell: "/usr/bin/bash",
-		Gecos: "gecos for " + name,
+		Name:   name,
+		UUID:   "uuid-" + name,
+		Home:   "/home/" + name,
+		Shell:  "/usr/bin/bash",
+		Groups: []groupJSONInfo{{Name: "group-" + name, UGID: "ugid-" + name}},
+		Gecos:  "gecos for " + name,
 	}
 
 	switch name {


### PR DESCRIPTION
I don't remember why I removed those. Let's try reverting the change.

This partly reverts 7a1442fbf3becf374947b4f443f1b1eb12c9da17.