### PR TITLE
docs: Surface brokers in docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -132,10 +132,8 @@ The built binary will be found in the current directory. The daemon can be run d
 
 #### Building the PAM module only
 
-To build the PAM module, from the top of the source tree run the following commands:
-
-> [!NOTE]
-> This command installs the tooling to hook up the Go GRPC modules to protoc.
+To build the PAM module, you first need to install the tooling to hook up the Go GRPC modules to protoc.
+From the top of the source tree run the following commands:
 
 ```shell
 cd tools/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -132,7 +132,7 @@ The built binary will be found in the current directory. The daemon can be run d
 
 #### Building the PAM module only
 
-To build the PAM module, you first need to install the tooling to hook up the Go GRPC modules to protoc.
+To build the PAM module, you first need to install the tooling to hook up the Go gRPC modules to protoc.
 From the top of the source tree run the following commands:
 
 ```shell

--- a/docs/explanation/index.md
+++ b/docs/explanation/index.md
@@ -2,6 +2,9 @@
 
 # Explanation
 
+Read about the modular design of authd and how it interfaces with
+multiple cloud providers through different identity brokers.
+
 ```{toctree}
 :titlesonly:
 

--- a/docs/howto/configure-authd.md
+++ b/docs/howto/configure-authd.md
@@ -1,10 +1,10 @@
-# Configure authd
 ---
 myst:
   html_meta:
     "description lang=en": "Configure authd and its identity brokers to enable authentication of Ubuntu devices with multiple cloud identity providers, including Google IAM and Microsoft Entra ID."
 ---
 
+# Configure authd for cloud identity providers
 ## Broker discovery
 
 Create the directory that will contain the declaration files of the broker and copy the one from a broker snap package, with a specific `<broker_name>`, such as `google` or `msentraid`:

--- a/docs/howto/configure-authd.md
+++ b/docs/howto/configure-authd.md
@@ -49,7 +49,7 @@ Several brokers can be enabled at the same time.
 
 ## Application registration
 
-This section demonstrate registering an OAuth 2.0 application that your chosen
+This section demonstrates registering an OAuth 2.0 application that your chosen
 broker can then use to authenticate users.
 
 :::::{tab-set}

--- a/docs/howto/configure-authd.md
+++ b/docs/howto/configure-authd.md
@@ -1,4 +1,9 @@
 # Configure authd
+---
+myst:
+  html_meta:
+    "description lang=en": "Configure authd and its identity brokers to enable authentication of Ubuntu devices with multiple cloud identity providers, including Google IAM and Microsoft Entra ID."
+---
 
 ## Broker discovery
 

--- a/docs/howto/index.md
+++ b/docs/howto/index.md
@@ -2,14 +2,48 @@
 
 # How-to guides
 
+## Installation and configuration
+
+Install authd and identity brokers then configure them for your cloud identity
+provider.
+
 ```{toctree}
 :titlesonly:
 
 Install authd <install-authd>
 Configure authd <configure-authd>
+```
+
+## Login and authentication
+
+Read about how users can authenticate when
+logging into Ubuntu Desktop or Server.
+
+
+```{toctree}
+:titlesonly:
+
 Log in with GDM <login-gdm>
 Log in with SSH <login-ssh>
+```
+
+## File-sharing
+
+Learn how to use authd with different file-sharing protocols.
+
+```{toctree}
+:titlesonly:
+
 Use authd with NFS <use-with-nfs>
 Use authd with Samba <use-with-samba>
+```
+
+## Contributing to authd
+
+Contribute to the development of authd and its brokers.
+
+```{toctree}
+:titlesonly:
+
 Contributing to authd <contributing>
 ```

--- a/docs/howto/index.md
+++ b/docs/howto/index.md
@@ -27,9 +27,9 @@ Log in with GDM <login-gdm>
 Log in with SSH <login-ssh>
 ```
 
-## File-sharing
+## Network file systems
 
-Learn how to use authd with different file-sharing protocols.
+Learn how to use authd with different network file systems.
 
 ```{toctree}
 :titlesonly:

--- a/docs/howto/install-authd.md
+++ b/docs/howto/install-authd.md
@@ -1,4 +1,9 @@
 # Installation
+---
+myst:
+  html_meta:
+    "description lang=en": "Install the authd authentication service and its identity brokers to enable Ubuntu devices to authenticate with multiple cloud identity providers, including Google IAM and Microsoft Entra ID."
+---
 
 This project consists of two components:
 * **authd**: The authentication daemon responsible for managing access to the authentication mechanism.

--- a/docs/howto/install-authd.md
+++ b/docs/howto/install-authd.md
@@ -1,9 +1,11 @@
-# Installation
 ---
 myst:
   html_meta:
     "description lang=en": "Install the authd authentication service and its identity brokers to enable Ubuntu devices to authenticate with multiple cloud identity providers, including Google IAM and Microsoft Entra ID."
 ---
+
+(howto::install)=
+# Install authd and brokers for cloud identity providers
 
 This project consists of two components:
 * **authd**: The authentication daemon responsible for managing access to the authentication mechanism.

--- a/docs/howto/install-authd.md
+++ b/docs/howto/install-authd.md
@@ -39,10 +39,8 @@ Then install authd and any additional Debian packages needed for your system of
 choice:
 
 :::::{tab-set}
-:sync-group: system
 
 ::::{tab-item} Ubuntu Desktop
-:sync: desktop
 
 ```shell
 sudo apt install authd gnome-shell yaru-theme-gnome-shell
@@ -50,7 +48,6 @@ sudo apt install authd gnome-shell yaru-theme-gnome-shell
 ::::
 
 ::::{tab-item} Ubuntu Server
-:sync: server
 
 ```shell
 sudo apt install authd

--- a/docs/howto/install-authd.md
+++ b/docs/howto/install-authd.md
@@ -63,7 +63,24 @@ sudo apt install authd
 The brokers are provided as Snap packages and are available from the Snap
 Store.
 
-### MS Entra ID broker
+:::::{tab-set}
+:sync-group: broker
+
+::::{tab-item} Google IAM
+:sync: google
+
+To install the Google IAM broker, run the following command:
+
+```shell
+sudo snap install authd-google
+```
+At this stage, you have installed the main service and an identity broker to
+authenticate against Google IAM.
+
+::::
+
+::::{tab-item} Microsoft Entra ID
+:sync: msentraid
 
 To install the MS Entra ID broker, run the following command:
 
@@ -74,13 +91,5 @@ sudo snap install authd-msentraid
 At this stage, you have installed the main service and an identity broker to
 authenticate against Microsoft Entra ID.
 
-### Google IAM broker
-
-To install the Google IAM broker, run the following command:
-
-```shell
-sudo snap install authd-google
-```
-
-At this stage, you have installed the main service and an identity broker to
-authenticate against Google IAM.
+::::
+:::::

--- a/docs/howto/install-authd.md
+++ b/docs/howto/install-authd.md
@@ -41,6 +41,7 @@ choice:
 :::::{tab-set}
 
 ::::{tab-item} Ubuntu Desktop
+:sync: desktop
 
 ```shell
 sudo apt install authd gnome-shell yaru-theme-gnome-shell
@@ -48,6 +49,7 @@ sudo apt install authd gnome-shell yaru-theme-gnome-shell
 ::::
 
 ::::{tab-item} Ubuntu Server
+:sync: server
 
 ```shell
 sudo apt install authd

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,6 +1,3 @@
-# authd
-
-authd is a versatile authentication service for Ubuntu, designed to seamlessly integrate with cloud identity providers like OpenID Connect and Entra ID. It offers a secure interface for system authentication, enabling cloud-based identity management. It can be used to support logins through both GDM and SSH.
 ---
 myst:
   html_meta:
@@ -8,13 +5,24 @@ myst:
       "authd is an authentication service for Ubuntu, offering integration with multiple cloud identity providers, including Google IAM and Microsoft Entra ID."
 ---
 
-authd features a modular structure, facilitating straightforward integration with different cloud services. This design aids in maintaining strong security and effective user authentication. It's well-suited for handling access to cloud identities, offering a balance of security and ease of use.
+# authd
 
-authd uses brokers to interface with cloud identity providers through a [DBus API](https://github.com/ubuntu/authd/blob/HEAD/examplebroker/com.ubuntu.auth.ExampleBroker.xml). Currently, both [MS Entra ID](https://learn.microsoft.com/en-us/entra/fundamentals/whatis) and [Google IAM](https://cloud.google.com/iam/docs/overview) are supported. For development purposes, authd also provides an example broker to help you develop your own.
-These brokers allow you to authenticate against MS Entra ID or Google IAM using multi-factor authentication and the device authentication flow.
+authd is an authentication service for Ubuntu that integrates with multiple
+cloud identity providers. It offers a secure interface for system
+authentication, enabling cloud-based identity management for Ubuntu Desktop and
+Server.
 
+authd has a modular design, comprising an authentication daemon and various
+identity brokers. This enables authd to support a growing list of cloud
+identity providers. Currently, authd supports authentication with both [MS
+Entra ID](https://learn.microsoft.com/en-us/entra/fundamentals/whatis) and
+[Google IAM](https://cloud.google.com/iam/docs/overview). An example broker is
+also provided to help developers create new brokers for additional identity
+services.
 
----------
+If an organization is pursuing cloud-based authentication of Ubuntu
+workstations and servers, authd is a secure and versatile service to support a
+full transition to the cloud.
 
 ## In this documentation
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -40,13 +40,13 @@ full transition to the cloud.
 :sync: google
 
 * <a href="howto/install-authd/?broker=google">Install authd and the Google IAM broker</a>
-* <a href="howto/install-authd/?broker=google">Configure the Google IAM broker</a>
+* <a href="howto/configure-authd/?broker=google">Configure the Google IAM broker</a>
 :::
 
 :::{tab-item} MS Entra ID
 :sync: msentraid
 
-* <a href="howto/configure-authd/?broker=msentraid">Install authd and the MS Entra ID broker</a>
+* <a href="howto/install-authd/?broker=msentraid">Install authd and the MS Entra ID broker</a>
 * <a href="howto/configure-authd/?broker=msentraid">Configure the MS Entra ID broker</a>
 :::
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,6 +1,12 @@
 # authd
 
 authd is a versatile authentication service for Ubuntu, designed to seamlessly integrate with cloud identity providers like OpenID Connect and Entra ID. It offers a secure interface for system authentication, enabling cloud-based identity management. It can be used to support logins through both GDM and SSH.
+---
+myst:
+  html_meta:
+    "description lang=en":
+      "authd is an authentication service for Ubuntu, offering integration with multiple cloud identity providers, including Google IAM and Microsoft Entra ID."
+---
 
 authd features a modular structure, facilitating straightforward integration with different cloud services. This design aids in maintaining strong security and effective user authentication. It's well-suited for handling access to cloud identities, offering a balance of security and ease of use.
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -27,36 +27,50 @@ full transition to the cloud.
 ## In this documentation
 
 <!-- NOTE: changed grid layout as there is only three cards -->
-````{grid} 1 1 1 1
+::::::{grid} 1 1 1 1
 
-```{grid-item-card} [How-to guides](howto/index)
-:link: howto/index
-:link-type: doc
+:::::{grid-item-card} [How-to guides](howto/index)
 
-**Step-by-step guides** covering key operations and common tasks
-```
+**Step-by-step guides** covering key operations for your chosen identity provider.
 
-````
+::::{tab-set}
+:sync-group: broker
 
-````{grid} 1 1 2 2
+:::{tab-item} Google IAM
+:sync: google
+
+* <a href="howto/install-authd/?broker=google">Install authd and the Google IAM broker</a>
+* <a href="howto/install-authd/?broker=google">Configure the Google IAM broker</a>
+:::
+
+:::{tab-item} MS Entra ID
+:sync: msentraid
+
+* <a href="howto/configure-authd/?broker=msentraid">Install authd and the MS Entra ID broker</a>
+* <a href="howto/configure-authd/?broker=msentraid">Configure the MS Entra ID broker</a>
+:::
+
+::::::
+
+::::::{grid} 1 1 2 2
 :reverse:
 
-```{grid-item-card} [Reference](reference/index)
+:::::{grid-item-card} [Reference](reference/index)
 :link: reference/index
 :link-type: doc
 
-**Technical information** on troubleshooting authd
-```
+**Technical information** on supported cloud providers and troubleshooting authd.
+:::::
 
-```{grid-item-card} [Explanation](explanation/index)
+:::::{grid-item-card} [Explanation](explanation/index)
 :link: explanation/index
 :link-type: doc
 
-**Discussion** of product architecture
-```
+**Architecture reference for authd**, showing how its brokers interface with multiple cloud
+providers.
+:::::
 
-
-````
+::::::
 
 Documentation for the [stable](https://canonical-authd.readthedocs-hosted.com/en/stable/) release of authd and the [latest](https://canonical-authd.readthedocs-hosted.com/en/latest/) development version are
 both available.

--- a/docs/reference/cloud-providers.md
+++ b/docs/reference/cloud-providers.md
@@ -6,8 +6,8 @@ Several brokers can be installed and enabled on a system.
 
 | Provider       | Broker snap                                             | Install as a snap             | Configure                                                           | Provider docs                                                            |
 | ---            | ---                                                     | ---                           | ---                                                                 | ---                                                                      |
-| Google IAM     | [authd-google](https://snapcraft.io/authd-google)       | `snap install authd-google`   | <a href="howto/install-authd/?broker=google">Google IAM guide</a>   | [Microsoft](https://learn.microsoft.com/en-us/entra/fundamentals/whatis) |
-| MS Entra ID    | [authd-msentraid](https://snapcraft.io/authd-msentraid) | `snap install authd-msentraid`| <a href="howto/install-authd/?broker=google">MS Entra ID guide</a>  | [Google](https://cloud.google.com/iam/docs/overview)                     |
+| Google IAM     | [authd-google](https://snapcraft.io/authd-google)       | `snap install authd-google`   | <a href="../../howto/configure-authd/?broker=google">Google IAM guide</a>   | [Microsoft](https://learn.microsoft.com/en-us/entra/fundamentals/whatis) |
+| MS Entra ID    | [authd-msentraid](https://snapcraft.io/authd-msentraid) | `snap install authd-msentraid`| <a href="../../howto/configure-authd/?broker=msentraid">MS Entra ID guide</a>  | [Google](https://cloud.google.com/iam/docs/overview)                     |
 
 ```{note}
 Support for multiple additional providers is planned for future releases of authd.

--- a/docs/reference/cloud-providers.md
+++ b/docs/reference/cloud-providers.md
@@ -1,0 +1,14 @@
+# Cloud providers that authd supports
+
+authd supports cloud providers through its identity brokers.
+Each broker is available as a snap.
+Several brokers can be installed and enabled on a system.
+
+| Provider       | Broker snap                                             | Install as a snap             | Configure                                                           | Provider docs                                                            |
+| ---            | ---                                                     | ---                           | ---                                                                 | ---                                                                      |
+| Google IAM     | [authd-google](https://snapcraft.io/authd-google)       | `snap install authd-google`   | <a href="howto/install-authd/?broker=google">Google IAM guide</a>   | [Microsoft](https://learn.microsoft.com/en-us/entra/fundamentals/whatis) |
+| MS Entra ID    | [authd-msentraid](https://snapcraft.io/authd-msentraid) | `snap install authd-msentraid`| <a href="howto/install-authd/?broker=google">MS Entra ID guide</a>  | [Google](https://cloud.google.com/iam/docs/overview)                     |
+
+```{note}
+Support for multiple additional providers is planned for future releases of authd.
+```

--- a/docs/reference/index.md
+++ b/docs/reference/index.md
@@ -2,9 +2,33 @@
 
 # Reference
 
+## Providers
+
+Find the cloud providers and brokers currently supported by authd.
+
+```{toctree}
+:titlesonly:
+
+Cloud providers <cloud-providers>
+```
+
+## Troubleshooting
+
+Read tips on troubleshooting the authd authentication service and its identity
+brokers.
+
 ```{toctree}
 :titlesonly:
 
 Troubleshooting <troubleshooting>
-Group Management <group-management>
+```
+
+## Groups
+
+Learn more about managing groups with authd and MS Entra ID.
+
+```{toctree}
+:titlesonly:
+
+Group management <group-management>
 ```

--- a/docs/reference/troubleshooting.md
+++ b/docs/reference/troubleshooting.md
@@ -6,7 +6,7 @@ myst:
 
 # Troubleshooting
 
-This page includes tips for troubleshooting tips for authd and the identity
+This page includes tips for troubleshooting authd and the identity
 brokers for different cloud providers.
 
 ## Logging

--- a/docs/reference/troubleshooting.md
+++ b/docs/reference/troubleshooting.md
@@ -21,6 +21,35 @@ For ```authd``` entries, run:
 journalctl -u authd.service
 ```
 
+If you want logs for authd and all brokers on the system, run:
+
+```shell
+journalctl -u authd.service -u "snap.authd-*.service"
+```
+
+For specific broker entries run the command for your chosen broker:
+
+::::{tab-set}
+:sync-group: broker
+
+:::{tab-item} Google IAM
+:sync: google
+
+```shell
+journalctl -u snap.authd-google.authd-google.service
+```
+:::
+
+:::{tab-item} MS Entra ID
+:sync: msentraid
+
+```shell
+journalctl -u snap.authd-msentraid.authd-msentraid.service
+```
+:::
+::::
+
+
 For the GDM integration:
 
 ```shell
@@ -75,29 +104,6 @@ Then you need to restart the service with `sudo systemctl restart gdm`.
 
 #### authd broker service
 
-The brokers for authd log to the system journal.
-
-For the broker entries run the command for your chosen broker:
-
-::::{tab-set}
-:sync-group: broker
-
-:::{tab-item} Google IAM
-:sync: google
-
-```shell
-journalctl -u snap.authd-google.authd-google.service
-```
-:::
-
-:::{tab-item} MS Entra ID
-:sync: msentraid
-
-```shell
-journalctl -u snap.authd-msentraid.authd-msentraid.service
-```
-:::
-::::
 
 To increase the verbosity of the broker service, edit the service file:
 

--- a/docs/reference/troubleshooting.md
+++ b/docs/reference/troubleshooting.md
@@ -1,3 +1,8 @@
+---
+myst:
+  html_meta:
+    "description lang=en": "Troubleshoot issues with authd when authenticating Ubuntu devices with cloud identity providers like Google IAM and Microsoft Entra ID."
+---
 # Troubleshooting
 
 ## Logging

--- a/docs/reference/troubleshooting.md
+++ b/docs/reference/troubleshooting.md
@@ -3,22 +3,22 @@ myst:
   html_meta:
     "description lang=en": "Troubleshoot issues with authd when authenticating Ubuntu devices with cloud identity providers like Google IAM and Microsoft Entra ID."
 ---
+
 # Troubleshooting
+
+This page includes tips for troubleshooting tips for authd and the identity
+brokers for different cloud providers.
 
 ## Logging
 
-```authd``` and the brokers are all logging to the system journal.
+### authd
+
+```authd``` logs to the system journal.
 
 For ```authd``` entries, run:
 
 ```shell
 journalctl -u authd.service
-```
-
-For the broker entries, substitute `<broker_name>` with your broker's name and run:
-
-```shell
-journalctl -u snap.authd-<broker_name>.authd-<broker_name>.service
 ```
 
 For the GDM integration:
@@ -75,37 +75,144 @@ Then you need to restart the service with `sudo systemctl restart gdm`.
 
 #### authd broker service
 
-To increase the verbosity of the broker service, edit the service file:
+The brokers for authd log to the system journal.
+
+For the broker entries run the command for your chosen broker:
+
+::::{tab-set}
+:sync-group: broker
+
+:::{tab-item} Google IAM
+:sync: google
 
 ```shell
-sudo systemctl edit snap.authd-<broker_name>.authd-<broker_name>.service
+journalctl -u snap.authd-google.authd-google.service
 ```
+:::
+
+:::{tab-item} MS Entra ID
+:sync: msentraid
+
+```shell
+journalctl -u snap.authd-msentraid.authd-msentraid.service
+```
+:::
+::::
+
+To increase the verbosity of the broker service, edit the service file:
+
+::::{tab-set}
+:sync-group: broker
+
+:::{tab-item} Google IAM
+:sync: google
+
+```shell
+sudo systemctl edit snap.authd-google.authd-google.service
+```
+:::
+
+:::{tab-item} MS Entra ID
+:sync: msentraid
+
+```shell
+sudo systemctl edit snap.authd-msentraid.authd-msentraid.service
+```
+:::
+::::
 
 Add the following lines to the override file and make sure to add `-vv` to the exec command:
+
+::::{tab-set}
+:sync-group: broker
+
+:::{tab-item} Google IAM
+:sync: google
 
 ```
 [Service]
 ExecStart=
-ExecStart=/usr/bin/snap run authd-<broker_name> -vv
+ExecStart=/usr/bin/snap run authd-google -vv
 ```
+:::
 
-You will then need to restart the service with `snap restart authd-<broker_name>`.
+:::{tab-item} MS Entra ID
+:sync: msentraid
+
+```
+[Service]
+ExecStart=
+ExecStart=/usr/bin/snap run authd-msentraid -vv
+```
+::::
+
+You will then need to restart the service with:
+
+::::{tab-set}
+:sync-group: broker
+
+:::{tab-item} Google IAM
+:sync: google
+
+`snap restart authd-google`.
+:::
+
+:::{tab-item} MS Entra ID
+:sync: msentraid
+
+`snap restart authd-msentraid`.
+:::
+::::
 
 ## Switch the snap to the edge channel
 
 Maybe your issue is already fixed! You should try switching to the edge channel of the broker snap. You can easily do that with:
 
+::::{tab-set}
+:sync-group: broker
+
+:::{tab-item} Google IAM
+:sync: google
+
 ```shell
-snap switch authd-<broker_name> --edge
-snap refresh authd-<broker_name>
+snap switch authd-google --edge
+snap refresh authd-google
 ```
+:::
+
+:::{tab-item} MS Entra ID
+:sync: msentraid
+
+```shell
+snap switch authd-msentraid --edge
+snap refresh authd-msentraid
+```
+:::
+::::
 
 Keep in mind that this version is not tested and may be incompatible with the current released version of authd. You should switch back to stable after trying the edge channel:
 
+::::{tab-set}
+:sync-group: broker
+
+:::{tab-item} Google IAM
+:sync: google
+
 ```shell
-snap switch authd-<broker_name> --stable
-snap refresh authd-<broker_name>
+snap switch authd-google --stable
+snap refresh authd-google
 ```
+:::
+
+:::{tab-item} MS Entra ID
+:sync: msentraid
+
+```shell
+snap switch authd-msentraid --stable
+snap refresh authd-msentraid
+```
+:::
+::::
 
 ```{note}
 If using an edge release, you can read the


### PR DESCRIPTION
This implements the discussed plans for better surfacing broker-specific content in the documentation.

## Surfacing the broker content with queryable tabs

The most notable change is the **introduction of tab-based content for different brokers**. This style of presentation is used immediately on the homepage. The motivation for that change is that the homepage tends to be the most popular page and the first encounter a user has with the documentation; it is therefore a good opportunity to show that there are multiple brokers to choose from, along with supporting documentation. The user can choose the provider/broker that most interests them and they will be pointed directly to broker-specific content. This is made possible by using URL query parameters, which allow toggling of tabs on page visit. When a user chooses `broker x` from a set of tabs on one page, all other tabs will be set to `broker x` on that page, in addition to other pages in the documentation (where that choice is presented).

## Readability, discoverability and SEO

* **Addition of meta descriptions:** a limitation of the tab-based approach is that we lose the opportunity to give a top-level heading for some broker-specific content, which could otherwise help with search engine optimisation (SEO). To help alleviate that problem, meta descriptions are added to affected pages. These are not readable in the docs but are consumed by search engines and can help with discoverability.
* **More descriptive page titles:** the top-level header has a significant impact on SEO. Several of the existing headers were nondescript and have been made more descriptive for user readability but also SEO and discoverability.
* **Rewritten homepage:** the homepage blurb was long and dense. It has been shortened and simplified to serve as a better introduction to authd and its brokers. Where more detail is required it should be found in the rest of the docs.
* **Cloud provider reference:** adds a table (to be extended over time) that summarises some key information, commands and links relating to specific brokers/providers.
* **Better landing pages:** structures the content of the landing pages (howto/index, explanation/index, reference/index) to present the content in a more organised way to the user.
* **Misc**: removed some syntax from contributing.md that did not play nicely with the rendered docs. Removed sync keys/values from tabbed interface for desktop/server, as it is not currently necessary and could create SEO issues (duplicated pages).

## Note on use of raw HTML links

When linking internally to pages using URL query params, raw HTML anchor links are used instead of markdown links. The markdown parser does not seem to work well with the parameterised URLs when used for internal links.

UDENG-5902