### PR TITLE
ci: Automatically sync branch "edge" on pushes to main

### DIFF
--- a/.github/workflows/sync-edge-branch.yaml
+++ b/.github/workflows/sync-edge-branch.yaml
@@ -1,0 +1,31 @@
+name: Sync edge with main
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  sync-edge:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Setup Git
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+      - name: Ensure edge branch exists
+        run: |
+          if ! git show-ref --verify --quiet refs/heads/edge; then
+            git branch edge
+          fi
+
+      - name: Sync edge with main
+        run: |
+          git fetch origin main
+          git checkout edge          
+          git reset --hard origin/main
+          git push origin edge --force

--- a/.github/workflows/sync-edge-branch.yaml
+++ b/.github/workflows/sync-edge-branch.yaml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+      - sync-edge
 
 jobs:
   sync-edge:


### PR DESCRIPTION
So that we can have an "edge" version on Read the Docs which shows the version of the documentation we have on main/edge.

# TODO
* [ ] Remove the `XXX: Test syncing to edge` commit