### PR TITLE
pam/nativemodel: generalize the qrcode labels

### DIFF
--- a/pam/integration-tests/testdata/golden/TestNativeAuthenticate/Authenticate_user_switching_auth_mode
+++ b/pam/integration-tests/testdata/golden/TestNativeAuthenticate/Authenticate_user_switching_auth_mode
@@ -1531,7 +1531,7 @@ Enter your pin code:
 Or enter 'r' to go back to choose the provider
 Choose your authentication method:
 > 7
-== Qr Code authentication ==
+== Use a QR code ==
 Scan the qrcode or enter the code in the login page
 █████████████████████████████████
 █████████████████████████████████
@@ -1553,7 +1553,7 @@ Scan the qrcode or enter the code in the login page
        https://ubuntu.com
               1337
 
-  1. Wait for the QR code scan result
+  1. Wait for authentication result
   2. Regenerate code
 Or enter 'r' to go back to select the authentication method
 Choose action:
@@ -1665,7 +1665,7 @@ Enter your pin code:
 Or enter 'r' to go back to choose the provider
 Choose your authentication method:
 > 7
-== Qr Code authentication ==
+== Use a QR code ==
 Scan the qrcode or enter the code in the login page
 █████████████████████████████████
 █████████████████████████████████
@@ -1687,7 +1687,7 @@ Scan the qrcode or enter the code in the login page
        https://ubuntu.com
               1337
 
-  1. Wait for the QR code scan result
+  1. Wait for authentication result
   2. Regenerate code
 Or enter 'r' to go back to select the authentication method
 Choose action:
@@ -1799,7 +1799,7 @@ Enter your pin code:
 Or enter 'r' to go back to choose the provider
 Choose your authentication method:
 > 7
-== Qr Code authentication ==
+== Use a QR code ==
 Scan the qrcode or enter the code in the login page
 █████████████████████████████████
 █████████████████████████████████
@@ -1821,7 +1821,7 @@ Scan the qrcode or enter the code in the login page
        https://ubuntu.com
               1337
 
-  1. Wait for the QR code scan result
+  1. Wait for authentication result
   2. Regenerate code
 Or enter 'r' to go back to select the authentication method
 Choose action:
@@ -1945,7 +1945,7 @@ Enter your pin code:
 Or enter 'r' to go back to choose the provider
 Choose your authentication method:
 > 7
-== Qr Code authentication ==
+== Use a QR code ==
 Scan the qrcode or enter the code in the login page
 █████████████████████████████████
 █████████████████████████████████
@@ -1967,153 +1967,7 @@ Scan the qrcode or enter the code in the login page
        https://ubuntu.com
               1337
 
-  1. Wait for the QR code scan result
-  2. Regenerate code
-Or enter 'r' to go back to select the authentication method
-Choose action:
-> r
-== Authentication method selection ==
-  1. Password authentication
-  2. Send URL to user-integration-switch-mode@gmail.com
-  3. Use your fido device foo
-  4. Use your phone +33...
-  5. Use your phone +1...
-  6. Pin code
-  7. Use a QR code
-  8. Authentication code
-Or enter 'r' to go back to choose the provider
-Choose your authentication method:
-> 8
-────────────────────────────────────────────────────────────────────────────────
-> ./pam_authd login socket=${AUTHD_TESTS_CLI_AUTHENTICATE_TESTS_SOCK} force_native_client=true
-== Provider selection ==
-  1. local
-  2. ExampleBroker
-Choose your provider:
-> 2
-== Password authentication ==
-Enter 'r' to cancel the request and go back to select the authentication method
-Gimme your password:
->
-== Authentication method selection ==
-  1. Password authentication
-  2. Send URL to user-integration-switch-mode@gmail.com
-  3. Use your fido device foo
-  4. Use your phone +33...
-  5. Use your phone +1...
-  6. Pin code
-  7. Use a QR code
-  8. Authentication code
-Or enter 'r' to go back to choose the provider
-Choose your authentication method:
-> 2
-== Send URL to user-integration-switch-mode@gmail.com ==
-Leave the input field empty to wait for the alternative authentication method or enter 'r' to go
- back to select the authentication method
-Click on the link received at user-integration-switch-mode@gmail.com or enter the code:
-> r
-== Authentication method selection ==
-  1. Password authentication
-  2. Send URL to user-integration-switch-mode@gmail.com
-  3. Use your fido device foo
-  4. Use your phone +33...
-  5. Use your phone +1...
-  6. Pin code
-  7. Use a QR code
-  8. Authentication code
-Or enter 'r' to go back to choose the provider
-Choose your authentication method:
-> 3
-== Use your fido device foo ==
-Press Enter to wait for authentication or enter 'r' to go back to select the authentication meth
-od
-Plug your fido device and press with your thumb:
-> r
-== Authentication method selection ==
-  1. Password authentication
-  2. Send URL to user-integration-switch-mode@gmail.com
-  3. Use your fido device foo
-  4. Use your phone +33...
-  5. Use your phone +1...
-  6. Pin code
-  7. Use a QR code
-  8. Authentication code
-Or enter 'r' to go back to choose the provider
-Choose your authentication method:
-> 4
-== Use your phone +33... ==
-Press Enter to wait for authentication or enter 'r' to go back to select the authentication meth
-od
-Unlock your phone +33... or accept request on web interface:
-> r
-== Authentication method selection ==
-  1. Password authentication
-  2. Send URL to user-integration-switch-mode@gmail.com
-  3. Use your fido device foo
-  4. Use your phone +33...
-  5. Use your phone +1...
-  6. Pin code
-  7. Use a QR code
-  8. Authentication code
-Or enter 'r' to go back to choose the provider
-Choose your authentication method:
-> 5
-== Use your phone +1... ==
-Press Enter to wait for authentication or enter 'r' to go back to select the authentication meth
-od
-Unlock your phone +1... or accept request on web interface:
-> r
-== Authentication method selection ==
-  1. Password authentication
-  2. Send URL to user-integration-switch-mode@gmail.com
-  3. Use your fido device foo
-  4. Use your phone +33...
-  5. Use your phone +1...
-  6. Pin code
-  7. Use a QR code
-  8. Authentication code
-Or enter 'r' to go back to choose the provider
-Choose your authentication method:
-> 6
-== Pin code ==
-Enter 'r' to cancel the request and go back to select the authentication method
-Enter your pin code:
-> r
-== Authentication method selection ==
-  1. Password authentication
-  2. Send URL to user-integration-switch-mode@gmail.com
-  3. Use your fido device foo
-  4. Use your phone +33...
-  5. Use your phone +1...
-  6. Pin code
-  7. Use a QR code
-  8. Authentication code
-Or enter 'r' to go back to choose the provider
-Choose your authentication method:
-> 7
-== Qr Code authentication ==
-Scan the qrcode or enter the code in the login page
-█████████████████████████████████
-█████████████████████████████████
-████ ▄▄▄▄▄ █  ▀▀█▄██ █ ▄▄▄▄▄ ████
-████ █   █ █▀▄██ ▄▄▄██ █   █ ████
-████ █▄▄▄█ ██▄ █ ▄ ▄▄█ █▄▄▄█ ████
-████▄▄▄▄▄▄▄█ ▀▄▀▄▀ ▀▄█▄▄▄▄▄▄▄████
-████▄█ ▄█ ▄ ▀█▄▀▀▄▄█ █▄▀█▄█ ▄████
-█████▀█▀▄ ▄ ▄▀█▀▀▀ ▀█▄▀▄▄▀▀██████
-████▄  █▀█▄▄▄██ █▀█▀█▄   █▄▄ ████
-████▀▄  ▀▄▄█ ▄▄█ ▀▄▀▀ ▀▀ █▄▄▀████
-███████▄▄█▄█  ▀▄▀▀█▀ ▄▄▄ ▄ ▄ ████
-████ ▄▄▄▄▄ █  █▄ ██▀ █▄█ █▄  ████
-████ █   █ █▀▄ ▄  ▀▀▄  ▄  ▀▀▀████
-████ █▄▄▄█ █▄█▄▄▄▄█ █  █ █ ▄█████
-████▄▄▄▄▄▄▄█▄█▄█▄█▄████▄▄▄▄▄▄████
-█████████████████████████████████
-▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀
-       https://ubuntu.com
-              1337
-
-  1. Wait for the QR code scan result
+  1. Wait for authentication result
   2. Regenerate code
 Or enter 'r' to go back to select the authentication method
 Choose action:
@@ -2130,12 +1984,6 @@ Choose action:
 Or enter 'r' to go back to choose the provider
 Choose your authentication method:
 > 8
-== Authentication code ==
-  1. Proceed with Authentication code
-  2. Resend SMS (1 sent)
-Or enter 'r' to go back to select the authentication method
-Choose action:
->
 ────────────────────────────────────────────────────────────────────────────────
 > ./pam_authd login socket=${AUTHD_TESTS_CLI_AUTHENTICATE_TESTS_SOCK} force_native_client=true
 == Provider selection ==
@@ -2243,7 +2091,7 @@ Enter your pin code:
 Or enter 'r' to go back to choose the provider
 Choose your authentication method:
 > 7
-== Qr Code authentication ==
+== Use a QR code ==
 Scan the qrcode or enter the code in the login page
 █████████████████████████████████
 █████████████████████████████████
@@ -2265,7 +2113,7 @@ Scan the qrcode or enter the code in the login page
        https://ubuntu.com
               1337
 
-  1. Wait for the QR code scan result
+  1. Wait for authentication result
   2. Regenerate code
 Or enter 'r' to go back to select the authentication method
 Choose action:
@@ -2287,7 +2135,7 @@ Choose your authentication method:
   2. Resend SMS (1 sent)
 Or enter 'r' to go back to select the authentication method
 Choose action:
-> r
+>
 ────────────────────────────────────────────────────────────────────────────────
 > ./pam_authd login socket=${AUTHD_TESTS_CLI_AUTHENTICATE_TESTS_SOCK} force_native_client=true
 == Provider selection ==
@@ -2395,7 +2243,7 @@ Enter your pin code:
 Or enter 'r' to go back to choose the provider
 Choose your authentication method:
 > 7
-== Qr Code authentication ==
+== Use a QR code ==
 Scan the qrcode or enter the code in the login page
 █████████████████████████████████
 █████████████████████████████████
@@ -2417,7 +2265,7 @@ Scan the qrcode or enter the code in the login page
        https://ubuntu.com
               1337
 
-  1. Wait for the QR code scan result
+  1. Wait for authentication result
   2. Regenerate code
 Or enter 'r' to go back to select the authentication method
 Choose action:
@@ -2440,18 +2288,6 @@ Choose your authentication method:
 Or enter 'r' to go back to select the authentication method
 Choose action:
 > r
-== Authentication method selection ==
-  1. Password authentication
-  2. Send URL to user-integration-switch-mode@gmail.com
-  3. Use your fido device foo
-  4. Use your phone +33...
-  5. Use your phone +1...
-  6. Pin code
-  7. Use a QR code
-  8. Authentication code
-Or enter 'r' to go back to choose the provider
-Choose your authentication method:
->
 ────────────────────────────────────────────────────────────────────────────────
 > ./pam_authd login socket=${AUTHD_TESTS_CLI_AUTHENTICATE_TESTS_SOCK} force_native_client=true
 == Provider selection ==
@@ -2559,7 +2395,7 @@ Enter your pin code:
 Or enter 'r' to go back to choose the provider
 Choose your authentication method:
 > 7
-== Qr Code authentication ==
+== Use a QR code ==
 Scan the qrcode or enter the code in the login page
 █████████████████████████████████
 █████████████████████████████████
@@ -2581,7 +2417,7 @@ Scan the qrcode or enter the code in the login page
        https://ubuntu.com
               1337
 
-  1. Wait for the QR code scan result
+  1. Wait for authentication result
   2. Regenerate code
 Or enter 'r' to go back to select the authentication method
 Choose action:
@@ -2615,7 +2451,7 @@ Choose action:
   8. Authentication code
 Or enter 'r' to go back to choose the provider
 Choose your authentication method:
-> invalid-selection
+>
 ────────────────────────────────────────────────────────────────────────────────
 > ./pam_authd login socket=${AUTHD_TESTS_CLI_AUTHENTICATE_TESTS_SOCK} force_native_client=true
 == Provider selection ==
@@ -2723,7 +2559,7 @@ Enter your pin code:
 Or enter 'r' to go back to choose the provider
 Choose your authentication method:
 > 7
-== Qr Code authentication ==
+== Use a QR code ==
 Scan the qrcode or enter the code in the login page
 █████████████████████████████████
 █████████████████████████████████
@@ -2745,7 +2581,7 @@ Scan the qrcode or enter the code in the login page
        https://ubuntu.com
               1337
 
-  1. Wait for the QR code scan result
+  1. Wait for authentication result
   2. Regenerate code
 Or enter 'r' to go back to select the authentication method
 Choose action:
@@ -2780,9 +2616,6 @@ Choose action:
 Or enter 'r' to go back to choose the provider
 Choose your authentication method:
 > invalid-selection
-PAM Error Message: Unsupported input
-Choose your authentication method:
->
 ────────────────────────────────────────────────────────────────────────────────
 > ./pam_authd login socket=${AUTHD_TESTS_CLI_AUTHENTICATE_TESTS_SOCK} force_native_client=true
 == Provider selection ==
@@ -2890,7 +2723,7 @@ Enter your pin code:
 Or enter 'r' to go back to choose the provider
 Choose your authentication method:
 > 7
-== Qr Code authentication ==
+== Use a QR code ==
 Scan the qrcode or enter the code in the login page
 █████████████████████████████████
 █████████████████████████████████
@@ -2912,7 +2745,7 @@ Scan the qrcode or enter the code in the login page
        https://ubuntu.com
               1337
 
-  1. Wait for the QR code scan result
+  1. Wait for authentication result
   2. Regenerate code
 Or enter 'r' to go back to select the authentication method
 Choose action:
@@ -2949,7 +2782,7 @@ Choose your authentication method:
 > invalid-selection
 PAM Error Message: Unsupported input
 Choose your authentication method:
-> -1
+>
 ────────────────────────────────────────────────────────────────────────────────
 > ./pam_authd login socket=${AUTHD_TESTS_CLI_AUTHENTICATE_TESTS_SOCK} force_native_client=true
 == Provider selection ==
@@ -3057,7 +2890,7 @@ Enter your pin code:
 Or enter 'r' to go back to choose the provider
 Choose your authentication method:
 > 7
-== Qr Code authentication ==
+== Use a QR code ==
 Scan the qrcode or enter the code in the login page
 █████████████████████████████████
 █████████████████████████████████
@@ -3079,7 +2912,7 @@ Scan the qrcode or enter the code in the login page
        https://ubuntu.com
               1337
 
-  1. Wait for the QR code scan result
+  1. Wait for authentication result
   2. Regenerate code
 Or enter 'r' to go back to select the authentication method
 Choose action:
@@ -3117,19 +2950,6 @@ Choose your authentication method:
 PAM Error Message: Unsupported input
 Choose your authentication method:
 > -1
-PAM Error Message: Invalid selection
-== Authentication method selection ==
-  1. Password authentication
-  2. Send URL to user-integration-switch-mode@gmail.com
-  3. Use your fido device foo
-  4. Use your phone +33...
-  5. Use your phone +1...
-  6. Pin code
-  7. Use a QR code
-  8. Authentication code
-Or enter 'r' to go back to choose the provider
-Choose your authentication method:
->
 ────────────────────────────────────────────────────────────────────────────────
 > ./pam_authd login socket=${AUTHD_TESTS_CLI_AUTHENTICATE_TESTS_SOCK} force_native_client=true
 == Provider selection ==
@@ -3237,7 +3057,7 @@ Enter your pin code:
 Or enter 'r' to go back to choose the provider
 Choose your authentication method:
 > 7
-== Qr Code authentication ==
+== Use a QR code ==
 Scan the qrcode or enter the code in the login page
 █████████████████████████████████
 █████████████████████████████████
@@ -3259,7 +3079,7 @@ Scan the qrcode or enter the code in the login page
        https://ubuntu.com
               1337
 
-  1. Wait for the QR code scan result
+  1. Wait for authentication result
   2. Regenerate code
 Or enter 'r' to go back to select the authentication method
 Choose action:
@@ -3309,7 +3129,7 @@ PAM Error Message: Invalid selection
   8. Authentication code
 Or enter 'r' to go back to choose the provider
 Choose your authentication method:
-> 6
+>
 ────────────────────────────────────────────────────────────────────────────────
 > ./pam_authd login socket=${AUTHD_TESTS_CLI_AUTHENTICATE_TESTS_SOCK} force_native_client=true
 == Provider selection ==
@@ -3417,7 +3237,7 @@ Enter your pin code:
 Or enter 'r' to go back to choose the provider
 Choose your authentication method:
 > 7
-== Qr Code authentication ==
+== Use a QR code ==
 Scan the qrcode or enter the code in the login page
 █████████████████████████████████
 █████████████████████████████████
@@ -3439,7 +3259,7 @@ Scan the qrcode or enter the code in the login page
        https://ubuntu.com
               1337
 
-  1. Wait for the QR code scan result
+  1. Wait for authentication result
   2. Regenerate code
 Or enter 'r' to go back to select the authentication method
 Choose action:
@@ -3490,6 +3310,186 @@ PAM Error Message: Invalid selection
 Or enter 'r' to go back to choose the provider
 Choose your authentication method:
 > 6
+────────────────────────────────────────────────────────────────────────────────
+> ./pam_authd login socket=${AUTHD_TESTS_CLI_AUTHENTICATE_TESTS_SOCK} force_native_client=true
+== Provider selection ==
+  1. local
+  2. ExampleBroker
+Choose your provider:
+> 2
+== Password authentication ==
+Enter 'r' to cancel the request and go back to select the authentication method
+Gimme your password:
+>
+== Authentication method selection ==
+  1. Password authentication
+  2. Send URL to user-integration-switch-mode@gmail.com
+  3. Use your fido device foo
+  4. Use your phone +33...
+  5. Use your phone +1...
+  6. Pin code
+  7. Use a QR code
+  8. Authentication code
+Or enter 'r' to go back to choose the provider
+Choose your authentication method:
+> 2
+== Send URL to user-integration-switch-mode@gmail.com ==
+Leave the input field empty to wait for the alternative authentication method or enter 'r' to go
+ back to select the authentication method
+Click on the link received at user-integration-switch-mode@gmail.com or enter the code:
+> r
+== Authentication method selection ==
+  1. Password authentication
+  2. Send URL to user-integration-switch-mode@gmail.com
+  3. Use your fido device foo
+  4. Use your phone +33...
+  5. Use your phone +1...
+  6. Pin code
+  7. Use a QR code
+  8. Authentication code
+Or enter 'r' to go back to choose the provider
+Choose your authentication method:
+> 3
+== Use your fido device foo ==
+Press Enter to wait for authentication or enter 'r' to go back to select the authentication meth
+od
+Plug your fido device and press with your thumb:
+> r
+== Authentication method selection ==
+  1. Password authentication
+  2. Send URL to user-integration-switch-mode@gmail.com
+  3. Use your fido device foo
+  4. Use your phone +33...
+  5. Use your phone +1...
+  6. Pin code
+  7. Use a QR code
+  8. Authentication code
+Or enter 'r' to go back to choose the provider
+Choose your authentication method:
+> 4
+== Use your phone +33... ==
+Press Enter to wait for authentication or enter 'r' to go back to select the authentication meth
+od
+Unlock your phone +33... or accept request on web interface:
+> r
+== Authentication method selection ==
+  1. Password authentication
+  2. Send URL to user-integration-switch-mode@gmail.com
+  3. Use your fido device foo
+  4. Use your phone +33...
+  5. Use your phone +1...
+  6. Pin code
+  7. Use a QR code
+  8. Authentication code
+Or enter 'r' to go back to choose the provider
+Choose your authentication method:
+> 5
+== Use your phone +1... ==
+Press Enter to wait for authentication or enter 'r' to go back to select the authentication meth
+od
+Unlock your phone +1... or accept request on web interface:
+> r
+== Authentication method selection ==
+  1. Password authentication
+  2. Send URL to user-integration-switch-mode@gmail.com
+  3. Use your fido device foo
+  4. Use your phone +33...
+  5. Use your phone +1...
+  6. Pin code
+  7. Use a QR code
+  8. Authentication code
+Or enter 'r' to go back to choose the provider
+Choose your authentication method:
+> 6
+== Pin code ==
+Enter 'r' to cancel the request and go back to select the authentication method
+Enter your pin code:
+> r
+== Authentication method selection ==
+  1. Password authentication
+  2. Send URL to user-integration-switch-mode@gmail.com
+  3. Use your fido device foo
+  4. Use your phone +33...
+  5. Use your phone +1...
+  6. Pin code
+  7. Use a QR code
+  8. Authentication code
+Or enter 'r' to go back to choose the provider
+Choose your authentication method:
+> 7
+== Use a QR code ==
+Scan the qrcode or enter the code in the login page
+█████████████████████████████████
+█████████████████████████████████
+████ ▄▄▄▄▄ █  ▀▀█▄██ █ ▄▄▄▄▄ ████
+████ █   █ █▀▄██ ▄▄▄██ █   █ ████
+████ █▄▄▄█ ██▄ █ ▄ ▄▄█ █▄▄▄█ ████
+████▄▄▄▄▄▄▄█ ▀▄▀▄▀ ▀▄█▄▄▄▄▄▄▄████
+████▄█ ▄█ ▄ ▀█▄▀▀▄▄█ █▄▀█▄█ ▄████
+█████▀█▀▄ ▄ ▄▀█▀▀▀ ▀█▄▀▄▄▀▀██████
+████▄  █▀█▄▄▄██ █▀█▀█▄   █▄▄ ████
+████▀▄  ▀▄▄█ ▄▄█ ▀▄▀▀ ▀▀ █▄▄▀████
+███████▄▄█▄█  ▀▄▀▀█▀ ▄▄▄ ▄ ▄ ████
+████ ▄▄▄▄▄ █  █▄ ██▀ █▄█ █▄  ████
+████ █   █ █▀▄ ▄  ▀▀▄  ▄  ▀▀▀████
+████ █▄▄▄█ █▄█▄▄▄▄█ █  █ █ ▄█████
+████▄▄▄▄▄▄▄█▄█▄█▄█▄████▄▄▄▄▄▄████
+█████████████████████████████████
+▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀
+       https://ubuntu.com
+              1337
+
+  1. Wait for authentication result
+  2. Regenerate code
+Or enter 'r' to go back to select the authentication method
+Choose action:
+> r
+== Authentication method selection ==
+  1. Password authentication
+  2. Send URL to user-integration-switch-mode@gmail.com
+  3. Use your fido device foo
+  4. Use your phone +33...
+  5. Use your phone +1...
+  6. Pin code
+  7. Use a QR code
+  8. Authentication code
+Or enter 'r' to go back to choose the provider
+Choose your authentication method:
+> 8
+== Authentication code ==
+  1. Proceed with Authentication code
+  2. Resend SMS (1 sent)
+Or enter 'r' to go back to select the authentication method
+Choose action:
+> r
+== Authentication method selection ==
+  1. Password authentication
+  2. Send URL to user-integration-switch-mode@gmail.com
+  3. Use your fido device foo
+  4. Use your phone +33...
+  5. Use your phone +1...
+  6. Pin code
+  7. Use a QR code
+  8. Authentication code
+Or enter 'r' to go back to choose the provider
+Choose your authentication method:
+> invalid-selection
+PAM Error Message: Unsupported input
+Choose your authentication method:
+> -1
+PAM Error Message: Invalid selection
+== Authentication method selection ==
+  1. Password authentication
+  2. Send URL to user-integration-switch-mode@gmail.com
+  3. Use your fido device foo
+  4. Use your phone +33...
+  5. Use your phone +1...
+  6. Pin code
+  7. Use a QR code
+  8. Authentication code
+Or enter 'r' to go back to choose the provider
+Choose your authentication method:
+> 6
 == Pin code ==
 Enter 'r' to cancel the request and go back to select the authentication method
 Enter your pin code:
@@ -3601,7 +3601,7 @@ Enter your pin code:
 Or enter 'r' to go back to choose the provider
 Choose your authentication method:
 > 7
-== Qr Code authentication ==
+== Use a QR code ==
 Scan the qrcode or enter the code in the login page
 █████████████████████████████████
 █████████████████████████████████
@@ -3623,7 +3623,7 @@ Scan the qrcode or enter the code in the login page
        https://ubuntu.com
               1337
 
-  1. Wait for the QR code scan result
+  1. Wait for authentication result
   2. Regenerate code
 Or enter 'r' to go back to select the authentication method
 Choose action:
@@ -3785,7 +3785,7 @@ Enter your pin code:
 Or enter 'r' to go back to choose the provider
 Choose your authentication method:
 > 7
-== Qr Code authentication ==
+== Use a QR code ==
 Scan the qrcode or enter the code in the login page
 █████████████████████████████████
 █████████████████████████████████
@@ -3807,7 +3807,7 @@ Scan the qrcode or enter the code in the login page
        https://ubuntu.com
               1337
 
-  1. Wait for the QR code scan result
+  1. Wait for authentication result
   2. Regenerate code
 Or enter 'r' to go back to select the authentication method
 Choose action:

--- a/pam/integration-tests/testdata/golden/TestNativeAuthenticate/Authenticate_user_with_qr_code
+++ b/pam/integration-tests/testdata/golden/TestNativeAuthenticate/Authenticate_user_with_qr_code
@@ -96,7 +96,7 @@ Gimme your password:
 Or enter 'r' to go back to choose the provider
 Choose your authentication method:
 > 7
-== Qr Code authentication ==
+== Use a QR code ==
 Scan the qrcode or enter the code in the login page
 █████████████████████████████████
 █████████████████████████████████
@@ -118,7 +118,7 @@ Scan the qrcode or enter the code in the login page
        https://ubuntu.com
               1337
 
-  1. Wait for the QR code scan result
+  1. Wait for authentication result
   2. Regenerate code
 Or enter 'r' to go back to select the authentication method
 Choose action:
@@ -147,7 +147,7 @@ Gimme your password:
 Or enter 'r' to go back to choose the provider
 Choose your authentication method:
 > 7
-== Qr Code authentication ==
+== Use a QR code ==
 Scan the qrcode or enter the code in the login page
 █████████████████████████████████
 █████████████████████████████████
@@ -169,7 +169,7 @@ Scan the qrcode or enter the code in the login page
        https://ubuntu.com
               1337
 
-  1. Wait for the QR code scan result
+  1. Wait for authentication result
   2. Regenerate code
 Or enter 'r' to go back to select the authentication method
 Choose action:
@@ -198,7 +198,7 @@ Gimme your password:
 Or enter 'r' to go back to choose the provider
 Choose your authentication method:
 > 7
-== Qr Code authentication ==
+== Use a QR code ==
 Scan the qrcode or enter the code in the login page
 █████████████████████████████████
 █████████████████████████████████
@@ -220,12 +220,12 @@ Scan the qrcode or enter the code in the login page
        https://ubuntu.com
               1337
 
-  1. Wait for the QR code scan result
+  1. Wait for authentication result
   2. Regenerate code
 Or enter 'r' to go back to select the authentication method
 Choose action:
 > 2
-== Qr Code authentication ==
+== Use a QR code ==
 Scan the qrcode or enter the code in the login page
 █████████████████████████████████
 █████████████████████████████████
@@ -247,7 +247,7 @@ Scan the qrcode or enter the code in the login page
        https://ubuntu.fr/
               1338
 
-  1. Wait for the QR code scan result
+  1. Wait for authentication result
   2. Regenerate code
 Or enter 'r' to go back to select the authentication method
 Choose action:
@@ -276,7 +276,7 @@ Gimme your password:
 Or enter 'r' to go back to choose the provider
 Choose your authentication method:
 > 7
-== Qr Code authentication ==
+== Use a QR code ==
 Scan the qrcode or enter the code in the login page
 █████████████████████████████████
 █████████████████████████████████
@@ -298,12 +298,12 @@ Scan the qrcode or enter the code in the login page
        https://ubuntu.com
               1337
 
-  1. Wait for the QR code scan result
+  1. Wait for authentication result
   2. Regenerate code
 Or enter 'r' to go back to select the authentication method
 Choose action:
 > 2
-== Qr Code authentication ==
+== Use a QR code ==
 Scan the qrcode or enter the code in the login page
 █████████████████████████████████
 █████████████████████████████████
@@ -325,7 +325,7 @@ Scan the qrcode or enter the code in the login page
        https://ubuntu.fr/
               1338
 
-  1. Wait for the QR code scan result
+  1. Wait for authentication result
   2. Regenerate code
 Or enter 'r' to go back to select the authentication method
 Choose action:
@@ -354,7 +354,7 @@ Gimme your password:
 Or enter 'r' to go back to choose the provider
 Choose your authentication method:
 > 7
-== Qr Code authentication ==
+== Use a QR code ==
 Scan the qrcode or enter the code in the login page
 █████████████████████████████████
 █████████████████████████████████
@@ -376,12 +376,12 @@ Scan the qrcode or enter the code in the login page
        https://ubuntu.com
               1337
 
-  1. Wait for the QR code scan result
+  1. Wait for authentication result
   2. Regenerate code
 Or enter 'r' to go back to select the authentication method
 Choose action:
 > 2
-== Qr Code authentication ==
+== Use a QR code ==
 Scan the qrcode or enter the code in the login page
 █████████████████████████████████
 █████████████████████████████████
@@ -403,12 +403,12 @@ Scan the qrcode or enter the code in the login page
        https://ubuntu.fr/
               1338
 
-  1. Wait for the QR code scan result
+  1. Wait for authentication result
   2. Regenerate code
 Or enter 'r' to go back to select the authentication method
 Choose action:
 > 2
-== Qr Code authentication ==
+== Use a QR code ==
 Scan the qrcode or enter the code in the login page
 █████████████████████████████████████
 █████████████████████████████████████
@@ -432,7 +432,7 @@ Scan the qrcode or enter the code in the login page
      https://ubuntuforum-br.org/
                 1339
 
-  1. Wait for the QR code scan result
+  1. Wait for authentication result
   2. Regenerate code
 Or enter 'r' to go back to select the authentication method
 Choose action:
@@ -461,7 +461,7 @@ Gimme your password:
 Or enter 'r' to go back to choose the provider
 Choose your authentication method:
 > 7
-== Qr Code authentication ==
+== Use a QR code ==
 Scan the qrcode or enter the code in the login page
 █████████████████████████████████
 █████████████████████████████████
@@ -483,12 +483,12 @@ Scan the qrcode or enter the code in the login page
        https://ubuntu.com
               1337
 
-  1. Wait for the QR code scan result
+  1. Wait for authentication result
   2. Regenerate code
 Or enter 'r' to go back to select the authentication method
 Choose action:
 > 2
-== Qr Code authentication ==
+== Use a QR code ==
 Scan the qrcode or enter the code in the login page
 █████████████████████████████████
 █████████████████████████████████
@@ -510,12 +510,12 @@ Scan the qrcode or enter the code in the login page
        https://ubuntu.fr/
               1338
 
-  1. Wait for the QR code scan result
+  1. Wait for authentication result
   2. Regenerate code
 Or enter 'r' to go back to select the authentication method
 Choose action:
 > 2
-== Qr Code authentication ==
+== Use a QR code ==
 Scan the qrcode or enter the code in the login page
 █████████████████████████████████████
 █████████████████████████████████████
@@ -539,7 +539,7 @@ Scan the qrcode or enter the code in the login page
      https://ubuntuforum-br.org/
                 1339
 
-  1. Wait for the QR code scan result
+  1. Wait for authentication result
   2. Regenerate code
 Or enter 'r' to go back to select the authentication method
 Choose action:
@@ -568,7 +568,7 @@ Gimme your password:
 Or enter 'r' to go back to choose the provider
 Choose your authentication method:
 > 7
-== Qr Code authentication ==
+== Use a QR code ==
 Scan the qrcode or enter the code in the login page
 █████████████████████████████████
 █████████████████████████████████
@@ -590,12 +590,12 @@ Scan the qrcode or enter the code in the login page
        https://ubuntu.com
               1337
 
-  1. Wait for the QR code scan result
+  1. Wait for authentication result
   2. Regenerate code
 Or enter 'r' to go back to select the authentication method
 Choose action:
 > 2
-== Qr Code authentication ==
+== Use a QR code ==
 Scan the qrcode or enter the code in the login page
 █████████████████████████████████
 █████████████████████████████████
@@ -617,12 +617,12 @@ Scan the qrcode or enter the code in the login page
        https://ubuntu.fr/
               1338
 
-  1. Wait for the QR code scan result
+  1. Wait for authentication result
   2. Regenerate code
 Or enter 'r' to go back to select the authentication method
 Choose action:
 > 2
-== Qr Code authentication ==
+== Use a QR code ==
 Scan the qrcode or enter the code in the login page
 █████████████████████████████████████
 █████████████████████████████████████
@@ -646,12 +646,12 @@ Scan the qrcode or enter the code in the login page
      https://ubuntuforum-br.org/
                 1339
 
-  1. Wait for the QR code scan result
+  1. Wait for authentication result
   2. Regenerate code
 Or enter 'r' to go back to select the authentication method
 Choose action:
 > 2
-== Qr Code authentication ==
+== Use a QR code ==
 Scan the qrcode or enter the code in the login page
 █████████████████████████████████
 █████████████████████████████████
@@ -673,7 +673,7 @@ Scan the qrcode or enter the code in the login page
    https://www.ubuntu-it.org/
               1340
 
-  1. Wait for the QR code scan result
+  1. Wait for authentication result
   2. Regenerate code
 Or enter 'r' to go back to select the authentication method
 Choose action:
@@ -702,7 +702,7 @@ Gimme your password:
 Or enter 'r' to go back to choose the provider
 Choose your authentication method:
 > 7
-== Qr Code authentication ==
+== Use a QR code ==
 Scan the qrcode or enter the code in the login page
 █████████████████████████████████
 █████████████████████████████████
@@ -724,12 +724,12 @@ Scan the qrcode or enter the code in the login page
        https://ubuntu.com
               1337
 
-  1. Wait for the QR code scan result
+  1. Wait for authentication result
   2. Regenerate code
 Or enter 'r' to go back to select the authentication method
 Choose action:
 > 2
-== Qr Code authentication ==
+== Use a QR code ==
 Scan the qrcode or enter the code in the login page
 █████████████████████████████████
 █████████████████████████████████
@@ -751,12 +751,12 @@ Scan the qrcode or enter the code in the login page
        https://ubuntu.fr/
               1338
 
-  1. Wait for the QR code scan result
+  1. Wait for authentication result
   2. Regenerate code
 Or enter 'r' to go back to select the authentication method
 Choose action:
 > 2
-== Qr Code authentication ==
+== Use a QR code ==
 Scan the qrcode or enter the code in the login page
 █████████████████████████████████████
 █████████████████████████████████████
@@ -780,12 +780,12 @@ Scan the qrcode or enter the code in the login page
      https://ubuntuforum-br.org/
                 1339
 
-  1. Wait for the QR code scan result
+  1. Wait for authentication result
   2. Regenerate code
 Or enter 'r' to go back to select the authentication method
 Choose action:
 > 2
-== Qr Code authentication ==
+== Use a QR code ==
 Scan the qrcode or enter the code in the login page
 █████████████████████████████████
 █████████████████████████████████
@@ -807,7 +807,7 @@ Scan the qrcode or enter the code in the login page
    https://www.ubuntu-it.org/
               1340
 
-  1. Wait for the QR code scan result
+  1. Wait for authentication result
   2. Regenerate code
 Or enter 'r' to go back to select the authentication method
 Choose action:
@@ -836,7 +836,7 @@ Gimme your password:
 Or enter 'r' to go back to choose the provider
 Choose your authentication method:
 > 7
-== Qr Code authentication ==
+== Use a QR code ==
 Scan the qrcode or enter the code in the login page
 █████████████████████████████████
 █████████████████████████████████
@@ -858,12 +858,12 @@ Scan the qrcode or enter the code in the login page
        https://ubuntu.com
               1337
 
-  1. Wait for the QR code scan result
+  1. Wait for authentication result
   2. Regenerate code
 Or enter 'r' to go back to select the authentication method
 Choose action:
 > 2
-== Qr Code authentication ==
+== Use a QR code ==
 Scan the qrcode or enter the code in the login page
 █████████████████████████████████
 █████████████████████████████████
@@ -885,12 +885,12 @@ Scan the qrcode or enter the code in the login page
        https://ubuntu.fr/
               1338
 
-  1. Wait for the QR code scan result
+  1. Wait for authentication result
   2. Regenerate code
 Or enter 'r' to go back to select the authentication method
 Choose action:
 > 2
-== Qr Code authentication ==
+== Use a QR code ==
 Scan the qrcode or enter the code in the login page
 █████████████████████████████████████
 █████████████████████████████████████
@@ -914,12 +914,12 @@ Scan the qrcode or enter the code in the login page
      https://ubuntuforum-br.org/
                 1339
 
-  1. Wait for the QR code scan result
+  1. Wait for authentication result
   2. Regenerate code
 Or enter 'r' to go back to select the authentication method
 Choose action:
 > 2
-== Qr Code authentication ==
+== Use a QR code ==
 Scan the qrcode or enter the code in the login page
 █████████████████████████████████
 █████████████████████████████████
@@ -941,12 +941,12 @@ Scan the qrcode or enter the code in the login page
    https://www.ubuntu-it.org/
               1340
 
-  1. Wait for the QR code scan result
+  1. Wait for authentication result
   2. Regenerate code
 Or enter 'r' to go back to select the authentication method
 Choose action:
 > 2
-== Qr Code authentication ==
+== Use a QR code ==
 Scan the qrcode or enter the code in the login page
 █████████████████████████████████
 █████████████████████████████████
@@ -968,7 +968,7 @@ Scan the qrcode or enter the code in the login page
        https://ubuntu.com
               1341
 
-  1. Wait for the QR code scan result
+  1. Wait for authentication result
   2. Regenerate code
 Or enter 'r' to go back to select the authentication method
 Choose action:
@@ -997,7 +997,7 @@ Gimme your password:
 Or enter 'r' to go back to choose the provider
 Choose your authentication method:
 > 7
-== Qr Code authentication ==
+== Use a QR code ==
 Scan the qrcode or enter the code in the login page
 █████████████████████████████████
 █████████████████████████████████
@@ -1019,12 +1019,12 @@ Scan the qrcode or enter the code in the login page
        https://ubuntu.com
               1337
 
-  1. Wait for the QR code scan result
+  1. Wait for authentication result
   2. Regenerate code
 Or enter 'r' to go back to select the authentication method
 Choose action:
 > 2
-== Qr Code authentication ==
+== Use a QR code ==
 Scan the qrcode or enter the code in the login page
 █████████████████████████████████
 █████████████████████████████████
@@ -1046,12 +1046,12 @@ Scan the qrcode or enter the code in the login page
        https://ubuntu.fr/
               1338
 
-  1. Wait for the QR code scan result
+  1. Wait for authentication result
   2. Regenerate code
 Or enter 'r' to go back to select the authentication method
 Choose action:
 > 2
-== Qr Code authentication ==
+== Use a QR code ==
 Scan the qrcode or enter the code in the login page
 █████████████████████████████████████
 █████████████████████████████████████
@@ -1075,12 +1075,12 @@ Scan the qrcode or enter the code in the login page
      https://ubuntuforum-br.org/
                 1339
 
-  1. Wait for the QR code scan result
+  1. Wait for authentication result
   2. Regenerate code
 Or enter 'r' to go back to select the authentication method
 Choose action:
 > 2
-== Qr Code authentication ==
+== Use a QR code ==
 Scan the qrcode or enter the code in the login page
 █████████████████████████████████
 █████████████████████████████████
@@ -1102,12 +1102,12 @@ Scan the qrcode or enter the code in the login page
    https://www.ubuntu-it.org/
               1340
 
-  1. Wait for the QR code scan result
+  1. Wait for authentication result
   2. Regenerate code
 Or enter 'r' to go back to select the authentication method
 Choose action:
 > 2
-== Qr Code authentication ==
+== Use a QR code ==
 Scan the qrcode or enter the code in the login page
 █████████████████████████████████
 █████████████████████████████████
@@ -1129,7 +1129,7 @@ Scan the qrcode or enter the code in the login page
        https://ubuntu.com
               1341
 
-  1. Wait for the QR code scan result
+  1. Wait for authentication result
   2. Regenerate code
 Or enter 'r' to go back to select the authentication method
 Choose action:
@@ -1158,7 +1158,7 @@ Gimme your password:
 Or enter 'r' to go back to choose the provider
 Choose your authentication method:
 > 7
-== Qr Code authentication ==
+== Use a QR code ==
 Scan the qrcode or enter the code in the login page
 █████████████████████████████████
 █████████████████████████████████
@@ -1180,12 +1180,12 @@ Scan the qrcode or enter the code in the login page
        https://ubuntu.com
               1337
 
-  1. Wait for the QR code scan result
+  1. Wait for authentication result
   2. Regenerate code
 Or enter 'r' to go back to select the authentication method
 Choose action:
 > 2
-== Qr Code authentication ==
+== Use a QR code ==
 Scan the qrcode or enter the code in the login page
 █████████████████████████████████
 █████████████████████████████████
@@ -1207,12 +1207,12 @@ Scan the qrcode or enter the code in the login page
        https://ubuntu.fr/
               1338
 
-  1. Wait for the QR code scan result
+  1. Wait for authentication result
   2. Regenerate code
 Or enter 'r' to go back to select the authentication method
 Choose action:
 > 2
-== Qr Code authentication ==
+== Use a QR code ==
 Scan the qrcode or enter the code in the login page
 █████████████████████████████████████
 █████████████████████████████████████
@@ -1236,12 +1236,12 @@ Scan the qrcode or enter the code in the login page
      https://ubuntuforum-br.org/
                 1339
 
-  1. Wait for the QR code scan result
+  1. Wait for authentication result
   2. Regenerate code
 Or enter 'r' to go back to select the authentication method
 Choose action:
 > 2
-== Qr Code authentication ==
+== Use a QR code ==
 Scan the qrcode or enter the code in the login page
 █████████████████████████████████
 █████████████████████████████████
@@ -1263,12 +1263,12 @@ Scan the qrcode or enter the code in the login page
    https://www.ubuntu-it.org/
               1340
 
-  1. Wait for the QR code scan result
+  1. Wait for authentication result
   2. Regenerate code
 Or enter 'r' to go back to select the authentication method
 Choose action:
 > 2
-== Qr Code authentication ==
+== Use a QR code ==
 Scan the qrcode or enter the code in the login page
 █████████████████████████████████
 █████████████████████████████████
@@ -1290,7 +1290,7 @@ Scan the qrcode or enter the code in the login page
        https://ubuntu.com
               1341
 
-  1. Wait for the QR code scan result
+  1. Wait for authentication result
   2. Regenerate code
 Or enter 'r' to go back to select the authentication method
 Choose action:

--- a/pam/integration-tests/testdata/golden/TestNativeAuthenticate/Authenticate_user_with_qr_code_in_a_TTY
+++ b/pam/integration-tests/testdata/golden/TestNativeAuthenticate/Authenticate_user_with_qr_code_in_a_TTY
@@ -96,7 +96,7 @@ Gimme your password:
 Or enter 'r' to go back to choose the provider
 Choose your authentication method:
 > 7
-== Qr Code authentication ==
+== Use a QR code ==
 Scan the qrcode or enter the code in the login page
 ██████████████████████████████████████████████████████████████████
 ██████████████████████████████████████████████████████████████████
@@ -134,7 +134,7 @@ Scan the qrcode or enter the code in the login page
                         https://ubuntu.com
                                1337
 
-  1. Wait for the QR code scan result
+  1. Wait for authentication result
   2. Regenerate code
 Or enter 'r' to go back to select the authentication method
 Choose action:
@@ -163,7 +163,7 @@ Gimme your password:
 Or enter 'r' to go back to choose the provider
 Choose your authentication method:
 > 7
-== Qr Code authentication ==
+== Use a QR code ==
 Scan the qrcode or enter the code in the login page
 ██████████████████████████████████████████████████████████████████
 ██████████████████████████████████████████████████████████████████
@@ -201,7 +201,7 @@ Scan the qrcode or enter the code in the login page
                         https://ubuntu.com
                                1337
 
-  1. Wait for the QR code scan result
+  1. Wait for authentication result
   2. Regenerate code
 Or enter 'r' to go back to select the authentication method
 Choose action:
@@ -230,7 +230,7 @@ Gimme your password:
 Or enter 'r' to go back to choose the provider
 Choose your authentication method:
 > 7
-== Qr Code authentication ==
+== Use a QR code ==
 Scan the qrcode or enter the code in the login page
 ██████████████████████████████████████████████████████████████████
 ██████████████████████████████████████████████████████████████████
@@ -268,12 +268,12 @@ Scan the qrcode or enter the code in the login page
                         https://ubuntu.com
                                1337
 
-  1. Wait for the QR code scan result
+  1. Wait for authentication result
   2. Regenerate code
 Or enter 'r' to go back to select the authentication method
 Choose action:
 > 2
-== Qr Code authentication ==
+== Use a QR code ==
 Scan the qrcode or enter the code in the login page
 ██████████████████████████████████████████████████████████████████
 ██████████████████████████████████████████████████████████████████
@@ -311,7 +311,7 @@ Scan the qrcode or enter the code in the login page
                         https://ubuntu.fr/
                                1338
 
-  1. Wait for the QR code scan result
+  1. Wait for authentication result
   2. Regenerate code
 Or enter 'r' to go back to select the authentication method
 Choose action:
@@ -340,7 +340,7 @@ Gimme your password:
 Or enter 'r' to go back to choose the provider
 Choose your authentication method:
 > 7
-== Qr Code authentication ==
+== Use a QR code ==
 Scan the qrcode or enter the code in the login page
 ██████████████████████████████████████████████████████████████████
 ██████████████████████████████████████████████████████████████████
@@ -378,12 +378,12 @@ Scan the qrcode or enter the code in the login page
                         https://ubuntu.com
                                1337
 
-  1. Wait for the QR code scan result
+  1. Wait for authentication result
   2. Regenerate code
 Or enter 'r' to go back to select the authentication method
 Choose action:
 > 2
-== Qr Code authentication ==
+== Use a QR code ==
 Scan the qrcode or enter the code in the login page
 ██████████████████████████████████████████████████████████████████
 ██████████████████████████████████████████████████████████████████
@@ -421,7 +421,7 @@ Scan the qrcode or enter the code in the login page
                         https://ubuntu.fr/
                                1338
 
-  1. Wait for the QR code scan result
+  1. Wait for authentication result
   2. Regenerate code
 Or enter 'r' to go back to select the authentication method
 Choose action:
@@ -450,7 +450,7 @@ Gimme your password:
 Or enter 'r' to go back to choose the provider
 Choose your authentication method:
 > 7
-== Qr Code authentication ==
+== Use a QR code ==
 Scan the qrcode or enter the code in the login page
 ██████████████████████████████████████████████████████████████████
 ██████████████████████████████████████████████████████████████████
@@ -488,12 +488,12 @@ Scan the qrcode or enter the code in the login page
                         https://ubuntu.com
                                1337
 
-  1. Wait for the QR code scan result
+  1. Wait for authentication result
   2. Regenerate code
 Or enter 'r' to go back to select the authentication method
 Choose action:
 > 2
-== Qr Code authentication ==
+== Use a QR code ==
 Scan the qrcode or enter the code in the login page
 ██████████████████████████████████████████████████████████████████
 ██████████████████████████████████████████████████████████████████
@@ -531,12 +531,12 @@ Scan the qrcode or enter the code in the login page
                         https://ubuntu.fr/
                                1338
 
-  1. Wait for the QR code scan result
+  1. Wait for authentication result
   2. Regenerate code
 Or enter 'r' to go back to select the authentication method
 Choose action:
 > 2
-== Qr Code authentication ==
+== Use a QR code ==
 Scan the qrcode or enter the code in the login page
 ██████████████████████████████████████████████████████████████████████████
 ██████████████████████████████████████████████████████████████████████████
@@ -578,7 +578,7 @@ Scan the qrcode or enter the code in the login page
                        https://ubuntuforum-br.org/
                                    1339
 
-  1. Wait for the QR code scan result
+  1. Wait for authentication result
   2. Regenerate code
 Or enter 'r' to go back to select the authentication method
 Choose action:
@@ -607,7 +607,7 @@ Gimme your password:
 Or enter 'r' to go back to choose the provider
 Choose your authentication method:
 > 7
-== Qr Code authentication ==
+== Use a QR code ==
 Scan the qrcode or enter the code in the login page
 ██████████████████████████████████████████████████████████████████
 ██████████████████████████████████████████████████████████████████
@@ -645,12 +645,12 @@ Scan the qrcode or enter the code in the login page
                         https://ubuntu.com
                                1337
 
-  1. Wait for the QR code scan result
+  1. Wait for authentication result
   2. Regenerate code
 Or enter 'r' to go back to select the authentication method
 Choose action:
 > 2
-== Qr Code authentication ==
+== Use a QR code ==
 Scan the qrcode or enter the code in the login page
 ██████████████████████████████████████████████████████████████████
 ██████████████████████████████████████████████████████████████████
@@ -688,12 +688,12 @@ Scan the qrcode or enter the code in the login page
                         https://ubuntu.fr/
                                1338
 
-  1. Wait for the QR code scan result
+  1. Wait for authentication result
   2. Regenerate code
 Or enter 'r' to go back to select the authentication method
 Choose action:
 > 2
-== Qr Code authentication ==
+== Use a QR code ==
 Scan the qrcode or enter the code in the login page
 ██████████████████████████████████████████████████████████████████████████
 ██████████████████████████████████████████████████████████████████████████
@@ -735,7 +735,7 @@ Scan the qrcode or enter the code in the login page
                        https://ubuntuforum-br.org/
                                    1339
 
-  1. Wait for the QR code scan result
+  1. Wait for authentication result
   2. Regenerate code
 Or enter 'r' to go back to select the authentication method
 Choose action:
@@ -764,7 +764,7 @@ Gimme your password:
 Or enter 'r' to go back to choose the provider
 Choose your authentication method:
 > 7
-== Qr Code authentication ==
+== Use a QR code ==
 Scan the qrcode or enter the code in the login page
 ██████████████████████████████████████████████████████████████████
 ██████████████████████████████████████████████████████████████████
@@ -802,12 +802,12 @@ Scan the qrcode or enter the code in the login page
                         https://ubuntu.com
                                1337
 
-  1. Wait for the QR code scan result
+  1. Wait for authentication result
   2. Regenerate code
 Or enter 'r' to go back to select the authentication method
 Choose action:
 > 2
-== Qr Code authentication ==
+== Use a QR code ==
 Scan the qrcode or enter the code in the login page
 ██████████████████████████████████████████████████████████████████
 ██████████████████████████████████████████████████████████████████
@@ -845,12 +845,12 @@ Scan the qrcode or enter the code in the login page
                         https://ubuntu.fr/
                                1338
 
-  1. Wait for the QR code scan result
+  1. Wait for authentication result
   2. Regenerate code
 Or enter 'r' to go back to select the authentication method
 Choose action:
 > 2
-== Qr Code authentication ==
+== Use a QR code ==
 Scan the qrcode or enter the code in the login page
 ██████████████████████████████████████████████████████████████████████████
 ██████████████████████████████████████████████████████████████████████████
@@ -892,12 +892,12 @@ Scan the qrcode or enter the code in the login page
                        https://ubuntuforum-br.org/
                                    1339
 
-  1. Wait for the QR code scan result
+  1. Wait for authentication result
   2. Regenerate code
 Or enter 'r' to go back to select the authentication method
 Choose action:
 > 2
-== Qr Code authentication ==
+== Use a QR code ==
 Scan the qrcode or enter the code in the login page
 ██████████████████████████████████████████████████████████████████
 ██████████████████████████████████████████████████████████████████
@@ -935,7 +935,7 @@ Scan the qrcode or enter the code in the login page
                     https://www.ubuntu-it.org/
                                1340
 
-  1. Wait for the QR code scan result
+  1. Wait for authentication result
   2. Regenerate code
 Or enter 'r' to go back to select the authentication method
 Choose action:
@@ -964,7 +964,7 @@ Gimme your password:
 Or enter 'r' to go back to choose the provider
 Choose your authentication method:
 > 7
-== Qr Code authentication ==
+== Use a QR code ==
 Scan the qrcode or enter the code in the login page
 ██████████████████████████████████████████████████████████████████
 ██████████████████████████████████████████████████████████████████
@@ -1002,12 +1002,12 @@ Scan the qrcode or enter the code in the login page
                         https://ubuntu.com
                                1337
 
-  1. Wait for the QR code scan result
+  1. Wait for authentication result
   2. Regenerate code
 Or enter 'r' to go back to select the authentication method
 Choose action:
 > 2
-== Qr Code authentication ==
+== Use a QR code ==
 Scan the qrcode or enter the code in the login page
 ██████████████████████████████████████████████████████████████████
 ██████████████████████████████████████████████████████████████████
@@ -1045,12 +1045,12 @@ Scan the qrcode or enter the code in the login page
                         https://ubuntu.fr/
                                1338
 
-  1. Wait for the QR code scan result
+  1. Wait for authentication result
   2. Regenerate code
 Or enter 'r' to go back to select the authentication method
 Choose action:
 > 2
-== Qr Code authentication ==
+== Use a QR code ==
 Scan the qrcode or enter the code in the login page
 ██████████████████████████████████████████████████████████████████████████
 ██████████████████████████████████████████████████████████████████████████
@@ -1092,12 +1092,12 @@ Scan the qrcode or enter the code in the login page
                        https://ubuntuforum-br.org/
                                    1339
 
-  1. Wait for the QR code scan result
+  1. Wait for authentication result
   2. Regenerate code
 Or enter 'r' to go back to select the authentication method
 Choose action:
 > 2
-== Qr Code authentication ==
+== Use a QR code ==
 Scan the qrcode or enter the code in the login page
 ██████████████████████████████████████████████████████████████████
 ██████████████████████████████████████████████████████████████████
@@ -1135,7 +1135,7 @@ Scan the qrcode or enter the code in the login page
                     https://www.ubuntu-it.org/
                                1340
 
-  1. Wait for the QR code scan result
+  1. Wait for authentication result
   2. Regenerate code
 Or enter 'r' to go back to select the authentication method
 Choose action:
@@ -1164,7 +1164,7 @@ Gimme your password:
 Or enter 'r' to go back to choose the provider
 Choose your authentication method:
 > 7
-== Qr Code authentication ==
+== Use a QR code ==
 Scan the qrcode or enter the code in the login page
 ██████████████████████████████████████████████████████████████████
 ██████████████████████████████████████████████████████████████████
@@ -1202,12 +1202,12 @@ Scan the qrcode or enter the code in the login page
                         https://ubuntu.com
                                1337
 
-  1. Wait for the QR code scan result
+  1. Wait for authentication result
   2. Regenerate code
 Or enter 'r' to go back to select the authentication method
 Choose action:
 > 2
-== Qr Code authentication ==
+== Use a QR code ==
 Scan the qrcode or enter the code in the login page
 ██████████████████████████████████████████████████████████████████
 ██████████████████████████████████████████████████████████████████
@@ -1245,12 +1245,12 @@ Scan the qrcode or enter the code in the login page
                         https://ubuntu.fr/
                                1338
 
-  1. Wait for the QR code scan result
+  1. Wait for authentication result
   2. Regenerate code
 Or enter 'r' to go back to select the authentication method
 Choose action:
 > 2
-== Qr Code authentication ==
+== Use a QR code ==
 Scan the qrcode or enter the code in the login page
 ██████████████████████████████████████████████████████████████████████████
 ██████████████████████████████████████████████████████████████████████████
@@ -1292,12 +1292,12 @@ Scan the qrcode or enter the code in the login page
                        https://ubuntuforum-br.org/
                                    1339
 
-  1. Wait for the QR code scan result
+  1. Wait for authentication result
   2. Regenerate code
 Or enter 'r' to go back to select the authentication method
 Choose action:
 > 2
-== Qr Code authentication ==
+== Use a QR code ==
 Scan the qrcode or enter the code in the login page
 ██████████████████████████████████████████████████████████████████
 ██████████████████████████████████████████████████████████████████
@@ -1335,12 +1335,12 @@ Scan the qrcode or enter the code in the login page
                     https://www.ubuntu-it.org/
                                1340
 
-  1. Wait for the QR code scan result
+  1. Wait for authentication result
   2. Regenerate code
 Or enter 'r' to go back to select the authentication method
 Choose action:
 > 2
-== Qr Code authentication ==
+== Use a QR code ==
 Scan the qrcode or enter the code in the login page
 ██████████████████████████████████████████████████████████████████
 ██████████████████████████████████████████████████████████████████
@@ -1378,7 +1378,7 @@ Scan the qrcode or enter the code in the login page
                         https://ubuntu.com
                                1341
 
-  1. Wait for the QR code scan result
+  1. Wait for authentication result
   2. Regenerate code
 Or enter 'r' to go back to select the authentication method
 Choose action:
@@ -1407,7 +1407,7 @@ Gimme your password:
 Or enter 'r' to go back to choose the provider
 Choose your authentication method:
 > 7
-== Qr Code authentication ==
+== Use a QR code ==
 Scan the qrcode or enter the code in the login page
 ██████████████████████████████████████████████████████████████████
 ██████████████████████████████████████████████████████████████████
@@ -1445,12 +1445,12 @@ Scan the qrcode or enter the code in the login page
                         https://ubuntu.com
                                1337
 
-  1. Wait for the QR code scan result
+  1. Wait for authentication result
   2. Regenerate code
 Or enter 'r' to go back to select the authentication method
 Choose action:
 > 2
-== Qr Code authentication ==
+== Use a QR code ==
 Scan the qrcode or enter the code in the login page
 ██████████████████████████████████████████████████████████████████
 ██████████████████████████████████████████████████████████████████
@@ -1488,12 +1488,12 @@ Scan the qrcode or enter the code in the login page
                         https://ubuntu.fr/
                                1338
 
-  1. Wait for the QR code scan result
+  1. Wait for authentication result
   2. Regenerate code
 Or enter 'r' to go back to select the authentication method
 Choose action:
 > 2
-== Qr Code authentication ==
+== Use a QR code ==
 Scan the qrcode or enter the code in the login page
 ██████████████████████████████████████████████████████████████████████████
 ██████████████████████████████████████████████████████████████████████████
@@ -1535,12 +1535,12 @@ Scan the qrcode or enter the code in the login page
                        https://ubuntuforum-br.org/
                                    1339
 
-  1. Wait for the QR code scan result
+  1. Wait for authentication result
   2. Regenerate code
 Or enter 'r' to go back to select the authentication method
 Choose action:
 > 2
-== Qr Code authentication ==
+== Use a QR code ==
 Scan the qrcode or enter the code in the login page
 ██████████████████████████████████████████████████████████████████
 ██████████████████████████████████████████████████████████████████
@@ -1578,12 +1578,12 @@ Scan the qrcode or enter the code in the login page
                     https://www.ubuntu-it.org/
                                1340
 
-  1. Wait for the QR code scan result
+  1. Wait for authentication result
   2. Regenerate code
 Or enter 'r' to go back to select the authentication method
 Choose action:
 > 2
-== Qr Code authentication ==
+== Use a QR code ==
 Scan the qrcode or enter the code in the login page
 ██████████████████████████████████████████████████████████████████
 ██████████████████████████████████████████████████████████████████
@@ -1621,7 +1621,7 @@ Scan the qrcode or enter the code in the login page
                         https://ubuntu.com
                                1341
 
-  1. Wait for the QR code scan result
+  1. Wait for authentication result
   2. Regenerate code
 Or enter 'r' to go back to select the authentication method
 Choose action:
@@ -1650,7 +1650,7 @@ Gimme your password:
 Or enter 'r' to go back to choose the provider
 Choose your authentication method:
 > 7
-== Qr Code authentication ==
+== Use a QR code ==
 Scan the qrcode or enter the code in the login page
 ██████████████████████████████████████████████████████████████████
 ██████████████████████████████████████████████████████████████████
@@ -1688,12 +1688,12 @@ Scan the qrcode or enter the code in the login page
                         https://ubuntu.com
                                1337
 
-  1. Wait for the QR code scan result
+  1. Wait for authentication result
   2. Regenerate code
 Or enter 'r' to go back to select the authentication method
 Choose action:
 > 2
-== Qr Code authentication ==
+== Use a QR code ==
 Scan the qrcode or enter the code in the login page
 ██████████████████████████████████████████████████████████████████
 ██████████████████████████████████████████████████████████████████
@@ -1731,12 +1731,12 @@ Scan the qrcode or enter the code in the login page
                         https://ubuntu.fr/
                                1338
 
-  1. Wait for the QR code scan result
+  1. Wait for authentication result
   2. Regenerate code
 Or enter 'r' to go back to select the authentication method
 Choose action:
 > 2
-== Qr Code authentication ==
+== Use a QR code ==
 Scan the qrcode or enter the code in the login page
 ██████████████████████████████████████████████████████████████████████████
 ██████████████████████████████████████████████████████████████████████████
@@ -1778,12 +1778,12 @@ Scan the qrcode or enter the code in the login page
                        https://ubuntuforum-br.org/
                                    1339
 
-  1. Wait for the QR code scan result
+  1. Wait for authentication result
   2. Regenerate code
 Or enter 'r' to go back to select the authentication method
 Choose action:
 > 2
-== Qr Code authentication ==
+== Use a QR code ==
 Scan the qrcode or enter the code in the login page
 ██████████████████████████████████████████████████████████████████
 ██████████████████████████████████████████████████████████████████
@@ -1821,12 +1821,12 @@ Scan the qrcode or enter the code in the login page
                     https://www.ubuntu-it.org/
                                1340
 
-  1. Wait for the QR code scan result
+  1. Wait for authentication result
   2. Regenerate code
 Or enter 'r' to go back to select the authentication method
 Choose action:
 > 2
-== Qr Code authentication ==
+== Use a QR code ==
 Scan the qrcode or enter the code in the login page
 ██████████████████████████████████████████████████████████████████
 ██████████████████████████████████████████████████████████████████
@@ -1864,7 +1864,7 @@ Scan the qrcode or enter the code in the login page
                         https://ubuntu.com
                                1341
 
-  1. Wait for the QR code scan result
+  1. Wait for authentication result
   2. Regenerate code
 Or enter 'r' to go back to select the authentication method
 Choose action:

--- a/pam/integration-tests/testdata/golden/TestNativeAuthenticate/Authenticate_user_with_qr_code_in_a_TTY_session
+++ b/pam/integration-tests/testdata/golden/TestNativeAuthenticate/Authenticate_user_with_qr_code_in_a_TTY_session
@@ -96,7 +96,7 @@ Gimme your password:
 Or enter 'r' to go back to choose the provider
 Choose your authentication method:
 > 7
-== Qr Code authentication ==
+== Use a QR code ==
 Scan the qrcode or enter the code in the login page
 ██████████████████████████████████████████████████████████████████
 ██████████████████████████████████████████████████████████████████
@@ -134,7 +134,7 @@ Scan the qrcode or enter the code in the login page
                         https://ubuntu.com
                                1337
 
-  1. Wait for the QR code scan result
+  1. Wait for authentication result
   2. Regenerate code
 Or enter 'r' to go back to select the authentication method
 Choose action:
@@ -163,7 +163,7 @@ Gimme your password:
 Or enter 'r' to go back to choose the provider
 Choose your authentication method:
 > 7
-== Qr Code authentication ==
+== Use a QR code ==
 Scan the qrcode or enter the code in the login page
 ██████████████████████████████████████████████████████████████████
 ██████████████████████████████████████████████████████████████████
@@ -201,7 +201,7 @@ Scan the qrcode or enter the code in the login page
                         https://ubuntu.com
                                1337
 
-  1. Wait for the QR code scan result
+  1. Wait for authentication result
   2. Regenerate code
 Or enter 'r' to go back to select the authentication method
 Choose action:
@@ -230,7 +230,7 @@ Gimme your password:
 Or enter 'r' to go back to choose the provider
 Choose your authentication method:
 > 7
-== Qr Code authentication ==
+== Use a QR code ==
 Scan the qrcode or enter the code in the login page
 ██████████████████████████████████████████████████████████████████
 ██████████████████████████████████████████████████████████████████
@@ -268,12 +268,12 @@ Scan the qrcode or enter the code in the login page
                         https://ubuntu.com
                                1337
 
-  1. Wait for the QR code scan result
+  1. Wait for authentication result
   2. Regenerate code
 Or enter 'r' to go back to select the authentication method
 Choose action:
 > 2
-== Qr Code authentication ==
+== Use a QR code ==
 Scan the qrcode or enter the code in the login page
 ██████████████████████████████████████████████████████████████████
 ██████████████████████████████████████████████████████████████████
@@ -311,7 +311,7 @@ Scan the qrcode or enter the code in the login page
                         https://ubuntu.fr/
                                1338
 
-  1. Wait for the QR code scan result
+  1. Wait for authentication result
   2. Regenerate code
 Or enter 'r' to go back to select the authentication method
 Choose action:
@@ -340,7 +340,7 @@ Gimme your password:
 Or enter 'r' to go back to choose the provider
 Choose your authentication method:
 > 7
-== Qr Code authentication ==
+== Use a QR code ==
 Scan the qrcode or enter the code in the login page
 ██████████████████████████████████████████████████████████████████
 ██████████████████████████████████████████████████████████████████
@@ -378,12 +378,12 @@ Scan the qrcode or enter the code in the login page
                         https://ubuntu.com
                                1337
 
-  1. Wait for the QR code scan result
+  1. Wait for authentication result
   2. Regenerate code
 Or enter 'r' to go back to select the authentication method
 Choose action:
 > 2
-== Qr Code authentication ==
+== Use a QR code ==
 Scan the qrcode or enter the code in the login page
 ██████████████████████████████████████████████████████████████████
 ██████████████████████████████████████████████████████████████████
@@ -421,7 +421,7 @@ Scan the qrcode or enter the code in the login page
                         https://ubuntu.fr/
                                1338
 
-  1. Wait for the QR code scan result
+  1. Wait for authentication result
   2. Regenerate code
 Or enter 'r' to go back to select the authentication method
 Choose action:
@@ -450,7 +450,7 @@ Gimme your password:
 Or enter 'r' to go back to choose the provider
 Choose your authentication method:
 > 7
-== Qr Code authentication ==
+== Use a QR code ==
 Scan the qrcode or enter the code in the login page
 ██████████████████████████████████████████████████████████████████
 ██████████████████████████████████████████████████████████████████
@@ -488,12 +488,12 @@ Scan the qrcode or enter the code in the login page
                         https://ubuntu.com
                                1337
 
-  1. Wait for the QR code scan result
+  1. Wait for authentication result
   2. Regenerate code
 Or enter 'r' to go back to select the authentication method
 Choose action:
 > 2
-== Qr Code authentication ==
+== Use a QR code ==
 Scan the qrcode or enter the code in the login page
 ██████████████████████████████████████████████████████████████████
 ██████████████████████████████████████████████████████████████████
@@ -531,12 +531,12 @@ Scan the qrcode or enter the code in the login page
                         https://ubuntu.fr/
                                1338
 
-  1. Wait for the QR code scan result
+  1. Wait for authentication result
   2. Regenerate code
 Or enter 'r' to go back to select the authentication method
 Choose action:
 > 2
-== Qr Code authentication ==
+== Use a QR code ==
 Scan the qrcode or enter the code in the login page
 ██████████████████████████████████████████████████████████████████████████
 ██████████████████████████████████████████████████████████████████████████
@@ -578,7 +578,7 @@ Scan the qrcode or enter the code in the login page
                        https://ubuntuforum-br.org/
                                    1339
 
-  1. Wait for the QR code scan result
+  1. Wait for authentication result
   2. Regenerate code
 Or enter 'r' to go back to select the authentication method
 Choose action:
@@ -607,7 +607,7 @@ Gimme your password:
 Or enter 'r' to go back to choose the provider
 Choose your authentication method:
 > 7
-== Qr Code authentication ==
+== Use a QR code ==
 Scan the qrcode or enter the code in the login page
 ██████████████████████████████████████████████████████████████████
 ██████████████████████████████████████████████████████████████████
@@ -645,12 +645,12 @@ Scan the qrcode or enter the code in the login page
                         https://ubuntu.com
                                1337
 
-  1. Wait for the QR code scan result
+  1. Wait for authentication result
   2. Regenerate code
 Or enter 'r' to go back to select the authentication method
 Choose action:
 > 2
-== Qr Code authentication ==
+== Use a QR code ==
 Scan the qrcode or enter the code in the login page
 ██████████████████████████████████████████████████████████████████
 ██████████████████████████████████████████████████████████████████
@@ -688,12 +688,12 @@ Scan the qrcode or enter the code in the login page
                         https://ubuntu.fr/
                                1338
 
-  1. Wait for the QR code scan result
+  1. Wait for authentication result
   2. Regenerate code
 Or enter 'r' to go back to select the authentication method
 Choose action:
 > 2
-== Qr Code authentication ==
+== Use a QR code ==
 Scan the qrcode or enter the code in the login page
 ██████████████████████████████████████████████████████████████████████████
 ██████████████████████████████████████████████████████████████████████████
@@ -735,7 +735,7 @@ Scan the qrcode or enter the code in the login page
                        https://ubuntuforum-br.org/
                                    1339
 
-  1. Wait for the QR code scan result
+  1. Wait for authentication result
   2. Regenerate code
 Or enter 'r' to go back to select the authentication method
 Choose action:
@@ -764,7 +764,7 @@ Gimme your password:
 Or enter 'r' to go back to choose the provider
 Choose your authentication method:
 > 7
-== Qr Code authentication ==
+== Use a QR code ==
 Scan the qrcode or enter the code in the login page
 ██████████████████████████████████████████████████████████████████
 ██████████████████████████████████████████████████████████████████
@@ -802,12 +802,12 @@ Scan the qrcode or enter the code in the login page
                         https://ubuntu.com
                                1337
 
-  1. Wait for the QR code scan result
+  1. Wait for authentication result
   2. Regenerate code
 Or enter 'r' to go back to select the authentication method
 Choose action:
 > 2
-== Qr Code authentication ==
+== Use a QR code ==
 Scan the qrcode or enter the code in the login page
 ██████████████████████████████████████████████████████████████████
 ██████████████████████████████████████████████████████████████████
@@ -845,12 +845,12 @@ Scan the qrcode or enter the code in the login page
                         https://ubuntu.fr/
                                1338
 
-  1. Wait for the QR code scan result
+  1. Wait for authentication result
   2. Regenerate code
 Or enter 'r' to go back to select the authentication method
 Choose action:
 > 2
-== Qr Code authentication ==
+== Use a QR code ==
 Scan the qrcode or enter the code in the login page
 ██████████████████████████████████████████████████████████████████████████
 ██████████████████████████████████████████████████████████████████████████
@@ -892,12 +892,12 @@ Scan the qrcode or enter the code in the login page
                        https://ubuntuforum-br.org/
                                    1339
 
-  1. Wait for the QR code scan result
+  1. Wait for authentication result
   2. Regenerate code
 Or enter 'r' to go back to select the authentication method
 Choose action:
 > 2
-== Qr Code authentication ==
+== Use a QR code ==
 Scan the qrcode or enter the code in the login page
 ██████████████████████████████████████████████████████████████████
 ██████████████████████████████████████████████████████████████████
@@ -935,7 +935,7 @@ Scan the qrcode or enter the code in the login page
                     https://www.ubuntu-it.org/
                                1340
 
-  1. Wait for the QR code scan result
+  1. Wait for authentication result
   2. Regenerate code
 Or enter 'r' to go back to select the authentication method
 Choose action:
@@ -964,7 +964,7 @@ Gimme your password:
 Or enter 'r' to go back to choose the provider
 Choose your authentication method:
 > 7
-== Qr Code authentication ==
+== Use a QR code ==
 Scan the qrcode or enter the code in the login page
 ██████████████████████████████████████████████████████████████████
 ██████████████████████████████████████████████████████████████████
@@ -1002,12 +1002,12 @@ Scan the qrcode or enter the code in the login page
                         https://ubuntu.com
                                1337
 
-  1. Wait for the QR code scan result
+  1. Wait for authentication result
   2. Regenerate code
 Or enter 'r' to go back to select the authentication method
 Choose action:
 > 2
-== Qr Code authentication ==
+== Use a QR code ==
 Scan the qrcode or enter the code in the login page
 ██████████████████████████████████████████████████████████████████
 ██████████████████████████████████████████████████████████████████
@@ -1045,12 +1045,12 @@ Scan the qrcode or enter the code in the login page
                         https://ubuntu.fr/
                                1338
 
-  1. Wait for the QR code scan result
+  1. Wait for authentication result
   2. Regenerate code
 Or enter 'r' to go back to select the authentication method
 Choose action:
 > 2
-== Qr Code authentication ==
+== Use a QR code ==
 Scan the qrcode or enter the code in the login page
 ██████████████████████████████████████████████████████████████████████████
 ██████████████████████████████████████████████████████████████████████████
@@ -1092,12 +1092,12 @@ Scan the qrcode or enter the code in the login page
                        https://ubuntuforum-br.org/
                                    1339
 
-  1. Wait for the QR code scan result
+  1. Wait for authentication result
   2. Regenerate code
 Or enter 'r' to go back to select the authentication method
 Choose action:
 > 2
-== Qr Code authentication ==
+== Use a QR code ==
 Scan the qrcode or enter the code in the login page
 ██████████████████████████████████████████████████████████████████
 ██████████████████████████████████████████████████████████████████
@@ -1135,7 +1135,7 @@ Scan the qrcode or enter the code in the login page
                     https://www.ubuntu-it.org/
                                1340
 
-  1. Wait for the QR code scan result
+  1. Wait for authentication result
   2. Regenerate code
 Or enter 'r' to go back to select the authentication method
 Choose action:
@@ -1164,7 +1164,7 @@ Gimme your password:
 Or enter 'r' to go back to choose the provider
 Choose your authentication method:
 > 7
-== Qr Code authentication ==
+== Use a QR code ==
 Scan the qrcode or enter the code in the login page
 ██████████████████████████████████████████████████████████████████
 ██████████████████████████████████████████████████████████████████
@@ -1202,12 +1202,12 @@ Scan the qrcode or enter the code in the login page
                         https://ubuntu.com
                                1337
 
-  1. Wait for the QR code scan result
+  1. Wait for authentication result
   2. Regenerate code
 Or enter 'r' to go back to select the authentication method
 Choose action:
 > 2
-== Qr Code authentication ==
+== Use a QR code ==
 Scan the qrcode or enter the code in the login page
 ██████████████████████████████████████████████████████████████████
 ██████████████████████████████████████████████████████████████████
@@ -1245,12 +1245,12 @@ Scan the qrcode or enter the code in the login page
                         https://ubuntu.fr/
                                1338
 
-  1. Wait for the QR code scan result
+  1. Wait for authentication result
   2. Regenerate code
 Or enter 'r' to go back to select the authentication method
 Choose action:
 > 2
-== Qr Code authentication ==
+== Use a QR code ==
 Scan the qrcode or enter the code in the login page
 ██████████████████████████████████████████████████████████████████████████
 ██████████████████████████████████████████████████████████████████████████
@@ -1292,12 +1292,12 @@ Scan the qrcode or enter the code in the login page
                        https://ubuntuforum-br.org/
                                    1339
 
-  1. Wait for the QR code scan result
+  1. Wait for authentication result
   2. Regenerate code
 Or enter 'r' to go back to select the authentication method
 Choose action:
 > 2
-== Qr Code authentication ==
+== Use a QR code ==
 Scan the qrcode or enter the code in the login page
 ██████████████████████████████████████████████████████████████████
 ██████████████████████████████████████████████████████████████████
@@ -1335,12 +1335,12 @@ Scan the qrcode or enter the code in the login page
                     https://www.ubuntu-it.org/
                                1340
 
-  1. Wait for the QR code scan result
+  1. Wait for authentication result
   2. Regenerate code
 Or enter 'r' to go back to select the authentication method
 Choose action:
 > 2
-== Qr Code authentication ==
+== Use a QR code ==
 Scan the qrcode or enter the code in the login page
 ██████████████████████████████████████████████████████████████████
 ██████████████████████████████████████████████████████████████████
@@ -1378,7 +1378,7 @@ Scan the qrcode or enter the code in the login page
                         https://ubuntu.com
                                1341
 
-  1. Wait for the QR code scan result
+  1. Wait for authentication result
   2. Regenerate code
 Or enter 'r' to go back to select the authentication method
 Choose action:
@@ -1407,7 +1407,7 @@ Gimme your password:
 Or enter 'r' to go back to choose the provider
 Choose your authentication method:
 > 7
-== Qr Code authentication ==
+== Use a QR code ==
 Scan the qrcode or enter the code in the login page
 ██████████████████████████████████████████████████████████████████
 ██████████████████████████████████████████████████████████████████
@@ -1445,12 +1445,12 @@ Scan the qrcode or enter the code in the login page
                         https://ubuntu.com
                                1337
 
-  1. Wait for the QR code scan result
+  1. Wait for authentication result
   2. Regenerate code
 Or enter 'r' to go back to select the authentication method
 Choose action:
 > 2
-== Qr Code authentication ==
+== Use a QR code ==
 Scan the qrcode or enter the code in the login page
 ██████████████████████████████████████████████████████████████████
 ██████████████████████████████████████████████████████████████████
@@ -1488,12 +1488,12 @@ Scan the qrcode or enter the code in the login page
                         https://ubuntu.fr/
                                1338
 
-  1. Wait for the QR code scan result
+  1. Wait for authentication result
   2. Regenerate code
 Or enter 'r' to go back to select the authentication method
 Choose action:
 > 2
-== Qr Code authentication ==
+== Use a QR code ==
 Scan the qrcode or enter the code in the login page
 ██████████████████████████████████████████████████████████████████████████
 ██████████████████████████████████████████████████████████████████████████
@@ -1535,12 +1535,12 @@ Scan the qrcode or enter the code in the login page
                        https://ubuntuforum-br.org/
                                    1339
 
-  1. Wait for the QR code scan result
+  1. Wait for authentication result
   2. Regenerate code
 Or enter 'r' to go back to select the authentication method
 Choose action:
 > 2
-== Qr Code authentication ==
+== Use a QR code ==
 Scan the qrcode or enter the code in the login page
 ██████████████████████████████████████████████████████████████████
 ██████████████████████████████████████████████████████████████████
@@ -1578,12 +1578,12 @@ Scan the qrcode or enter the code in the login page
                     https://www.ubuntu-it.org/
                                1340
 
-  1. Wait for the QR code scan result
+  1. Wait for authentication result
   2. Regenerate code
 Or enter 'r' to go back to select the authentication method
 Choose action:
 > 2
-== Qr Code authentication ==
+== Use a QR code ==
 Scan the qrcode or enter the code in the login page
 ██████████████████████████████████████████████████████████████████
 ██████████████████████████████████████████████████████████████████
@@ -1621,7 +1621,7 @@ Scan the qrcode or enter the code in the login page
                         https://ubuntu.com
                                1341
 
-  1. Wait for the QR code scan result
+  1. Wait for authentication result
   2. Regenerate code
 Or enter 'r' to go back to select the authentication method
 Choose action:
@@ -1650,7 +1650,7 @@ Gimme your password:
 Or enter 'r' to go back to choose the provider
 Choose your authentication method:
 > 7
-== Qr Code authentication ==
+== Use a QR code ==
 Scan the qrcode or enter the code in the login page
 ██████████████████████████████████████████████████████████████████
 ██████████████████████████████████████████████████████████████████
@@ -1688,12 +1688,12 @@ Scan the qrcode or enter the code in the login page
                         https://ubuntu.com
                                1337
 
-  1. Wait for the QR code scan result
+  1. Wait for authentication result
   2. Regenerate code
 Or enter 'r' to go back to select the authentication method
 Choose action:
 > 2
-== Qr Code authentication ==
+== Use a QR code ==
 Scan the qrcode or enter the code in the login page
 ██████████████████████████████████████████████████████████████████
 ██████████████████████████████████████████████████████████████████
@@ -1731,12 +1731,12 @@ Scan the qrcode or enter the code in the login page
                         https://ubuntu.fr/
                                1338
 
-  1. Wait for the QR code scan result
+  1. Wait for authentication result
   2. Regenerate code
 Or enter 'r' to go back to select the authentication method
 Choose action:
 > 2
-== Qr Code authentication ==
+== Use a QR code ==
 Scan the qrcode or enter the code in the login page
 ██████████████████████████████████████████████████████████████████████████
 ██████████████████████████████████████████████████████████████████████████
@@ -1778,12 +1778,12 @@ Scan the qrcode or enter the code in the login page
                        https://ubuntuforum-br.org/
                                    1339
 
-  1. Wait for the QR code scan result
+  1. Wait for authentication result
   2. Regenerate code
 Or enter 'r' to go back to select the authentication method
 Choose action:
 > 2
-== Qr Code authentication ==
+== Use a QR code ==
 Scan the qrcode or enter the code in the login page
 ██████████████████████████████████████████████████████████████████
 ██████████████████████████████████████████████████████████████████
@@ -1821,12 +1821,12 @@ Scan the qrcode or enter the code in the login page
                     https://www.ubuntu-it.org/
                                1340
 
-  1. Wait for the QR code scan result
+  1. Wait for authentication result
   2. Regenerate code
 Or enter 'r' to go back to select the authentication method
 Choose action:
 > 2
-== Qr Code authentication ==
+== Use a QR code ==
 Scan the qrcode or enter the code in the login page
 ██████████████████████████████████████████████████████████████████
 ██████████████████████████████████████████████████████████████████
@@ -1864,7 +1864,7 @@ Scan the qrcode or enter the code in the login page
                         https://ubuntu.com
                                1341
 
-  1. Wait for the QR code scan result
+  1. Wait for authentication result
   2. Regenerate code
 Or enter 'r' to go back to select the authentication method
 Choose action:

--- a/pam/integration-tests/testdata/golden/TestNativeAuthenticate/Authenticate_user_with_qr_code_in_polkit
+++ b/pam/integration-tests/testdata/golden/TestNativeAuthenticate/Authenticate_user_with_qr_code_in_polkit
@@ -96,12 +96,12 @@ Gimme your password:
 Or enter 'r' to go back to choose the provider
 Choose your authentication method:
 > 2
-== Qr Code authentication ==
+== Use a Login code ==
 Enter the code in the login page
 https://ubuntu.com
        1337
 
-  1. Wait for the QR code scan result
+  1. Wait for authentication result
   2. Regenerate code
 Or enter 'r' to go back to select the authentication method
 Choose action:
@@ -130,12 +130,12 @@ Gimme your password:
 Or enter 'r' to go back to choose the provider
 Choose your authentication method:
 > 2
-== Qr Code authentication ==
+== Use a Login code ==
 Enter the code in the login page
 https://ubuntu.com
        1337
 
-  1. Wait for the QR code scan result
+  1. Wait for authentication result
   2. Regenerate code
 Or enter 'r' to go back to select the authentication method
 Choose action:
@@ -164,22 +164,22 @@ Gimme your password:
 Or enter 'r' to go back to choose the provider
 Choose your authentication method:
 > 2
-== Qr Code authentication ==
+== Use a Login code ==
 Enter the code in the login page
 https://ubuntu.com
        1337
 
-  1. Wait for the QR code scan result
+  1. Wait for authentication result
   2. Regenerate code
 Or enter 'r' to go back to select the authentication method
 Choose action:
 > 2
-== Qr Code authentication ==
+== Use a Login code ==
 Enter the code in the login page
 https://ubuntu.fr/
        1338
 
-  1. Wait for the QR code scan result
+  1. Wait for authentication result
   2. Regenerate code
 Or enter 'r' to go back to select the authentication method
 Choose action:
@@ -208,22 +208,22 @@ Gimme your password:
 Or enter 'r' to go back to choose the provider
 Choose your authentication method:
 > 2
-== Qr Code authentication ==
+== Use a Login code ==
 Enter the code in the login page
 https://ubuntu.com
        1337
 
-  1. Wait for the QR code scan result
+  1. Wait for authentication result
   2. Regenerate code
 Or enter 'r' to go back to select the authentication method
 Choose action:
 > 2
-== Qr Code authentication ==
+== Use a Login code ==
 Enter the code in the login page
 https://ubuntu.fr/
        1338
 
-  1. Wait for the QR code scan result
+  1. Wait for authentication result
   2. Regenerate code
 Or enter 'r' to go back to select the authentication method
 Choose action:
@@ -252,32 +252,32 @@ Gimme your password:
 Or enter 'r' to go back to choose the provider
 Choose your authentication method:
 > 2
-== Qr Code authentication ==
+== Use a Login code ==
 Enter the code in the login page
 https://ubuntu.com
        1337
 
-  1. Wait for the QR code scan result
+  1. Wait for authentication result
   2. Regenerate code
 Or enter 'r' to go back to select the authentication method
 Choose action:
 > 2
-== Qr Code authentication ==
+== Use a Login code ==
 Enter the code in the login page
 https://ubuntu.fr/
        1338
 
-  1. Wait for the QR code scan result
+  1. Wait for authentication result
   2. Regenerate code
 Or enter 'r' to go back to select the authentication method
 Choose action:
 > 2
-== Qr Code authentication ==
+== Use a Login code ==
 Enter the code in the login page
 https://ubuntuforum-br.org/
            1339
 
-  1. Wait for the QR code scan result
+  1. Wait for authentication result
   2. Regenerate code
 Or enter 'r' to go back to select the authentication method
 Choose action:
@@ -306,32 +306,32 @@ Gimme your password:
 Or enter 'r' to go back to choose the provider
 Choose your authentication method:
 > 2
-== Qr Code authentication ==
+== Use a Login code ==
 Enter the code in the login page
 https://ubuntu.com
        1337
 
-  1. Wait for the QR code scan result
+  1. Wait for authentication result
   2. Regenerate code
 Or enter 'r' to go back to select the authentication method
 Choose action:
 > 2
-== Qr Code authentication ==
+== Use a Login code ==
 Enter the code in the login page
 https://ubuntu.fr/
        1338
 
-  1. Wait for the QR code scan result
+  1. Wait for authentication result
   2. Regenerate code
 Or enter 'r' to go back to select the authentication method
 Choose action:
 > 2
-== Qr Code authentication ==
+== Use a Login code ==
 Enter the code in the login page
 https://ubuntuforum-br.org/
            1339
 
-  1. Wait for the QR code scan result
+  1. Wait for authentication result
   2. Regenerate code
 Or enter 'r' to go back to select the authentication method
 Choose action:
@@ -360,42 +360,42 @@ Gimme your password:
 Or enter 'r' to go back to choose the provider
 Choose your authentication method:
 > 2
-== Qr Code authentication ==
+== Use a Login code ==
 Enter the code in the login page
 https://ubuntu.com
        1337
 
-  1. Wait for the QR code scan result
+  1. Wait for authentication result
   2. Regenerate code
 Or enter 'r' to go back to select the authentication method
 Choose action:
 > 2
-== Qr Code authentication ==
+== Use a Login code ==
 Enter the code in the login page
 https://ubuntu.fr/
        1338
 
-  1. Wait for the QR code scan result
+  1. Wait for authentication result
   2. Regenerate code
 Or enter 'r' to go back to select the authentication method
 Choose action:
 > 2
-== Qr Code authentication ==
+== Use a Login code ==
 Enter the code in the login page
 https://ubuntuforum-br.org/
            1339
 
-  1. Wait for the QR code scan result
+  1. Wait for authentication result
   2. Regenerate code
 Or enter 'r' to go back to select the authentication method
 Choose action:
 > 2
-== Qr Code authentication ==
+== Use a Login code ==
 Enter the code in the login page
 https://www.ubuntu-it.org/
            1340
 
-  1. Wait for the QR code scan result
+  1. Wait for authentication result
   2. Regenerate code
 Or enter 'r' to go back to select the authentication method
 Choose action:
@@ -424,42 +424,42 @@ Gimme your password:
 Or enter 'r' to go back to choose the provider
 Choose your authentication method:
 > 2
-== Qr Code authentication ==
+== Use a Login code ==
 Enter the code in the login page
 https://ubuntu.com
        1337
 
-  1. Wait for the QR code scan result
+  1. Wait for authentication result
   2. Regenerate code
 Or enter 'r' to go back to select the authentication method
 Choose action:
 > 2
-== Qr Code authentication ==
+== Use a Login code ==
 Enter the code in the login page
 https://ubuntu.fr/
        1338
 
-  1. Wait for the QR code scan result
+  1. Wait for authentication result
   2. Regenerate code
 Or enter 'r' to go back to select the authentication method
 Choose action:
 > 2
-== Qr Code authentication ==
+== Use a Login code ==
 Enter the code in the login page
 https://ubuntuforum-br.org/
            1339
 
-  1. Wait for the QR code scan result
+  1. Wait for authentication result
   2. Regenerate code
 Or enter 'r' to go back to select the authentication method
 Choose action:
 > 2
-== Qr Code authentication ==
+== Use a Login code ==
 Enter the code in the login page
 https://www.ubuntu-it.org/
            1340
 
-  1. Wait for the QR code scan result
+  1. Wait for authentication result
   2. Regenerate code
 Or enter 'r' to go back to select the authentication method
 Choose action:
@@ -488,52 +488,52 @@ Gimme your password:
 Or enter 'r' to go back to choose the provider
 Choose your authentication method:
 > 2
-== Qr Code authentication ==
+== Use a Login code ==
 Enter the code in the login page
 https://ubuntu.com
        1337
 
-  1. Wait for the QR code scan result
+  1. Wait for authentication result
   2. Regenerate code
 Or enter 'r' to go back to select the authentication method
 Choose action:
 > 2
-== Qr Code authentication ==
+== Use a Login code ==
 Enter the code in the login page
 https://ubuntu.fr/
        1338
 
-  1. Wait for the QR code scan result
+  1. Wait for authentication result
   2. Regenerate code
 Or enter 'r' to go back to select the authentication method
 Choose action:
 > 2
-== Qr Code authentication ==
+== Use a Login code ==
 Enter the code in the login page
 https://ubuntuforum-br.org/
            1339
 
-  1. Wait for the QR code scan result
+  1. Wait for authentication result
   2. Regenerate code
 Or enter 'r' to go back to select the authentication method
 Choose action:
 > 2
-== Qr Code authentication ==
+== Use a Login code ==
 Enter the code in the login page
 https://www.ubuntu-it.org/
            1340
 
-  1. Wait for the QR code scan result
+  1. Wait for authentication result
   2. Regenerate code
 Or enter 'r' to go back to select the authentication method
 Choose action:
 > 2
-== Qr Code authentication ==
+== Use a Login code ==
 Enter the code in the login page
 https://ubuntu.com
        1341
 
-  1. Wait for the QR code scan result
+  1. Wait for authentication result
   2. Regenerate code
 Or enter 'r' to go back to select the authentication method
 Choose action:
@@ -562,52 +562,52 @@ Gimme your password:
 Or enter 'r' to go back to choose the provider
 Choose your authentication method:
 > 2
-== Qr Code authentication ==
+== Use a Login code ==
 Enter the code in the login page
 https://ubuntu.com
        1337
 
-  1. Wait for the QR code scan result
+  1. Wait for authentication result
   2. Regenerate code
 Or enter 'r' to go back to select the authentication method
 Choose action:
 > 2
-== Qr Code authentication ==
+== Use a Login code ==
 Enter the code in the login page
 https://ubuntu.fr/
        1338
 
-  1. Wait for the QR code scan result
+  1. Wait for authentication result
   2. Regenerate code
 Or enter 'r' to go back to select the authentication method
 Choose action:
 > 2
-== Qr Code authentication ==
+== Use a Login code ==
 Enter the code in the login page
 https://ubuntuforum-br.org/
            1339
 
-  1. Wait for the QR code scan result
+  1. Wait for authentication result
   2. Regenerate code
 Or enter 'r' to go back to select the authentication method
 Choose action:
 > 2
-== Qr Code authentication ==
+== Use a Login code ==
 Enter the code in the login page
 https://www.ubuntu-it.org/
            1340
 
-  1. Wait for the QR code scan result
+  1. Wait for authentication result
   2. Regenerate code
 Or enter 'r' to go back to select the authentication method
 Choose action:
 > 2
-== Qr Code authentication ==
+== Use a Login code ==
 Enter the code in the login page
 https://ubuntu.com
        1341
 
-  1. Wait for the QR code scan result
+  1. Wait for authentication result
   2. Regenerate code
 Or enter 'r' to go back to select the authentication method
 Choose action:
@@ -636,52 +636,52 @@ Gimme your password:
 Or enter 'r' to go back to choose the provider
 Choose your authentication method:
 > 2
-== Qr Code authentication ==
+== Use a Login code ==
 Enter the code in the login page
 https://ubuntu.com
        1337
 
-  1. Wait for the QR code scan result
+  1. Wait for authentication result
   2. Regenerate code
 Or enter 'r' to go back to select the authentication method
 Choose action:
 > 2
-== Qr Code authentication ==
+== Use a Login code ==
 Enter the code in the login page
 https://ubuntu.fr/
        1338
 
-  1. Wait for the QR code scan result
+  1. Wait for authentication result
   2. Regenerate code
 Or enter 'r' to go back to select the authentication method
 Choose action:
 > 2
-== Qr Code authentication ==
+== Use a Login code ==
 Enter the code in the login page
 https://ubuntuforum-br.org/
            1339
 
-  1. Wait for the QR code scan result
+  1. Wait for authentication result
   2. Regenerate code
 Or enter 'r' to go back to select the authentication method
 Choose action:
 > 2
-== Qr Code authentication ==
+== Use a Login code ==
 Enter the code in the login page
 https://www.ubuntu-it.org/
            1340
 
-  1. Wait for the QR code scan result
+  1. Wait for authentication result
   2. Regenerate code
 Or enter 'r' to go back to select the authentication method
 Choose action:
 > 2
-== Qr Code authentication ==
+== Use a Login code ==
 Enter the code in the login page
 https://ubuntu.com
        1341
 
-  1. Wait for the QR code scan result
+  1. Wait for authentication result
   2. Regenerate code
 Or enter 'r' to go back to select the authentication method
 Choose action:

--- a/pam/integration-tests/testdata/golden/TestNativeAuthenticate/Authenticate_user_with_qr_code_in_screen
+++ b/pam/integration-tests/testdata/golden/TestNativeAuthenticate/Authenticate_user_with_qr_code_in_screen
@@ -96,7 +96,7 @@ Gimme your password:
 Or enter 'r' to go back to choose the provider
 Choose your authentication method:
 > 7
-== Qr Code authentication ==
+== Use a QR code ==
 Scan the qrcode or enter the code in the login page
 ██████████████████████████████████████████████████████████████████
 ██████████████████████████████████████████████████████████████████
@@ -134,7 +134,7 @@ Scan the qrcode or enter the code in the login page
                         https://ubuntu.com
                                1337
 
-  1. Wait for the QR code scan result
+  1. Wait for authentication result
   2. Regenerate code
 Or enter 'r' to go back to select the authentication method
 Choose action:
@@ -163,7 +163,7 @@ Gimme your password:
 Or enter 'r' to go back to choose the provider
 Choose your authentication method:
 > 7
-== Qr Code authentication ==
+== Use a QR code ==
 Scan the qrcode or enter the code in the login page
 ██████████████████████████████████████████████████████████████████
 ██████████████████████████████████████████████████████████████████
@@ -201,7 +201,7 @@ Scan the qrcode or enter the code in the login page
                         https://ubuntu.com
                                1337
 
-  1. Wait for the QR code scan result
+  1. Wait for authentication result
   2. Regenerate code
 Or enter 'r' to go back to select the authentication method
 Choose action:
@@ -230,7 +230,7 @@ Gimme your password:
 Or enter 'r' to go back to choose the provider
 Choose your authentication method:
 > 7
-== Qr Code authentication ==
+== Use a QR code ==
 Scan the qrcode or enter the code in the login page
 ██████████████████████████████████████████████████████████████████
 ██████████████████████████████████████████████████████████████████
@@ -268,12 +268,12 @@ Scan the qrcode or enter the code in the login page
                         https://ubuntu.com
                                1337
 
-  1. Wait for the QR code scan result
+  1. Wait for authentication result
   2. Regenerate code
 Or enter 'r' to go back to select the authentication method
 Choose action:
 > 2
-== Qr Code authentication ==
+== Use a QR code ==
 Scan the qrcode or enter the code in the login page
 ██████████████████████████████████████████████████████████████████
 ██████████████████████████████████████████████████████████████████
@@ -311,7 +311,7 @@ Scan the qrcode or enter the code in the login page
                         https://ubuntu.fr/
                                1338
 
-  1. Wait for the QR code scan result
+  1. Wait for authentication result
   2. Regenerate code
 Or enter 'r' to go back to select the authentication method
 Choose action:
@@ -340,7 +340,7 @@ Gimme your password:
 Or enter 'r' to go back to choose the provider
 Choose your authentication method:
 > 7
-== Qr Code authentication ==
+== Use a QR code ==
 Scan the qrcode or enter the code in the login page
 ██████████████████████████████████████████████████████████████████
 ██████████████████████████████████████████████████████████████████
@@ -378,12 +378,12 @@ Scan the qrcode or enter the code in the login page
                         https://ubuntu.com
                                1337
 
-  1. Wait for the QR code scan result
+  1. Wait for authentication result
   2. Regenerate code
 Or enter 'r' to go back to select the authentication method
 Choose action:
 > 2
-== Qr Code authentication ==
+== Use a QR code ==
 Scan the qrcode or enter the code in the login page
 ██████████████████████████████████████████████████████████████████
 ██████████████████████████████████████████████████████████████████
@@ -421,7 +421,7 @@ Scan the qrcode or enter the code in the login page
                         https://ubuntu.fr/
                                1338
 
-  1. Wait for the QR code scan result
+  1. Wait for authentication result
   2. Regenerate code
 Or enter 'r' to go back to select the authentication method
 Choose action:
@@ -450,7 +450,7 @@ Gimme your password:
 Or enter 'r' to go back to choose the provider
 Choose your authentication method:
 > 7
-== Qr Code authentication ==
+== Use a QR code ==
 Scan the qrcode or enter the code in the login page
 ██████████████████████████████████████████████████████████████████
 ██████████████████████████████████████████████████████████████████
@@ -488,12 +488,12 @@ Scan the qrcode or enter the code in the login page
                         https://ubuntu.com
                                1337
 
-  1. Wait for the QR code scan result
+  1. Wait for authentication result
   2. Regenerate code
 Or enter 'r' to go back to select the authentication method
 Choose action:
 > 2
-== Qr Code authentication ==
+== Use a QR code ==
 Scan the qrcode or enter the code in the login page
 ██████████████████████████████████████████████████████████████████
 ██████████████████████████████████████████████████████████████████
@@ -531,12 +531,12 @@ Scan the qrcode or enter the code in the login page
                         https://ubuntu.fr/
                                1338
 
-  1. Wait for the QR code scan result
+  1. Wait for authentication result
   2. Regenerate code
 Or enter 'r' to go back to select the authentication method
 Choose action:
 > 2
-== Qr Code authentication ==
+== Use a QR code ==
 Scan the qrcode or enter the code in the login page
 ██████████████████████████████████████████████████████████████████████████
 ██████████████████████████████████████████████████████████████████████████
@@ -578,7 +578,7 @@ Scan the qrcode or enter the code in the login page
                        https://ubuntuforum-br.org/
                                    1339
 
-  1. Wait for the QR code scan result
+  1. Wait for authentication result
   2. Regenerate code
 Or enter 'r' to go back to select the authentication method
 Choose action:
@@ -607,7 +607,7 @@ Gimme your password:
 Or enter 'r' to go back to choose the provider
 Choose your authentication method:
 > 7
-== Qr Code authentication ==
+== Use a QR code ==
 Scan the qrcode or enter the code in the login page
 ██████████████████████████████████████████████████████████████████
 ██████████████████████████████████████████████████████████████████
@@ -645,12 +645,12 @@ Scan the qrcode or enter the code in the login page
                         https://ubuntu.com
                                1337
 
-  1. Wait for the QR code scan result
+  1. Wait for authentication result
   2. Regenerate code
 Or enter 'r' to go back to select the authentication method
 Choose action:
 > 2
-== Qr Code authentication ==
+== Use a QR code ==
 Scan the qrcode or enter the code in the login page
 ██████████████████████████████████████████████████████████████████
 ██████████████████████████████████████████████████████████████████
@@ -688,12 +688,12 @@ Scan the qrcode or enter the code in the login page
                         https://ubuntu.fr/
                                1338
 
-  1. Wait for the QR code scan result
+  1. Wait for authentication result
   2. Regenerate code
 Or enter 'r' to go back to select the authentication method
 Choose action:
 > 2
-== Qr Code authentication ==
+== Use a QR code ==
 Scan the qrcode or enter the code in the login page
 ██████████████████████████████████████████████████████████████████████████
 ██████████████████████████████████████████████████████████████████████████
@@ -735,7 +735,7 @@ Scan the qrcode or enter the code in the login page
                        https://ubuntuforum-br.org/
                                    1339
 
-  1. Wait for the QR code scan result
+  1. Wait for authentication result
   2. Regenerate code
 Or enter 'r' to go back to select the authentication method
 Choose action:
@@ -764,7 +764,7 @@ Gimme your password:
 Or enter 'r' to go back to choose the provider
 Choose your authentication method:
 > 7
-== Qr Code authentication ==
+== Use a QR code ==
 Scan the qrcode or enter the code in the login page
 ██████████████████████████████████████████████████████████████████
 ██████████████████████████████████████████████████████████████████
@@ -802,12 +802,12 @@ Scan the qrcode or enter the code in the login page
                         https://ubuntu.com
                                1337
 
-  1. Wait for the QR code scan result
+  1. Wait for authentication result
   2. Regenerate code
 Or enter 'r' to go back to select the authentication method
 Choose action:
 > 2
-== Qr Code authentication ==
+== Use a QR code ==
 Scan the qrcode or enter the code in the login page
 ██████████████████████████████████████████████████████████████████
 ██████████████████████████████████████████████████████████████████
@@ -845,12 +845,12 @@ Scan the qrcode or enter the code in the login page
                         https://ubuntu.fr/
                                1338
 
-  1. Wait for the QR code scan result
+  1. Wait for authentication result
   2. Regenerate code
 Or enter 'r' to go back to select the authentication method
 Choose action:
 > 2
-== Qr Code authentication ==
+== Use a QR code ==
 Scan the qrcode or enter the code in the login page
 ██████████████████████████████████████████████████████████████████████████
 ██████████████████████████████████████████████████████████████████████████
@@ -892,12 +892,12 @@ Scan the qrcode or enter the code in the login page
                        https://ubuntuforum-br.org/
                                    1339
 
-  1. Wait for the QR code scan result
+  1. Wait for authentication result
   2. Regenerate code
 Or enter 'r' to go back to select the authentication method
 Choose action:
 > 2
-== Qr Code authentication ==
+== Use a QR code ==
 Scan the qrcode or enter the code in the login page
 ██████████████████████████████████████████████████████████████████
 ██████████████████████████████████████████████████████████████████
@@ -935,7 +935,7 @@ Scan the qrcode or enter the code in the login page
                     https://www.ubuntu-it.org/
                                1340
 
-  1. Wait for the QR code scan result
+  1. Wait for authentication result
   2. Regenerate code
 Or enter 'r' to go back to select the authentication method
 Choose action:
@@ -964,7 +964,7 @@ Gimme your password:
 Or enter 'r' to go back to choose the provider
 Choose your authentication method:
 > 7
-== Qr Code authentication ==
+== Use a QR code ==
 Scan the qrcode or enter the code in the login page
 ██████████████████████████████████████████████████████████████████
 ██████████████████████████████████████████████████████████████████
@@ -1002,12 +1002,12 @@ Scan the qrcode or enter the code in the login page
                         https://ubuntu.com
                                1337
 
-  1. Wait for the QR code scan result
+  1. Wait for authentication result
   2. Regenerate code
 Or enter 'r' to go back to select the authentication method
 Choose action:
 > 2
-== Qr Code authentication ==
+== Use a QR code ==
 Scan the qrcode or enter the code in the login page
 ██████████████████████████████████████████████████████████████████
 ██████████████████████████████████████████████████████████████████
@@ -1045,12 +1045,12 @@ Scan the qrcode or enter the code in the login page
                         https://ubuntu.fr/
                                1338
 
-  1. Wait for the QR code scan result
+  1. Wait for authentication result
   2. Regenerate code
 Or enter 'r' to go back to select the authentication method
 Choose action:
 > 2
-== Qr Code authentication ==
+== Use a QR code ==
 Scan the qrcode or enter the code in the login page
 ██████████████████████████████████████████████████████████████████████████
 ██████████████████████████████████████████████████████████████████████████
@@ -1092,12 +1092,12 @@ Scan the qrcode or enter the code in the login page
                        https://ubuntuforum-br.org/
                                    1339
 
-  1. Wait for the QR code scan result
+  1. Wait for authentication result
   2. Regenerate code
 Or enter 'r' to go back to select the authentication method
 Choose action:
 > 2
-== Qr Code authentication ==
+== Use a QR code ==
 Scan the qrcode or enter the code in the login page
 ██████████████████████████████████████████████████████████████████
 ██████████████████████████████████████████████████████████████████
@@ -1135,7 +1135,7 @@ Scan the qrcode or enter the code in the login page
                     https://www.ubuntu-it.org/
                                1340
 
-  1. Wait for the QR code scan result
+  1. Wait for authentication result
   2. Regenerate code
 Or enter 'r' to go back to select the authentication method
 Choose action:
@@ -1164,7 +1164,7 @@ Gimme your password:
 Or enter 'r' to go back to choose the provider
 Choose your authentication method:
 > 7
-== Qr Code authentication ==
+== Use a QR code ==
 Scan the qrcode or enter the code in the login page
 ██████████████████████████████████████████████████████████████████
 ██████████████████████████████████████████████████████████████████
@@ -1202,12 +1202,12 @@ Scan the qrcode or enter the code in the login page
                         https://ubuntu.com
                                1337
 
-  1. Wait for the QR code scan result
+  1. Wait for authentication result
   2. Regenerate code
 Or enter 'r' to go back to select the authentication method
 Choose action:
 > 2
-== Qr Code authentication ==
+== Use a QR code ==
 Scan the qrcode or enter the code in the login page
 ██████████████████████████████████████████████████████████████████
 ██████████████████████████████████████████████████████████████████
@@ -1245,12 +1245,12 @@ Scan the qrcode or enter the code in the login page
                         https://ubuntu.fr/
                                1338
 
-  1. Wait for the QR code scan result
+  1. Wait for authentication result
   2. Regenerate code
 Or enter 'r' to go back to select the authentication method
 Choose action:
 > 2
-== Qr Code authentication ==
+== Use a QR code ==
 Scan the qrcode or enter the code in the login page
 ██████████████████████████████████████████████████████████████████████████
 ██████████████████████████████████████████████████████████████████████████
@@ -1292,12 +1292,12 @@ Scan the qrcode or enter the code in the login page
                        https://ubuntuforum-br.org/
                                    1339
 
-  1. Wait for the QR code scan result
+  1. Wait for authentication result
   2. Regenerate code
 Or enter 'r' to go back to select the authentication method
 Choose action:
 > 2
-== Qr Code authentication ==
+== Use a QR code ==
 Scan the qrcode or enter the code in the login page
 ██████████████████████████████████████████████████████████████████
 ██████████████████████████████████████████████████████████████████
@@ -1335,12 +1335,12 @@ Scan the qrcode or enter the code in the login page
                     https://www.ubuntu-it.org/
                                1340
 
-  1. Wait for the QR code scan result
+  1. Wait for authentication result
   2. Regenerate code
 Or enter 'r' to go back to select the authentication method
 Choose action:
 > 2
-== Qr Code authentication ==
+== Use a QR code ==
 Scan the qrcode or enter the code in the login page
 ██████████████████████████████████████████████████████████████████
 ██████████████████████████████████████████████████████████████████
@@ -1378,7 +1378,7 @@ Scan the qrcode or enter the code in the login page
                         https://ubuntu.com
                                1341
 
-  1. Wait for the QR code scan result
+  1. Wait for authentication result
   2. Regenerate code
 Or enter 'r' to go back to select the authentication method
 Choose action:
@@ -1407,7 +1407,7 @@ Gimme your password:
 Or enter 'r' to go back to choose the provider
 Choose your authentication method:
 > 7
-== Qr Code authentication ==
+== Use a QR code ==
 Scan the qrcode or enter the code in the login page
 ██████████████████████████████████████████████████████████████████
 ██████████████████████████████████████████████████████████████████
@@ -1445,12 +1445,12 @@ Scan the qrcode or enter the code in the login page
                         https://ubuntu.com
                                1337
 
-  1. Wait for the QR code scan result
+  1. Wait for authentication result
   2. Regenerate code
 Or enter 'r' to go back to select the authentication method
 Choose action:
 > 2
-== Qr Code authentication ==
+== Use a QR code ==
 Scan the qrcode or enter the code in the login page
 ██████████████████████████████████████████████████████████████████
 ██████████████████████████████████████████████████████████████████
@@ -1488,12 +1488,12 @@ Scan the qrcode or enter the code in the login page
                         https://ubuntu.fr/
                                1338
 
-  1. Wait for the QR code scan result
+  1. Wait for authentication result
   2. Regenerate code
 Or enter 'r' to go back to select the authentication method
 Choose action:
 > 2
-== Qr Code authentication ==
+== Use a QR code ==
 Scan the qrcode or enter the code in the login page
 ██████████████████████████████████████████████████████████████████████████
 ██████████████████████████████████████████████████████████████████████████
@@ -1535,12 +1535,12 @@ Scan the qrcode or enter the code in the login page
                        https://ubuntuforum-br.org/
                                    1339
 
-  1. Wait for the QR code scan result
+  1. Wait for authentication result
   2. Regenerate code
 Or enter 'r' to go back to select the authentication method
 Choose action:
 > 2
-== Qr Code authentication ==
+== Use a QR code ==
 Scan the qrcode or enter the code in the login page
 ██████████████████████████████████████████████████████████████████
 ██████████████████████████████████████████████████████████████████
@@ -1578,12 +1578,12 @@ Scan the qrcode or enter the code in the login page
                     https://www.ubuntu-it.org/
                                1340
 
-  1. Wait for the QR code scan result
+  1. Wait for authentication result
   2. Regenerate code
 Or enter 'r' to go back to select the authentication method
 Choose action:
 > 2
-== Qr Code authentication ==
+== Use a QR code ==
 Scan the qrcode or enter the code in the login page
 ██████████████████████████████████████████████████████████████████
 ██████████████████████████████████████████████████████████████████
@@ -1621,7 +1621,7 @@ Scan the qrcode or enter the code in the login page
                         https://ubuntu.com
                                1341
 
-  1. Wait for the QR code scan result
+  1. Wait for authentication result
   2. Regenerate code
 Or enter 'r' to go back to select the authentication method
 Choose action:
@@ -1650,7 +1650,7 @@ Gimme your password:
 Or enter 'r' to go back to choose the provider
 Choose your authentication method:
 > 7
-== Qr Code authentication ==
+== Use a QR code ==
 Scan the qrcode or enter the code in the login page
 ██████████████████████████████████████████████████████████████████
 ██████████████████████████████████████████████████████████████████
@@ -1688,12 +1688,12 @@ Scan the qrcode or enter the code in the login page
                         https://ubuntu.com
                                1337
 
-  1. Wait for the QR code scan result
+  1. Wait for authentication result
   2. Regenerate code
 Or enter 'r' to go back to select the authentication method
 Choose action:
 > 2
-== Qr Code authentication ==
+== Use a QR code ==
 Scan the qrcode or enter the code in the login page
 ██████████████████████████████████████████████████████████████████
 ██████████████████████████████████████████████████████████████████
@@ -1731,12 +1731,12 @@ Scan the qrcode or enter the code in the login page
                         https://ubuntu.fr/
                                1338
 
-  1. Wait for the QR code scan result
+  1. Wait for authentication result
   2. Regenerate code
 Or enter 'r' to go back to select the authentication method
 Choose action:
 > 2
-== Qr Code authentication ==
+== Use a QR code ==
 Scan the qrcode or enter the code in the login page
 ██████████████████████████████████████████████████████████████████████████
 ██████████████████████████████████████████████████████████████████████████
@@ -1778,12 +1778,12 @@ Scan the qrcode or enter the code in the login page
                        https://ubuntuforum-br.org/
                                    1339
 
-  1. Wait for the QR code scan result
+  1. Wait for authentication result
   2. Regenerate code
 Or enter 'r' to go back to select the authentication method
 Choose action:
 > 2
-== Qr Code authentication ==
+== Use a QR code ==
 Scan the qrcode or enter the code in the login page
 ██████████████████████████████████████████████████████████████████
 ██████████████████████████████████████████████████████████████████
@@ -1821,12 +1821,12 @@ Scan the qrcode or enter the code in the login page
                     https://www.ubuntu-it.org/
                                1340
 
-  1. Wait for the QR code scan result
+  1. Wait for authentication result
   2. Regenerate code
 Or enter 'r' to go back to select the authentication method
 Choose action:
 > 2
-== Qr Code authentication ==
+== Use a QR code ==
 Scan the qrcode or enter the code in the login page
 ██████████████████████████████████████████████████████████████████
 ██████████████████████████████████████████████████████████████████
@@ -1864,7 +1864,7 @@ Scan the qrcode or enter the code in the login page
                         https://ubuntu.com
                                1341
 
-  1. Wait for the QR code scan result
+  1. Wait for authentication result
   2. Regenerate code
 Or enter 'r' to go back to select the authentication method
 Choose action:

--- a/pam/integration-tests/testdata/golden/TestNativeAuthenticate/Authenticate_user_with_qr_code_in_ssh
+++ b/pam/integration-tests/testdata/golden/TestNativeAuthenticate/Authenticate_user_with_qr_code_in_ssh
@@ -96,12 +96,12 @@ Gimme your password:
 Or enter 'r' to go back to choose the provider
 Choose your authentication method:
 > 2
-== Qr Code authentication ==
+== Use a Login code ==
 Enter the code in the login page
 https://ubuntu.com
        1337
 
-  1. Wait for the QR code scan result
+  1. Wait for authentication result
   2. Regenerate code
 Or enter 'r' to go back to select the authentication method
 Choose action:
@@ -130,12 +130,12 @@ Gimme your password:
 Or enter 'r' to go back to choose the provider
 Choose your authentication method:
 > 2
-== Qr Code authentication ==
+== Use a Login code ==
 Enter the code in the login page
 https://ubuntu.com
        1337
 
-  1. Wait for the QR code scan result
+  1. Wait for authentication result
   2. Regenerate code
 Or enter 'r' to go back to select the authentication method
 Choose action:
@@ -164,22 +164,22 @@ Gimme your password:
 Or enter 'r' to go back to choose the provider
 Choose your authentication method:
 > 2
-== Qr Code authentication ==
+== Use a Login code ==
 Enter the code in the login page
 https://ubuntu.com
        1337
 
-  1. Wait for the QR code scan result
+  1. Wait for authentication result
   2. Regenerate code
 Or enter 'r' to go back to select the authentication method
 Choose action:
 > 2
-== Qr Code authentication ==
+== Use a Login code ==
 Enter the code in the login page
 https://ubuntu.fr/
        1338
 
-  1. Wait for the QR code scan result
+  1. Wait for authentication result
   2. Regenerate code
 Or enter 'r' to go back to select the authentication method
 Choose action:
@@ -208,22 +208,22 @@ Gimme your password:
 Or enter 'r' to go back to choose the provider
 Choose your authentication method:
 > 2
-== Qr Code authentication ==
+== Use a Login code ==
 Enter the code in the login page
 https://ubuntu.com
        1337
 
-  1. Wait for the QR code scan result
+  1. Wait for authentication result
   2. Regenerate code
 Or enter 'r' to go back to select the authentication method
 Choose action:
 > 2
-== Qr Code authentication ==
+== Use a Login code ==
 Enter the code in the login page
 https://ubuntu.fr/
        1338
 
-  1. Wait for the QR code scan result
+  1. Wait for authentication result
   2. Regenerate code
 Or enter 'r' to go back to select the authentication method
 Choose action:
@@ -252,32 +252,32 @@ Gimme your password:
 Or enter 'r' to go back to choose the provider
 Choose your authentication method:
 > 2
-== Qr Code authentication ==
+== Use a Login code ==
 Enter the code in the login page
 https://ubuntu.com
        1337
 
-  1. Wait for the QR code scan result
+  1. Wait for authentication result
   2. Regenerate code
 Or enter 'r' to go back to select the authentication method
 Choose action:
 > 2
-== Qr Code authentication ==
+== Use a Login code ==
 Enter the code in the login page
 https://ubuntu.fr/
        1338
 
-  1. Wait for the QR code scan result
+  1. Wait for authentication result
   2. Regenerate code
 Or enter 'r' to go back to select the authentication method
 Choose action:
 > 2
-== Qr Code authentication ==
+== Use a Login code ==
 Enter the code in the login page
 https://ubuntuforum-br.org/
            1339
 
-  1. Wait for the QR code scan result
+  1. Wait for authentication result
   2. Regenerate code
 Or enter 'r' to go back to select the authentication method
 Choose action:
@@ -306,32 +306,32 @@ Gimme your password:
 Or enter 'r' to go back to choose the provider
 Choose your authentication method:
 > 2
-== Qr Code authentication ==
+== Use a Login code ==
 Enter the code in the login page
 https://ubuntu.com
        1337
 
-  1. Wait for the QR code scan result
+  1. Wait for authentication result
   2. Regenerate code
 Or enter 'r' to go back to select the authentication method
 Choose action:
 > 2
-== Qr Code authentication ==
+== Use a Login code ==
 Enter the code in the login page
 https://ubuntu.fr/
        1338
 
-  1. Wait for the QR code scan result
+  1. Wait for authentication result
   2. Regenerate code
 Or enter 'r' to go back to select the authentication method
 Choose action:
 > 2
-== Qr Code authentication ==
+== Use a Login code ==
 Enter the code in the login page
 https://ubuntuforum-br.org/
            1339
 
-  1. Wait for the QR code scan result
+  1. Wait for authentication result
   2. Regenerate code
 Or enter 'r' to go back to select the authentication method
 Choose action:
@@ -360,42 +360,42 @@ Gimme your password:
 Or enter 'r' to go back to choose the provider
 Choose your authentication method:
 > 2
-== Qr Code authentication ==
+== Use a Login code ==
 Enter the code in the login page
 https://ubuntu.com
        1337
 
-  1. Wait for the QR code scan result
+  1. Wait for authentication result
   2. Regenerate code
 Or enter 'r' to go back to select the authentication method
 Choose action:
 > 2
-== Qr Code authentication ==
+== Use a Login code ==
 Enter the code in the login page
 https://ubuntu.fr/
        1338
 
-  1. Wait for the QR code scan result
+  1. Wait for authentication result
   2. Regenerate code
 Or enter 'r' to go back to select the authentication method
 Choose action:
 > 2
-== Qr Code authentication ==
+== Use a Login code ==
 Enter the code in the login page
 https://ubuntuforum-br.org/
            1339
 
-  1. Wait for the QR code scan result
+  1. Wait for authentication result
   2. Regenerate code
 Or enter 'r' to go back to select the authentication method
 Choose action:
 > 2
-== Qr Code authentication ==
+== Use a Login code ==
 Enter the code in the login page
 https://www.ubuntu-it.org/
            1340
 
-  1. Wait for the QR code scan result
+  1. Wait for authentication result
   2. Regenerate code
 Or enter 'r' to go back to select the authentication method
 Choose action:
@@ -424,42 +424,42 @@ Gimme your password:
 Or enter 'r' to go back to choose the provider
 Choose your authentication method:
 > 2
-== Qr Code authentication ==
+== Use a Login code ==
 Enter the code in the login page
 https://ubuntu.com
        1337
 
-  1. Wait for the QR code scan result
+  1. Wait for authentication result
   2. Regenerate code
 Or enter 'r' to go back to select the authentication method
 Choose action:
 > 2
-== Qr Code authentication ==
+== Use a Login code ==
 Enter the code in the login page
 https://ubuntu.fr/
        1338
 
-  1. Wait for the QR code scan result
+  1. Wait for authentication result
   2. Regenerate code
 Or enter 'r' to go back to select the authentication method
 Choose action:
 > 2
-== Qr Code authentication ==
+== Use a Login code ==
 Enter the code in the login page
 https://ubuntuforum-br.org/
            1339
 
-  1. Wait for the QR code scan result
+  1. Wait for authentication result
   2. Regenerate code
 Or enter 'r' to go back to select the authentication method
 Choose action:
 > 2
-== Qr Code authentication ==
+== Use a Login code ==
 Enter the code in the login page
 https://www.ubuntu-it.org/
            1340
 
-  1. Wait for the QR code scan result
+  1. Wait for authentication result
   2. Regenerate code
 Or enter 'r' to go back to select the authentication method
 Choose action:
@@ -488,52 +488,52 @@ Gimme your password:
 Or enter 'r' to go back to choose the provider
 Choose your authentication method:
 > 2
-== Qr Code authentication ==
+== Use a Login code ==
 Enter the code in the login page
 https://ubuntu.com
        1337
 
-  1. Wait for the QR code scan result
+  1. Wait for authentication result
   2. Regenerate code
 Or enter 'r' to go back to select the authentication method
 Choose action:
 > 2
-== Qr Code authentication ==
+== Use a Login code ==
 Enter the code in the login page
 https://ubuntu.fr/
        1338
 
-  1. Wait for the QR code scan result
+  1. Wait for authentication result
   2. Regenerate code
 Or enter 'r' to go back to select the authentication method
 Choose action:
 > 2
-== Qr Code authentication ==
+== Use a Login code ==
 Enter the code in the login page
 https://ubuntuforum-br.org/
            1339
 
-  1. Wait for the QR code scan result
+  1. Wait for authentication result
   2. Regenerate code
 Or enter 'r' to go back to select the authentication method
 Choose action:
 > 2
-== Qr Code authentication ==
+== Use a Login code ==
 Enter the code in the login page
 https://www.ubuntu-it.org/
            1340
 
-  1. Wait for the QR code scan result
+  1. Wait for authentication result
   2. Regenerate code
 Or enter 'r' to go back to select the authentication method
 Choose action:
 > 2
-== Qr Code authentication ==
+== Use a Login code ==
 Enter the code in the login page
 https://ubuntu.com
        1341
 
-  1. Wait for the QR code scan result
+  1. Wait for authentication result
   2. Regenerate code
 Or enter 'r' to go back to select the authentication method
 Choose action:
@@ -562,52 +562,52 @@ Gimme your password:
 Or enter 'r' to go back to choose the provider
 Choose your authentication method:
 > 2
-== Qr Code authentication ==
+== Use a Login code ==
 Enter the code in the login page
 https://ubuntu.com
        1337
 
-  1. Wait for the QR code scan result
+  1. Wait for authentication result
   2. Regenerate code
 Or enter 'r' to go back to select the authentication method
 Choose action:
 > 2
-== Qr Code authentication ==
+== Use a Login code ==
 Enter the code in the login page
 https://ubuntu.fr/
        1338
 
-  1. Wait for the QR code scan result
+  1. Wait for authentication result
   2. Regenerate code
 Or enter 'r' to go back to select the authentication method
 Choose action:
 > 2
-== Qr Code authentication ==
+== Use a Login code ==
 Enter the code in the login page
 https://ubuntuforum-br.org/
            1339
 
-  1. Wait for the QR code scan result
+  1. Wait for authentication result
   2. Regenerate code
 Or enter 'r' to go back to select the authentication method
 Choose action:
 > 2
-== Qr Code authentication ==
+== Use a Login code ==
 Enter the code in the login page
 https://www.ubuntu-it.org/
            1340
 
-  1. Wait for the QR code scan result
+  1. Wait for authentication result
   2. Regenerate code
 Or enter 'r' to go back to select the authentication method
 Choose action:
 > 2
-== Qr Code authentication ==
+== Use a Login code ==
 Enter the code in the login page
 https://ubuntu.com
        1341
 
-  1. Wait for the QR code scan result
+  1. Wait for authentication result
   2. Regenerate code
 Or enter 'r' to go back to select the authentication method
 Choose action:
@@ -636,52 +636,52 @@ Gimme your password:
 Or enter 'r' to go back to choose the provider
 Choose your authentication method:
 > 2
-== Qr Code authentication ==
+== Use a Login code ==
 Enter the code in the login page
 https://ubuntu.com
        1337
 
-  1. Wait for the QR code scan result
+  1. Wait for authentication result
   2. Regenerate code
 Or enter 'r' to go back to select the authentication method
 Choose action:
 > 2
-== Qr Code authentication ==
+== Use a Login code ==
 Enter the code in the login page
 https://ubuntu.fr/
        1338
 
-  1. Wait for the QR code scan result
+  1. Wait for authentication result
   2. Regenerate code
 Or enter 'r' to go back to select the authentication method
 Choose action:
 > 2
-== Qr Code authentication ==
+== Use a Login code ==
 Enter the code in the login page
 https://ubuntuforum-br.org/
            1339
 
-  1. Wait for the QR code scan result
+  1. Wait for authentication result
   2. Regenerate code
 Or enter 'r' to go back to select the authentication method
 Choose action:
 > 2
-== Qr Code authentication ==
+== Use a Login code ==
 Enter the code in the login page
 https://www.ubuntu-it.org/
            1340
 
-  1. Wait for the QR code scan result
+  1. Wait for authentication result
   2. Regenerate code
 Or enter 'r' to go back to select the authentication method
 Choose action:
 > 2
-== Qr Code authentication ==
+== Use a Login code ==
 Enter the code in the login page
 https://ubuntu.com
        1341
 
-  1. Wait for the QR code scan result
+  1. Wait for authentication result
   2. Regenerate code
 Or enter 'r' to go back to select the authentication method
 Choose action:

--- a/pam/integration-tests/testdata/golden/TestSSHAuthenticate/Authenticate_user_switching_auth_mode
+++ b/pam/integration-tests/testdata/golden/TestSSHAuthenticate/Authenticate_user_switching_auth_mode
@@ -1492,12 +1492,12 @@ Enter 'r' to cancel the request and go back to select the authentication method
 Or enter 'r' to go back to choose the provider
 (user-integration-pre-check-authenticate-user-switching-auth-mode@localhost) Choose your authentication method:
 > 2
-== Qr Code authentication ==
+== Use a Login code ==
 Enter the code in the login page
 https://ubuntu.com
        1337
 
-  1. Wait for the QR code scan result
+  1. Wait for authentication result
   2. Regenerate code
 Or enter 'r' to go back to select the authentication method
 (user-integration-pre-check-authenticate-user-switching-auth-mode@localhost) Choose action:
@@ -1606,12 +1606,12 @@ Enter 'r' to cancel the request and go back to select the authentication method
 Or enter 'r' to go back to choose the provider
 (user-integration-pre-check-authenticate-user-switching-auth-mode@localhost) Choose your authentication method:
 > 2
-== Qr Code authentication ==
+== Use a Login code ==
 Enter the code in the login page
 https://ubuntu.com
        1337
 
-  1. Wait for the QR code scan result
+  1. Wait for authentication result
   2. Regenerate code
 Or enter 'r' to go back to select the authentication method
 (user-integration-pre-check-authenticate-user-switching-auth-mode@localhost) Choose action:
@@ -1720,12 +1720,12 @@ Enter 'r' to cancel the request and go back to select the authentication method
 Or enter 'r' to go back to choose the provider
 (user-integration-pre-check-authenticate-user-switching-auth-mode@localhost) Choose your authentication method:
 > 2
-== Qr Code authentication ==
+== Use a Login code ==
 Enter the code in the login page
 https://ubuntu.com
        1337
 
-  1. Wait for the QR code scan result
+  1. Wait for authentication result
   2. Regenerate code
 Or enter 'r' to go back to select the authentication method
 (user-integration-pre-check-authenticate-user-switching-auth-mode@localhost) Choose action:
@@ -1846,138 +1846,12 @@ Enter 'r' to cancel the request and go back to select the authentication method
 Or enter 'r' to go back to choose the provider
 (user-integration-pre-check-authenticate-user-switching-auth-mode@localhost) Choose your authentication method:
 > 2
-== Qr Code authentication ==
+== Use a Login code ==
 Enter the code in the login page
 https://ubuntu.com
        1337
 
-  1. Wait for the QR code scan result
-  2. Regenerate code
-Or enter 'r' to go back to select the authentication method
-(user-integration-pre-check-authenticate-user-switching-auth-mode@localhost) Choose action:
-> r
-== Authentication method selection ==
-  1. Password authentication
-  2. Use a Login code
-  3. Send URL to user-integration-pre-check-authenticate-user-switching-auth-mode@gmail.com
-  4. Use your fido device foo
-  5. Use your phone +33...
-  6. Use your phone +1...
-  7. Pin code
-  8. Authentication code
-Or enter 'r' to go back to choose the provider
-(user-integration-pre-check-authenticate-user-switching-auth-mode@localhost) Choose your authentication method:
-> 8
-────────────────────────────────────────────────────────────────────────────────
-> ssh ${AUTHD_PAM_SSH_USER}@localhost ${AUTHD_PAM_SSH_ARGS}
-== Provider selection ==
-  1. local
-  2. ExampleBroker
-(user-integration-pre-check-authenticate-user-switching-auth-mode@localhost) Choose your provider:
-> 2
-== Password authentication ==
-Enter 'r' to cancel the request and go back to select the authentication method
-(user-integration-pre-check-authenticate-user-switching-auth-mode@localhost) Gimme your password:
->
-== Authentication method selection ==
-  1. Password authentication
-  2. Use a Login code
-  3. Send URL to user-integration-pre-check-authenticate-user-switching-auth-mode@gmail.com
-  4. Use your fido device foo
-  5. Use your phone +33...
-  6. Use your phone +1...
-  7. Pin code
-  8. Authentication code
-Or enter 'r' to go back to choose the provider
-(user-integration-pre-check-authenticate-user-switching-auth-mode@localhost) Choose your authentication method:
-> 3
-== Send URL to user-integration-pre-check-authenticate-user-switching-auth-mode@gmail.com ==
-Leave the input field empty to wait for the alternative authentication method or enter 'r' to go back to select the authentication method
-(user-integration-pre-check-authenticate-user-switching-auth-mode@localhost) Click on the link received at user-integration-pre-check-authenticate-user-switching-auth-mode@gmail.com or
- enter the code:
-> r
-== Authentication method selection ==
-  1. Password authentication
-  2. Use a Login code
-  3. Send URL to user-integration-pre-check-authenticate-user-switching-auth-mode@gmail.com
-  4. Use your fido device foo
-  5. Use your phone +33...
-  6. Use your phone +1...
-  7. Pin code
-  8. Authentication code
-Or enter 'r' to go back to choose the provider
-(user-integration-pre-check-authenticate-user-switching-auth-mode@localhost) Choose your authentication method:
-> 4
-== Use your fido device foo ==
-Press Enter to wait for authentication or enter 'r' to go back to select the authentication method
-(user-integration-pre-check-authenticate-user-switching-auth-mode@localhost) Plug your fido device and press with your thumb:
-> r
-== Authentication method selection ==
-  1. Password authentication
-  2. Use a Login code
-  3. Send URL to user-integration-pre-check-authenticate-user-switching-auth-mode@gmail.com
-  4. Use your fido device foo
-  5. Use your phone +33...
-  6. Use your phone +1...
-  7. Pin code
-  8. Authentication code
-Or enter 'r' to go back to choose the provider
-(user-integration-pre-check-authenticate-user-switching-auth-mode@localhost) Choose your authentication method:
-> 5
-== Use your phone +33... ==
-Press Enter to wait for authentication or enter 'r' to go back to select the authentication method
-(user-integration-pre-check-authenticate-user-switching-auth-mode@localhost) Unlock your phone +33... or accept request on web interface:
-> r
-== Authentication method selection ==
-  1. Password authentication
-  2. Use a Login code
-  3. Send URL to user-integration-pre-check-authenticate-user-switching-auth-mode@gmail.com
-  4. Use your fido device foo
-  5. Use your phone +33...
-  6. Use your phone +1...
-  7. Pin code
-  8. Authentication code
-Or enter 'r' to go back to choose the provider
-(user-integration-pre-check-authenticate-user-switching-auth-mode@localhost) Choose your authentication method:
-> 6
-== Use your phone +1... ==
-Press Enter to wait for authentication or enter 'r' to go back to select the authentication method
-(user-integration-pre-check-authenticate-user-switching-auth-mode@localhost) Unlock your phone +1... or accept request on web interface:
-> r
-== Authentication method selection ==
-  1. Password authentication
-  2. Use a Login code
-  3. Send URL to user-integration-pre-check-authenticate-user-switching-auth-mode@gmail.com
-  4. Use your fido device foo
-  5. Use your phone +33...
-  6. Use your phone +1...
-  7. Pin code
-  8. Authentication code
-Or enter 'r' to go back to choose the provider
-(user-integration-pre-check-authenticate-user-switching-auth-mode@localhost) Choose your authentication method:
-> 7
-== Pin code ==
-Enter 'r' to cancel the request and go back to select the authentication method
-(user-integration-pre-check-authenticate-user-switching-auth-mode@localhost) Enter your pin code:
-> r
-== Authentication method selection ==
-  1. Password authentication
-  2. Use a Login code
-  3. Send URL to user-integration-pre-check-authenticate-user-switching-auth-mode@gmail.com
-  4. Use your fido device foo
-  5. Use your phone +33...
-  6. Use your phone +1...
-  7. Pin code
-  8. Authentication code
-Or enter 'r' to go back to choose the provider
-(user-integration-pre-check-authenticate-user-switching-auth-mode@localhost) Choose your authentication method:
-> 2
-== Qr Code authentication ==
-Enter the code in the login page
-https://ubuntu.com
-       1337
-
-  1. Wait for the QR code scan result
+  1. Wait for authentication result
   2. Regenerate code
 Or enter 'r' to go back to select the authentication method
 (user-integration-pre-check-authenticate-user-switching-auth-mode@localhost) Choose action:
@@ -1994,12 +1868,6 @@ Or enter 'r' to go back to select the authentication method
 Or enter 'r' to go back to choose the provider
 (user-integration-pre-check-authenticate-user-switching-auth-mode@localhost) Choose your authentication method:
 > 8
-== Authentication code ==
-  1. Proceed with Authentication code
-  2. Resend SMS (1 sent)
-Or enter 'r' to go back to select the authentication method
-(user-integration-pre-check-authenticate-user-switching-auth-mode@localhost) Choose action:
->
 ────────────────────────────────────────────────────────────────────────────────
 > ssh ${AUTHD_PAM_SSH_USER}@localhost ${AUTHD_PAM_SSH_ARGS}
 == Provider selection ==
@@ -2104,12 +1972,12 @@ Enter 'r' to cancel the request and go back to select the authentication method
 Or enter 'r' to go back to choose the provider
 (user-integration-pre-check-authenticate-user-switching-auth-mode@localhost) Choose your authentication method:
 > 2
-== Qr Code authentication ==
+== Use a Login code ==
 Enter the code in the login page
 https://ubuntu.com
        1337
 
-  1. Wait for the QR code scan result
+  1. Wait for authentication result
   2. Regenerate code
 Or enter 'r' to go back to select the authentication method
 (user-integration-pre-check-authenticate-user-switching-auth-mode@localhost) Choose action:
@@ -2131,7 +1999,7 @@ Or enter 'r' to go back to choose the provider
   2. Resend SMS (1 sent)
 Or enter 'r' to go back to select the authentication method
 (user-integration-pre-check-authenticate-user-switching-auth-mode@localhost) Choose action:
-> r
+>
 ────────────────────────────────────────────────────────────────────────────────
 > ssh ${AUTHD_PAM_SSH_USER}@localhost ${AUTHD_PAM_SSH_ARGS}
 == Provider selection ==
@@ -2236,12 +2104,12 @@ Enter 'r' to cancel the request and go back to select the authentication method
 Or enter 'r' to go back to choose the provider
 (user-integration-pre-check-authenticate-user-switching-auth-mode@localhost) Choose your authentication method:
 > 2
-== Qr Code authentication ==
+== Use a Login code ==
 Enter the code in the login page
 https://ubuntu.com
        1337
 
-  1. Wait for the QR code scan result
+  1. Wait for authentication result
   2. Regenerate code
 Or enter 'r' to go back to select the authentication method
 (user-integration-pre-check-authenticate-user-switching-auth-mode@localhost) Choose action:
@@ -2264,18 +2132,6 @@ Or enter 'r' to go back to choose the provider
 Or enter 'r' to go back to select the authentication method
 (user-integration-pre-check-authenticate-user-switching-auth-mode@localhost) Choose action:
 > r
-== Authentication method selection ==
-  1. Password authentication
-  2. Use a Login code
-  3. Send URL to user-integration-pre-check-authenticate-user-switching-auth-mode@gmail.com
-  4. Use your fido device foo
-  5. Use your phone +33...
-  6. Use your phone +1...
-  7. Pin code
-  8. Authentication code
-Or enter 'r' to go back to choose the provider
-(user-integration-pre-check-authenticate-user-switching-auth-mode@localhost) Choose your authentication method:
->
 ────────────────────────────────────────────────────────────────────────────────
 > ssh ${AUTHD_PAM_SSH_USER}@localhost ${AUTHD_PAM_SSH_ARGS}
 == Provider selection ==
@@ -2380,12 +2236,12 @@ Enter 'r' to cancel the request and go back to select the authentication method
 Or enter 'r' to go back to choose the provider
 (user-integration-pre-check-authenticate-user-switching-auth-mode@localhost) Choose your authentication method:
 > 2
-== Qr Code authentication ==
+== Use a Login code ==
 Enter the code in the login page
 https://ubuntu.com
        1337
 
-  1. Wait for the QR code scan result
+  1. Wait for authentication result
   2. Regenerate code
 Or enter 'r' to go back to select the authentication method
 (user-integration-pre-check-authenticate-user-switching-auth-mode@localhost) Choose action:
@@ -2419,7 +2275,7 @@ Or enter 'r' to go back to select the authentication method
   8. Authentication code
 Or enter 'r' to go back to choose the provider
 (user-integration-pre-check-authenticate-user-switching-auth-mode@localhost) Choose your authentication method:
-> invalid-selection
+>
 ────────────────────────────────────────────────────────────────────────────────
 > ssh ${AUTHD_PAM_SSH_USER}@localhost ${AUTHD_PAM_SSH_ARGS}
 == Provider selection ==
@@ -2524,12 +2380,12 @@ Enter 'r' to cancel the request and go back to select the authentication method
 Or enter 'r' to go back to choose the provider
 (user-integration-pre-check-authenticate-user-switching-auth-mode@localhost) Choose your authentication method:
 > 2
-== Qr Code authentication ==
+== Use a Login code ==
 Enter the code in the login page
 https://ubuntu.com
        1337
 
-  1. Wait for the QR code scan result
+  1. Wait for authentication result
   2. Regenerate code
 Or enter 'r' to go back to select the authentication method
 (user-integration-pre-check-authenticate-user-switching-auth-mode@localhost) Choose action:
@@ -2564,9 +2420,6 @@ Or enter 'r' to go back to select the authentication method
 Or enter 'r' to go back to choose the provider
 (user-integration-pre-check-authenticate-user-switching-auth-mode@localhost) Choose your authentication method:
 > invalid-selection
-Unsupported input
-(user-integration-pre-check-authenticate-user-switching-auth-mode@localhost) Choose your authentication method:
->
 ────────────────────────────────────────────────────────────────────────────────
 > ssh ${AUTHD_PAM_SSH_USER}@localhost ${AUTHD_PAM_SSH_ARGS}
 == Provider selection ==
@@ -2671,12 +2524,12 @@ Enter 'r' to cancel the request and go back to select the authentication method
 Or enter 'r' to go back to choose the provider
 (user-integration-pre-check-authenticate-user-switching-auth-mode@localhost) Choose your authentication method:
 > 2
-== Qr Code authentication ==
+== Use a Login code ==
 Enter the code in the login page
 https://ubuntu.com
        1337
 
-  1. Wait for the QR code scan result
+  1. Wait for authentication result
   2. Regenerate code
 Or enter 'r' to go back to select the authentication method
 (user-integration-pre-check-authenticate-user-switching-auth-mode@localhost) Choose action:
@@ -2713,7 +2566,7 @@ Or enter 'r' to go back to choose the provider
 > invalid-selection
 Unsupported input
 (user-integration-pre-check-authenticate-user-switching-auth-mode@localhost) Choose your authentication method:
-> -1
+>
 ────────────────────────────────────────────────────────────────────────────────
 > ssh ${AUTHD_PAM_SSH_USER}@localhost ${AUTHD_PAM_SSH_ARGS}
 == Provider selection ==
@@ -2818,12 +2671,12 @@ Enter 'r' to cancel the request and go back to select the authentication method
 Or enter 'r' to go back to choose the provider
 (user-integration-pre-check-authenticate-user-switching-auth-mode@localhost) Choose your authentication method:
 > 2
-== Qr Code authentication ==
+== Use a Login code ==
 Enter the code in the login page
 https://ubuntu.com
        1337
 
-  1. Wait for the QR code scan result
+  1. Wait for authentication result
   2. Regenerate code
 Or enter 'r' to go back to select the authentication method
 (user-integration-pre-check-authenticate-user-switching-auth-mode@localhost) Choose action:
@@ -2861,19 +2714,6 @@ Or enter 'r' to go back to choose the provider
 Unsupported input
 (user-integration-pre-check-authenticate-user-switching-auth-mode@localhost) Choose your authentication method:
 > -1
-Invalid selection
-== Authentication method selection ==
-  1. Password authentication
-  2. Use a Login code
-  3. Send URL to user-integration-pre-check-authenticate-user-switching-auth-mode@gmail.com
-  4. Use your fido device foo
-  5. Use your phone +33...
-  6. Use your phone +1...
-  7. Pin code
-  8. Authentication code
-Or enter 'r' to go back to choose the provider
-(user-integration-pre-check-authenticate-user-switching-auth-mode@localhost) Choose your authentication method:
->
 ────────────────────────────────────────────────────────────────────────────────
 > ssh ${AUTHD_PAM_SSH_USER}@localhost ${AUTHD_PAM_SSH_ARGS}
 == Provider selection ==
@@ -2978,12 +2818,12 @@ Enter 'r' to cancel the request and go back to select the authentication method
 Or enter 'r' to go back to choose the provider
 (user-integration-pre-check-authenticate-user-switching-auth-mode@localhost) Choose your authentication method:
 > 2
-== Qr Code authentication ==
+== Use a Login code ==
 Enter the code in the login page
 https://ubuntu.com
        1337
 
-  1. Wait for the QR code scan result
+  1. Wait for authentication result
   2. Regenerate code
 Or enter 'r' to go back to select the authentication method
 (user-integration-pre-check-authenticate-user-switching-auth-mode@localhost) Choose action:
@@ -3033,7 +2873,7 @@ Invalid selection
   8. Authentication code
 Or enter 'r' to go back to choose the provider
 (user-integration-pre-check-authenticate-user-switching-auth-mode@localhost) Choose your authentication method:
-> 7
+>
 ────────────────────────────────────────────────────────────────────────────────
 > ssh ${AUTHD_PAM_SSH_USER}@localhost ${AUTHD_PAM_SSH_ARGS}
 == Provider selection ==
@@ -3138,12 +2978,12 @@ Enter 'r' to cancel the request and go back to select the authentication method
 Or enter 'r' to go back to choose the provider
 (user-integration-pre-check-authenticate-user-switching-auth-mode@localhost) Choose your authentication method:
 > 2
-== Qr Code authentication ==
+== Use a Login code ==
 Enter the code in the login page
 https://ubuntu.com
        1337
 
-  1. Wait for the QR code scan result
+  1. Wait for authentication result
   2. Regenerate code
 Or enter 'r' to go back to select the authentication method
 (user-integration-pre-check-authenticate-user-switching-auth-mode@localhost) Choose action:
@@ -3194,6 +3034,166 @@ Invalid selection
 Or enter 'r' to go back to choose the provider
 (user-integration-pre-check-authenticate-user-switching-auth-mode@localhost) Choose your authentication method:
 > 7
+────────────────────────────────────────────────────────────────────────────────
+> ssh ${AUTHD_PAM_SSH_USER}@localhost ${AUTHD_PAM_SSH_ARGS}
+== Provider selection ==
+  1. local
+  2. ExampleBroker
+(user-integration-pre-check-authenticate-user-switching-auth-mode@localhost) Choose your provider:
+> 2
+== Password authentication ==
+Enter 'r' to cancel the request and go back to select the authentication method
+(user-integration-pre-check-authenticate-user-switching-auth-mode@localhost) Gimme your password:
+>
+== Authentication method selection ==
+  1. Password authentication
+  2. Use a Login code
+  3. Send URL to user-integration-pre-check-authenticate-user-switching-auth-mode@gmail.com
+  4. Use your fido device foo
+  5. Use your phone +33...
+  6. Use your phone +1...
+  7. Pin code
+  8. Authentication code
+Or enter 'r' to go back to choose the provider
+(user-integration-pre-check-authenticate-user-switching-auth-mode@localhost) Choose your authentication method:
+> 3
+== Send URL to user-integration-pre-check-authenticate-user-switching-auth-mode@gmail.com ==
+Leave the input field empty to wait for the alternative authentication method or enter 'r' to go back to select the authentication method
+(user-integration-pre-check-authenticate-user-switching-auth-mode@localhost) Click on the link received at user-integration-pre-check-authenticate-user-switching-auth-mode@gmail.com or
+ enter the code:
+> r
+== Authentication method selection ==
+  1. Password authentication
+  2. Use a Login code
+  3. Send URL to user-integration-pre-check-authenticate-user-switching-auth-mode@gmail.com
+  4. Use your fido device foo
+  5. Use your phone +33...
+  6. Use your phone +1...
+  7. Pin code
+  8. Authentication code
+Or enter 'r' to go back to choose the provider
+(user-integration-pre-check-authenticate-user-switching-auth-mode@localhost) Choose your authentication method:
+> 4
+== Use your fido device foo ==
+Press Enter to wait for authentication or enter 'r' to go back to select the authentication method
+(user-integration-pre-check-authenticate-user-switching-auth-mode@localhost) Plug your fido device and press with your thumb:
+> r
+== Authentication method selection ==
+  1. Password authentication
+  2. Use a Login code
+  3. Send URL to user-integration-pre-check-authenticate-user-switching-auth-mode@gmail.com
+  4. Use your fido device foo
+  5. Use your phone +33...
+  6. Use your phone +1...
+  7. Pin code
+  8. Authentication code
+Or enter 'r' to go back to choose the provider
+(user-integration-pre-check-authenticate-user-switching-auth-mode@localhost) Choose your authentication method:
+> 5
+== Use your phone +33... ==
+Press Enter to wait for authentication or enter 'r' to go back to select the authentication method
+(user-integration-pre-check-authenticate-user-switching-auth-mode@localhost) Unlock your phone +33... or accept request on web interface:
+> r
+== Authentication method selection ==
+  1. Password authentication
+  2. Use a Login code
+  3. Send URL to user-integration-pre-check-authenticate-user-switching-auth-mode@gmail.com
+  4. Use your fido device foo
+  5. Use your phone +33...
+  6. Use your phone +1...
+  7. Pin code
+  8. Authentication code
+Or enter 'r' to go back to choose the provider
+(user-integration-pre-check-authenticate-user-switching-auth-mode@localhost) Choose your authentication method:
+> 6
+== Use your phone +1... ==
+Press Enter to wait for authentication or enter 'r' to go back to select the authentication method
+(user-integration-pre-check-authenticate-user-switching-auth-mode@localhost) Unlock your phone +1... or accept request on web interface:
+> r
+== Authentication method selection ==
+  1. Password authentication
+  2. Use a Login code
+  3. Send URL to user-integration-pre-check-authenticate-user-switching-auth-mode@gmail.com
+  4. Use your fido device foo
+  5. Use your phone +33...
+  6. Use your phone +1...
+  7. Pin code
+  8. Authentication code
+Or enter 'r' to go back to choose the provider
+(user-integration-pre-check-authenticate-user-switching-auth-mode@localhost) Choose your authentication method:
+> 7
+== Pin code ==
+Enter 'r' to cancel the request and go back to select the authentication method
+(user-integration-pre-check-authenticate-user-switching-auth-mode@localhost) Enter your pin code:
+> r
+== Authentication method selection ==
+  1. Password authentication
+  2. Use a Login code
+  3. Send URL to user-integration-pre-check-authenticate-user-switching-auth-mode@gmail.com
+  4. Use your fido device foo
+  5. Use your phone +33...
+  6. Use your phone +1...
+  7. Pin code
+  8. Authentication code
+Or enter 'r' to go back to choose the provider
+(user-integration-pre-check-authenticate-user-switching-auth-mode@localhost) Choose your authentication method:
+> 2
+== Use a Login code ==
+Enter the code in the login page
+https://ubuntu.com
+       1337
+
+  1. Wait for authentication result
+  2. Regenerate code
+Or enter 'r' to go back to select the authentication method
+(user-integration-pre-check-authenticate-user-switching-auth-mode@localhost) Choose action:
+> r
+== Authentication method selection ==
+  1. Password authentication
+  2. Use a Login code
+  3. Send URL to user-integration-pre-check-authenticate-user-switching-auth-mode@gmail.com
+  4. Use your fido device foo
+  5. Use your phone +33...
+  6. Use your phone +1...
+  7. Pin code
+  8. Authentication code
+Or enter 'r' to go back to choose the provider
+(user-integration-pre-check-authenticate-user-switching-auth-mode@localhost) Choose your authentication method:
+> 8
+== Authentication code ==
+  1. Proceed with Authentication code
+  2. Resend SMS (1 sent)
+Or enter 'r' to go back to select the authentication method
+(user-integration-pre-check-authenticate-user-switching-auth-mode@localhost) Choose action:
+> r
+== Authentication method selection ==
+  1. Password authentication
+  2. Use a Login code
+  3. Send URL to user-integration-pre-check-authenticate-user-switching-auth-mode@gmail.com
+  4. Use your fido device foo
+  5. Use your phone +33...
+  6. Use your phone +1...
+  7. Pin code
+  8. Authentication code
+Or enter 'r' to go back to choose the provider
+(user-integration-pre-check-authenticate-user-switching-auth-mode@localhost) Choose your authentication method:
+> invalid-selection
+Unsupported input
+(user-integration-pre-check-authenticate-user-switching-auth-mode@localhost) Choose your authentication method:
+> -1
+Invalid selection
+== Authentication method selection ==
+  1. Password authentication
+  2. Use a Login code
+  3. Send URL to user-integration-pre-check-authenticate-user-switching-auth-mode@gmail.com
+  4. Use your fido device foo
+  5. Use your phone +33...
+  6. Use your phone +1...
+  7. Pin code
+  8. Authentication code
+Or enter 'r' to go back to choose the provider
+(user-integration-pre-check-authenticate-user-switching-auth-mode@localhost) Choose your authentication method:
+> 7
 == Pin code ==
 Enter 'r' to cancel the request and go back to select the authentication method
 (user-integration-pre-check-authenticate-user-switching-auth-mode@localhost) Enter your pin code:
@@ -3302,12 +3302,12 @@ Enter 'r' to cancel the request and go back to select the authentication method
 Or enter 'r' to go back to choose the provider
 (user-integration-pre-check-authenticate-user-switching-auth-mode@localhost) Choose your authentication method:
 > 2
-== Qr Code authentication ==
+== Use a Login code ==
 Enter the code in the login page
 https://ubuntu.com
        1337
 
-  1. Wait for the QR code scan result
+  1. Wait for authentication result
   2. Regenerate code
 Or enter 'r' to go back to select the authentication method
 (user-integration-pre-check-authenticate-user-switching-auth-mode@localhost) Choose action:
@@ -3466,12 +3466,12 @@ Enter 'r' to cancel the request and go back to select the authentication method
 Or enter 'r' to go back to choose the provider
 (user-integration-pre-check-authenticate-user-switching-auth-mode@localhost) Choose your authentication method:
 > 2
-== Qr Code authentication ==
+== Use a Login code ==
 Enter the code in the login page
 https://ubuntu.com
        1337
 
-  1. Wait for the QR code scan result
+  1. Wait for authentication result
   2. Regenerate code
 Or enter 'r' to go back to select the authentication method
 (user-integration-pre-check-authenticate-user-switching-auth-mode@localhost) Choose action:

--- a/pam/integration-tests/testdata/golden/TestSSHAuthenticate/Authenticate_user_switching_auth_mode_on_shared_SSHd
+++ b/pam/integration-tests/testdata/golden/TestSSHAuthenticate/Authenticate_user_switching_auth_mode_on_shared_SSHd
@@ -1492,12 +1492,12 @@ Enter 'r' to cancel the request and go back to select the authentication method
 Or enter 'r' to go back to choose the provider
 (user-integration-pre-check-authenticate-user-switching-auth-mode-on-shared-sshd@localhost) Choose your authentication method:
 > 2
-== Qr Code authentication ==
+== Use a Login code ==
 Enter the code in the login page
 https://ubuntu.com
        1337
 
-  1. Wait for the QR code scan result
+  1. Wait for authentication result
   2. Regenerate code
 Or enter 'r' to go back to select the authentication method
 (user-integration-pre-check-authenticate-user-switching-auth-mode-on-shared-sshd@localhost) Choose action:
@@ -1606,12 +1606,12 @@ Enter 'r' to cancel the request and go back to select the authentication method
 Or enter 'r' to go back to choose the provider
 (user-integration-pre-check-authenticate-user-switching-auth-mode-on-shared-sshd@localhost) Choose your authentication method:
 > 2
-== Qr Code authentication ==
+== Use a Login code ==
 Enter the code in the login page
 https://ubuntu.com
        1337
 
-  1. Wait for the QR code scan result
+  1. Wait for authentication result
   2. Regenerate code
 Or enter 'r' to go back to select the authentication method
 (user-integration-pre-check-authenticate-user-switching-auth-mode-on-shared-sshd@localhost) Choose action:
@@ -1720,12 +1720,12 @@ Enter 'r' to cancel the request and go back to select the authentication method
 Or enter 'r' to go back to choose the provider
 (user-integration-pre-check-authenticate-user-switching-auth-mode-on-shared-sshd@localhost) Choose your authentication method:
 > 2
-== Qr Code authentication ==
+== Use a Login code ==
 Enter the code in the login page
 https://ubuntu.com
        1337
 
-  1. Wait for the QR code scan result
+  1. Wait for authentication result
   2. Regenerate code
 Or enter 'r' to go back to select the authentication method
 (user-integration-pre-check-authenticate-user-switching-auth-mode-on-shared-sshd@localhost) Choose action:
@@ -1846,138 +1846,12 @@ Enter 'r' to cancel the request and go back to select the authentication method
 Or enter 'r' to go back to choose the provider
 (user-integration-pre-check-authenticate-user-switching-auth-mode-on-shared-sshd@localhost) Choose your authentication method:
 > 2
-== Qr Code authentication ==
+== Use a Login code ==
 Enter the code in the login page
 https://ubuntu.com
        1337
 
-  1. Wait for the QR code scan result
-  2. Regenerate code
-Or enter 'r' to go back to select the authentication method
-(user-integration-pre-check-authenticate-user-switching-auth-mode-on-shared-sshd@localhost) Choose action:
-> r
-== Authentication method selection ==
-  1. Password authentication
-  2. Use a Login code
-  3. Send URL to user-integration-pre-check-authenticate-user-switching-auth-mode-on-shared-sshd@gmail.com
-  4. Use your fido device foo
-  5. Use your phone +33...
-  6. Use your phone +1...
-  7. Pin code
-  8. Authentication code
-Or enter 'r' to go back to choose the provider
-(user-integration-pre-check-authenticate-user-switching-auth-mode-on-shared-sshd@localhost) Choose your authentication method:
-> 8
-────────────────────────────────────────────────────────────────────────────────
-> ssh ${AUTHD_PAM_SSH_USER}@localhost ${AUTHD_PAM_SSH_ARGS}
-== Provider selection ==
-  1. local
-  2. ExampleBroker
-(user-integration-pre-check-authenticate-user-switching-auth-mode-on-shared-sshd@localhost) Choose your provider:
-> 2
-== Password authentication ==
-Enter 'r' to cancel the request and go back to select the authentication method
-(user-integration-pre-check-authenticate-user-switching-auth-mode-on-shared-sshd@localhost) Gimme your password:
->
-== Authentication method selection ==
-  1. Password authentication
-  2. Use a Login code
-  3. Send URL to user-integration-pre-check-authenticate-user-switching-auth-mode-on-shared-sshd@gmail.com
-  4. Use your fido device foo
-  5. Use your phone +33...
-  6. Use your phone +1...
-  7. Pin code
-  8. Authentication code
-Or enter 'r' to go back to choose the provider
-(user-integration-pre-check-authenticate-user-switching-auth-mode-on-shared-sshd@localhost) Choose your authentication method:
-> 3
-== Send URL to user-integration-pre-check-authenticate-user-switching-auth-mode-on-shared-sshd@gmail.com ==
-Leave the input field empty to wait for the alternative authentication method or enter 'r' to go back to select the authentication method
-(user-integration-pre-check-authenticate-user-switching-auth-mode-on-shared-sshd@localhost) Click on the link received at user-integration-pre-check-authenticate-user-switching-auth-mo
-de-on-shared-sshd@gmail.com or enter the code:
-> r
-== Authentication method selection ==
-  1. Password authentication
-  2. Use a Login code
-  3. Send URL to user-integration-pre-check-authenticate-user-switching-auth-mode-on-shared-sshd@gmail.com
-  4. Use your fido device foo
-  5. Use your phone +33...
-  6. Use your phone +1...
-  7. Pin code
-  8. Authentication code
-Or enter 'r' to go back to choose the provider
-(user-integration-pre-check-authenticate-user-switching-auth-mode-on-shared-sshd@localhost) Choose your authentication method:
-> 4
-== Use your fido device foo ==
-Press Enter to wait for authentication or enter 'r' to go back to select the authentication method
-(user-integration-pre-check-authenticate-user-switching-auth-mode-on-shared-sshd@localhost) Plug your fido device and press with your thumb:
-> r
-== Authentication method selection ==
-  1. Password authentication
-  2. Use a Login code
-  3. Send URL to user-integration-pre-check-authenticate-user-switching-auth-mode-on-shared-sshd@gmail.com
-  4. Use your fido device foo
-  5. Use your phone +33...
-  6. Use your phone +1...
-  7. Pin code
-  8. Authentication code
-Or enter 'r' to go back to choose the provider
-(user-integration-pre-check-authenticate-user-switching-auth-mode-on-shared-sshd@localhost) Choose your authentication method:
-> 5
-== Use your phone +33... ==
-Press Enter to wait for authentication or enter 'r' to go back to select the authentication method
-(user-integration-pre-check-authenticate-user-switching-auth-mode-on-shared-sshd@localhost) Unlock your phone +33... or accept request on web interface:
-> r
-== Authentication method selection ==
-  1. Password authentication
-  2. Use a Login code
-  3. Send URL to user-integration-pre-check-authenticate-user-switching-auth-mode-on-shared-sshd@gmail.com
-  4. Use your fido device foo
-  5. Use your phone +33...
-  6. Use your phone +1...
-  7. Pin code
-  8. Authentication code
-Or enter 'r' to go back to choose the provider
-(user-integration-pre-check-authenticate-user-switching-auth-mode-on-shared-sshd@localhost) Choose your authentication method:
-> 6
-== Use your phone +1... ==
-Press Enter to wait for authentication or enter 'r' to go back to select the authentication method
-(user-integration-pre-check-authenticate-user-switching-auth-mode-on-shared-sshd@localhost) Unlock your phone +1... or accept request on web interface:
-> r
-== Authentication method selection ==
-  1. Password authentication
-  2. Use a Login code
-  3. Send URL to user-integration-pre-check-authenticate-user-switching-auth-mode-on-shared-sshd@gmail.com
-  4. Use your fido device foo
-  5. Use your phone +33...
-  6. Use your phone +1...
-  7. Pin code
-  8. Authentication code
-Or enter 'r' to go back to choose the provider
-(user-integration-pre-check-authenticate-user-switching-auth-mode-on-shared-sshd@localhost) Choose your authentication method:
-> 7
-== Pin code ==
-Enter 'r' to cancel the request and go back to select the authentication method
-(user-integration-pre-check-authenticate-user-switching-auth-mode-on-shared-sshd@localhost) Enter your pin code:
-> r
-== Authentication method selection ==
-  1. Password authentication
-  2. Use a Login code
-  3. Send URL to user-integration-pre-check-authenticate-user-switching-auth-mode-on-shared-sshd@gmail.com
-  4. Use your fido device foo
-  5. Use your phone +33...
-  6. Use your phone +1...
-  7. Pin code
-  8. Authentication code
-Or enter 'r' to go back to choose the provider
-(user-integration-pre-check-authenticate-user-switching-auth-mode-on-shared-sshd@localhost) Choose your authentication method:
-> 2
-== Qr Code authentication ==
-Enter the code in the login page
-https://ubuntu.com
-       1337
-
-  1. Wait for the QR code scan result
+  1. Wait for authentication result
   2. Regenerate code
 Or enter 'r' to go back to select the authentication method
 (user-integration-pre-check-authenticate-user-switching-auth-mode-on-shared-sshd@localhost) Choose action:
@@ -1994,12 +1868,6 @@ Or enter 'r' to go back to select the authentication method
 Or enter 'r' to go back to choose the provider
 (user-integration-pre-check-authenticate-user-switching-auth-mode-on-shared-sshd@localhost) Choose your authentication method:
 > 8
-== Authentication code ==
-  1. Proceed with Authentication code
-  2. Resend SMS (1 sent)
-Or enter 'r' to go back to select the authentication method
-(user-integration-pre-check-authenticate-user-switching-auth-mode-on-shared-sshd@localhost) Choose action:
->
 ────────────────────────────────────────────────────────────────────────────────
 > ssh ${AUTHD_PAM_SSH_USER}@localhost ${AUTHD_PAM_SSH_ARGS}
 == Provider selection ==
@@ -2104,12 +1972,12 @@ Enter 'r' to cancel the request and go back to select the authentication method
 Or enter 'r' to go back to choose the provider
 (user-integration-pre-check-authenticate-user-switching-auth-mode-on-shared-sshd@localhost) Choose your authentication method:
 > 2
-== Qr Code authentication ==
+== Use a Login code ==
 Enter the code in the login page
 https://ubuntu.com
        1337
 
-  1. Wait for the QR code scan result
+  1. Wait for authentication result
   2. Regenerate code
 Or enter 'r' to go back to select the authentication method
 (user-integration-pre-check-authenticate-user-switching-auth-mode-on-shared-sshd@localhost) Choose action:
@@ -2131,7 +1999,7 @@ Or enter 'r' to go back to choose the provider
   2. Resend SMS (1 sent)
 Or enter 'r' to go back to select the authentication method
 (user-integration-pre-check-authenticate-user-switching-auth-mode-on-shared-sshd@localhost) Choose action:
-> r
+>
 ────────────────────────────────────────────────────────────────────────────────
 > ssh ${AUTHD_PAM_SSH_USER}@localhost ${AUTHD_PAM_SSH_ARGS}
 == Provider selection ==
@@ -2236,12 +2104,12 @@ Enter 'r' to cancel the request and go back to select the authentication method
 Or enter 'r' to go back to choose the provider
 (user-integration-pre-check-authenticate-user-switching-auth-mode-on-shared-sshd@localhost) Choose your authentication method:
 > 2
-== Qr Code authentication ==
+== Use a Login code ==
 Enter the code in the login page
 https://ubuntu.com
        1337
 
-  1. Wait for the QR code scan result
+  1. Wait for authentication result
   2. Regenerate code
 Or enter 'r' to go back to select the authentication method
 (user-integration-pre-check-authenticate-user-switching-auth-mode-on-shared-sshd@localhost) Choose action:
@@ -2264,18 +2132,6 @@ Or enter 'r' to go back to choose the provider
 Or enter 'r' to go back to select the authentication method
 (user-integration-pre-check-authenticate-user-switching-auth-mode-on-shared-sshd@localhost) Choose action:
 > r
-== Authentication method selection ==
-  1. Password authentication
-  2. Use a Login code
-  3. Send URL to user-integration-pre-check-authenticate-user-switching-auth-mode-on-shared-sshd@gmail.com
-  4. Use your fido device foo
-  5. Use your phone +33...
-  6. Use your phone +1...
-  7. Pin code
-  8. Authentication code
-Or enter 'r' to go back to choose the provider
-(user-integration-pre-check-authenticate-user-switching-auth-mode-on-shared-sshd@localhost) Choose your authentication method:
->
 ────────────────────────────────────────────────────────────────────────────────
 > ssh ${AUTHD_PAM_SSH_USER}@localhost ${AUTHD_PAM_SSH_ARGS}
 == Provider selection ==
@@ -2380,12 +2236,12 @@ Enter 'r' to cancel the request and go back to select the authentication method
 Or enter 'r' to go back to choose the provider
 (user-integration-pre-check-authenticate-user-switching-auth-mode-on-shared-sshd@localhost) Choose your authentication method:
 > 2
-== Qr Code authentication ==
+== Use a Login code ==
 Enter the code in the login page
 https://ubuntu.com
        1337
 
-  1. Wait for the QR code scan result
+  1. Wait for authentication result
   2. Regenerate code
 Or enter 'r' to go back to select the authentication method
 (user-integration-pre-check-authenticate-user-switching-auth-mode-on-shared-sshd@localhost) Choose action:
@@ -2419,7 +2275,7 @@ Or enter 'r' to go back to select the authentication method
   8. Authentication code
 Or enter 'r' to go back to choose the provider
 (user-integration-pre-check-authenticate-user-switching-auth-mode-on-shared-sshd@localhost) Choose your authentication method:
-> invalid-selection
+>
 ────────────────────────────────────────────────────────────────────────────────
 > ssh ${AUTHD_PAM_SSH_USER}@localhost ${AUTHD_PAM_SSH_ARGS}
 == Provider selection ==
@@ -2524,12 +2380,12 @@ Enter 'r' to cancel the request and go back to select the authentication method
 Or enter 'r' to go back to choose the provider
 (user-integration-pre-check-authenticate-user-switching-auth-mode-on-shared-sshd@localhost) Choose your authentication method:
 > 2
-== Qr Code authentication ==
+== Use a Login code ==
 Enter the code in the login page
 https://ubuntu.com
        1337
 
-  1. Wait for the QR code scan result
+  1. Wait for authentication result
   2. Regenerate code
 Or enter 'r' to go back to select the authentication method
 (user-integration-pre-check-authenticate-user-switching-auth-mode-on-shared-sshd@localhost) Choose action:
@@ -2564,9 +2420,6 @@ Or enter 'r' to go back to select the authentication method
 Or enter 'r' to go back to choose the provider
 (user-integration-pre-check-authenticate-user-switching-auth-mode-on-shared-sshd@localhost) Choose your authentication method:
 > invalid-selection
-Unsupported input
-(user-integration-pre-check-authenticate-user-switching-auth-mode-on-shared-sshd@localhost) Choose your authentication method:
->
 ────────────────────────────────────────────────────────────────────────────────
 > ssh ${AUTHD_PAM_SSH_USER}@localhost ${AUTHD_PAM_SSH_ARGS}
 == Provider selection ==
@@ -2671,12 +2524,12 @@ Enter 'r' to cancel the request and go back to select the authentication method
 Or enter 'r' to go back to choose the provider
 (user-integration-pre-check-authenticate-user-switching-auth-mode-on-shared-sshd@localhost) Choose your authentication method:
 > 2
-== Qr Code authentication ==
+== Use a Login code ==
 Enter the code in the login page
 https://ubuntu.com
        1337
 
-  1. Wait for the QR code scan result
+  1. Wait for authentication result
   2. Regenerate code
 Or enter 'r' to go back to select the authentication method
 (user-integration-pre-check-authenticate-user-switching-auth-mode-on-shared-sshd@localhost) Choose action:
@@ -2713,7 +2566,7 @@ Or enter 'r' to go back to choose the provider
 > invalid-selection
 Unsupported input
 (user-integration-pre-check-authenticate-user-switching-auth-mode-on-shared-sshd@localhost) Choose your authentication method:
-> -1
+>
 ────────────────────────────────────────────────────────────────────────────────
 > ssh ${AUTHD_PAM_SSH_USER}@localhost ${AUTHD_PAM_SSH_ARGS}
 == Provider selection ==
@@ -2818,12 +2671,12 @@ Enter 'r' to cancel the request and go back to select the authentication method
 Or enter 'r' to go back to choose the provider
 (user-integration-pre-check-authenticate-user-switching-auth-mode-on-shared-sshd@localhost) Choose your authentication method:
 > 2
-== Qr Code authentication ==
+== Use a Login code ==
 Enter the code in the login page
 https://ubuntu.com
        1337
 
-  1. Wait for the QR code scan result
+  1. Wait for authentication result
   2. Regenerate code
 Or enter 'r' to go back to select the authentication method
 (user-integration-pre-check-authenticate-user-switching-auth-mode-on-shared-sshd@localhost) Choose action:
@@ -2861,19 +2714,6 @@ Or enter 'r' to go back to choose the provider
 Unsupported input
 (user-integration-pre-check-authenticate-user-switching-auth-mode-on-shared-sshd@localhost) Choose your authentication method:
 > -1
-Invalid selection
-== Authentication method selection ==
-  1. Password authentication
-  2. Use a Login code
-  3. Send URL to user-integration-pre-check-authenticate-user-switching-auth-mode-on-shared-sshd@gmail.com
-  4. Use your fido device foo
-  5. Use your phone +33...
-  6. Use your phone +1...
-  7. Pin code
-  8. Authentication code
-Or enter 'r' to go back to choose the provider
-(user-integration-pre-check-authenticate-user-switching-auth-mode-on-shared-sshd@localhost) Choose your authentication method:
->
 ────────────────────────────────────────────────────────────────────────────────
 > ssh ${AUTHD_PAM_SSH_USER}@localhost ${AUTHD_PAM_SSH_ARGS}
 == Provider selection ==
@@ -2978,12 +2818,12 @@ Enter 'r' to cancel the request and go back to select the authentication method
 Or enter 'r' to go back to choose the provider
 (user-integration-pre-check-authenticate-user-switching-auth-mode-on-shared-sshd@localhost) Choose your authentication method:
 > 2
-== Qr Code authentication ==
+== Use a Login code ==
 Enter the code in the login page
 https://ubuntu.com
        1337
 
-  1. Wait for the QR code scan result
+  1. Wait for authentication result
   2. Regenerate code
 Or enter 'r' to go back to select the authentication method
 (user-integration-pre-check-authenticate-user-switching-auth-mode-on-shared-sshd@localhost) Choose action:
@@ -3033,7 +2873,7 @@ Invalid selection
   8. Authentication code
 Or enter 'r' to go back to choose the provider
 (user-integration-pre-check-authenticate-user-switching-auth-mode-on-shared-sshd@localhost) Choose your authentication method:
-> 7
+>
 ────────────────────────────────────────────────────────────────────────────────
 > ssh ${AUTHD_PAM_SSH_USER}@localhost ${AUTHD_PAM_SSH_ARGS}
 == Provider selection ==
@@ -3138,12 +2978,12 @@ Enter 'r' to cancel the request and go back to select the authentication method
 Or enter 'r' to go back to choose the provider
 (user-integration-pre-check-authenticate-user-switching-auth-mode-on-shared-sshd@localhost) Choose your authentication method:
 > 2
-== Qr Code authentication ==
+== Use a Login code ==
 Enter the code in the login page
 https://ubuntu.com
        1337
 
-  1. Wait for the QR code scan result
+  1. Wait for authentication result
   2. Regenerate code
 Or enter 'r' to go back to select the authentication method
 (user-integration-pre-check-authenticate-user-switching-auth-mode-on-shared-sshd@localhost) Choose action:
@@ -3194,6 +3034,166 @@ Invalid selection
 Or enter 'r' to go back to choose the provider
 (user-integration-pre-check-authenticate-user-switching-auth-mode-on-shared-sshd@localhost) Choose your authentication method:
 > 7
+────────────────────────────────────────────────────────────────────────────────
+> ssh ${AUTHD_PAM_SSH_USER}@localhost ${AUTHD_PAM_SSH_ARGS}
+== Provider selection ==
+  1. local
+  2. ExampleBroker
+(user-integration-pre-check-authenticate-user-switching-auth-mode-on-shared-sshd@localhost) Choose your provider:
+> 2
+== Password authentication ==
+Enter 'r' to cancel the request and go back to select the authentication method
+(user-integration-pre-check-authenticate-user-switching-auth-mode-on-shared-sshd@localhost) Gimme your password:
+>
+== Authentication method selection ==
+  1. Password authentication
+  2. Use a Login code
+  3. Send URL to user-integration-pre-check-authenticate-user-switching-auth-mode-on-shared-sshd@gmail.com
+  4. Use your fido device foo
+  5. Use your phone +33...
+  6. Use your phone +1...
+  7. Pin code
+  8. Authentication code
+Or enter 'r' to go back to choose the provider
+(user-integration-pre-check-authenticate-user-switching-auth-mode-on-shared-sshd@localhost) Choose your authentication method:
+> 3
+== Send URL to user-integration-pre-check-authenticate-user-switching-auth-mode-on-shared-sshd@gmail.com ==
+Leave the input field empty to wait for the alternative authentication method or enter 'r' to go back to select the authentication method
+(user-integration-pre-check-authenticate-user-switching-auth-mode-on-shared-sshd@localhost) Click on the link received at user-integration-pre-check-authenticate-user-switching-auth-mo
+de-on-shared-sshd@gmail.com or enter the code:
+> r
+== Authentication method selection ==
+  1. Password authentication
+  2. Use a Login code
+  3. Send URL to user-integration-pre-check-authenticate-user-switching-auth-mode-on-shared-sshd@gmail.com
+  4. Use your fido device foo
+  5. Use your phone +33...
+  6. Use your phone +1...
+  7. Pin code
+  8. Authentication code
+Or enter 'r' to go back to choose the provider
+(user-integration-pre-check-authenticate-user-switching-auth-mode-on-shared-sshd@localhost) Choose your authentication method:
+> 4
+== Use your fido device foo ==
+Press Enter to wait for authentication or enter 'r' to go back to select the authentication method
+(user-integration-pre-check-authenticate-user-switching-auth-mode-on-shared-sshd@localhost) Plug your fido device and press with your thumb:
+> r
+== Authentication method selection ==
+  1. Password authentication
+  2. Use a Login code
+  3. Send URL to user-integration-pre-check-authenticate-user-switching-auth-mode-on-shared-sshd@gmail.com
+  4. Use your fido device foo
+  5. Use your phone +33...
+  6. Use your phone +1...
+  7. Pin code
+  8. Authentication code
+Or enter 'r' to go back to choose the provider
+(user-integration-pre-check-authenticate-user-switching-auth-mode-on-shared-sshd@localhost) Choose your authentication method:
+> 5
+== Use your phone +33... ==
+Press Enter to wait for authentication or enter 'r' to go back to select the authentication method
+(user-integration-pre-check-authenticate-user-switching-auth-mode-on-shared-sshd@localhost) Unlock your phone +33... or accept request on web interface:
+> r
+== Authentication method selection ==
+  1. Password authentication
+  2. Use a Login code
+  3. Send URL to user-integration-pre-check-authenticate-user-switching-auth-mode-on-shared-sshd@gmail.com
+  4. Use your fido device foo
+  5. Use your phone +33...
+  6. Use your phone +1...
+  7. Pin code
+  8. Authentication code
+Or enter 'r' to go back to choose the provider
+(user-integration-pre-check-authenticate-user-switching-auth-mode-on-shared-sshd@localhost) Choose your authentication method:
+> 6
+== Use your phone +1... ==
+Press Enter to wait for authentication or enter 'r' to go back to select the authentication method
+(user-integration-pre-check-authenticate-user-switching-auth-mode-on-shared-sshd@localhost) Unlock your phone +1... or accept request on web interface:
+> r
+== Authentication method selection ==
+  1. Password authentication
+  2. Use a Login code
+  3. Send URL to user-integration-pre-check-authenticate-user-switching-auth-mode-on-shared-sshd@gmail.com
+  4. Use your fido device foo
+  5. Use your phone +33...
+  6. Use your phone +1...
+  7. Pin code
+  8. Authentication code
+Or enter 'r' to go back to choose the provider
+(user-integration-pre-check-authenticate-user-switching-auth-mode-on-shared-sshd@localhost) Choose your authentication method:
+> 7
+== Pin code ==
+Enter 'r' to cancel the request and go back to select the authentication method
+(user-integration-pre-check-authenticate-user-switching-auth-mode-on-shared-sshd@localhost) Enter your pin code:
+> r
+== Authentication method selection ==
+  1. Password authentication
+  2. Use a Login code
+  3. Send URL to user-integration-pre-check-authenticate-user-switching-auth-mode-on-shared-sshd@gmail.com
+  4. Use your fido device foo
+  5. Use your phone +33...
+  6. Use your phone +1...
+  7. Pin code
+  8. Authentication code
+Or enter 'r' to go back to choose the provider
+(user-integration-pre-check-authenticate-user-switching-auth-mode-on-shared-sshd@localhost) Choose your authentication method:
+> 2
+== Use a Login code ==
+Enter the code in the login page
+https://ubuntu.com
+       1337
+
+  1. Wait for authentication result
+  2. Regenerate code
+Or enter 'r' to go back to select the authentication method
+(user-integration-pre-check-authenticate-user-switching-auth-mode-on-shared-sshd@localhost) Choose action:
+> r
+== Authentication method selection ==
+  1. Password authentication
+  2. Use a Login code
+  3. Send URL to user-integration-pre-check-authenticate-user-switching-auth-mode-on-shared-sshd@gmail.com
+  4. Use your fido device foo
+  5. Use your phone +33...
+  6. Use your phone +1...
+  7. Pin code
+  8. Authentication code
+Or enter 'r' to go back to choose the provider
+(user-integration-pre-check-authenticate-user-switching-auth-mode-on-shared-sshd@localhost) Choose your authentication method:
+> 8
+== Authentication code ==
+  1. Proceed with Authentication code
+  2. Resend SMS (1 sent)
+Or enter 'r' to go back to select the authentication method
+(user-integration-pre-check-authenticate-user-switching-auth-mode-on-shared-sshd@localhost) Choose action:
+> r
+== Authentication method selection ==
+  1. Password authentication
+  2. Use a Login code
+  3. Send URL to user-integration-pre-check-authenticate-user-switching-auth-mode-on-shared-sshd@gmail.com
+  4. Use your fido device foo
+  5. Use your phone +33...
+  6. Use your phone +1...
+  7. Pin code
+  8. Authentication code
+Or enter 'r' to go back to choose the provider
+(user-integration-pre-check-authenticate-user-switching-auth-mode-on-shared-sshd@localhost) Choose your authentication method:
+> invalid-selection
+Unsupported input
+(user-integration-pre-check-authenticate-user-switching-auth-mode-on-shared-sshd@localhost) Choose your authentication method:
+> -1
+Invalid selection
+== Authentication method selection ==
+  1. Password authentication
+  2. Use a Login code
+  3. Send URL to user-integration-pre-check-authenticate-user-switching-auth-mode-on-shared-sshd@gmail.com
+  4. Use your fido device foo
+  5. Use your phone +33...
+  6. Use your phone +1...
+  7. Pin code
+  8. Authentication code
+Or enter 'r' to go back to choose the provider
+(user-integration-pre-check-authenticate-user-switching-auth-mode-on-shared-sshd@localhost) Choose your authentication method:
+> 7
 == Pin code ==
 Enter 'r' to cancel the request and go back to select the authentication method
 (user-integration-pre-check-authenticate-user-switching-auth-mode-on-shared-sshd@localhost) Enter your pin code:
@@ -3302,12 +3302,12 @@ Enter 'r' to cancel the request and go back to select the authentication method
 Or enter 'r' to go back to choose the provider
 (user-integration-pre-check-authenticate-user-switching-auth-mode-on-shared-sshd@localhost) Choose your authentication method:
 > 2
-== Qr Code authentication ==
+== Use a Login code ==
 Enter the code in the login page
 https://ubuntu.com
        1337
 
-  1. Wait for the QR code scan result
+  1. Wait for authentication result
   2. Regenerate code
 Or enter 'r' to go back to select the authentication method
 (user-integration-pre-check-authenticate-user-switching-auth-mode-on-shared-sshd@localhost) Choose action:
@@ -3466,12 +3466,12 @@ Enter 'r' to cancel the request and go back to select the authentication method
 Or enter 'r' to go back to choose the provider
 (user-integration-pre-check-authenticate-user-switching-auth-mode-on-shared-sshd@localhost) Choose your authentication method:
 > 2
-== Qr Code authentication ==
+== Use a Login code ==
 Enter the code in the login page
 https://ubuntu.com
        1337
 
-  1. Wait for the QR code scan result
+  1. Wait for authentication result
   2. Regenerate code
 Or enter 'r' to go back to select the authentication method
 (user-integration-pre-check-authenticate-user-switching-auth-mode-on-shared-sshd@localhost) Choose action:

--- a/pam/integration-tests/testdata/golden/TestSSHAuthenticate/Authenticate_user_with_qr_code
+++ b/pam/integration-tests/testdata/golden/TestSSHAuthenticate/Authenticate_user_with_qr_code
@@ -96,12 +96,12 @@ Enter 'r' to cancel the request and go back to select the authentication method
 Or enter 'r' to go back to choose the provider
 (user-integration-pre-check-authenticate-user-with-qr-code@localhost) Choose your authentication method:
 > 2
-== Qr Code authentication ==
+== Use a Login code ==
 Enter the code in the login page
 https://ubuntu.com
        1337
 
-  1. Wait for the QR code scan result
+  1. Wait for authentication result
   2. Regenerate code
 Or enter 'r' to go back to select the authentication method
 (user-integration-pre-check-authenticate-user-with-qr-code@localhost) Choose action:
@@ -130,12 +130,12 @@ Enter 'r' to cancel the request and go back to select the authentication method
 Or enter 'r' to go back to choose the provider
 (user-integration-pre-check-authenticate-user-with-qr-code@localhost) Choose your authentication method:
 > 2
-== Qr Code authentication ==
+== Use a Login code ==
 Enter the code in the login page
 https://ubuntu.com
        1337
 
-  1. Wait for the QR code scan result
+  1. Wait for authentication result
   2. Regenerate code
 Or enter 'r' to go back to select the authentication method
 (user-integration-pre-check-authenticate-user-with-qr-code@localhost) Choose action:
@@ -164,22 +164,22 @@ Enter 'r' to cancel the request and go back to select the authentication method
 Or enter 'r' to go back to choose the provider
 (user-integration-pre-check-authenticate-user-with-qr-code@localhost) Choose your authentication method:
 > 2
-== Qr Code authentication ==
+== Use a Login code ==
 Enter the code in the login page
 https://ubuntu.com
        1337
 
-  1. Wait for the QR code scan result
+  1. Wait for authentication result
   2. Regenerate code
 Or enter 'r' to go back to select the authentication method
 (user-integration-pre-check-authenticate-user-with-qr-code@localhost) Choose action:
 > 2
-== Qr Code authentication ==
+== Use a Login code ==
 Enter the code in the login page
 https://ubuntu.fr/
        1338
 
-  1. Wait for the QR code scan result
+  1. Wait for authentication result
   2. Regenerate code
 Or enter 'r' to go back to select the authentication method
 (user-integration-pre-check-authenticate-user-with-qr-code@localhost) Choose action:
@@ -208,22 +208,22 @@ Enter 'r' to cancel the request and go back to select the authentication method
 Or enter 'r' to go back to choose the provider
 (user-integration-pre-check-authenticate-user-with-qr-code@localhost) Choose your authentication method:
 > 2
-== Qr Code authentication ==
+== Use a Login code ==
 Enter the code in the login page
 https://ubuntu.com
        1337
 
-  1. Wait for the QR code scan result
+  1. Wait for authentication result
   2. Regenerate code
 Or enter 'r' to go back to select the authentication method
 (user-integration-pre-check-authenticate-user-with-qr-code@localhost) Choose action:
 > 2
-== Qr Code authentication ==
+== Use a Login code ==
 Enter the code in the login page
 https://ubuntu.fr/
        1338
 
-  1. Wait for the QR code scan result
+  1. Wait for authentication result
   2. Regenerate code
 Or enter 'r' to go back to select the authentication method
 (user-integration-pre-check-authenticate-user-with-qr-code@localhost) Choose action:
@@ -252,32 +252,32 @@ Enter 'r' to cancel the request and go back to select the authentication method
 Or enter 'r' to go back to choose the provider
 (user-integration-pre-check-authenticate-user-with-qr-code@localhost) Choose your authentication method:
 > 2
-== Qr Code authentication ==
+== Use a Login code ==
 Enter the code in the login page
 https://ubuntu.com
        1337
 
-  1. Wait for the QR code scan result
+  1. Wait for authentication result
   2. Regenerate code
 Or enter 'r' to go back to select the authentication method
 (user-integration-pre-check-authenticate-user-with-qr-code@localhost) Choose action:
 > 2
-== Qr Code authentication ==
+== Use a Login code ==
 Enter the code in the login page
 https://ubuntu.fr/
        1338
 
-  1. Wait for the QR code scan result
+  1. Wait for authentication result
   2. Regenerate code
 Or enter 'r' to go back to select the authentication method
 (user-integration-pre-check-authenticate-user-with-qr-code@localhost) Choose action:
 > 2
-== Qr Code authentication ==
+== Use a Login code ==
 Enter the code in the login page
 https://ubuntuforum-br.org/
            1339
 
-  1. Wait for the QR code scan result
+  1. Wait for authentication result
   2. Regenerate code
 Or enter 'r' to go back to select the authentication method
 (user-integration-pre-check-authenticate-user-with-qr-code@localhost) Choose action:
@@ -306,32 +306,32 @@ Enter 'r' to cancel the request and go back to select the authentication method
 Or enter 'r' to go back to choose the provider
 (user-integration-pre-check-authenticate-user-with-qr-code@localhost) Choose your authentication method:
 > 2
-== Qr Code authentication ==
+== Use a Login code ==
 Enter the code in the login page
 https://ubuntu.com
        1337
 
-  1. Wait for the QR code scan result
+  1. Wait for authentication result
   2. Regenerate code
 Or enter 'r' to go back to select the authentication method
 (user-integration-pre-check-authenticate-user-with-qr-code@localhost) Choose action:
 > 2
-== Qr Code authentication ==
+== Use a Login code ==
 Enter the code in the login page
 https://ubuntu.fr/
        1338
 
-  1. Wait for the QR code scan result
+  1. Wait for authentication result
   2. Regenerate code
 Or enter 'r' to go back to select the authentication method
 (user-integration-pre-check-authenticate-user-with-qr-code@localhost) Choose action:
 > 2
-== Qr Code authentication ==
+== Use a Login code ==
 Enter the code in the login page
 https://ubuntuforum-br.org/
            1339
 
-  1. Wait for the QR code scan result
+  1. Wait for authentication result
   2. Regenerate code
 Or enter 'r' to go back to select the authentication method
 (user-integration-pre-check-authenticate-user-with-qr-code@localhost) Choose action:
@@ -360,42 +360,42 @@ Enter 'r' to cancel the request and go back to select the authentication method
 Or enter 'r' to go back to choose the provider
 (user-integration-pre-check-authenticate-user-with-qr-code@localhost) Choose your authentication method:
 > 2
-== Qr Code authentication ==
+== Use a Login code ==
 Enter the code in the login page
 https://ubuntu.com
        1337
 
-  1. Wait for the QR code scan result
+  1. Wait for authentication result
   2. Regenerate code
 Or enter 'r' to go back to select the authentication method
 (user-integration-pre-check-authenticate-user-with-qr-code@localhost) Choose action:
 > 2
-== Qr Code authentication ==
+== Use a Login code ==
 Enter the code in the login page
 https://ubuntu.fr/
        1338
 
-  1. Wait for the QR code scan result
+  1. Wait for authentication result
   2. Regenerate code
 Or enter 'r' to go back to select the authentication method
 (user-integration-pre-check-authenticate-user-with-qr-code@localhost) Choose action:
 > 2
-== Qr Code authentication ==
+== Use a Login code ==
 Enter the code in the login page
 https://ubuntuforum-br.org/
            1339
 
-  1. Wait for the QR code scan result
+  1. Wait for authentication result
   2. Regenerate code
 Or enter 'r' to go back to select the authentication method
 (user-integration-pre-check-authenticate-user-with-qr-code@localhost) Choose action:
 > 2
-== Qr Code authentication ==
+== Use a Login code ==
 Enter the code in the login page
 https://www.ubuntu-it.org/
            1340
 
-  1. Wait for the QR code scan result
+  1. Wait for authentication result
   2. Regenerate code
 Or enter 'r' to go back to select the authentication method
 (user-integration-pre-check-authenticate-user-with-qr-code@localhost) Choose action:
@@ -424,42 +424,42 @@ Enter 'r' to cancel the request and go back to select the authentication method
 Or enter 'r' to go back to choose the provider
 (user-integration-pre-check-authenticate-user-with-qr-code@localhost) Choose your authentication method:
 > 2
-== Qr Code authentication ==
+== Use a Login code ==
 Enter the code in the login page
 https://ubuntu.com
        1337
 
-  1. Wait for the QR code scan result
+  1. Wait for authentication result
   2. Regenerate code
 Or enter 'r' to go back to select the authentication method
 (user-integration-pre-check-authenticate-user-with-qr-code@localhost) Choose action:
 > 2
-== Qr Code authentication ==
+== Use a Login code ==
 Enter the code in the login page
 https://ubuntu.fr/
        1338
 
-  1. Wait for the QR code scan result
+  1. Wait for authentication result
   2. Regenerate code
 Or enter 'r' to go back to select the authentication method
 (user-integration-pre-check-authenticate-user-with-qr-code@localhost) Choose action:
 > 2
-== Qr Code authentication ==
+== Use a Login code ==
 Enter the code in the login page
 https://ubuntuforum-br.org/
            1339
 
-  1. Wait for the QR code scan result
+  1. Wait for authentication result
   2. Regenerate code
 Or enter 'r' to go back to select the authentication method
 (user-integration-pre-check-authenticate-user-with-qr-code@localhost) Choose action:
 > 2
-== Qr Code authentication ==
+== Use a Login code ==
 Enter the code in the login page
 https://www.ubuntu-it.org/
            1340
 
-  1. Wait for the QR code scan result
+  1. Wait for authentication result
   2. Regenerate code
 Or enter 'r' to go back to select the authentication method
 (user-integration-pre-check-authenticate-user-with-qr-code@localhost) Choose action:
@@ -488,52 +488,52 @@ Enter 'r' to cancel the request and go back to select the authentication method
 Or enter 'r' to go back to choose the provider
 (user-integration-pre-check-authenticate-user-with-qr-code@localhost) Choose your authentication method:
 > 2
-== Qr Code authentication ==
+== Use a Login code ==
 Enter the code in the login page
 https://ubuntu.com
        1337
 
-  1. Wait for the QR code scan result
+  1. Wait for authentication result
   2. Regenerate code
 Or enter 'r' to go back to select the authentication method
 (user-integration-pre-check-authenticate-user-with-qr-code@localhost) Choose action:
 > 2
-== Qr Code authentication ==
+== Use a Login code ==
 Enter the code in the login page
 https://ubuntu.fr/
        1338
 
-  1. Wait for the QR code scan result
+  1. Wait for authentication result
   2. Regenerate code
 Or enter 'r' to go back to select the authentication method
 (user-integration-pre-check-authenticate-user-with-qr-code@localhost) Choose action:
 > 2
-== Qr Code authentication ==
+== Use a Login code ==
 Enter the code in the login page
 https://ubuntuforum-br.org/
            1339
 
-  1. Wait for the QR code scan result
+  1. Wait for authentication result
   2. Regenerate code
 Or enter 'r' to go back to select the authentication method
 (user-integration-pre-check-authenticate-user-with-qr-code@localhost) Choose action:
 > 2
-== Qr Code authentication ==
+== Use a Login code ==
 Enter the code in the login page
 https://www.ubuntu-it.org/
            1340
 
-  1. Wait for the QR code scan result
+  1. Wait for authentication result
   2. Regenerate code
 Or enter 'r' to go back to select the authentication method
 (user-integration-pre-check-authenticate-user-with-qr-code@localhost) Choose action:
 > 2
-== Qr Code authentication ==
+== Use a Login code ==
 Enter the code in the login page
 https://ubuntu.com
        1341
 
-  1. Wait for the QR code scan result
+  1. Wait for authentication result
   2. Regenerate code
 Or enter 'r' to go back to select the authentication method
 (user-integration-pre-check-authenticate-user-with-qr-code@localhost) Choose action:
@@ -562,52 +562,52 @@ Enter 'r' to cancel the request and go back to select the authentication method
 Or enter 'r' to go back to choose the provider
 (user-integration-pre-check-authenticate-user-with-qr-code@localhost) Choose your authentication method:
 > 2
-== Qr Code authentication ==
+== Use a Login code ==
 Enter the code in the login page
 https://ubuntu.com
        1337
 
-  1. Wait for the QR code scan result
+  1. Wait for authentication result
   2. Regenerate code
 Or enter 'r' to go back to select the authentication method
 (user-integration-pre-check-authenticate-user-with-qr-code@localhost) Choose action:
 > 2
-== Qr Code authentication ==
+== Use a Login code ==
 Enter the code in the login page
 https://ubuntu.fr/
        1338
 
-  1. Wait for the QR code scan result
+  1. Wait for authentication result
   2. Regenerate code
 Or enter 'r' to go back to select the authentication method
 (user-integration-pre-check-authenticate-user-with-qr-code@localhost) Choose action:
 > 2
-== Qr Code authentication ==
+== Use a Login code ==
 Enter the code in the login page
 https://ubuntuforum-br.org/
            1339
 
-  1. Wait for the QR code scan result
+  1. Wait for authentication result
   2. Regenerate code
 Or enter 'r' to go back to select the authentication method
 (user-integration-pre-check-authenticate-user-with-qr-code@localhost) Choose action:
 > 2
-== Qr Code authentication ==
+== Use a Login code ==
 Enter the code in the login page
 https://www.ubuntu-it.org/
            1340
 
-  1. Wait for the QR code scan result
+  1. Wait for authentication result
   2. Regenerate code
 Or enter 'r' to go back to select the authentication method
 (user-integration-pre-check-authenticate-user-with-qr-code@localhost) Choose action:
 > 2
-== Qr Code authentication ==
+== Use a Login code ==
 Enter the code in the login page
 https://ubuntu.com
        1341
 
-  1. Wait for the QR code scan result
+  1. Wait for authentication result
   2. Regenerate code
 Or enter 'r' to go back to select the authentication method
 (user-integration-pre-check-authenticate-user-with-qr-code@localhost) Choose action:
@@ -636,52 +636,52 @@ Enter 'r' to cancel the request and go back to select the authentication method
 Or enter 'r' to go back to choose the provider
 (user-integration-pre-check-authenticate-user-with-qr-code@localhost) Choose your authentication method:
 > 2
-== Qr Code authentication ==
+== Use a Login code ==
 Enter the code in the login page
 https://ubuntu.com
        1337
 
-  1. Wait for the QR code scan result
+  1. Wait for authentication result
   2. Regenerate code
 Or enter 'r' to go back to select the authentication method
 (user-integration-pre-check-authenticate-user-with-qr-code@localhost) Choose action:
 > 2
-== Qr Code authentication ==
+== Use a Login code ==
 Enter the code in the login page
 https://ubuntu.fr/
        1338
 
-  1. Wait for the QR code scan result
+  1. Wait for authentication result
   2. Regenerate code
 Or enter 'r' to go back to select the authentication method
 (user-integration-pre-check-authenticate-user-with-qr-code@localhost) Choose action:
 > 2
-== Qr Code authentication ==
+== Use a Login code ==
 Enter the code in the login page
 https://ubuntuforum-br.org/
            1339
 
-  1. Wait for the QR code scan result
+  1. Wait for authentication result
   2. Regenerate code
 Or enter 'r' to go back to select the authentication method
 (user-integration-pre-check-authenticate-user-with-qr-code@localhost) Choose action:
 > 2
-== Qr Code authentication ==
+== Use a Login code ==
 Enter the code in the login page
 https://www.ubuntu-it.org/
            1340
 
-  1. Wait for the QR code scan result
+  1. Wait for authentication result
   2. Regenerate code
 Or enter 'r' to go back to select the authentication method
 (user-integration-pre-check-authenticate-user-with-qr-code@localhost) Choose action:
 > 2
-== Qr Code authentication ==
+== Use a Login code ==
 Enter the code in the login page
 https://ubuntu.com
        1341
 
-  1. Wait for the QR code scan result
+  1. Wait for authentication result
   2. Regenerate code
 Or enter 'r' to go back to select the authentication method
 (user-integration-pre-check-authenticate-user-with-qr-code@localhost) Choose action:

--- a/pam/integration-tests/testdata/golden/TestSSHAuthenticate/Authenticate_user_with_qr_code_on_shared_SSHd
+++ b/pam/integration-tests/testdata/golden/TestSSHAuthenticate/Authenticate_user_with_qr_code_on_shared_SSHd
@@ -96,12 +96,12 @@ Enter 'r' to cancel the request and go back to select the authentication method
 Or enter 'r' to go back to choose the provider
 (user-integration-pre-check-authenticate-user-with-qr-code-on-shared-sshd@localhost) Choose your authentication method:
 > 2
-== Qr Code authentication ==
+== Use a Login code ==
 Enter the code in the login page
 https://ubuntu.com
        1337
 
-  1. Wait for the QR code scan result
+  1. Wait for authentication result
   2. Regenerate code
 Or enter 'r' to go back to select the authentication method
 (user-integration-pre-check-authenticate-user-with-qr-code-on-shared-sshd@localhost) Choose action:
@@ -130,12 +130,12 @@ Enter 'r' to cancel the request and go back to select the authentication method
 Or enter 'r' to go back to choose the provider
 (user-integration-pre-check-authenticate-user-with-qr-code-on-shared-sshd@localhost) Choose your authentication method:
 > 2
-== Qr Code authentication ==
+== Use a Login code ==
 Enter the code in the login page
 https://ubuntu.com
        1337
 
-  1. Wait for the QR code scan result
+  1. Wait for authentication result
   2. Regenerate code
 Or enter 'r' to go back to select the authentication method
 (user-integration-pre-check-authenticate-user-with-qr-code-on-shared-sshd@localhost) Choose action:
@@ -164,22 +164,22 @@ Enter 'r' to cancel the request and go back to select the authentication method
 Or enter 'r' to go back to choose the provider
 (user-integration-pre-check-authenticate-user-with-qr-code-on-shared-sshd@localhost) Choose your authentication method:
 > 2
-== Qr Code authentication ==
+== Use a Login code ==
 Enter the code in the login page
 https://ubuntu.com
        1337
 
-  1. Wait for the QR code scan result
+  1. Wait for authentication result
   2. Regenerate code
 Or enter 'r' to go back to select the authentication method
 (user-integration-pre-check-authenticate-user-with-qr-code-on-shared-sshd@localhost) Choose action:
 > 2
-== Qr Code authentication ==
+== Use a Login code ==
 Enter the code in the login page
 https://ubuntu.fr/
        1338
 
-  1. Wait for the QR code scan result
+  1. Wait for authentication result
   2. Regenerate code
 Or enter 'r' to go back to select the authentication method
 (user-integration-pre-check-authenticate-user-with-qr-code-on-shared-sshd@localhost) Choose action:
@@ -208,22 +208,22 @@ Enter 'r' to cancel the request and go back to select the authentication method
 Or enter 'r' to go back to choose the provider
 (user-integration-pre-check-authenticate-user-with-qr-code-on-shared-sshd@localhost) Choose your authentication method:
 > 2
-== Qr Code authentication ==
+== Use a Login code ==
 Enter the code in the login page
 https://ubuntu.com
        1337
 
-  1. Wait for the QR code scan result
+  1. Wait for authentication result
   2. Regenerate code
 Or enter 'r' to go back to select the authentication method
 (user-integration-pre-check-authenticate-user-with-qr-code-on-shared-sshd@localhost) Choose action:
 > 2
-== Qr Code authentication ==
+== Use a Login code ==
 Enter the code in the login page
 https://ubuntu.fr/
        1338
 
-  1. Wait for the QR code scan result
+  1. Wait for authentication result
   2. Regenerate code
 Or enter 'r' to go back to select the authentication method
 (user-integration-pre-check-authenticate-user-with-qr-code-on-shared-sshd@localhost) Choose action:
@@ -252,32 +252,32 @@ Enter 'r' to cancel the request and go back to select the authentication method
 Or enter 'r' to go back to choose the provider
 (user-integration-pre-check-authenticate-user-with-qr-code-on-shared-sshd@localhost) Choose your authentication method:
 > 2
-== Qr Code authentication ==
+== Use a Login code ==
 Enter the code in the login page
 https://ubuntu.com
        1337
 
-  1. Wait for the QR code scan result
+  1. Wait for authentication result
   2. Regenerate code
 Or enter 'r' to go back to select the authentication method
 (user-integration-pre-check-authenticate-user-with-qr-code-on-shared-sshd@localhost) Choose action:
 > 2
-== Qr Code authentication ==
+== Use a Login code ==
 Enter the code in the login page
 https://ubuntu.fr/
        1338
 
-  1. Wait for the QR code scan result
+  1. Wait for authentication result
   2. Regenerate code
 Or enter 'r' to go back to select the authentication method
 (user-integration-pre-check-authenticate-user-with-qr-code-on-shared-sshd@localhost) Choose action:
 > 2
-== Qr Code authentication ==
+== Use a Login code ==
 Enter the code in the login page
 https://ubuntuforum-br.org/
            1339
 
-  1. Wait for the QR code scan result
+  1. Wait for authentication result
   2. Regenerate code
 Or enter 'r' to go back to select the authentication method
 (user-integration-pre-check-authenticate-user-with-qr-code-on-shared-sshd@localhost) Choose action:
@@ -306,32 +306,32 @@ Enter 'r' to cancel the request and go back to select the authentication method
 Or enter 'r' to go back to choose the provider
 (user-integration-pre-check-authenticate-user-with-qr-code-on-shared-sshd@localhost) Choose your authentication method:
 > 2
-== Qr Code authentication ==
+== Use a Login code ==
 Enter the code in the login page
 https://ubuntu.com
        1337
 
-  1. Wait for the QR code scan result
+  1. Wait for authentication result
   2. Regenerate code
 Or enter 'r' to go back to select the authentication method
 (user-integration-pre-check-authenticate-user-with-qr-code-on-shared-sshd@localhost) Choose action:
 > 2
-== Qr Code authentication ==
+== Use a Login code ==
 Enter the code in the login page
 https://ubuntu.fr/
        1338
 
-  1. Wait for the QR code scan result
+  1. Wait for authentication result
   2. Regenerate code
 Or enter 'r' to go back to select the authentication method
 (user-integration-pre-check-authenticate-user-with-qr-code-on-shared-sshd@localhost) Choose action:
 > 2
-== Qr Code authentication ==
+== Use a Login code ==
 Enter the code in the login page
 https://ubuntuforum-br.org/
            1339
 
-  1. Wait for the QR code scan result
+  1. Wait for authentication result
   2. Regenerate code
 Or enter 'r' to go back to select the authentication method
 (user-integration-pre-check-authenticate-user-with-qr-code-on-shared-sshd@localhost) Choose action:
@@ -360,42 +360,42 @@ Enter 'r' to cancel the request and go back to select the authentication method
 Or enter 'r' to go back to choose the provider
 (user-integration-pre-check-authenticate-user-with-qr-code-on-shared-sshd@localhost) Choose your authentication method:
 > 2
-== Qr Code authentication ==
+== Use a Login code ==
 Enter the code in the login page
 https://ubuntu.com
        1337
 
-  1. Wait for the QR code scan result
+  1. Wait for authentication result
   2. Regenerate code
 Or enter 'r' to go back to select the authentication method
 (user-integration-pre-check-authenticate-user-with-qr-code-on-shared-sshd@localhost) Choose action:
 > 2
-== Qr Code authentication ==
+== Use a Login code ==
 Enter the code in the login page
 https://ubuntu.fr/
        1338
 
-  1. Wait for the QR code scan result
+  1. Wait for authentication result
   2. Regenerate code
 Or enter 'r' to go back to select the authentication method
 (user-integration-pre-check-authenticate-user-with-qr-code-on-shared-sshd@localhost) Choose action:
 > 2
-== Qr Code authentication ==
+== Use a Login code ==
 Enter the code in the login page
 https://ubuntuforum-br.org/
            1339
 
-  1. Wait for the QR code scan result
+  1. Wait for authentication result
   2. Regenerate code
 Or enter 'r' to go back to select the authentication method
 (user-integration-pre-check-authenticate-user-with-qr-code-on-shared-sshd@localhost) Choose action:
 > 2
-== Qr Code authentication ==
+== Use a Login code ==
 Enter the code in the login page
 https://www.ubuntu-it.org/
            1340
 
-  1. Wait for the QR code scan result
+  1. Wait for authentication result
   2. Regenerate code
 Or enter 'r' to go back to select the authentication method
 (user-integration-pre-check-authenticate-user-with-qr-code-on-shared-sshd@localhost) Choose action:
@@ -424,42 +424,42 @@ Enter 'r' to cancel the request and go back to select the authentication method
 Or enter 'r' to go back to choose the provider
 (user-integration-pre-check-authenticate-user-with-qr-code-on-shared-sshd@localhost) Choose your authentication method:
 > 2
-== Qr Code authentication ==
+== Use a Login code ==
 Enter the code in the login page
 https://ubuntu.com
        1337
 
-  1. Wait for the QR code scan result
+  1. Wait for authentication result
   2. Regenerate code
 Or enter 'r' to go back to select the authentication method
 (user-integration-pre-check-authenticate-user-with-qr-code-on-shared-sshd@localhost) Choose action:
 > 2
-== Qr Code authentication ==
+== Use a Login code ==
 Enter the code in the login page
 https://ubuntu.fr/
        1338
 
-  1. Wait for the QR code scan result
+  1. Wait for authentication result
   2. Regenerate code
 Or enter 'r' to go back to select the authentication method
 (user-integration-pre-check-authenticate-user-with-qr-code-on-shared-sshd@localhost) Choose action:
 > 2
-== Qr Code authentication ==
+== Use a Login code ==
 Enter the code in the login page
 https://ubuntuforum-br.org/
            1339
 
-  1. Wait for the QR code scan result
+  1. Wait for authentication result
   2. Regenerate code
 Or enter 'r' to go back to select the authentication method
 (user-integration-pre-check-authenticate-user-with-qr-code-on-shared-sshd@localhost) Choose action:
 > 2
-== Qr Code authentication ==
+== Use a Login code ==
 Enter the code in the login page
 https://www.ubuntu-it.org/
            1340
 
-  1. Wait for the QR code scan result
+  1. Wait for authentication result
   2. Regenerate code
 Or enter 'r' to go back to select the authentication method
 (user-integration-pre-check-authenticate-user-with-qr-code-on-shared-sshd@localhost) Choose action:
@@ -488,52 +488,52 @@ Enter 'r' to cancel the request and go back to select the authentication method
 Or enter 'r' to go back to choose the provider
 (user-integration-pre-check-authenticate-user-with-qr-code-on-shared-sshd@localhost) Choose your authentication method:
 > 2
-== Qr Code authentication ==
+== Use a Login code ==
 Enter the code in the login page
 https://ubuntu.com
        1337
 
-  1. Wait for the QR code scan result
+  1. Wait for authentication result
   2. Regenerate code
 Or enter 'r' to go back to select the authentication method
 (user-integration-pre-check-authenticate-user-with-qr-code-on-shared-sshd@localhost) Choose action:
 > 2
-== Qr Code authentication ==
+== Use a Login code ==
 Enter the code in the login page
 https://ubuntu.fr/
        1338
 
-  1. Wait for the QR code scan result
+  1. Wait for authentication result
   2. Regenerate code
 Or enter 'r' to go back to select the authentication method
 (user-integration-pre-check-authenticate-user-with-qr-code-on-shared-sshd@localhost) Choose action:
 > 2
-== Qr Code authentication ==
+== Use a Login code ==
 Enter the code in the login page
 https://ubuntuforum-br.org/
            1339
 
-  1. Wait for the QR code scan result
+  1. Wait for authentication result
   2. Regenerate code
 Or enter 'r' to go back to select the authentication method
 (user-integration-pre-check-authenticate-user-with-qr-code-on-shared-sshd@localhost) Choose action:
 > 2
-== Qr Code authentication ==
+== Use a Login code ==
 Enter the code in the login page
 https://www.ubuntu-it.org/
            1340
 
-  1. Wait for the QR code scan result
+  1. Wait for authentication result
   2. Regenerate code
 Or enter 'r' to go back to select the authentication method
 (user-integration-pre-check-authenticate-user-with-qr-code-on-shared-sshd@localhost) Choose action:
 > 2
-== Qr Code authentication ==
+== Use a Login code ==
 Enter the code in the login page
 https://ubuntu.com
        1341
 
-  1. Wait for the QR code scan result
+  1. Wait for authentication result
   2. Regenerate code
 Or enter 'r' to go back to select the authentication method
 (user-integration-pre-check-authenticate-user-with-qr-code-on-shared-sshd@localhost) Choose action:
@@ -562,52 +562,52 @@ Enter 'r' to cancel the request and go back to select the authentication method
 Or enter 'r' to go back to choose the provider
 (user-integration-pre-check-authenticate-user-with-qr-code-on-shared-sshd@localhost) Choose your authentication method:
 > 2
-== Qr Code authentication ==
+== Use a Login code ==
 Enter the code in the login page
 https://ubuntu.com
        1337
 
-  1. Wait for the QR code scan result
+  1. Wait for authentication result
   2. Regenerate code
 Or enter 'r' to go back to select the authentication method
 (user-integration-pre-check-authenticate-user-with-qr-code-on-shared-sshd@localhost) Choose action:
 > 2
-== Qr Code authentication ==
+== Use a Login code ==
 Enter the code in the login page
 https://ubuntu.fr/
        1338
 
-  1. Wait for the QR code scan result
+  1. Wait for authentication result
   2. Regenerate code
 Or enter 'r' to go back to select the authentication method
 (user-integration-pre-check-authenticate-user-with-qr-code-on-shared-sshd@localhost) Choose action:
 > 2
-== Qr Code authentication ==
+== Use a Login code ==
 Enter the code in the login page
 https://ubuntuforum-br.org/
            1339
 
-  1. Wait for the QR code scan result
+  1. Wait for authentication result
   2. Regenerate code
 Or enter 'r' to go back to select the authentication method
 (user-integration-pre-check-authenticate-user-with-qr-code-on-shared-sshd@localhost) Choose action:
 > 2
-== Qr Code authentication ==
+== Use a Login code ==
 Enter the code in the login page
 https://www.ubuntu-it.org/
            1340
 
-  1. Wait for the QR code scan result
+  1. Wait for authentication result
   2. Regenerate code
 Or enter 'r' to go back to select the authentication method
 (user-integration-pre-check-authenticate-user-with-qr-code-on-shared-sshd@localhost) Choose action:
 > 2
-== Qr Code authentication ==
+== Use a Login code ==
 Enter the code in the login page
 https://ubuntu.com
        1341
 
-  1. Wait for the QR code scan result
+  1. Wait for authentication result
   2. Regenerate code
 Or enter 'r' to go back to select the authentication method
 (user-integration-pre-check-authenticate-user-with-qr-code-on-shared-sshd@localhost) Choose action:
@@ -636,52 +636,52 @@ Enter 'r' to cancel the request and go back to select the authentication method
 Or enter 'r' to go back to choose the provider
 (user-integration-pre-check-authenticate-user-with-qr-code-on-shared-sshd@localhost) Choose your authentication method:
 > 2
-== Qr Code authentication ==
+== Use a Login code ==
 Enter the code in the login page
 https://ubuntu.com
        1337
 
-  1. Wait for the QR code scan result
+  1. Wait for authentication result
   2. Regenerate code
 Or enter 'r' to go back to select the authentication method
 (user-integration-pre-check-authenticate-user-with-qr-code-on-shared-sshd@localhost) Choose action:
 > 2
-== Qr Code authentication ==
+== Use a Login code ==
 Enter the code in the login page
 https://ubuntu.fr/
        1338
 
-  1. Wait for the QR code scan result
+  1. Wait for authentication result
   2. Regenerate code
 Or enter 'r' to go back to select the authentication method
 (user-integration-pre-check-authenticate-user-with-qr-code-on-shared-sshd@localhost) Choose action:
 > 2
-== Qr Code authentication ==
+== Use a Login code ==
 Enter the code in the login page
 https://ubuntuforum-br.org/
            1339
 
-  1. Wait for the QR code scan result
+  1. Wait for authentication result
   2. Regenerate code
 Or enter 'r' to go back to select the authentication method
 (user-integration-pre-check-authenticate-user-with-qr-code-on-shared-sshd@localhost) Choose action:
 > 2
-== Qr Code authentication ==
+== Use a Login code ==
 Enter the code in the login page
 https://www.ubuntu-it.org/
            1340
 
-  1. Wait for the QR code scan result
+  1. Wait for authentication result
   2. Regenerate code
 Or enter 'r' to go back to select the authentication method
 (user-integration-pre-check-authenticate-user-with-qr-code-on-shared-sshd@localhost) Choose action:
 > 2
-== Qr Code authentication ==
+== Use a Login code ==
 Enter the code in the login page
 https://ubuntu.com
        1341
 
-  1. Wait for the QR code scan result
+  1. Wait for authentication result
   2. Regenerate code
 Or enter 'r' to go back to select the authentication method
 (user-integration-pre-check-authenticate-user-with-qr-code-on-shared-sshd@localhost) Choose action:

--- a/pam/internal/adapter/nativemodel.go
+++ b/pam/internal/adapter/nativemodel.go
@@ -709,13 +709,13 @@ func (m nativeModel) handleQrCode() tea.Cmd {
 	qrcodeView = append(qrcodeView, " ")
 
 	choices := []choicePair{
-		{id: layouts.Wait, label: "Wait for the QR code scan result"},
+		{id: layouts.Wait, label: "Wait for authentication result"},
 	}
 	if buttonLabel := m.uiLayout.GetButton(); buttonLabel != "" {
 		choices = append(choices, choicePair{id: layouts.Button, label: buttonLabel})
 	}
 
-	id, err := m.promptForChoiceWithMessage("Qr Code authentication",
+	id, err := m.promptForChoiceWithMessage(m.selectedAuthModeLabel("QR code"),
 		strings.Join(qrcodeView, "\n"), choices, "Choose action")
 	if errors.Is(err, errGoBack) {
 		return sendEvent(nativeGoBack{})


### PR DESCRIPTION
When using the qr code mode we may actually just require a login code, so instead on hardcoding the labels binding them to the qrcode case, let's just use what the broker provides us.

Closes: #755

UDENG-5862