### PR TITLE
Add changelog entry for 0.4.1

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,4 @@
-authd (0.4.1) UNRELEASED; urgency=medium
+authd (0.4.1) plucky; urgency=medium
 
   * New Launchpad upload
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+authd (0.4.1) UNRELEASED; urgency=medium
+
+  * New Launchpad upload
+
+ --  <adrian.dombeck@canonical.com>  Thu, 30 Jan 2025 15:06:09 +0100
+
 authd (0.4.0) plucky; urgency=medium
 
   * Generate random UIDs and GIDs. This fixes an issue which can lead to login


### PR DESCRIPTION
To be able to upload to Launchpad again. The build of 0.4.0 failed because the XS-Vendored-Sources-Rust value in debian/control, which allowed me to build the package on my host, caused the build to fail on Launchpad.