### PR TITLE
Add tags to ignore static check on helper files

### DIFF
--- a/cmd/authd/integrationtests.go
+++ b/cmd/authd/integrationtests.go
@@ -1,3 +1,5 @@
+// TiCS: disabled // Should only be built when running integration tests.
+
 //go:build integrationtests
 
 package main

--- a/internal/services/withexamples.go
+++ b/internal/services/withexamples.go
@@ -1,3 +1,5 @@
+// TiCS: disabled // Should only be built when building authd with the examplebroker enabled for tests.
+
 //go:build withexamplebroker
 
 package services

--- a/internal/testsdetection/integrationtests.go
+++ b/internal/testsdetection/integrationtests.go
@@ -1,3 +1,5 @@
+// TiCS: disabled // Should only be built when running integration tests.
+
 //go:build integrationtests
 
 package testsdetection

--- a/internal/testsdetection/testdata/binary.go
+++ b/internal/testsdetection/testdata/binary.go
@@ -1,3 +1,5 @@
+// TiCS: disabled // Should only be built when running integration tests.
+
 package main
 
 import (

--- a/pam/generate.go
+++ b/pam/generate.go
@@ -1,3 +1,5 @@
+// TiCS: disabled // This is a helper file to generate the pam module easily.
+
 //go:build generate && !pam_module_generation && !pam_debug
 
 //go:generate go generate -C internal/proto

--- a/pam/generate_debug.go
+++ b/pam/generate_debug.go
@@ -1,3 +1,5 @@
+// TiCS: disabled // This is a helper file to generate the pam module easily in debug mode.
+
 //go:build generate && !pam_module_generation && pam_debug
 
 //go:generate go generate -C internal/proto

--- a/pam/go-exec/module.c
+++ b/pam/go-exec/module.c
@@ -1,3 +1,5 @@
+// TiCS: disabled // This file is compiled indirectly through go generate.
+
 /* A simple PAM wrapper for GO based pam modules
  *
  * Copyright (C) 2024 Canonical Ltd.

--- a/pam/integration-tests/cmd/exec-client/client.go
+++ b/pam/integration-tests/cmd/exec-client/client.go
@@ -1,3 +1,5 @@
+// TiCS: disabled // This is a test helper.
+
 //go:build pam_tests_exec_client
 
 // Package main is the package for the exec test client.

--- a/pam/integration-tests/cmd/exec-client/modulewrapper.go
+++ b/pam/integration-tests/cmd/exec-client/modulewrapper.go
@@ -1,3 +1,5 @@
+// TiCS: disabled // This is a test helper.
+
 //go:build pam_tests_exec_client
 
 package main

--- a/pam/integration-tests/sshd_preloader/sshd_preloader.c
+++ b/pam/integration-tests/sshd_preloader/sshd_preloader.c
@@ -1,3 +1,5 @@
+// TiCS: disabled // This is a test helper.
+
 #define _GNU_SOURCE 1
 #include <assert.h>
 #include <stdlib.h>

--- a/pam/internal/gdm/debug.go
+++ b/pam/internal/gdm/debug.go
@@ -1,3 +1,5 @@
+// TiCS: disabled // This is only built for tests.
+
 //go:build pam_gdm_debug
 
 package gdm

--- a/pam/internal/gdm/extension.h
+++ b/pam/internal/gdm/extension.h
@@ -1,3 +1,5 @@
+// TiCS: disabled // Header files are not built by default.
+
 #include <stdlib.h>
 #include <string.h>
 

--- a/pam/internal/gdm/extensions/gdm-custom-json-pam-extension.h
+++ b/pam/internal/gdm/extensions/gdm-custom-json-pam-extension.h
@@ -1,3 +1,5 @@
+// TiCS: disabled // Header files are not built by default.
+
 /* -*- Mode: C; tab-width: 8; indent-tabs-mode: nil; c-basic-offset: 8 -*-
  *
  * Copyright (C) 2023 Canonical Ltd.

--- a/pam/internal/gdm/extensions/gdm-pam-extensions-common.h
+++ b/pam/internal/gdm/extensions/gdm-pam-extensions-common.h
@@ -1,3 +1,5 @@
+// TiCS: disabled // Header files are not built by default.
+
 /* -*- Mode: C; tab-width: 8; indent-tabs-mode: nil; c-basic-offset: 8 -*-
  *
  * Copyright (C) 2017 Red Hat, Inc.

--- a/pam/internal/proto/generate.go
+++ b/pam/internal/proto/generate.go
@@ -1,3 +1,5 @@
+// TiCS: disabled // This is a helper to compile the proto files.
+
 //go:build generate
 
 //go:generate ../../../tools/generate-proto.sh pam.proto

--- a/pam/tools/pam-runner/pam-runner.go
+++ b/pam/tools/pam-runner/pam-runner.go
@@ -1,3 +1,5 @@
+// TiCS: disabled // This is a test helper.
+
 //go:build withpamrunner
 
 package main

--- a/tools/tools.go
+++ b/tools/tools.go
@@ -1,3 +1,5 @@
+// TiCS: disabled // This is to pin the tools versions that we use.
+
 //go:build tools
 
 package tools


### PR DESCRIPTION
We have a lot of helper files to help us test our project and those are protected to not be built with "go build" to avoid having those in the release binary. To avoid having to update tics configuration every time we rename those files or add new ones, let's tag them and filter those out in the analysis.