### PR TITLE
docs: adjust language on releases

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -210,7 +210,7 @@ linkcheck_anchors_ignore_for_url = [r"https://github\.com/.*"]
 # NOTE: By default, the following MyST extensions are enabled:
 #       substitution, deflist, linkify
 
-# myst_enable_extensions = set()
+myst_enable_extensions = set({"colon_fence"})
 
 
 # Auto-generate header anchors

--- a/docs/howto/install-authd.md
+++ b/docs/howto/install-authd.md
@@ -22,6 +22,12 @@ sudo add-apt-repository ppa:ubuntu-enterprise-desktop/authd
 sudo apt update
 ```
 
+```{note}
+The stable PPA release of authd can be used today as an authentication service.
+This project is under active development and the release of authd to the
+official archive is planned for Ubuntu 26.04 LTS.
+```
+
 Then install authd and any additional Debian packages needed for your system of
 choice:
 

--- a/docs/howto/install-authd.md
+++ b/docs/howto/install-authd.md
@@ -4,7 +4,7 @@ This project consists of two components:
 * authd: The authentication daemon responsible for managing access to the authentication mechanism.
 * an identity broker: The services that handle the interface with an identity provider. There can be several identity brokers installed and enabled on the system.
 
-authd is delivered as a Debian package.
+authd is delivered as a Debian package for Ubuntu Desktop and Ubuntu Server.
 
 ## System requirements
 
@@ -22,11 +22,28 @@ sudo add-apt-repository ppa:ubuntu-enterprise-desktop/authd
 sudo apt update
 ```
 
-Install the following Debian packages (note that `gnome-shell` and `yaru-theme*` are only required for desktop integration, server installations may ignore them):
+Then install authd and any additional Debian packages needed for your system of
+choice:
+
+:::::{tab-set}
+:sync-group: system
+
+::::{tab-item} Ubuntu Desktop
+:sync: desktop
 
 ```shell
 sudo apt install authd gnome-shell yaru-theme-gnome-shell
 ```
+::::
+
+::::{tab-item} Ubuntu Server
+:sync: server
+
+```shell
+sudo apt install authd
+```
+::::
+:::::
 
 ## Install brokers
 

--- a/docs/howto/install-authd.md
+++ b/docs/howto/install-authd.md
@@ -13,7 +13,7 @@ authd is delivered as a Debian package.
 
 
 ```{note}
-While this project is in active development, a version for Ubuntu 24.04 is available from the [authd testing PPA](https://launchpad.net/~ubuntu-enterprise-desktop/+archive/ubuntu/authd). <br />
+You can install authd from the [stable PPA](https://launchpad.net/~ubuntu-enterprise-desktop/+archive/ubuntu/authd).
 
 You can add this PPA to your system's software sources with the following commands:
 

--- a/docs/howto/install-authd.md
+++ b/docs/howto/install-authd.md
@@ -1,8 +1,8 @@
 # Installation
 
 This project consists of two components:
-* authd: The authentication daemon responsible for managing access to the authentication mechanism.
-* an identity broker: The services that handle the interface with an identity provider. There can be several identity brokers installed and enabled on the system.
+* **authd**: The authentication daemon responsible for managing access to the authentication mechanism.
+* **identity broker**: The services that handle the interface with an identity provider. There can be several identity brokers installed and enabled on the system.
 
 authd is delivered as a Debian package for Ubuntu Desktop and Ubuntu Server.
 
@@ -11,11 +11,11 @@ authd is delivered as a Debian package for Ubuntu Desktop and Ubuntu Server.
 * Distribution: Ubuntu Desktop 24.04 LTS or Ubuntu Server 24.04 LTS
 * Architectures: amd64, arm64
 
+## Install authd
 
-```{note}
 You can install authd from the [stable PPA](https://launchpad.net/~ubuntu-enterprise-desktop/+archive/ubuntu/authd).
 
-You can add this PPA to your system's software sources with the following commands:
+To add this PPA to your system's software sources, run the following commands:
 
 ```shell
 sudo add-apt-repository ppa:ubuntu-enterprise-desktop/authd
@@ -47,7 +47,8 @@ sudo apt install authd
 
 ## Install brokers
 
-The brokers are provided as Snap packages and available from the Snap Store.
+The brokers are provided as Snap packages and are available from the Snap
+Store.
 
 ### MS Entra ID broker
 
@@ -57,7 +58,8 @@ To install the MS Entra ID broker, run the following command:
 sudo snap install authd-msentraid
 ```
 
-At this stage, you have installed the main service and an identity broker to authenticate against Microsoft Entra ID.
+At this stage, you have installed the main service and an identity broker to
+authenticate against Microsoft Entra ID.
 
 ### Google IAM broker
 
@@ -67,4 +69,5 @@ To install the Google IAM broker, run the following command:
 sudo snap install authd-google
 ```
 
-At this stage, you have installed the main service and an identity broker to authenticate against Google IAM.
+At this stage, you have installed the main service and an identity broker to
+authenticate against Google IAM.


### PR DESCRIPTION
This PR makes small changes to authd's howto/install guide to improve clarity and consistency:

* **Be more consistent in release language:** The 'stable' release of authd is referred to elsewhere, including the homepage, the README and the PPA page. To be consistent, we should not refer to it as a 'testing' release in the how-to install guide.
* **Try to clearly highlight Desktop and Server offering**: Instead of giving the install commands for Desktop, and then saying some of the packages in that command aren't needed for Server, the specific commands for both cases are now provided in a tabbed interface.  The user can choose the relevant one and copy the appropriate command. That authd can be installed on both systems is also highlighted at the start of the page.

Other minor changes were made to formatting, language and the documentation config file.

UDENG-5903