### PR TITLE
Bump Go toolchain version to 1.23.6

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/ubuntu/authd
 
 go 1.23.0
 
-toolchain go1.23.5
+toolchain go1.23.6
 
 require (
 	github.com/charmbracelet/bubbles v0.20.0


### PR DESCRIPTION
govulncheck reports the following vulnerability in nistec@go1.23.5:

```
Vulnerability #1: GO-2025-3447
    Timing sidechannel for P-256 on ppc64le in crypto/internal/nistec
  More info: https://pkg.go.dev/vuln/GO-2025-3447
  Standard library
    Found in: crypto/internal/nistec@go1.23.5
    Fixed in: crypto/internal/nistec@go1.23.6
    Platforms: ppc64le
```