### PR TITLE
pam/nativemodel: Ensure we're in the expected stage before initiating it

### DIFF
--- a/pam/integration-tests/testdata/tapes/native/switch_auth_mode.tape
+++ b/pam/integration-tests/testdata/tapes/native/switch_auth_mode.tape
@@ -109,7 +109,7 @@ Wait+Prompt /Enter your pin code/
 Show
 
 Hide
-Type "r"
+TypeInPrompt "r"
 Show
 
 Hide

--- a/pam/internal/adapter/authentication.go
+++ b/pam/internal/adapter/authentication.go
@@ -397,6 +397,7 @@ func (m *authenticationModel) Compose(brokerID, sessionID string, encryptionKey 
 	m.errorMsg = ""
 
 	if m.clientType != InteractiveTerminal {
+		m.currentModel = &focusTrackerModel{}
 		return tea.Sequence(sendEvent(ChangeStage{pam_proto.Stage_challenge}),
 			sendEvent(startAuthentication{}))
 	}

--- a/pam/internal/adapter/focustracker.go
+++ b/pam/internal/adapter/focustracker.go
@@ -1,0 +1,45 @@
+package adapter
+
+import (
+	"context"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/ubuntu/authd/log"
+)
+
+type focusTrackerModel struct {
+	focused bool
+}
+
+// Init initializes the model.
+func (m *focusTrackerModel) Init() tea.Cmd {
+	return nil
+}
+
+// Update handles events and actions.
+func (m *focusTrackerModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+	return convertTo[tea.Model](m), nil
+}
+
+// View renders the model.
+func (m *focusTrackerModel) View() string {
+	return ""
+}
+
+// Focus focuses the model.
+func (m *focusTrackerModel) Focus() tea.Cmd {
+	log.Debugf(context.TODO(), "%T: Focus", m)
+	m.focused = true
+	return nil
+}
+
+// Focused returns whether the model is focused.
+func (m *focusTrackerModel) Focused() bool {
+	return m.focused
+}
+
+// Blur blurs the model.
+func (m *focusTrackerModel) Blur() {
+	log.Debugf(context.TODO(), "%T: Blur", m)
+	m.focused = false
+}

--- a/pam/internal/adapter/model.go
+++ b/pam/internal/adapter/model.go
@@ -445,6 +445,7 @@ func (m *UIModel) changeStage(s pam_proto.Stage) tea.Cmd {
 			m.authModeSelectionModel.Blur()
 		case pam_proto.Stage_challenge:
 			m.authenticationModel.Blur()
+			commands = append(commands, m.authenticationModel.Reset())
 		}
 
 		if m.ClientType == Gdm {
@@ -467,7 +468,6 @@ func (m *UIModel) changeStage(s pam_proto.Stage) tea.Cmd {
 		commands = append(commands, endSession(m.client, m.currentSession), m.brokerSelectionModel.Focus())
 
 	case pam_proto.Stage_authModeSelection:
-		commands = append(commands, m.authenticationModel.Reset())
 		commands = append(commands, m.authModeSelectionModel.Focus())
 
 	case pam_proto.Stage_challenge:

--- a/pam/internal/adapter/nativemodel.go
+++ b/pam/internal/adapter/nativemodel.go
@@ -298,7 +298,13 @@ func (m nativeModel) Update(msg tea.Msg) (nativeModel, tea.Cmd) {
 		if !m.checkStage(pam_proto.Stage_challenge) {
 			return m, nil
 		}
-		return m, m.startChallenge()
+		if m.busy {
+			// We may receive multiple concurrent requests, but due to the sync nature
+			// of this model, we can't just accept them once we've one in progress already
+			log.Debug(context.TODO(), "Challenge already in progress")
+			return m, nil
+		}
+		return m.startAsyncOp(m.startChallenge)
 
 	case newPasswordCheckResult:
 		if msg.msg != "" {

--- a/pam/internal/adapter/nativemodel.go
+++ b/pam/internal/adapter/nativemodel.go
@@ -160,21 +160,20 @@ func (m nativeModel) Update(msg tea.Msg) (nativeModel, tea.Cmd) {
 		m.currentStage = msg.Stage
 
 	case nativeStageChangeRequest:
-		var baseCmd tea.Cmd
 		if m.currentStage != msg.Stage {
-			m.currentStage = msg.Stage
-			baseCmd = sendEvent(ChangeStage(msg))
+			// Stage is not matching yet, ask for stage change first and repeat.
+			return m, tea.Sequence(sendEvent(ChangeStage(msg)), sendEvent(msg))
 		}
 
 		switch m.currentStage {
 		case proto.Stage_userSelection:
-			return m, tea.Sequence(baseCmd, sendEvent(nativeUserSelection{}))
+			return m, sendEvent(nativeUserSelection{})
 		case proto.Stage_brokerSelection:
-			return m, tea.Sequence(baseCmd, sendEvent(nativeBrokerSelection{}))
+			return m, sendEvent(nativeBrokerSelection{})
 		case proto.Stage_authModeSelection:
-			return m, tea.Sequence(baseCmd, sendEvent(nativeAuthSelection{}))
+			return m, sendEvent(nativeAuthSelection{})
 		case proto.Stage_challenge:
-			return m, tea.Sequence(baseCmd, sendEvent(nativeChallengeRequested{}))
+			return m, sendEvent(nativeChallengeRequested{})
 		}
 
 	case nativeAsyncOperationCompleted:

--- a/pam/internal/adapter/nativemodel.go
+++ b/pam/internal/adapter/nativemodel.go
@@ -139,6 +139,15 @@ func (m nativeModel) changeStage(stage proto.Stage) tea.Cmd {
 	return sendEvent(nativeChangeStage{stage})
 }
 
+func (m nativeModel) checkStage(expected proto.Stage) bool {
+	if m.currentStage != expected {
+		log.Debugf(context.Background(),
+			"Current stage %q is not matching expected %q", m.currentStage, expected)
+		return false
+	}
+	return true
+}
+
 func (m nativeModel) requestStageChange(stage proto.Stage) tea.Cmd {
 	return sendEvent(nativeStageChangeRequest{stage})
 }
@@ -179,7 +188,7 @@ func (m nativeModel) Update(msg tea.Msg) (nativeModel, tea.Cmd) {
 		return m, m.requestStageChange(pam_proto.Stage_userSelection)
 
 	case nativeUserSelection:
-		if m.currentStage != proto.Stage_userSelection {
+		if !m.checkStage(proto.Stage_userSelection) {
 			return m, nil
 		}
 		if m.busy {
@@ -227,7 +236,7 @@ func (m nativeModel) Update(msg tea.Msg) (nativeModel, tea.Cmd) {
 		})
 
 	case nativeBrokerSelection:
-		if m.currentStage != proto.Stage_brokerSelection {
+		if !m.checkStage(proto.Stage_brokerSelection) {
 			return m, nil
 		}
 		if m.busy {
@@ -251,7 +260,7 @@ func (m nativeModel) Update(msg tea.Msg) (nativeModel, tea.Cmd) {
 		return m.startAsyncOp(m.brokerSelection)
 
 	case nativeAuthSelection:
-		if m.currentStage != proto.Stage_authModeSelection {
+		if !m.checkStage(proto.Stage_authModeSelection) {
 			return m, nil
 		}
 		if m.busy {
@@ -286,7 +295,7 @@ func (m nativeModel) Update(msg tea.Msg) (nativeModel, tea.Cmd) {
 		return m, m.requestStageChange(pam_proto.Stage_challenge)
 
 	case nativeChallengeRequested:
-		if m.currentStage != pam_proto.Stage_challenge {
+		if !m.checkStage(pam_proto.Stage_challenge) {
 			return m, nil
 		}
 		return m, m.startChallenge()

--- a/pam/internal/adapter/nativemodel.go
+++ b/pam/internal/adapter/nativemodel.go
@@ -327,14 +327,9 @@ func (m nativeModel) Update(msg tea.Msg) (nativeModel, tea.Cmd) {
 		case auth.Denied:
 			// This is handled by the main authentication model
 			return m, nil
-		case auth.Cancelled:
-			return m, sendEvent(isAuthenticatedCancelled{})
 		default:
 			return m, maybeSendPamError(m.sendError("Access %q is not valid", access))
 		}
-
-	case isAuthenticatedCancelled:
-		return m.goBackCommand()
 	}
 
 	return m, nil
@@ -854,7 +849,6 @@ func (m nativeModel) newPasswordChallenge(previousPassword *string) tea.Cmd {
 func (m nativeModel) goBackCommand() (nativeModel, tea.Cmd) {
 	if m.currentStage >= proto.Stage_challenge && m.uiLayout != nil {
 		m.uiLayout = nil
-		return m, sendEvent(isAuthenticatedCancelled{})
 	}
 	if m.currentStage >= proto.Stage_authModeSelection {
 		m.selectedAuthMode = ""


### PR DESCRIPTION
Fixed handling of focus for authentication stage when not using the CLI interface, and fix the race we had for some time, making impossible to go back to auth-selection if going back from the challenge stage was fast enough (VHS quick typing speed was a good friend here :)).

From main commit:
```
In some cases (when the "goBack{}" request via the 'r' cancel key is
performed very quickly on the UI) we might end up doing a
nativeAuthSelection{} request when we are still technically performing
the stage change from the challenge stage to auth-mode selection.

This was particularly a problem in the "Wait" cases, given that these
events could have been arriving without a proper order, because the
cancellation of the previous event could lead to a delayed stage-change
request that we didn't handle, but it could happen also in non-wait
cases, for example:

  authd-pam-exec-DEBUG: 23:46:32.560: authenticate: called method
    Prompt((1, 'Gimme your password:\n> '))
  Native model update: tea.sequenceMsg{(tea.Cmd)(0xca47c0),
    (tea.Cmd)(nil)}
  Native model update: adapter.nativeGoBack{}
  adapter.isAuthenticatedCancelled{msg:""}
  Native model update: adapter.isAuthenticatedCancelled{msg:""}
  Native model update: adapter.nativeStageChangeRequest{Stage:2}
  Native model update: tea.sequenceMsg{(tea.Cmd)(0xca47c0),
    (tea.Cmd)(0xca47c0)}
  Native model update: adapter.nativeChangeStage{Stage:3}
  *adapter.ChangeStage{Stage:2}
  *adapter.authenticationModel: Reset"
  *adapter.authModeSelectionModel: Focus"
  Native model update: adapter.nativeAuthSelection{}
  Native model update: tea.sequenceMsg{(tea.Cmd)(0xca47c0),
        (tea.Cmd)(0xc96b00), (tea.Cmd)(0xca47c0)}
  Native model update: adapter.nativeChangeStage{Stage:2}
  adapter.authModeSelectionModel: adapter.authModeSelectionFocused{}
  Native model update: adapter.authModeSelectionFocused{}

or:

  authenticate: called method Prompt((2, 'Choose action:\n> '))
  Native model update: adapter.nativeChangeStage{Stage:3}
  Native model update: tea.sequenceMsg{(tea.Cmd)(0x1496660),
    (tea.Cmd)(nil)}
  Native model update: adapter.nativeGoBack{}
  adapter.isAuthenticatedCancelled{msg:""}
  Native model update: adapter.isAuthenticatedCancelled{msg:""}
  Native model update: adapter.nativeStageChangeRequest{Stage:2}
  Native model update: adapter.nativeChangeStage{Stage:3}
  Native model update: tea.sequenceMsg{(tea.Cmd)(0x1496660),
    (tea.Cmd)(0x1496660)}
  adapter.ChangeStage{Stage:2}
  *adapter.authenticationModel: Reset
  *adapter.authModeSelectionModel: Focus
  Native model update: adapter.nativeAuthSelection{}
  Native model update: tea.sequenceMsg{(tea.Cmd)(0x1496660),
    (tea.Cmd)(0x1483980), (tea.Cmd)(0x1496660)}
  Native model update: adapter.nativeChangeStage{Stage:2}
  adapter.authModeSelectionModel: adapter.authModeSelectionFocused{}
  Native model update: adapter.authModeSelectionFocused{}

As visible, the nativeStageChangeRequest (which triggered the selection
via nativeAuthSelection{}) was arriving *before* that the request of
changing the internal stage value (via nativeChangeStage{}) was actually
delivered. And this prevented nativeAuthSelection{} to anything (or any
other stage-change request in general).

So, basically we need to ensure that the request is happening only after
the internal stage is changed, and this is now fixed by relying on the
main StageChange event request that eventually will update the internal
state, after we're triggering again nativeStageChangeRequest{}.
```

Closes: #719

UDENG-6191