### PR TITLE
pam/native: Do not support device authentication mode in polkit

### DIFF
--- a/examplebroker/users.go
+++ b/examplebroker/users.go
@@ -47,4 +47,7 @@ const (
 	UserIntegrationPreCheckPrefix = UserIntegrationPrefix + UserIntegrationPreCheckValue + "-"
 	// UserIntegrationUnexistent is an unexistent user leading to a non-existent user error.
 	UserIntegrationUnexistent = "user-unexistent"
+	// UserIntegrationAuthModesPrefix is the prefix for an user listing for supported auth modes.
+	// The modes can be exposed as list, in the form: `user-auth-modes-id1,id2,id3-integration-whatever`.
+	UserIntegrationAuthModesPrefix = "user-auth-modes-"
 )

--- a/pam/integration-tests/cli_test.go
+++ b/pam/integration-tests/cli_test.go
@@ -56,6 +56,12 @@ func TestCLIAuthenticate(t *testing.T) {
 			},
 			clientOptions: clientOptions{PamTimeout: "invalid"},
 		},
+		"Authenticate_user_successfully_with_password_only_supported_method": {
+			tape: "simple_auth",
+			tapeVariables: map[string]string{
+				"AUTHD_SIMPLE_AUTH_TAPE_USER": examplebroker.UserIntegrationAuthModesPrefix + "password-integration-cli",
+			},
+		},
 		"Authenticate_user_successfully_after_trying_empty_user": {
 			tape: "simple_auth_empty_user",
 		},

--- a/pam/integration-tests/gdm_test.go
+++ b/pam/integration-tests/gdm_test.go
@@ -163,6 +163,16 @@ func TestGdmModule(t *testing.T) {
 				},
 			},
 		},
+		"Authenticate_user_successfully_with_password_only_supported_method": {
+			pamUser: ptrValue(examplebroker.UserIntegrationAuthModesPrefix + "password-integration-gdm"),
+			eventPollResponses: map[gdm.EventType][]*gdm.EventData{
+				gdm.EventType_startAuthentication: {
+					gdm_test.IsAuthenticatedEvent(&authd.IARequest_AuthenticationData_Challenge{
+						Challenge: "goodpass",
+					}),
+				},
+			},
+		},
 		"Authenticates_user_with_multiple_retries": {
 			wantAuthModeIDs: []string{passwordAuthID, passwordAuthID, passwordAuthID},
 			eventPollResponses: map[gdm.EventType][]*gdm.EventData{

--- a/pam/integration-tests/native_test.go
+++ b/pam/integration-tests/native_test.go
@@ -87,7 +87,7 @@ func TestNativeAuthenticate(t *testing.T) {
 			},
 		},
 		"Authenticate_user_with_form_mode_with_button_in_polkit": {
-			tape:          "form_with_button",
+			tape:          "form_with_button_polkit",
 			tapeSettings:  []tapeSetting{{vhsHeight, 700}},
 			clientOptions: clientOptions{PamServiceName: "polkit-1"},
 			tapeVariables: map[string]string{

--- a/pam/integration-tests/native_test.go
+++ b/pam/integration-tests/native_test.go
@@ -66,6 +66,17 @@ func TestNativeAuthenticate(t *testing.T) {
 		"Authenticate_user_with_form_mode_with_button": {
 			tape:         "form_with_button",
 			tapeSettings: []tapeSetting{{vhsHeight, 700}},
+			tapeVariables: map[string]string{
+				"AUTHD_FORM_BUTTON_TAPE_ITEM": "8",
+			},
+		},
+		"Authenticate_user_with_form_mode_with_button_in_polkit": {
+			tape:          "form_with_button",
+			tapeSettings:  []tapeSetting{{vhsHeight, 700}},
+			clientOptions: clientOptions{PamServiceName: "polkit-1"},
+			tapeVariables: map[string]string{
+				"AUTHD_FORM_BUTTON_TAPE_ITEM": "7",
+			},
 		},
 		"Authenticate_user_with_qr_code": {
 			tape:         "qr_code",
@@ -106,17 +117,6 @@ func TestNativeAuthenticate(t *testing.T) {
 			},
 			clientOptions: clientOptions{
 				Term: "screen",
-			},
-		},
-		"Authenticate_user_with_qr_code_in_polkit": {
-			tape:         "qr_code",
-			tapeSettings: []tapeSetting{{vhsHeight, 3500}},
-			tapeVariables: map[string]string{
-				"AUTHD_QRCODE_TAPE_ITEM":      "2",
-				"AUTHD_QRCODE_TAPE_ITEM_NAME": "Login code",
-			},
-			clientOptions: clientOptions{
-				PamServiceName: "polkit-1",
 			},
 		},
 		"Authenticate_user_with_qr_code_in_ssh": {

--- a/pam/integration-tests/native_test.go
+++ b/pam/integration-tests/native_test.go
@@ -56,6 +56,12 @@ func TestNativeAuthenticate(t *testing.T) {
 				PamTimeout: "invalid",
 			},
 		},
+		"Authenticate_user_successfully_with_password_only_supported_method": {
+			tape: "simple_auth",
+			clientOptions: clientOptions{
+				PamUser: examplebroker.UserIntegrationAuthModesPrefix + "password-integration-native",
+			},
+		},
 		"Authenticate_user_with_mfa": {
 			tape:         "mfa_auth",
 			tapeSettings: []tapeSetting{{vhsHeight, 1200}},
@@ -68,6 +74,16 @@ func TestNativeAuthenticate(t *testing.T) {
 			tapeSettings: []tapeSetting{{vhsHeight, 700}},
 			tapeVariables: map[string]string{
 				"AUTHD_FORM_BUTTON_TAPE_ITEM": "8",
+			},
+		},
+		"Authenticate_user_with_form_mode_with_button_two_supported_methods": {
+			tape: "form_with_button",
+			clientOptions: clientOptions{
+				PamUser: examplebroker.UserIntegrationAuthModesPrefix + "totp_with_button,password-integration-native",
+			},
+			tapeSettings: []tapeSetting{{vhsHeight, 700}},
+			tapeVariables: map[string]string{
+				"AUTHD_FORM_BUTTON_TAPE_ITEM": "2",
 			},
 		},
 		"Authenticate_user_with_form_mode_with_button_in_polkit": {

--- a/pam/integration-tests/ssh_test.go
+++ b/pam/integration-tests/ssh_test.go
@@ -124,6 +124,9 @@ func testSSHAuthenticate(t *testing.T, sharedSSHd bool) {
 		"Authenticate_user_with_form_mode_with_button": {
 			tape:         "form_with_button",
 			tapeSettings: []tapeSetting{{vhsHeight, 1500}},
+			tapeVariables: map[string]string{
+				"AUTHD_FORM_BUTTON_TAPE_ITEM": "8",
+			},
 		},
 		"Authenticate_user_with_qr_code": {
 			tape:         "qr_code",

--- a/pam/integration-tests/testdata/golden/TestCLIAuthenticate/Authenticate_user_successfully_with_password_only_supported_method
+++ b/pam/integration-tests/testdata/golden/TestCLIAuthenticate/Authenticate_user_successfully_with_password_only_supported_method
@@ -1,0 +1,29 @@
+> ./pam_authd login socket=${AUTHD_TESTS_CLI_AUTHENTICATE_TESTS_SOCK}
+Username: user name
+────────────────────────────────────────────────────────────────────────────────
+> ./pam_authd login socket=${AUTHD_TESTS_CLI_AUTHENTICATE_TESTS_SOCK}
+Username: user-auth-modes-password-integration-cli
+────────────────────────────────────────────────────────────────────────────────
+> ./pam_authd login socket=${AUTHD_TESTS_CLI_AUTHENTICATE_TESTS_SOCK}
+  Select your provider
+
+> 1. local
+  2. ExampleBroker
+────────────────────────────────────────────────────────────────────────────────
+> ./pam_authd login socket=${AUTHD_TESTS_CLI_AUTHENTICATE_TESTS_SOCK}
+Gimme your password:
+>
+────────────────────────────────────────────────────────────────────────────────
+> ./pam_authd login socket=${AUTHD_TESTS_CLI_AUTHENTICATE_TESTS_SOCK}
+Gimme your password:
+> ********
+────────────────────────────────────────────────────────────────────────────────
+> ./pam_authd login socket=${AUTHD_TESTS_CLI_AUTHENTICATE_TESTS_SOCK}
+PAM Authenticate()
+  User: "user-auth-modes-password-integration-cli"
+  Result: success
+PAM AcctMgmt()
+  User: "user-auth-modes-password-integration-cli"
+  Result: success
+>
+────────────────────────────────────────────────────────────────────────────────

--- a/pam/integration-tests/testdata/golden/TestNativeAuthenticate/Authenticate_user_successfully_with_password_only_supported_method
+++ b/pam/integration-tests/testdata/golden/TestNativeAuthenticate/Authenticate_user_successfully_with_password_only_supported_method
@@ -1,0 +1,43 @@
+> ./pam_authd login socket=${AUTHD_TESTS_CLI_AUTHENTICATE_TESTS_SOCK} force_native_client=true
+== Provider selection ==
+  1. local
+  2. ExampleBroker
+Choose your provider:
+>
+────────────────────────────────────────────────────────────────────────────────
+> ./pam_authd login socket=${AUTHD_TESTS_CLI_AUTHENTICATE_TESTS_SOCK} force_native_client=true
+== Provider selection ==
+  1. local
+  2. ExampleBroker
+Choose your provider:
+> 2
+────────────────────────────────────────────────────────────────────────────────
+> ./pam_authd login socket=${AUTHD_TESTS_CLI_AUTHENTICATE_TESTS_SOCK} force_native_client=true
+== Provider selection ==
+  1. local
+  2. ExampleBroker
+Choose your provider:
+> 2
+== Password authentication ==
+Enter 'r' to cancel the request and go back to choose the provider
+Gimme your password:
+>
+────────────────────────────────────────────────────────────────────────────────
+> ./pam_authd login socket=${AUTHD_TESTS_CLI_AUTHENTICATE_TESTS_SOCK} force_native_client=true
+== Provider selection ==
+  1. local
+  2. ExampleBroker
+Choose your provider:
+> 2
+== Password authentication ==
+Enter 'r' to cancel the request and go back to choose the provider
+Gimme your password:
+>
+PAM Authenticate()
+  User: "user-auth-modes-password-integration-native"
+  Result: success
+PAM AcctMgmt()
+  User: "user-auth-modes-password-integration-native"
+  Result: success
+>
+────────────────────────────────────────────────────────────────────────────────

--- a/pam/integration-tests/testdata/golden/TestNativeAuthenticate/Authenticate_user_with_form_mode_with_button_in_polkit
+++ b/pam/integration-tests/testdata/golden/TestNativeAuthenticate/Authenticate_user_with_form_mode_with_button_in_polkit
@@ -1,34 +1,16 @@
 > ./pam_authd login socket=${AUTHD_TESTS_CLI_AUTHENTICATE_TESTS_SOCK} force_native_client=true
-== Provider selection ==
-  1. local
-  2. ExampleBroker
-Choose your provider:
->
-────────────────────────────────────────────────────────────────────────────────
-> ./pam_authd login socket=${AUTHD_TESTS_CLI_AUTHENTICATE_TESTS_SOCK} force_native_client=true
-== Provider selection ==
-  1. local
-  2. ExampleBroker
-Choose your provider:
-> 2
-────────────────────────────────────────────────────────────────────────────────
-> ./pam_authd login socket=${AUTHD_TESTS_CLI_AUTHENTICATE_TESTS_SOCK} force_native_client=true
-== Provider selection ==
-  1. local
-  2. ExampleBroker
-Choose your provider:
-> 2
 == Password authentication ==
 Enter 'r' to cancel the request and go back to select the authentication method
 Gimme your password:
 >
 ────────────────────────────────────────────────────────────────────────────────
 > ./pam_authd login socket=${AUTHD_TESTS_CLI_AUTHENTICATE_TESTS_SOCK} force_native_client=true
-== Provider selection ==
-  1. local
-  2. ExampleBroker
-Choose your provider:
-> 2
+== Password authentication ==
+Enter 'r' to cancel the request and go back to select the authentication method
+Gimme your password:
+>
+────────────────────────────────────────────────────────────────────────────────
+> ./pam_authd login socket=${AUTHD_TESTS_CLI_AUTHENTICATE_TESTS_SOCK} force_native_client=true
 == Password authentication ==
 Enter 'r' to cancel the request and go back to select the authentication method
 Gimme your password:
@@ -42,16 +24,10 @@ gmail.com
   5. Use your phone +1...
   6. Pin code
   7. Authentication code
-Or enter 'r' to go back to choose the provider
 Choose your authentication method:
 >
 ────────────────────────────────────────────────────────────────────────────────
 > ./pam_authd login socket=${AUTHD_TESTS_CLI_AUTHENTICATE_TESTS_SOCK} force_native_client=true
-== Provider selection ==
-  1. local
-  2. ExampleBroker
-Choose your provider:
-> 2
 == Password authentication ==
 Enter 'r' to cancel the request and go back to select the authentication method
 Gimme your password:
@@ -65,16 +41,10 @@ gmail.com
   5. Use your phone +1...
   6. Pin code
   7. Authentication code
-Or enter 'r' to go back to choose the provider
 Choose your authentication method:
 > 7
 ────────────────────────────────────────────────────────────────────────────────
 > ./pam_authd login socket=${AUTHD_TESTS_CLI_AUTHENTICATE_TESTS_SOCK} force_native_client=true
-== Provider selection ==
-  1. local
-  2. ExampleBroker
-Choose your provider:
-> 2
 == Password authentication ==
 Enter 'r' to cancel the request and go back to select the authentication method
 Gimme your password:
@@ -88,7 +58,6 @@ gmail.com
   5. Use your phone +1...
   6. Pin code
   7. Authentication code
-Or enter 'r' to go back to choose the provider
 Choose your authentication method:
 > 7
 == Authentication code ==
@@ -99,11 +68,6 @@ Choose action:
 >
 ────────────────────────────────────────────────────────────────────────────────
 > ./pam_authd login socket=${AUTHD_TESTS_CLI_AUTHENTICATE_TESTS_SOCK} force_native_client=true
-== Provider selection ==
-  1. local
-  2. ExampleBroker
-Choose your provider:
-> 2
 == Password authentication ==
 Enter 'r' to cancel the request and go back to select the authentication method
 Gimme your password:
@@ -117,7 +81,6 @@ gmail.com
   5. Use your phone +1...
   6. Pin code
   7. Authentication code
-Or enter 'r' to go back to choose the provider
 Choose your authentication method:
 > 7
 == Authentication code ==
@@ -128,11 +91,6 @@ Choose action:
 > 2
 ────────────────────────────────────────────────────────────────────────────────
 > ./pam_authd login socket=${AUTHD_TESTS_CLI_AUTHENTICATE_TESTS_SOCK} force_native_client=true
-== Provider selection ==
-  1. local
-  2. ExampleBroker
-Choose your provider:
-> 2
 == Password authentication ==
 Enter 'r' to cancel the request and go back to select the authentication method
 Gimme your password:
@@ -146,7 +104,6 @@ gmail.com
   5. Use your phone +1...
   6. Pin code
   7. Authentication code
-Or enter 'r' to go back to choose the provider
 Choose your authentication method:
 > 7
 == Authentication code ==
@@ -163,11 +120,6 @@ Choose action:
 >
 ────────────────────────────────────────────────────────────────────────────────
 > ./pam_authd login socket=${AUTHD_TESTS_CLI_AUTHENTICATE_TESTS_SOCK} force_native_client=true
-== Provider selection ==
-  1. local
-  2. ExampleBroker
-Choose your provider:
-> 2
 == Password authentication ==
 Enter 'r' to cancel the request and go back to select the authentication method
 Gimme your password:
@@ -181,7 +133,6 @@ gmail.com
   5. Use your phone +1...
   6. Pin code
   7. Authentication code
-Or enter 'r' to go back to choose the provider
 Choose your authentication method:
 > 7
 == Authentication code ==
@@ -198,11 +149,6 @@ Choose action:
 > 1
 ────────────────────────────────────────────────────────────────────────────────
 > ./pam_authd login socket=${AUTHD_TESTS_CLI_AUTHENTICATE_TESTS_SOCK} force_native_client=true
-== Provider selection ==
-  1. local
-  2. ExampleBroker
-Choose your provider:
-> 2
 == Password authentication ==
 Enter 'r' to cancel the request and go back to select the authentication method
 Gimme your password:
@@ -216,7 +162,6 @@ gmail.com
   5. Use your phone +1...
   6. Pin code
   7. Authentication code
-Or enter 'r' to go back to choose the provider
 Choose your authentication method:
 > 7
 == Authentication code ==
@@ -237,11 +182,6 @@ Enter your one time credential:
 >
 ────────────────────────────────────────────────────────────────────────────────
 > ./pam_authd login socket=${AUTHD_TESTS_CLI_AUTHENTICATE_TESTS_SOCK} force_native_client=true
-== Provider selection ==
-  1. local
-  2. ExampleBroker
-Choose your provider:
-> 2
 == Password authentication ==
 Enter 'r' to cancel the request and go back to select the authentication method
 Gimme your password:
@@ -255,7 +195,6 @@ gmail.com
   5. Use your phone +1...
   6. Pin code
   7. Authentication code
-Or enter 'r' to go back to choose the provider
 Choose your authentication method:
 > 7
 == Authentication code ==
@@ -276,11 +215,6 @@ Enter your one time credential:
 > temporary pass00
 ────────────────────────────────────────────────────────────────────────────────
 > ./pam_authd login socket=${AUTHD_TESTS_CLI_AUTHENTICATE_TESTS_SOCK} force_native_client=true
-== Provider selection ==
-  1. local
-  2. ExampleBroker
-Choose your provider:
-> 2
 == Password authentication ==
 Enter 'r' to cancel the request and go back to select the authentication method
 Gimme your password:
@@ -294,7 +228,6 @@ gmail.com
   5. Use your phone +1...
   6. Pin code
   7. Authentication code
-Or enter 'r' to go back to choose the provider
 Choose your authentication method:
 > 7
 == Authentication code ==

--- a/pam/integration-tests/testdata/golden/TestNativeAuthenticate/Authenticate_user_with_form_mode_with_button_in_polkit
+++ b/pam/integration-tests/testdata/golden/TestNativeAuthenticate/Authenticate_user_with_form_mode_with_button_in_polkit
@@ -1,0 +1,323 @@
+> ./pam_authd login socket=${AUTHD_TESTS_CLI_AUTHENTICATE_TESTS_SOCK} force_native_client=true
+== Provider selection ==
+  1. local
+  2. ExampleBroker
+Choose your provider:
+>
+────────────────────────────────────────────────────────────────────────────────
+> ./pam_authd login socket=${AUTHD_TESTS_CLI_AUTHENTICATE_TESTS_SOCK} force_native_client=true
+== Provider selection ==
+  1. local
+  2. ExampleBroker
+Choose your provider:
+> 2
+────────────────────────────────────────────────────────────────────────────────
+> ./pam_authd login socket=${AUTHD_TESTS_CLI_AUTHENTICATE_TESTS_SOCK} force_native_client=true
+== Provider selection ==
+  1. local
+  2. ExampleBroker
+Choose your provider:
+> 2
+== Password authentication ==
+Enter 'r' to cancel the request and go back to select the authentication method
+Gimme your password:
+>
+────────────────────────────────────────────────────────────────────────────────
+> ./pam_authd login socket=${AUTHD_TESTS_CLI_AUTHENTICATE_TESTS_SOCK} force_native_client=true
+== Provider selection ==
+  1. local
+  2. ExampleBroker
+Choose your provider:
+> 2
+== Password authentication ==
+Enter 'r' to cancel the request and go back to select the authentication method
+Gimme your password:
+>
+== Authentication method selection ==
+  1. Password authentication
+  2. Send URL to user-integration-native-authenticate-user-with-form-mode-with-button-in-polkit@
+gmail.com
+  3. Use your fido device foo
+  4. Use your phone +33...
+  5. Use your phone +1...
+  6. Pin code
+  7. Authentication code
+Or enter 'r' to go back to choose the provider
+Choose your authentication method:
+>
+────────────────────────────────────────────────────────────────────────────────
+> ./pam_authd login socket=${AUTHD_TESTS_CLI_AUTHENTICATE_TESTS_SOCK} force_native_client=true
+== Provider selection ==
+  1. local
+  2. ExampleBroker
+Choose your provider:
+> 2
+== Password authentication ==
+Enter 'r' to cancel the request and go back to select the authentication method
+Gimme your password:
+>
+== Authentication method selection ==
+  1. Password authentication
+  2. Send URL to user-integration-native-authenticate-user-with-form-mode-with-button-in-polkit@
+gmail.com
+  3. Use your fido device foo
+  4. Use your phone +33...
+  5. Use your phone +1...
+  6. Pin code
+  7. Authentication code
+Or enter 'r' to go back to choose the provider
+Choose your authentication method:
+> 7
+────────────────────────────────────────────────────────────────────────────────
+> ./pam_authd login socket=${AUTHD_TESTS_CLI_AUTHENTICATE_TESTS_SOCK} force_native_client=true
+== Provider selection ==
+  1. local
+  2. ExampleBroker
+Choose your provider:
+> 2
+== Password authentication ==
+Enter 'r' to cancel the request and go back to select the authentication method
+Gimme your password:
+>
+== Authentication method selection ==
+  1. Password authentication
+  2. Send URL to user-integration-native-authenticate-user-with-form-mode-with-button-in-polkit@
+gmail.com
+  3. Use your fido device foo
+  4. Use your phone +33...
+  5. Use your phone +1...
+  6. Pin code
+  7. Authentication code
+Or enter 'r' to go back to choose the provider
+Choose your authentication method:
+> 7
+== Authentication code ==
+  1. Proceed with Authentication code
+  2. Resend SMS (1 sent)
+Or enter 'r' to go back to select the authentication method
+Choose action:
+>
+────────────────────────────────────────────────────────────────────────────────
+> ./pam_authd login socket=${AUTHD_TESTS_CLI_AUTHENTICATE_TESTS_SOCK} force_native_client=true
+== Provider selection ==
+  1. local
+  2. ExampleBroker
+Choose your provider:
+> 2
+== Password authentication ==
+Enter 'r' to cancel the request and go back to select the authentication method
+Gimme your password:
+>
+== Authentication method selection ==
+  1. Password authentication
+  2. Send URL to user-integration-native-authenticate-user-with-form-mode-with-button-in-polkit@
+gmail.com
+  3. Use your fido device foo
+  4. Use your phone +33...
+  5. Use your phone +1...
+  6. Pin code
+  7. Authentication code
+Or enter 'r' to go back to choose the provider
+Choose your authentication method:
+> 7
+== Authentication code ==
+  1. Proceed with Authentication code
+  2. Resend SMS (1 sent)
+Or enter 'r' to go back to select the authentication method
+Choose action:
+> 2
+────────────────────────────────────────────────────────────────────────────────
+> ./pam_authd login socket=${AUTHD_TESTS_CLI_AUTHENTICATE_TESTS_SOCK} force_native_client=true
+== Provider selection ==
+  1. local
+  2. ExampleBroker
+Choose your provider:
+> 2
+== Password authentication ==
+Enter 'r' to cancel the request and go back to select the authentication method
+Gimme your password:
+>
+== Authentication method selection ==
+  1. Password authentication
+  2. Send URL to user-integration-native-authenticate-user-with-form-mode-with-button-in-polkit@
+gmail.com
+  3. Use your fido device foo
+  4. Use your phone +33...
+  5. Use your phone +1...
+  6. Pin code
+  7. Authentication code
+Or enter 'r' to go back to choose the provider
+Choose your authentication method:
+> 7
+== Authentication code ==
+  1. Proceed with Authentication code
+  2. Resend SMS (1 sent)
+Or enter 'r' to go back to select the authentication method
+Choose action:
+> 2
+== Authentication code ==
+  1. Proceed with Authentication code
+  2. Resend SMS (2 sent)
+Or enter 'r' to go back to select the authentication method
+Choose action:
+>
+────────────────────────────────────────────────────────────────────────────────
+> ./pam_authd login socket=${AUTHD_TESTS_CLI_AUTHENTICATE_TESTS_SOCK} force_native_client=true
+== Provider selection ==
+  1. local
+  2. ExampleBroker
+Choose your provider:
+> 2
+== Password authentication ==
+Enter 'r' to cancel the request and go back to select the authentication method
+Gimme your password:
+>
+== Authentication method selection ==
+  1. Password authentication
+  2. Send URL to user-integration-native-authenticate-user-with-form-mode-with-button-in-polkit@
+gmail.com
+  3. Use your fido device foo
+  4. Use your phone +33...
+  5. Use your phone +1...
+  6. Pin code
+  7. Authentication code
+Or enter 'r' to go back to choose the provider
+Choose your authentication method:
+> 7
+== Authentication code ==
+  1. Proceed with Authentication code
+  2. Resend SMS (1 sent)
+Or enter 'r' to go back to select the authentication method
+Choose action:
+> 2
+== Authentication code ==
+  1. Proceed with Authentication code
+  2. Resend SMS (2 sent)
+Or enter 'r' to go back to select the authentication method
+Choose action:
+> 1
+────────────────────────────────────────────────────────────────────────────────
+> ./pam_authd login socket=${AUTHD_TESTS_CLI_AUTHENTICATE_TESTS_SOCK} force_native_client=true
+== Provider selection ==
+  1. local
+  2. ExampleBroker
+Choose your provider:
+> 2
+== Password authentication ==
+Enter 'r' to cancel the request and go back to select the authentication method
+Gimme your password:
+>
+== Authentication method selection ==
+  1. Password authentication
+  2. Send URL to user-integration-native-authenticate-user-with-form-mode-with-button-in-polkit@
+gmail.com
+  3. Use your fido device foo
+  4. Use your phone +33...
+  5. Use your phone +1...
+  6. Pin code
+  7. Authentication code
+Or enter 'r' to go back to choose the provider
+Choose your authentication method:
+> 7
+== Authentication code ==
+  1. Proceed with Authentication code
+  2. Resend SMS (1 sent)
+Or enter 'r' to go back to select the authentication method
+Choose action:
+> 2
+== Authentication code ==
+  1. Proceed with Authentication code
+  2. Resend SMS (2 sent)
+Or enter 'r' to go back to select the authentication method
+Choose action:
+> 1
+== Authentication code ==
+Enter 'r' to cancel the request and go back to select the authentication method
+Enter your one time credential:
+>
+────────────────────────────────────────────────────────────────────────────────
+> ./pam_authd login socket=${AUTHD_TESTS_CLI_AUTHENTICATE_TESTS_SOCK} force_native_client=true
+== Provider selection ==
+  1. local
+  2. ExampleBroker
+Choose your provider:
+> 2
+== Password authentication ==
+Enter 'r' to cancel the request and go back to select the authentication method
+Gimme your password:
+>
+== Authentication method selection ==
+  1. Password authentication
+  2. Send URL to user-integration-native-authenticate-user-with-form-mode-with-button-in-polkit@
+gmail.com
+  3. Use your fido device foo
+  4. Use your phone +33...
+  5. Use your phone +1...
+  6. Pin code
+  7. Authentication code
+Or enter 'r' to go back to choose the provider
+Choose your authentication method:
+> 7
+== Authentication code ==
+  1. Proceed with Authentication code
+  2. Resend SMS (1 sent)
+Or enter 'r' to go back to select the authentication method
+Choose action:
+> 2
+== Authentication code ==
+  1. Proceed with Authentication code
+  2. Resend SMS (2 sent)
+Or enter 'r' to go back to select the authentication method
+Choose action:
+> 1
+== Authentication code ==
+Enter 'r' to cancel the request and go back to select the authentication method
+Enter your one time credential:
+> temporary pass00
+────────────────────────────────────────────────────────────────────────────────
+> ./pam_authd login socket=${AUTHD_TESTS_CLI_AUTHENTICATE_TESTS_SOCK} force_native_client=true
+== Provider selection ==
+  1. local
+  2. ExampleBroker
+Choose your provider:
+> 2
+== Password authentication ==
+Enter 'r' to cancel the request and go back to select the authentication method
+Gimme your password:
+>
+== Authentication method selection ==
+  1. Password authentication
+  2. Send URL to user-integration-native-authenticate-user-with-form-mode-with-button-in-polkit@
+gmail.com
+  3. Use your fido device foo
+  4. Use your phone +33...
+  5. Use your phone +1...
+  6. Pin code
+  7. Authentication code
+Or enter 'r' to go back to choose the provider
+Choose your authentication method:
+> 7
+== Authentication code ==
+  1. Proceed with Authentication code
+  2. Resend SMS (1 sent)
+Or enter 'r' to go back to select the authentication method
+Choose action:
+> 2
+== Authentication code ==
+  1. Proceed with Authentication code
+  2. Resend SMS (2 sent)
+Or enter 'r' to go back to select the authentication method
+Choose action:
+> 1
+== Authentication code ==
+Enter 'r' to cancel the request and go back to select the authentication method
+Enter your one time credential:
+> temporary pass00
+PAM Authenticate()
+  User: "user-integration-native-authenticate-user-with-form-mode-with-button-in-polkit"
+  Result: success
+PAM AcctMgmt()
+  User: "user-integration-native-authenticate-user-with-form-mode-with-button-in-polkit"
+  Result: success
+>
+────────────────────────────────────────────────────────────────────────────────

--- a/pam/integration-tests/testdata/golden/TestNativeAuthenticate/Authenticate_user_with_form_mode_with_button_two_supported_methods
+++ b/pam/integration-tests/testdata/golden/TestNativeAuthenticate/Authenticate_user_with_form_mode_with_button_two_supported_methods
@@ -1,0 +1,269 @@
+> ./pam_authd login socket=${AUTHD_TESTS_CLI_AUTHENTICATE_TESTS_SOCK} force_native_client=true
+== Provider selection ==
+  1. local
+  2. ExampleBroker
+Choose your provider:
+>
+────────────────────────────────────────────────────────────────────────────────
+> ./pam_authd login socket=${AUTHD_TESTS_CLI_AUTHENTICATE_TESTS_SOCK} force_native_client=true
+== Provider selection ==
+  1. local
+  2. ExampleBroker
+Choose your provider:
+> 2
+────────────────────────────────────────────────────────────────────────────────
+> ./pam_authd login socket=${AUTHD_TESTS_CLI_AUTHENTICATE_TESTS_SOCK} force_native_client=true
+== Provider selection ==
+  1. local
+  2. ExampleBroker
+Choose your provider:
+> 2
+== Password authentication ==
+Enter 'r' to cancel the request and go back to select the authentication method
+Gimme your password:
+>
+────────────────────────────────────────────────────────────────────────────────
+> ./pam_authd login socket=${AUTHD_TESTS_CLI_AUTHENTICATE_TESTS_SOCK} force_native_client=true
+== Provider selection ==
+  1. local
+  2. ExampleBroker
+Choose your provider:
+> 2
+== Password authentication ==
+Enter 'r' to cancel the request and go back to select the authentication method
+Gimme your password:
+>
+== Authentication method selection ==
+  1. Password authentication
+  2. Authentication code
+Or enter 'r' to go back to choose the provider
+Choose your authentication method:
+>
+────────────────────────────────────────────────────────────────────────────────
+> ./pam_authd login socket=${AUTHD_TESTS_CLI_AUTHENTICATE_TESTS_SOCK} force_native_client=true
+== Provider selection ==
+  1. local
+  2. ExampleBroker
+Choose your provider:
+> 2
+== Password authentication ==
+Enter 'r' to cancel the request and go back to select the authentication method
+Gimme your password:
+>
+== Authentication method selection ==
+  1. Password authentication
+  2. Authentication code
+Or enter 'r' to go back to choose the provider
+Choose your authentication method:
+> 2
+────────────────────────────────────────────────────────────────────────────────
+> ./pam_authd login socket=${AUTHD_TESTS_CLI_AUTHENTICATE_TESTS_SOCK} force_native_client=true
+== Provider selection ==
+  1. local
+  2. ExampleBroker
+Choose your provider:
+> 2
+== Password authentication ==
+Enter 'r' to cancel the request and go back to select the authentication method
+Gimme your password:
+>
+== Authentication method selection ==
+  1. Password authentication
+  2. Authentication code
+Or enter 'r' to go back to choose the provider
+Choose your authentication method:
+> 2
+== Authentication code ==
+  1. Proceed with Authentication code
+  2. Resend SMS (1 sent)
+Or enter 'r' to go back to select the authentication method
+Choose action:
+>
+────────────────────────────────────────────────────────────────────────────────
+> ./pam_authd login socket=${AUTHD_TESTS_CLI_AUTHENTICATE_TESTS_SOCK} force_native_client=true
+== Provider selection ==
+  1. local
+  2. ExampleBroker
+Choose your provider:
+> 2
+== Password authentication ==
+Enter 'r' to cancel the request and go back to select the authentication method
+Gimme your password:
+>
+== Authentication method selection ==
+  1. Password authentication
+  2. Authentication code
+Or enter 'r' to go back to choose the provider
+Choose your authentication method:
+> 2
+== Authentication code ==
+  1. Proceed with Authentication code
+  2. Resend SMS (1 sent)
+Or enter 'r' to go back to select the authentication method
+Choose action:
+> 2
+────────────────────────────────────────────────────────────────────────────────
+> ./pam_authd login socket=${AUTHD_TESTS_CLI_AUTHENTICATE_TESTS_SOCK} force_native_client=true
+== Provider selection ==
+  1. local
+  2. ExampleBroker
+Choose your provider:
+> 2
+== Password authentication ==
+Enter 'r' to cancel the request and go back to select the authentication method
+Gimme your password:
+>
+== Authentication method selection ==
+  1. Password authentication
+  2. Authentication code
+Or enter 'r' to go back to choose the provider
+Choose your authentication method:
+> 2
+== Authentication code ==
+  1. Proceed with Authentication code
+  2. Resend SMS (1 sent)
+Or enter 'r' to go back to select the authentication method
+Choose action:
+> 2
+== Authentication code ==
+  1. Proceed with Authentication code
+  2. Resend SMS (2 sent)
+Or enter 'r' to go back to select the authentication method
+Choose action:
+>
+────────────────────────────────────────────────────────────────────────────────
+> ./pam_authd login socket=${AUTHD_TESTS_CLI_AUTHENTICATE_TESTS_SOCK} force_native_client=true
+== Provider selection ==
+  1. local
+  2. ExampleBroker
+Choose your provider:
+> 2
+== Password authentication ==
+Enter 'r' to cancel the request and go back to select the authentication method
+Gimme your password:
+>
+== Authentication method selection ==
+  1. Password authentication
+  2. Authentication code
+Or enter 'r' to go back to choose the provider
+Choose your authentication method:
+> 2
+== Authentication code ==
+  1. Proceed with Authentication code
+  2. Resend SMS (1 sent)
+Or enter 'r' to go back to select the authentication method
+Choose action:
+> 2
+== Authentication code ==
+  1. Proceed with Authentication code
+  2. Resend SMS (2 sent)
+Or enter 'r' to go back to select the authentication method
+Choose action:
+> 1
+────────────────────────────────────────────────────────────────────────────────
+> ./pam_authd login socket=${AUTHD_TESTS_CLI_AUTHENTICATE_TESTS_SOCK} force_native_client=true
+== Provider selection ==
+  1. local
+  2. ExampleBroker
+Choose your provider:
+> 2
+== Password authentication ==
+Enter 'r' to cancel the request and go back to select the authentication method
+Gimme your password:
+>
+== Authentication method selection ==
+  1. Password authentication
+  2. Authentication code
+Or enter 'r' to go back to choose the provider
+Choose your authentication method:
+> 2
+== Authentication code ==
+  1. Proceed with Authentication code
+  2. Resend SMS (1 sent)
+Or enter 'r' to go back to select the authentication method
+Choose action:
+> 2
+== Authentication code ==
+  1. Proceed with Authentication code
+  2. Resend SMS (2 sent)
+Or enter 'r' to go back to select the authentication method
+Choose action:
+> 1
+== Authentication code ==
+Enter 'r' to cancel the request and go back to select the authentication method
+Enter your one time credential:
+>
+────────────────────────────────────────────────────────────────────────────────
+> ./pam_authd login socket=${AUTHD_TESTS_CLI_AUTHENTICATE_TESTS_SOCK} force_native_client=true
+== Provider selection ==
+  1. local
+  2. ExampleBroker
+Choose your provider:
+> 2
+== Password authentication ==
+Enter 'r' to cancel the request and go back to select the authentication method
+Gimme your password:
+>
+== Authentication method selection ==
+  1. Password authentication
+  2. Authentication code
+Or enter 'r' to go back to choose the provider
+Choose your authentication method:
+> 2
+== Authentication code ==
+  1. Proceed with Authentication code
+  2. Resend SMS (1 sent)
+Or enter 'r' to go back to select the authentication method
+Choose action:
+> 2
+== Authentication code ==
+  1. Proceed with Authentication code
+  2. Resend SMS (2 sent)
+Or enter 'r' to go back to select the authentication method
+Choose action:
+> 1
+== Authentication code ==
+Enter 'r' to cancel the request and go back to select the authentication method
+Enter your one time credential:
+> temporary pass00
+────────────────────────────────────────────────────────────────────────────────
+> ./pam_authd login socket=${AUTHD_TESTS_CLI_AUTHENTICATE_TESTS_SOCK} force_native_client=true
+== Provider selection ==
+  1. local
+  2. ExampleBroker
+Choose your provider:
+> 2
+== Password authentication ==
+Enter 'r' to cancel the request and go back to select the authentication method
+Gimme your password:
+>
+== Authentication method selection ==
+  1. Password authentication
+  2. Authentication code
+Or enter 'r' to go back to choose the provider
+Choose your authentication method:
+> 2
+== Authentication code ==
+  1. Proceed with Authentication code
+  2. Resend SMS (1 sent)
+Or enter 'r' to go back to select the authentication method
+Choose action:
+> 2
+== Authentication code ==
+  1. Proceed with Authentication code
+  2. Resend SMS (2 sent)
+Or enter 'r' to go back to select the authentication method
+Choose action:
+> 1
+== Authentication code ==
+Enter 'r' to cancel the request and go back to select the authentication method
+Enter your one time credential:
+> temporary pass00
+PAM Authenticate()
+  User: "user-auth-modes-totp_with_button,password-integration-native"
+  Result: success
+PAM AcctMgmt()
+  User: "user-auth-modes-totp_with_button,password-integration-native"
+  Result: success
+>
+────────────────────────────────────────────────────────────────────────────────

--- a/pam/integration-tests/testdata/tapes/native/form_with_button.tape
+++ b/pam/integration-tests/testdata/tapes/native/form_with_button.tape
@@ -20,12 +20,12 @@ Show
 
 Hide
 Enter
-Wait+Screen /8\. Authentication code/
+Wait+Screen /${AUTHD_FORM_BUTTON_TAPE_ITEM}\. Authentication code/
 Wait+Prompt /Choose your authentication method/
 Show
 
 Hide
-TypeInPrompt "8"
+TypeInPrompt "${AUTHD_FORM_BUTTON_TAPE_ITEM}"
 Show
 
 Hide

--- a/pam/integration-tests/testdata/tapes/native/form_with_button_polkit.tape
+++ b/pam/integration-tests/testdata/tapes/native/form_with_button_polkit.tape
@@ -1,0 +1,52 @@
+Hide
+Wait
+Type "${AUTHD_TEST_TAPE_COMMAND}"
+Enter
+Wait+Prompt /Gimme your password/
+Show
+
+Hide
+Type "r"
+Show
+
+Hide
+Enter
+Wait+Screen /${AUTHD_FORM_BUTTON_TAPE_ITEM}\. Authentication code/
+Wait+Prompt /Choose your authentication method/
+Show
+
+Hide
+TypeInPrompt "${AUTHD_FORM_BUTTON_TAPE_ITEM}"
+Show
+
+Hide
+Enter
+Wait+Prompt /Choose action/
+Show
+
+Hide
+TypeInPrompt "2"
+Show
+
+Hide
+Enter
+Wait+Prompt /Choose action/
+Show
+
+Hide
+TypeInPrompt "1"
+Show
+
+Hide
+Enter
+Wait+Prompt /Enter your one time credential/
+Show
+
+Hide
+TypeInPrompt "temporary pass00"
+Show
+
+Hide
+Enter
+${AUTHD_TEST_TAPE_COMMAND_AUTH_FINAL_WAIT}
+Show

--- a/pam/internal/adapter/nativemodel.go
+++ b/pam/internal/adapter/nativemodel.go
@@ -196,6 +196,14 @@ func (m nativeModel) Update(msg tea.Msg) (nativeModel, tea.Cmd) {
 		return m.startAsyncOp(m.userSelection)
 
 	case brokersListReceived:
+		if m.serviceName == polkitServiceName {
+			// Do not support using local broker in the polkit case.
+			// FIXME: This should be up to authd to keep a list of brokers based on service.
+			m.availableBrokers = slices.DeleteFunc(msg.brokers, func(b *authd.ABResponse_BrokerInfo) bool {
+				return b.Id == brokers.LocalBrokerName
+			})
+			return m, nil
+		}
 		m.availableBrokers = msg.brokers
 
 	case authModesReceived:

--- a/pam/internal/adapter/nativemodel.go
+++ b/pam/internal/adapter/nativemodel.go
@@ -90,6 +90,7 @@ func (m *nativeModel) Init() tea.Cmd {
 
 	m.interactive = isSSHSession(m.pamMTx) || IsTerminalTTY(m.pamMTx)
 	rendersQrCode := m.isQrcodeRenderingSupported()
+	supportsQrCode := m.serviceName != polkitServiceName
 
 	return func() tea.Msg {
 		required, optional := layouts.Required, layouts.Optional
@@ -100,7 +101,7 @@ func (m *nativeModel) Init() tea.Cmd {
 			entries.DigitsPassword,
 		)
 
-		return supportedUILayoutsReceived{
+		supportedLayouts := supportedUILayoutsReceived{
 			layouts: []*authd.UILayout{
 				{
 					Type:   layouts.Form,
@@ -110,15 +111,6 @@ func (m *nativeModel) Init() tea.Cmd {
 					Button: &optional,
 				},
 				{
-					Type:          layouts.QrCode,
-					Content:       &required,
-					Code:          &optional,
-					Wait:          &layouts.RequiredWithBooleans,
-					Label:         &optional,
-					Button:        &optional,
-					RendersQrcode: &rendersQrCode,
-				},
-				{
 					Type:   layouts.NewPassword,
 					Label:  &required,
 					Entry:  &supportedEntries,
@@ -126,6 +118,20 @@ func (m *nativeModel) Init() tea.Cmd {
 				},
 			},
 		}
+
+		if supportsQrCode {
+			supportedLayouts.layouts = append(supportedLayouts.layouts, &authd.UILayout{
+				Type:          layouts.QrCode,
+				Content:       &required,
+				Code:          &optional,
+				Wait:          &layouts.RequiredWithBooleans,
+				Label:         &optional,
+				Button:        &optional,
+				RendersQrcode: &rendersQrCode,
+			})
+		}
+
+		return supportedLayouts
 	}
 }
 


### PR DESCRIPTION
Polkit UI is quite limited so, although the device authentication works
as expected, it's far from being user friendly so disable the "qrcode"
UI at all in such case.

Ultimately it should be up to the broker to decide whether to support an
UI or not, but since we can't provide it the service name, we have to
handle it in the module.

At the same time, ignore the local broker when using polkit service.

---

That said this avoids polkit to show the device authentication as it's something we already mentioned we don't want, but we can't by design do this kind of filtering in the PAM module, that should be thinnest layer between authd and the broker, but instead I think we should re-consider refactoring this so that:
 1. The broker mandates the supported authentication modes depending on the PAM environment (service name, interactive or not)
 2. It's up to authd to enable or not the availability of a broker (the local one in this case).

UDENG-5154