### PR TITLE
ci: Use quoted values for paths[-ignore] values

### DIFF
--- a/.github/workflows/auto-updates.yaml
+++ b/.github/workflows/auto-updates.yaml
@@ -4,7 +4,7 @@ on:
     branches:
       - main
     paths-ignore:
-      - debian/control
+      - 'debian/control'
 concurrency: auto-update
 
 permissions:

--- a/.github/workflows/automatic-doc-checks.yml
+++ b/.github/workflows/automatic-doc-checks.yml
@@ -4,14 +4,14 @@ on:
   push:
     branches: [main]
     paths:
-      - .github/workflows/automatic-doc-checks.yml
-      - .readthedocs.yaml
-      - docs/**
+      - '.github/workflows/automatic-doc-checks.yml'
+      - '.readthedocs.yaml'
+      - 'docs/**'
   pull_request:
     paths:
-      - .github/workflows/automatic-doc-checks.yml
-      - .readthedocs.yaml
-      - docs/**
+      - '.github/workflows/automatic-doc-checks.yml'
+      - '.readthedocs.yaml'
+      - 'docs/**'
   schedule:
     - cron:  '0 12 * * MON'
   # Manual trigger

--- a/.github/workflows/qa.yaml
+++ b/.github/workflows/qa.yaml
@@ -4,16 +4,16 @@ on:
     branches:
       - main
     paths-ignore:
-      - .github/workflows/automatic-doc-checks.yml
-      - .readthedocs.yaml
-      - docs/**
+      - '.github/workflows/automatic-doc-checks.yml'
+      - '.readthedocs.yaml'
+      - 'docs/**'
     tags:
       - "*"
   pull_request:
     paths-ignore:
-      - .github/workflows/automatic-doc-checks.yml
-      - .readthedocs.yaml
-      - docs/**
+      - '.github/workflows/automatic-doc-checks.yml'
+      - '.readthedocs.yaml'
+      - 'docs/**'
 
 env:
   DEBIAN_FRONTEND: noninteractive


### PR DESCRIPTION
This is to follow the specs:
  https://docs.github.com/en/actions/writing-workflows/workflow-syntax-for-github-actions#example-including-paths