### PR TITLE
Fix invalid golangci-lint config

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -48,10 +48,6 @@ issues:
     # Sometimes it is more readable it do a `if err:=a(); err != nil` tha simpy `return a()`
     - if-return
 
-nolintlint:
-  require-explanation: true
-  require-specific: true
-
 linters-settings:
   # Forbid the usage of deprecated ioutil and debug prints
   forbidigo:
@@ -61,3 +57,6 @@ linters-settings:
   # Never have naked return ever
   nakedret:
     max-func-lines: 1
+  nolintlint:
+    require-explanation: true
+    require-specific: true

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -58,5 +58,7 @@ linters-settings:
   nakedret:
     max-func-lines: 1
   nolintlint:
+    # Require an explanation of nonzero length after each nolint directive.
     require-explanation: true
+    # Require nolint directives to mention the specific linter being suppressed.
     require-specific: true

--- a/pam/internal/pam_test/module-transaction-dummy.go
+++ b/pam/internal/pam_test/module-transaction-dummy.go
@@ -196,8 +196,7 @@ func (m *ModuleTransactionDummy) handleBinaryRequest(req pam.ConvRequest) (pam.B
 		return nil, errors.New("no binary handler provided")
 	}
 
-	//nolint:forcetypeassert
-	// req must be a pam.BinaryConvRequester, if that's not the case we should
+	//nolint:forcetypeassert // req must be a pam.BinaryConvRequester, if that's not the case we should
 	// just panic since this code is only expected to run in tests.
 	binReq := req.(pam.BinaryConvRequester)
 


### PR DESCRIPTION
The nolintlint settings must be part of the "linters-settings" list.

Fixes that golangci-lint fails in the CI with:

    Failed to run: Error: Command failed: /home/runner/golangci-lint-1.63.4-linux-amd64/golangci-lint config verify
    jsonschema: "" does not validate with "/additionalProperties": additional properties 'nolintlint' not allowed
    Failed executing command with error: the configuration contains invalid elements
