### PR TITLE
Fix systemd service warnings

### DIFF
--- a/debian/authd.service.in
+++ b/debian/authd.service.in
@@ -28,10 +28,6 @@ RestrictRealtime=yes
 RestrictSUIDSGID=yes
 SystemCallArchitectures=native
 
-# This always corresponds to /var/cache/authd
-CacheDirectory=authd
-CacheDirectoryMode=0700
-
 # This always corresponds to /var/lib/authd
 StateDirectory=authd
 StateDirectoryMode=0700

--- a/debian/postinst
+++ b/debian/postinst
@@ -29,8 +29,17 @@ insert_nss_entry() {
 }
 
 action="$1"
+previous_version="$2"
 
 if [ configure = "$action" ]; then
     pam-auth-update --package
     insert_nss_entry
+
+    # We installed /etc/authd with permissions 777 - umask in versions prior to 0.4.0
+    if dpkg --compare-versions "$previous_version" lt-nl "0.4.0~"; then
+        # Ensure that the /etc/authd directory has mode 700
+        if [ -d /etc/authd ] && [ "$(stat -c %a /etc/authd)" != "700" ]; then
+            chmod 700 /etc/authd
+        fi
+    fi
 fi


### PR DESCRIPTION
Fixes two warnings caused by the changes made to the systemd service definition:

```
authd.service: ConfigurationDirectory 'authd' already exists but the mode is different. (File system: 755 ConfigurationDirectoryMode: 700)
```

and 

```
Both old and new database directories exist, can't migrate "/var/cache/authd/" to "/var/lib/authd/"
```

UDENG-5857
UDENG-5858