### PR TITLE
ci/doc-checks: Only perform docs checks on docs changes

### DIFF
--- a/.github/workflows/automatic-doc-checks.yml
+++ b/.github/workflows/automatic-doc-checks.yml
@@ -12,6 +12,8 @@ on:
       - .github/workflows/automatic-doc-checks.yml
       - .readthedocs.yaml
       - docs/**
+  schedule:
+    - cron:  '0 12 * * MON'
   # Manual trigger
   workflow_dispatch:
 

--- a/.github/workflows/automatic-doc-checks.yml
+++ b/.github/workflows/automatic-doc-checks.yml
@@ -3,7 +3,15 @@ name: Main Documentation Checks
 on:
   push:
     branches: [main]
+    paths:
+      - .github/workflows/automatic-doc-checks.yml
+      - .readthedocs.yaml
+      - docs/**
   pull_request:
+    paths:
+      - .github/workflows/automatic-doc-checks.yml
+      - .readthedocs.yaml
+      - docs/**
   # Manual trigger
   workflow_dispatch:
 

--- a/.github/workflows/build-deb.yaml
+++ b/.github/workflows/build-deb.yaml
@@ -4,9 +4,17 @@ on:
   push:
     branches:
       - main
+    paths-ignore:
+      - .github/workflows/automatic-doc-checks.yml
+      - .readthedocs.yaml
+      - docs/**
     tags:
       - "*"
   pull_request:
+    paths-ignore:
+      - .github/workflows/automatic-doc-checks.yml
+      - .readthedocs.yaml
+      - docs/**
 
 env:
   UBUNTU_VERSIONS: |

--- a/.github/workflows/qa.yaml
+++ b/.github/workflows/qa.yaml
@@ -3,9 +3,17 @@ on:
   push:
     branches:
       - main
+    paths-ignore:
+      - .github/workflows/automatic-doc-checks.yml
+      - .readthedocs.yaml
+      - docs/**
     tags:
       - "*"
   pull_request:
+    paths-ignore:
+      - .github/workflows/automatic-doc-checks.yml
+      - .readthedocs.yaml
+      - docs/**
 
 env:
   DEBIAN_FRONTEND: noninteractive


### PR DESCRIPTION
There's no need to perform docs CI jobs if nothing changed, so let's save some CI resources.