### PR TITLE
pam/gdm: Redefine jsonProtoMessage type for go 1.24

### DIFF
--- a/pam/internal/gdm/conversation.go
+++ b/pam/internal/gdm/conversation.go
@@ -1,7 +1,5 @@
 package gdm
 
-import "C"
-
 import (
 	"context"
 	"errors"

--- a/pam/internal/gdm/extension.go
+++ b/pam/internal/gdm/extension.go
@@ -68,7 +68,7 @@ func AdvertisePamExtensions(extensions []string) {
 	C.gdm_extensions_advertise_supported(&cArray[0], C.size_t(len(extensions)))
 }
 
-type jsonProtoMessage = C.GdmPamExtensionJSONProtocol
+type jsonProtoMessage C.GdmPamExtensionJSONProtocol
 
 func allocateJSONProtoMessage() *jsonProtoMessage {
 	// We do manual memory management here, instead of returning a go-allocated
@@ -100,7 +100,8 @@ func (msg *jsonProtoMessage) init(protoName string, protoVersion uint, jsonValue
 		// them via finalizer functions.
 		cJSON = (*C.char)(C.CBytes(append(jsonValue, 0)))
 	}
-	C.gdm_custom_json_request_init(msg, cProto, C.uint(protoVersion), cJSON)
+	C.gdm_custom_json_request_init((*C.GdmPamExtensionJSONProtocol)(msg),
+		cProto, C.uint(protoVersion), cJSON)
 }
 
 func (msg *jsonProtoMessage) release() {


### PR DESCRIPTION
Fix the definition as it wouldn't work in newer go:

```
# github.com/ubuntu/authd/pam/internal/gdm [github.com/ubuntu/authd/pam/internal/gdm.test]
./extension.go:91:12: cannot define new methods on non-local type jsonProtoMessage
./extension.go:106:12: cannot define new methods on non-local type jsonProtoMessage
./extension.go:115:12: cannot define new methods on non-local type jsonProtoMessage
./extension.go:119:12: cannot define new methods on non-local type jsonProtoMessage
./extension.go:123:12: cannot define new methods on non-local type jsonProtoMessage
./extension.go:137:12: cannot define new methods on non-local type jsonProtoMessage
FAIL	github.com/ubuntu/authd/pam/internal/gdm [build failed]
```

See: https://github.com/golang/go/issues/71917

UDENG-6160