### PR TITLE
Remove database on schema creation failure

### DIFF
--- a/internal/users/db/db.go
+++ b/internal/users/db/db.go
@@ -73,6 +73,11 @@ func New(dbDir string) (*Manager, error) {
 		log.Debugf(context.Background(), "Creating new SQLite database at %v", dbPath)
 		_, err = db.Exec(createSchema)
 		if err != nil {
+			// Remove the database file if we failed to create the schema, to avoid that authd tries to use a broken
+			// database on the next start.
+			if removeErr := os.Remove(dbPath); removeErr != nil {
+				log.Warningf(context.Background(), "Failed to remove database file after failed schema creation: %v", removeErr)
+			}
 			return nil, fmt.Errorf("failed to create schema: %w", err)
 		}
 	}

--- a/internal/users/db/export_test.go
+++ b/internal/users/db/export_test.go
@@ -4,3 +4,13 @@ package db
 func (m *Manager) Path() string {
 	return m.path
 }
+
+// GetCreateSchemaQuery exposes the query to create the schema for testing.
+func GetCreateSchemaQuery() string {
+	return createSchema
+}
+
+// SetCreateSchemaQuery sets the query to create the schema for testing.
+func SetCreateSchemaQuery(query string) {
+	createSchema = query
+}


### PR DESCRIPTION
I noticed that if the schema creation fails (e.g. because the schema is invalid), the database file is still created and authd uses it the next time it's started. That results in authd starting up successfully but in failure of each request which uses the broken database.

Let's avoid that by ensuring that the database file is removed when the schema creation fails.

UDENG-6482