### PR TITLE
pam/gdm/conversation: Early handle errors on NewDataFromJSON (fixing potential null pointer)

### DIFF
--- a/pam/internal/gdm/conversation_test.go
+++ b/pam/internal/gdm/conversation_test.go
@@ -505,7 +505,7 @@ func reformatJSONIndented(t *testing.T, input []byte) []byte {
 	return indented.Bytes()
 }
 
-func requireEqualData(t *testing.T, want *Data, actual *Data) {
+func requireEqualData(t *testing.T, want *Data, actual *Data, args ...any) {
 	t.Helper()
 
 	// We can't compare data values as their content may contain elements
@@ -513,12 +513,12 @@ func requireEqualData(t *testing.T, want *Data, actual *Data) {
 	// So let's compare the data JSON representation instead since that's what
 	// we care about anyways.
 	wantJSON, err := want.JSON()
-	require.NoError(t, err)
+	require.NoError(t, err, "Failed converting want value to JSON: %#v", want)
 	actualJSON, err := actual.JSON()
-	require.NoError(t, err)
+	require.NoError(t, err, "Failed converting actual value to JSON: %#v", actual)
 
 	require.Equal(t, string(reformatJSONIndented(t, wantJSON)),
-		string(reformatJSONIndented(t, actualJSON)))
+		string(reformatJSONIndented(t, actualJSON)), args...)
 }
 
 type invalidRequest struct {

--- a/pam/internal/gdm/main_test.go
+++ b/pam/internal/gdm/main_test.go
@@ -4,10 +4,13 @@ import (
 	"os"
 	"testing"
 
+	"github.com/ubuntu/authd/log"
 	"github.com/ubuntu/authd/pam/internal/pam_test"
 )
 
 func TestMain(m *testing.M) {
+	log.SetLevel(log.DebugLevel)
+
 	exit := m.Run()
 	pam_test.MaybeDoLeakCheck()
 	os.Exit(exit)


### PR DESCRIPTION
I noticed an error locally (not really happening in production since I was injecting some bad code from gdm side):

```
feb 24 16:38:41 ubuntu-vmware gdm-session-worker[96114]: panic: runtime error: invalid memory address or nil pointer dereference
feb 24 16:38:41 ubuntu-vmware gdm-session-worker[96114]: [signal SIGSEGV: segmentation violation code=0x1 addr=0x28 pc=0x790190c74b9b]
feb 24 16:38:41 ubuntu-vmware gdm-session-worker[96114]: goroutine 17 [running, locked to thread]:
feb 24 16:38:41 ubuntu-vmware gdm-session-worker[96114]: github.com/ubuntu/authd/pam/internal/gdm.SendData({0x790190f28e20?, 0xc000202000?}, 0x0?)
feb 24 16:38:41 ubuntu-vmware gdm-session-worker[96114]:         /home/marco/Dev/authd/pam/internal/gdm/conversation.go:73 +0x5b
feb 24 16:38:41 ubuntu-vmware gdm-session-worker[96114]: github.com/ubuntu/authd/pam/internal/adapter.(*gdmModel).protoHello(0xc000175588)
feb 24 16:38:41 ubuntu-vmware gdm-session-worker[96114]:         /home/marco/Dev/authd/pam/internal/adapter/gdmmodel.go:50 +0x4f
feb 24 16:38:41 ubuntu-vmware gdm-session-worker[96114]: github.com/ubuntu/authd/pam/internal/adapter.(*gdmModel).Init(0xc000175588)
feb 24 16:38:41 ubuntu-vmware gdm-session-worker[96114]:         /home/marco/Dev/authd/pam/internal/adapter/gdmmodel.go:44 +0x1c
feb 24 16:38:41 ubuntu-vmware gdm-session-worker[96114]: github.com/ubuntu/authd/pam/internal/adapter.(*UIModel).Init(0xc00016a000)
feb 24 16:38:41 ubuntu-vmware gdm-session-worker[96114]:         /home/marco/Dev/authd/pam/internal/adapter/model.go:126 +0x2f3
feb 24 16:38:41 ubuntu-vmware gdm-session-worker[96114]: github.com/charmbracelet/bubbletea.(*Program).Run(0xc000166140)
feb 24 16:38:41 ubuntu-vmware gdm-session-worker[96114]:         /tmp/go-path/pkg/mod/github.com/charmbracelet/bubbletea@v1.3.3/tea.go:591 +0x79c
feb 24 16:38:41 ubuntu-vmware gdm-session-worker[96114]: main.(*pamModule).handleAuthRequest(0x7901913cdb00?, 0x1, {0x790190f28e20, 0xc000202000}, 0x0, 0xc00020a000, 0xc00020e000)
feb 24 16:38:41 ubuntu-vmware gdm-session-worker[96114]:         /home/marco/Dev/authd/pam/pam.go:329 +0x109f
feb 24 16:38:41 ubuntu-vmware gdm-session-worker[96114]: main.(*pamModule).Authenticate(0x7901913cdb00, {0x790190f28e20, 0xc000202000}, 0x0, {0xc000206000?, 0x7901937f4ff8?, 0x18?})
feb 24 16:38:41 ubuntu-vmware gdm-session-worker[96114]:         /home/marco/Dev/authd/pam/pam.go:200 +0x245
feb 24 16:38:41 ubuntu-vmware gdm-session-worker[96114]: github.com/msteinert/pam/v2.(*moduleTransaction).InvokeHandler.func1()
feb 24 16:38:41 ubuntu-vmware gdm-session-worker[96114]:         /tmp/go-path/pkg/mod/github.com/3v1n0/go-pam/v2@v2.0.0-20240321054421-f19903865176/module-transaction.go:96 +0x52
feb 24 16:38:41 ubuntu-vmware gdm-session-worker[96114]: github.com/msteinert/pam/v2.(*moduleTransaction).InvokeHandler(0xc000202000, 0x585ac5834bd0?, 0xc00004aa08?, {0xc000206000?, 0x79019075d1c8?, 0xc00011a000?})
feb 24 16:38:41 ubuntu-vmware gdm-session-worker[96114]:         /tmp/go-path/pkg/mod/github.com/3v1n0/go-pam/v2@v2.0.0-20240321054421-f19903865176/module-transaction.go:113 +0x70
feb 24 16:38:41 ubuntu-vmware gdm-session-worker[96114]: main.handlePamCall(0x585ac585f340, 0x0, 0x1, 0x585ac5834bd0, 0xc00006ee40)
feb 24 16:38:41 ubuntu-vmware gdm-session-worker[96114]:         /home/marco/Dev/authd/pam/pam_module.go:49 +0xf2
feb 24 16:38:41 ubuntu-vmware gdm-session-worker[96114]: main.pam_sm_authenticate(...)
feb 24 16:38:41 ubuntu-vmware gdm-session-worker[96114]:         /home/marco/Dev/authd/pam/pam_module.go:69
```

So handle the issue (introduced as per commit c608853d2b6db17120e3a930f924f41dca331f02)

UDENG-6161