### PR TITLE
GitHub issue template: Use sudo to collect config file contents

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -98,16 +98,16 @@ body:
         \`\`\`
 
         #### authd broker configuration
-        $(if ! find /etc/authd/brokers.d -name '*.conf' | grep -q .; then echo ":warning: No config files in /etc/authd/brokers.d/"; else for f in /etc/authd/brokers.d/*.conf; do echo "#### $f"; echo "\`\`\`";  cat $f; echo "\`\`\`"; done; fi)
+        $(sudo sh -c 'if ! find /etc/authd/brokers.d -name \*.conf | grep -q .; then echo ":warning: No config files in /etc/authd/brokers.d/"; else for f in /etc/authd/brokers.d/*.conf; do echo "#### $f"; echo "\`\`\`";  cat $f; echo "\`\`\`"; done; fi')
 
         #### authd-msentraid configuration
         \`\`\`
-        $(cat 2>&1 /var/snap/authd-msentraid/current/broker.conf | sed -E 's/[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}/<UUID redacted>/g')
+        $(sudo cat 2>&1 /var/snap/authd-msentraid/current/broker.conf | sed -E 's/[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}/<UUID redacted>/g')
         \`\`\`
 
         #### authd-google configuration
         \`\`\`
-        $(cat 2>&1 /var/snap/authd-google/current/broker.conf | sed -E 's/client_id = .*/client_id = <redacted>/g' | sed -E 's/client_secret = .*/client_secret = <redacted>/g')
+        $(sudo cat 2>&1 /var/snap/authd-google/current/broker.conf | sed -E 's/client_id = .*/client_id = <redacted>/g' | sed -E 's/client_secret = .*/client_secret = <redacted>/g')
         \`\`\`
 
         EOF


### PR DESCRIPTION
The config files are only readable by root since 9ff0d1a3840db0d1dc46a05cfc260c7d23897ba0 and https://github.com/ubuntu/authd-oidc-brokers/commit/6116ba9c70d0fcae9df197d02c0e1c766d5fc9cd.