### PR TITLE
doc(ref/cloud-providers): fix swapped order of cloud providers

### DIFF
--- a/docs/reference/cloud-providers.md
+++ b/docs/reference/cloud-providers.md
@@ -6,8 +6,8 @@ Several brokers can be installed and enabled on a system.
 
 | Provider       | Broker snap                                             | Install as a snap             | Configure                                                           | Provider docs                                                            |
 | ---            | ---                                                     | ---                           | ---                                                                 | ---                                                                      |
-| Google IAM     | [authd-google](https://snapcraft.io/authd-google)       | `snap install authd-google`   | <a href="../../howto/configure-authd/?broker=google">Google IAM guide</a>   | [Microsoft](https://learn.microsoft.com/en-us/entra/fundamentals/whatis) |
-| MS Entra ID    | [authd-msentraid](https://snapcraft.io/authd-msentraid) | `snap install authd-msentraid`| <a href="../../howto/configure-authd/?broker=msentraid">MS Entra ID guide</a>  | [Google](https://cloud.google.com/iam/docs/overview)                     |
+| Google IAM     | [authd-google](https://snapcraft.io/authd-google)       | `snap install authd-google`   | <a href="../../howto/configure-authd/?broker=google">Google IAM guide</a>   | [Google](https://cloud.google.com/iam/docs/overview)  |
+| MS Entra ID    | [authd-msentraid](https://snapcraft.io/authd-msentraid) | `snap install authd-msentraid`| <a href="../../howto/configure-authd/?broker=msentraid">MS Entra ID guide</a>  | [Microsoft](https://learn.microsoft.com/en-us/entra/fundamentals/whatis)                     |
 
 ```{note}
 Support for multiple additional providers is planned for future releases of authd.


### PR DESCRIPTION
- Fix the order of cloud providers to be aligned with the table without changing the formatting in the table.
- Fixes https://github.com/ubuntu/authd/issues/843