### PR TITLE
Revert usage of unexplained <ISSUER_URL> placeholder

### DIFF
--- a/docs/howto/configure-authd.md
+++ b/docs/howto/configure-authd.md
@@ -142,7 +142,7 @@ To configure Entra ID, edit  `/var/snap/authd-msentraid/current/broker.conf`:
 
 ```ini
 [oidc]
-issuer = <ISSUER_URL>
+issuer = https://login.microsoftonline.com/<ISSUER_ID>/v2.0
 client_id = <CLIENT_ID>
 ```
 


### PR DESCRIPTION
Commit 7872c99a2797b0333cb228ef2316e3c69abfdd1c replaced

    https://login.microsoftonline.com/<ISSUER_ID>/v2.0

with

    <ISSUER_URL>

However, `ISSUER_URL` is not explained in the documentation or Microsoft Entra admin center, so the user has no indication that the URL should be of the form `https://login.microsoftonline.com/<ISSUER_ID>/v2.0` (where `<ISSUER_ID>` is the Directory (tenant) ID as mentioned earlier on the same page).

Closes #800 
UDENG-6141