### PR TITLE
cgo optimizations for go 1.24

### DIFF
--- a/internal/errno/errno_c.go
+++ b/internal/errno/errno_c.go
@@ -5,10 +5,12 @@ package errno
 #include <errno.h>
 #include <string.h>
 
+#cgo nocallback unset_errno
 static void unset_errno(void) {
   errno = 0;
 }
 
+#cgo nocallback get_errno
 static int get_errno(void) {
   return errno;
 }

--- a/internal/users/localentries/getgrent_c.go
+++ b/internal/users/localentries/getgrent_c.go
@@ -12,6 +12,7 @@ package localentries
 #cgo nocallback endgrent
 #cgo nocallback getgrent
 #cgo nocallback getgrnam
+#cgo noescape getgrnam
 #cgo nocallback setgrent
 */
 import "C"

--- a/internal/users/localentries/getgrent_c.go
+++ b/internal/users/localentries/getgrent_c.go
@@ -8,6 +8,11 @@ package localentries
 #include <pwd.h>
 #include <grp.h>
 #include <errno.h>
+
+#cgo nocallback endgrent
+#cgo nocallback getgrent
+#cgo nocallback getgrnam
+#cgo nocallback setgrent
 */
 import "C"
 

--- a/internal/users/localentries/getpwent_c.go
+++ b/internal/users/localentries/getpwent_c.go
@@ -12,6 +12,7 @@ package localentries
 #cgo nocallback endpwent
 #cgo nocallback getpwent
 #cgo nocallback getpwnam
+#cgo noescape getpwnam
 #cgo nocallback setpwent
 */
 import "C"

--- a/internal/users/localentries/getpwent_c.go
+++ b/internal/users/localentries/getpwent_c.go
@@ -8,6 +8,11 @@ package localentries
 #include <pwd.h>
 #include <grp.h>
 #include <errno.h>
+
+#cgo nocallback endpwent
+#cgo nocallback getpwent
+#cgo nocallback getpwnam
+#cgo nocallback setpwent
 */
 import "C"
 

--- a/pam/internal/adapter/pwquality_c.go
+++ b/pam/internal/adapter/pwquality_c.go
@@ -1,8 +1,16 @@
 package adapter
 
-// #cgo pkg-config: pwquality
-// #include <stdlib.h>
-// #include <pwquality.h>
+/*
+#cgo pkg-config: pwquality
+#include <stdlib.h>
+#include <pwquality.h>
+
+#cgo nocallback pwquality_check
+#cgo nocallback pwquality_default_settings
+#cgo nocallback pwquality_free_settings
+#cgo nocallback pwquality_read_config
+#cgo nocallback pwquality_strerror
+*/
 import "C"
 
 import (

--- a/pam/internal/adapter/pwquality_c.go
+++ b/pam/internal/adapter/pwquality_c.go
@@ -6,10 +6,14 @@ package adapter
 #include <pwquality.h>
 
 #cgo nocallback pwquality_check
+#cgo noescape pwquality_check
 #cgo nocallback pwquality_default_settings
 #cgo nocallback pwquality_free_settings
+#cgo noescape pwquality_free_settings
 #cgo nocallback pwquality_read_config
+#cgo noescape pwquality_read_config
 #cgo nocallback pwquality_strerror
+#cgo noescape pwquality_strerror
 */
 import "C"
 

--- a/pam/internal/gdm/conversation.go
+++ b/pam/internal/gdm/conversation.go
@@ -1,7 +1,5 @@
 package gdm
 
-import "C"
-
 import (
 	"context"
 	"errors"

--- a/pam/internal/gdm/extension.go
+++ b/pam/internal/gdm/extension.go
@@ -3,6 +3,10 @@ package gdm
 /*
 // FIXME: Use pkg-config to include extension protocol headers once available
 //#cgo pkg-config: gdm-pam-extensions
+#cgo nocallback gdm_extensions_advertise_supported
+#cgo nocallback is_gdm_pam_extension_supported
+#cgo nocallback gdm_custom_json_request_init
+
 #include "extension.h"
 */
 import "C"

--- a/pam/internal/gdm/extension.go
+++ b/pam/internal/gdm/extension.go
@@ -68,7 +68,7 @@ func AdvertisePamExtensions(extensions []string) {
 	C.gdm_extensions_advertise_supported(&cArray[0], C.size_t(len(extensions)))
 }
 
-type jsonProtoMessage = C.GdmPamExtensionJSONProtocol
+type jsonProtoMessage C.GdmPamExtensionJSONProtocol
 
 func allocateJSONProtoMessage() *jsonProtoMessage {
 	// We do manual memory management here, instead of returning a go-allocated
@@ -100,7 +100,8 @@ func (msg *jsonProtoMessage) init(protoName string, protoVersion uint, jsonValue
 		// them via finalizer functions.
 		cJSON = (*C.char)(C.CBytes(append(jsonValue, 0)))
 	}
-	C.gdm_custom_json_request_init(msg, cProto, C.uint(protoVersion), cJSON)
+	C.gdm_custom_json_request_init((*C.GdmPamExtensionJSONProtocol)(msg),
+		cProto, C.uint(protoVersion), cJSON)
 }
 
 func (msg *jsonProtoMessage) release() {

--- a/pam/internal/gdm/extension.go
+++ b/pam/internal/gdm/extension.go
@@ -4,8 +4,11 @@ package gdm
 // FIXME: Use pkg-config to include extension protocol headers once available
 //#cgo pkg-config: gdm-pam-extensions
 #cgo nocallback gdm_extensions_advertise_supported
+#cgo noescape gdm_extensions_advertise_supported
 #cgo nocallback is_gdm_pam_extension_supported
+#cgo noescape is_gdm_pam_extension_supported
 #cgo nocallback gdm_custom_json_request_init
+#cgo noescape gdm_custom_json_request_init
 
 #include "extension.h"
 */

--- a/pam/internal/pam_test/utils.go
+++ b/pam/internal/pam_test/utils.go
@@ -9,6 +9,8 @@ package pam_test
 #include <sanitizer/lsan_interface.h>
 #endif
 
+#cgo nocallback have_asan_support
+
 static inline bool
 have_asan_support (void)
 {


### PR DESCRIPTION
Mark functions with `nocallback` and `noescape` for optimization reasons when possible.

Still a draft since we don't use such go version yet.