### PR TITLE
Bump Go toolchain version to 1.23.5

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,7 @@
 module github.com/ubuntu/authd
 
 go 1.23.0
+toolchain go1.23.5
 
 require (
 	github.com/charmbracelet/bubbles v0.20.0

--- a/tools/go.mod
+++ b/tools/go.mod
@@ -1,6 +1,7 @@
 module github.com/ubuntu/authd/tools
 
 go 1.23.0
+toolchain go1.23.5
 
 require (
 	github.com/golang/protobuf v1.5.4


### PR DESCRIPTION
govulncheck reports the following vulnerability in crypto/x509@go1.23:

```
Vulnerability #1: GO-2025-3373
    Usage of IPv6 zone IDs can bypass URI name constraints in crypto/x509
  More info: https://pkg.go.dev/vuln/GO-2025-3373
  Standard library
    Found in: crypto/x509@go1.23
    Fixed in: crypto/x509@go1.23.5
```