### PR TITLE
docs: add references to stable and latest docs versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,8 @@
 [goreport-url]: https://goreportcard.com/report/github.com/ubuntu/authd
 
 [docs-image]: https://readthedocs.com/projects/canonical-authd/badge/?version=latest
-[docs-url]: https://canonical-authd.readthedocs-hosted.com/en/latest/
+[docs-url-stable]: https://canonical-authd.readthedocs-hosted.com/en/stable/
+[docs-url-latest]: https://canonical-authd.readthedocs-hosted.com/en/latest/
 
 [![Code quality][actions-image]][actions-url]
 [![License][license-image]](COPYING)
@@ -23,7 +24,7 @@
 [![Go Report Card][goreport-image]][goreport-url]
 [![Reference documentation][reference-documentation-image]][reference-documentation-url]
 
-[![Documentation Status][docs-image]][docs-url]
+[![Documentation Status][docs-image]][docs-url-stable]
 
 authd is an authentication daemon for cloud-based identity providers. It helps
 ensure the secure management of identity and access for Ubuntu machines anywhere
@@ -34,8 +35,11 @@ supported and several other identity providers are under active development.
 
 ## Documentation
 
-If you want to know more about using authd, refer to the
-[official authd documentation][docs-url].
+To find out more about using authd, refer to the
+[official authd documentation][docs-url-stable].
+If you are on an edge release then you can also read the
+[latest development version of the documentation][docs-url-latest],
+which may include features not yet available in the stable release.
 
 The documentation includes how-to guides on installing and configuring authd,
 in addition to information about authd architecture and troubleshooting.

--- a/docs/index.md
+++ b/docs/index.md
@@ -41,7 +41,11 @@ These brokers allow you to authenticate against MS Entra ID or Google IAM using 
 **Discussion** of product architecture
 ```
 
+
 ````
+
+Documentation for the [stable](https://canonical-authd.readthedocs-hosted.com/en/stable/) release of authd and the [latest](https://canonical-authd.readthedocs-hosted.com/en/latest/) development version are
+both available.
 
 ---------
 

--- a/docs/reference/troubleshooting.md
+++ b/docs/reference/troubleshooting.md
@@ -102,6 +102,11 @@ snap switch authd-<broker_name> --stable
 snap refresh authd-<broker_name>
 ```
 
+```{note}
+If using an edge release, you can read the
+[latest development version of the documentation](https://canonical-authd.readthedocs-hosted.com/en/latest/)
+```
+
 ## Common issues and limitations
 
 ### File ownership on shared network resources (e.g. NFS, Samba)


### PR DESCRIPTION
The authd docs now include `stable` and `latest` versions.
The `stable` points to that last tagged release (excluding alphas and betas) and is the default.
The `latest` points to the last commit in the main branch and can be toggled in the dialog on the bottom right of each page:

![image](https://github.com/user-attachments/assets/469d9f75-75a0-4a17-aea7-cb0b321a70ec)

Helpfully, when a user switches to `latest`, Read the Docs shows a notification that some features that are documented may not be available in the stable release:

![image](https://github.com/user-attachments/assets/66700fe0-d98d-4faf-8b50-e592a2d602cd)

Despite these affordances, it is still a good idea to mention explicitly that there are two versions of the docs, providing links where appropriate.

Main changes here are:

* updating README docs links to include stable and latest
* adds comment on docs versions to README and docs homepage
* adds comment on latest docs in troubleshooting section that mentions using edge release

UDENG-5737