### PR TITLE
Improve warning logged when home directory has incorrect owner/group

### DIFF
--- a/internal/users/manager.go
+++ b/internal/users/manager.go
@@ -297,14 +297,14 @@ func checkHomeDirOwnership(home string, uid, gid uint32) error {
 
 	// Check if the home directory is owned by the user.
 	if oldUID != uid && oldGID != gid {
-		log.Warningf(context.Background(), "Home directory %q is not owned by UID %d and GID %d. To fix this, run `sudo chown -R %d:%d %s`.", home, uid, gid, uid, gid, home)
+		log.Warningf(context.Background(), "Home directory %q is not owned by UID %d and GID %d. To fix this, run `sudo chown -R %d:%d %q`.", home, uid, gid, uid, gid, home)
 		return nil
 	}
 	if oldUID != uid {
-		log.Warningf(context.Background(), "Home directory %q is not owned by UID %d. To fix this, run `sudo chown -R --from=%d %d %s`.", home, oldUID, oldUID, uid, home)
+		log.Warningf(context.Background(), "Home directory %q is not owned by UID %d. To fix this, run `sudo chown -R --from=%d %d %q`.", home, oldUID, oldUID, uid, home)
 	}
 	if oldGID != gid {
-		log.Warningf(context.Background(), "Home directory %q is not owned by GID %d. To fix this, run `sudo chown -R --from=:%d :%d %s`.", home, oldGID, oldGID, gid, home)
+		log.Warningf(context.Background(), "Home directory %q is not owned by GID %d. To fix this, run `sudo chown -R --from=:%d :%d %q`.", home, oldGID, oldGID, gid, home)
 	}
 
 	return nil

--- a/internal/users/manager.go
+++ b/internal/users/manager.go
@@ -296,6 +296,10 @@ func checkHomeDirOwnership(home string, uid, gid uint32) error {
 	oldUID, oldGID := sys.Uid, sys.Gid
 
 	// Check if the home directory is owned by the user.
+	if oldUID != uid && oldGID != gid {
+		log.Warningf(context.Background(), "Home directory %q is not owned by UID %d and GID %d. To fix this, run `sudo chown -R %d:%d %s`.", home, uid, gid, uid, gid, home)
+		return nil
+	}
 	if oldUID != uid {
 		log.Warningf(context.Background(), "Home directory %q is not owned by UID %d. To fix this, run `sudo chown -R --from=%d %d %s`.", home, oldUID, oldUID, uid, home)
 	}


### PR DESCRIPTION
Log only a single warning with a single `chown` command if both the owner and group are incorrect.