### PR TITLE
pam: Fix races handling in VHS tests and fix bubbletea models implementations

### DIFF
--- a/.github/workflows/qa.yaml
+++ b/.github/workflows/qa.yaml
@@ -254,6 +254,7 @@ jobs:
         if: matrix.test == 'race'
         env:
           GO_TESTS_TIMEOUT: 35m
+          AUTHD_TESTS_SLEEP_MULTIPLIER: 3
         run: |
           go test -json -timeout ${GO_TESTS_TIMEOUT} -race ./... | \
             gotestfmt --logfile "${AUTHD_TEST_ARTIFACTS_PATH}/gotestfmt.race.log"
@@ -266,6 +267,7 @@ jobs:
           CGO_CFLAGS: "-O0 -g3 -fno-omit-frame-pointer"
           G_DEBUG: "fatal-criticals"
           GO_TESTS_TIMEOUT: 30m
+          AUTHD_TESTS_SLEEP_MULTIPLIER: 1.5
           # Use these flags to give ASAN a better time to unwind the stack trace
           GO_GC_FLAGS: -N -l
         run: |

--- a/examplebroker/broker.go
+++ b/examplebroker/broker.go
@@ -843,6 +843,9 @@ func (b *Broker) UserPreCheck(ctx context.Context, username string) (string, err
 		strings.Contains(username, fmt.Sprintf("-%s-", UserIntegrationPreCheckValue)) {
 		return userInfoFromName(username), nil
 	}
+
+	exampleUsersMu.Lock()
+	defer exampleUsersMu.Unlock()
 	if _, exists := exampleUsers[username]; !exists {
 		return "", fmt.Errorf("user %q does not exist", username)
 	}

--- a/internal/testutils/args.go
+++ b/internal/testutils/args.go
@@ -79,6 +79,7 @@ func SleepMultiplier() float64 {
 			if sleepMultiplier <= 0 {
 				panic("Negative or 0 sleep multiplier is not supported")
 			}
+			return
 		}
 
 		if IsAsan() {

--- a/internal/testutils/daemon.go
+++ b/internal/testutils/daemon.go
@@ -24,6 +24,7 @@ type daemonOptions struct {
 	existentDB string
 	socketPath string
 	pidFile    string
+	outputFile string
 	env        []string
 }
 
@@ -63,6 +64,13 @@ func WithEnvironment(env ...string) DaemonOption {
 func WithPidFile(pidFile string) DaemonOption {
 	return func(o *daemonOptions) {
 		o.pidFile = pidFile
+	}
+}
+
+// WithOutputFile sets the path where the process log will be saved.
+func WithOutputFile(outputFile string) DaemonOption {
+	return func(o *daemonOptions) {
+		o.outputFile = outputFile
 	}
 }
 
@@ -136,6 +144,12 @@ paths:
 		}
 		err = cmd.Wait()
 		out := b.Bytes()
+		if opts.outputFile != "" {
+			t.Log("writing authd log files to", opts.outputFile)
+			if err := os.WriteFile(opts.outputFile, out, 0600); err != nil {
+				t.Logf("TearDown: failed to save output file %q: %v", opts.outputFile, err)
+			}
+		}
 		require.ErrorIs(t, err, context.Canceled, "Setup: daemon stopped unexpectedly: %s", out)
 		if opts.pidFile != "" {
 			defer cancel(nil)

--- a/pam/integration-tests/helpers_test.go
+++ b/pam/integration-tests/helpers_test.go
@@ -127,7 +127,8 @@ func sharedAuthd(t *testing.T) (socketPath string, gpasswdFile string) {
 
 	sa.gPasswdOutputPath = filepath.Join(t.TempDir(), "gpasswd.output")
 	sa.groupsFile = filepath.Join(testutils.TestFamilyPath(t), "gpasswd.group")
-	sa.socketPath, sa.cleanup = runAuthdForTesting(t, sa.gPasswdOutputPath, sa.groupsFile, true)
+	sa.socketPath, sa.cleanup = runAuthdForTesting(t, sa.gPasswdOutputPath,
+		sa.groupsFile, true, testutils.WithSharedDaemon(true))
 	return sa.socketPath, sa.gPasswdOutputPath
 }
 

--- a/pam/integration-tests/vhs-helpers_test.go
+++ b/pam/integration-tests/vhs-helpers_test.go
@@ -1,7 +1,6 @@
 package main_test
 
 import (
-	"errors"
 	"fmt"
 	"maps"
 	"math"
@@ -260,14 +259,13 @@ func (td tapeData) RunVhs(t *testing.T, testType vhsTestType, outDir string, cli
 	var raceLog string
 	if testutils.IsRace() {
 		raceLog = filepath.Join(t.TempDir(), "gorace.log")
-		cmd.Env = append(cmd.Env, fmt.Sprintf("GORACE=log_path=%s", raceLog))
-		saveArtifactsForDebugOnCleanup(t, []string{raceLog})
+		cmd.Env = append(cmd.Env, fmt.Sprintf("GORACE=log_path=%s exitcode=0", raceLog))
 	}
 
 	cmd.Args = append(cmd.Args, td.PrepareTape(t, testType, outDir))
 	out, err := cmd.CombinedOutput()
-	if err != nil {
-		checkDataRace(t, raceLog)
+	if raceLog != "" {
+		checkDataRaces(t, raceLog)
 	}
 
 	isSSHError := func(processOut []byte) bool {
@@ -324,17 +322,38 @@ func (td tapeData) Output() string {
 	return txt
 }
 
+func checkDataRaces(t *testing.T, raceLog string) {
+	t.Helper()
+
+	if !testutils.IsRace() {
+		return
+	}
+
+	var raceLogs []string
+	err := filepath.Walk(filepath.Dir(raceLog),
+		func(path string, info os.FileInfo, err error) error {
+			if err != nil {
+				return err
+			}
+			if !strings.HasPrefix(info.Name(), filepath.Base(raceLog)) {
+				return nil
+			}
+			t.Logf("Found data race %s", info.Name())
+			raceLogs = append(raceLogs, filepath.Join(filepath.Dir(raceLog), info.Name()))
+			return nil
+		})
+
+	require.NoError(t, err, "TearDown: Check for races")
+	saveArtifactsForDebugOnCleanup(t, raceLogs)
+	for _, raceLog := range raceLogs {
+		checkDataRace(t, raceLog)
+	}
+}
+
 func checkDataRace(t *testing.T, raceLog string) {
 	t.Helper()
 
-	if !testutils.IsRace() || raceLog == "" {
-		return
-	}
-
 	content, err := os.ReadFile(raceLog)
-	if err == nil || errors.Is(err, os.ErrNotExist) {
-		return
-	}
 	require.NoError(t, err, "TearDown: Error reading race log %q", raceLog)
 
 	out := string(content)

--- a/pam/integration-tests/vhs-helpers_test.go
+++ b/pam/integration-tests/vhs-helpers_test.go
@@ -361,17 +361,6 @@ func checkDataRace(t *testing.T, raceLog string) {
 		return
 	}
 
-	if strings.Contains(out, "bubbles/cursor.(*Model).BlinkCmd.func1") {
-		// FIXME: This is a well known race of bubble tea:
-		// https://github.com/charmbracelet/bubbletea/issues/909
-		// We can't do much here, as the workaround will likely affect the
-		// GUI behavior, but we ignore this since it's definitely not our bug.
-
-		// TODO: In case other races are detected, we should still fail here.
-		t.Skipf("This is a very well known bubble tea bug (#909), ignoring it:\n%s", out)
-		return
-	}
-
 	t.Fatalf("Got a GO Race on vhs child:\n%s", out)
 }
 

--- a/pam/internal/adapter/authentication.go
+++ b/pam/internal/adapter/authentication.go
@@ -362,7 +362,7 @@ func (m authenticationModel) Update(msg tea.Msg) (authModel authenticationModel,
 }
 
 // Focus focuses this model.
-func (m *authenticationModel) Focus() tea.Cmd {
+func (m authenticationModel) Focus() tea.Cmd {
 	log.Debugf(context.TODO(), "%T: Focus", m)
 	if m.currentModel == nil {
 		return nil
@@ -372,7 +372,7 @@ func (m *authenticationModel) Focus() tea.Cmd {
 }
 
 // Focused returns if this model is focused.
-func (m *authenticationModel) Focused() bool {
+func (m authenticationModel) Focused() bool {
 	if m.currentModel == nil {
 		return false
 	}

--- a/pam/internal/adapter/authentication.go
+++ b/pam/internal/adapter/authentication.go
@@ -174,7 +174,7 @@ func newAuthenticationModel(client authd.PAMClient, clientType PamClientType) au
 }
 
 // Init initializes authenticationModel.
-func (m *authenticationModel) Init() tea.Cmd {
+func (m authenticationModel) Init() tea.Cmd {
 	return nil
 }
 

--- a/pam/internal/adapter/authmodeselection.go
+++ b/pam/internal/adapter/authmodeselection.go
@@ -57,7 +57,7 @@ func newAuthModeSelectionModel(clientType PamClientType) authModeSelectionModel 
 }
 
 // Init initializes authModeSelectionModel.
-func (m *authModeSelectionModel) Init() tea.Cmd {
+func (m authModeSelectionModel) Init() tea.Cmd {
 	if m.clientType != InteractiveTerminal {
 		// This is handled by the GDM or Native model!
 		return nil

--- a/pam/internal/adapter/commands.go
+++ b/pam/internal/adapter/commands.go
@@ -98,7 +98,7 @@ func getLayout(client authd.PAMClient, sessionID, authModeID string) tea.Cmd {
 }
 
 // quit tears down any active session and quit the main loop.
-func (m UIModel) quit() tea.Cmd {
+func (m uiModel) quit() tea.Cmd {
 	if m.currentSession == nil {
 		return sendEvent(tea.QuitMsg{})
 	}

--- a/pam/internal/adapter/commands.go
+++ b/pam/internal/adapter/commands.go
@@ -98,9 +98,9 @@ func getLayout(client authd.PAMClient, sessionID, authModeID string) tea.Cmd {
 }
 
 // quit tears down any active session and quit the main loop.
-func (m *UIModel) quit() tea.Cmd {
+func (m UIModel) quit() tea.Cmd {
 	if m.currentSession == nil {
-		return tea.Quit
+		return sendEvent(tea.QuitMsg{})
 	}
 	return tea.Sequence(endSession(m.client, m.currentSession), tea.Quit)
 }

--- a/pam/internal/adapter/focustracker.go
+++ b/pam/internal/adapter/focustracker.go
@@ -12,17 +12,17 @@ type focusTrackerModel struct {
 }
 
 // Init initializes the model.
-func (m *focusTrackerModel) Init() tea.Cmd {
+func (m focusTrackerModel) Init() tea.Cmd {
 	return nil
 }
 
 // Update handles events and actions.
-func (m *focusTrackerModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
-	return convertTo[tea.Model](m), nil
+func (m focusTrackerModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+	return m, nil
 }
 
 // View renders the model.
-func (m *focusTrackerModel) View() string {
+func (m focusTrackerModel) View() string {
 	return ""
 }
 
@@ -34,7 +34,7 @@ func (m *focusTrackerModel) Focus() tea.Cmd {
 }
 
 // Focused returns whether the model is focused.
-func (m *focusTrackerModel) Focused() bool {
+func (m focusTrackerModel) Focused() bool {
 	return m.focused
 }
 

--- a/pam/internal/adapter/gdmmodel.go
+++ b/pam/internal/adapter/gdmmodel.go
@@ -40,13 +40,13 @@ type gdmPollDone struct{}
 type gdmIsAuthenticatedResultReceived isAuthenticatedResultReceived
 
 // Init initializes the main model orchestrator.
-func (m *gdmModel) Init() tea.Cmd {
+func (m gdmModel) Init() tea.Cmd {
 	return tea.Sequence(m.protoHello(),
 		requestUICapabilities(m.pamMTx),
 		m.pollGdm())
 }
 
-func (m *gdmModel) protoHello() tea.Cmd {
+func (m gdmModel) protoHello() tea.Cmd {
 	reply, err := gdm.SendData(m.pamMTx, &gdm.Data{Type: gdm.DataType_hello})
 	if err != nil {
 		return sendEvent(pamError{
@@ -166,13 +166,13 @@ func (m *gdmModel) pollGdm() tea.Cmd {
 	return tea.Sequence(commands...)
 }
 
-func (m *gdmModel) emitEvent(event gdm.Event) tea.Cmd {
+func (m gdmModel) emitEvent(event gdm.Event) tea.Cmd {
 	return func() tea.Msg {
 		return m.emitEventSync(event)
 	}
 }
 
-func (m *gdmModel) emitEventSync(event gdm.Event) tea.Msg {
+func (m gdmModel) emitEventSync(event gdm.Event) tea.Msg {
 	err := gdm.EmitEvent(m.pamMTx, event)
 	log.Debug(context.TODO(), "EventSend", event, "result", err)
 	if err != nil {

--- a/pam/internal/adapter/gdmmodel_test.go
+++ b/pam/internal/adapter/gdmmodel_test.go
@@ -2245,7 +2245,7 @@ func TestGdmModel(t *testing.T) {
 				Gdm, authd.SessionMode_LOGIN, tc.client, nil, &exitStatus)
 
 			appState := gdmTestUIModel{
-				UIModel:             uiModel,
+				uiModel:             uiModel,
 				gdmHandler:          gdmHandler,
 				wantMessages:        slices.Clone(messagesToWait),
 				wantMessagesHandled: make(chan struct{}),
@@ -2260,7 +2260,7 @@ func TestGdmModel(t *testing.T) {
 			}
 
 			if tc.pamUser != "" {
-				require.NoError(t, uiModel.PamMTx.SetItem(pam.User, tc.pamUser))
+				require.NoError(t, uiModel.pamMTx.SetItem(pam.User, tc.pamUser))
 			}
 			if tc.pamUser != "" && tc.wantUsername == "" {
 				tc.wantUsername = tc.pamUser
@@ -2426,7 +2426,7 @@ func TestGdmModel(t *testing.T) {
 
 			require.Empty(t, appState.wantMessages, "Wanted messages have not all been processed")
 
-			username, err := appState.PamMTx.GetItem(pam.User)
+			username, err := appState.pamMTx.GetItem(pam.User)
 			require.NoError(t, err)
 			require.Equal(t, tc.wantUsername, username)
 			gdm_test.RequireEqualData(t, tc.wantGdmAuthRes, gdmHandler.authEvents)

--- a/pam/internal/adapter/gdmmodel_test.go
+++ b/pam/internal/adapter/gdmmodel_test.go
@@ -2251,6 +2251,9 @@ func TestGdmModel(t *testing.T) {
 				wantMessagesHandled: make(chan struct{}),
 			}
 
+			var exitStatus PamReturnStatus
+			appState.ExitStatus.Store(&exitStatus)
+
 			if tc.supportedLayouts == nil {
 				gdmHandler.supportedLayouts = []*authd.UILayout{pam_test.FormUILayout()}
 			}
@@ -2387,17 +2390,17 @@ func TestGdmModel(t *testing.T) {
 			if tc.wantExitStatus.Message() == gdmTestIgnoredMessage {
 				switch wantRet := tc.wantExitStatus.(type) {
 				case PamReturnError:
-					exitErr, ok := appState.ExitStatus().(PamReturnError)
+					exitErr, ok := exitStatus.(PamReturnError)
 					require.True(t, ok, "exit status should be an error")
 					require.Equal(t, wantRet.Status(), exitErr.Status())
 				case PamSuccess:
-					_, ok := appState.ExitStatus().(PamSuccess)
+					_, ok := exitStatus.(PamSuccess)
 					require.True(t, ok, "exit status should be a success")
 				default:
 					t.Fatalf("Unexpected exit status: %v", wantRet)
 				}
 			} else {
-				require.Equal(t, tc.wantExitStatus, appState.ExitStatus())
+				require.Equal(t, tc.wantExitStatus, exitStatus)
 			}
 
 			require.True(t, appState.gdmModel.conversationsStopped)

--- a/pam/internal/adapter/gdmmodel_test.go
+++ b/pam/internal/adapter/gdmmodel_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/ubuntu/authd/internal/brokers/auth"
 	"github.com/ubuntu/authd/internal/brokers/layouts"
 	"github.com/ubuntu/authd/internal/proto/authd"
+	"github.com/ubuntu/authd/internal/testutils"
 	"github.com/ubuntu/authd/pam/internal/gdm"
 	"github.com/ubuntu/authd/pam/internal/gdm_test"
 	"github.com/ubuntu/authd/pam/internal/pam_test"
@@ -2325,7 +2326,8 @@ func TestGdmModel(t *testing.T) {
 					close(waitChan)
 				}()
 				select {
-				case <-time.After(tc.timeout):
+				case <-time.After(time.Duration(testutils.SleepMultiplier() *
+					float64(tc.timeout))):
 					t.Log("Timeout waiting for all the expectancies")
 				case <-waitChan:
 				}
@@ -2370,7 +2372,7 @@ func TestGdmModel(t *testing.T) {
 			}
 
 			select {
-			case <-time.After(5 * time.Second):
+			case <-time.After(time.Duration(testutils.SleepMultiplier()*5) * time.Second):
 				logStatus()
 				t.Fatalf("timeout waiting for test expected results")
 			case <-controlDone:

--- a/pam/internal/adapter/gdmmodel_test.go
+++ b/pam/internal/adapter/gdmmodel_test.go
@@ -2326,6 +2326,7 @@ func TestGdmModel(t *testing.T) {
 				}()
 				select {
 				case <-time.After(tc.timeout):
+					t.Log("Timeout waiting for all the expectancies")
 				case <-waitChan:
 				}
 				t.Log("Waiting for events done...")

--- a/pam/internal/adapter/gdmmodel_test.go
+++ b/pam/internal/adapter/gdmmodel_test.go
@@ -2239,10 +2239,13 @@ func TestGdmModel(t *testing.T) {
 				wantEvents:           tc.wantGdmEvents,
 				wantRequests:         tc.wantGdmRequests,
 			}
+
+			var exitStatus PamReturnStatus
 			uiModel := UIModel{
 				PamMTx:     pam_test.NewModuleTransactionDummy(gdmHandler),
 				ClientType: Gdm,
 				client:     tc.client,
+				ExitStatus: &exitStatus,
 			}
 			appState := gdmTestUIModel{
 				UIModel:             uiModel,
@@ -2250,9 +2253,6 @@ func TestGdmModel(t *testing.T) {
 				wantMessages:        slices.Clone(messagesToWait),
 				wantMessagesHandled: make(chan struct{}),
 			}
-
-			var exitStatus PamReturnStatus
-			appState.ExitStatus.Store(&exitStatus)
 
 			if tc.supportedLayouts == nil {
 				gdmHandler.supportedLayouts = []*authd.UILayout{pam_test.FormUILayout()}

--- a/pam/internal/adapter/gdmmodel_test.go
+++ b/pam/internal/adapter/gdmmodel_test.go
@@ -1170,7 +1170,7 @@ func TestGdmModel(t *testing.T) {
 			wantExitStatus: PamSuccess{BrokerID: firstBrokerInfo.Id},
 		},
 		"Authenticated_with_qrcode_regenerated_after_auth_selection_stage_from_client_after_client-side_broker_and_auth_mode_selection": {
-			timeout: 10 * time.Second,
+			timeout: 15 * time.Second,
 			supportedLayouts: []*authd.UILayout{
 				pam_test.FormUILayout(),
 				pam_test.QrCodeUILayout(),
@@ -1252,7 +1252,7 @@ func TestGdmModel(t *testing.T) {
 			wantExitStatus: PamSuccess{BrokerID: firstBrokerInfo.Id},
 		},
 		"Authenticated_with_qrcode_regenerated_after_wait_started_at_auth_selection_stage_from_client_after_client-side_broker_and_auth_mode_selection": {
-			timeout: 10 * time.Second,
+			timeout: 15 * time.Second,
 			supportedLayouts: []*authd.UILayout{
 				pam_test.FormUILayout(),
 				pam_test.QrCodeUILayout(),
@@ -2317,7 +2317,7 @@ func TestGdmModel(t *testing.T) {
 
 				t.Log("Waiting for expected events")
 				if tc.timeout == 0 {
-					tc.timeout = 5 * time.Second
+					tc.timeout = 10 * time.Second
 				}
 				waitChan := make(chan struct{})
 				go func() {

--- a/pam/internal/adapter/gdmmodel_test.go
+++ b/pam/internal/adapter/gdmmodel_test.go
@@ -2241,12 +2241,9 @@ func TestGdmModel(t *testing.T) {
 			}
 
 			var exitStatus PamReturnStatus
-			uiModel := UIModel{
-				PamMTx:     pam_test.NewModuleTransactionDummy(gdmHandler),
-				ClientType: Gdm,
-				client:     tc.client,
-				ExitStatus: &exitStatus,
-			}
+			uiModel := newUIModelForClients(pam_test.NewModuleTransactionDummy(gdmHandler),
+				Gdm, authd.SessionMode_LOGIN, tc.client, nil, &exitStatus)
+
 			appState := gdmTestUIModel{
 				UIModel:             uiModel,
 				gdmHandler:          gdmHandler,

--- a/pam/internal/adapter/gdmmodel_uimodel_test.go
+++ b/pam/internal/adapter/gdmmodel_uimodel_test.go
@@ -94,7 +94,8 @@ func (m *gdmTestUIModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 	commands := []tea.Cmd{}
 
-	_, cmd := m.UIModel.Update(msg)
+	uiModel, cmd := m.UIModel.Update(msg)
+	m.UIModel = *convertTo[*UIModel](uiModel)
 	commands = append(commands, cmd)
 
 	switch msg := msg.(type) {
@@ -174,5 +175,5 @@ func (m *gdmTestUIModel) filterFunc(model tea.Model, msg tea.Msg) tea.Msg {
 		}
 	}
 
-	return m.MsgFilter(model, msg)
+	return m.MsgFilter(&convertTo[*gdmTestUIModel](model).UIModel, msg)
 }

--- a/pam/internal/adapter/gdmmodel_uimodel_test.go
+++ b/pam/internal/adapter/gdmmodel_uimodel_test.go
@@ -175,5 +175,5 @@ func (m *gdmTestUIModel) filterFunc(model tea.Model, msg tea.Msg) tea.Msg {
 		}
 	}
 
-	return m.MsgFilter(&convertTo[*gdmTestUIModel](model).UIModel, msg)
+	return m.MsgFilter(model, msg)
 }

--- a/pam/internal/adapter/gdmmodel_uimodel_test.go
+++ b/pam/internal/adapter/gdmmodel_uimodel_test.go
@@ -95,7 +95,7 @@ func (m *gdmTestUIModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	commands := []tea.Cmd{}
 
 	uiModel, cmd := m.UIModel.Update(msg)
-	m.UIModel = *convertTo[*UIModel](uiModel)
+	m.UIModel = convertTo[UIModel](uiModel)
 	commands = append(commands, cmd)
 
 	switch msg := msg.(type) {

--- a/pam/internal/adapter/gdmmodel_uimodel_test.go
+++ b/pam/internal/adapter/gdmmodel_uimodel_test.go
@@ -18,9 +18,9 @@ import (
 
 var gdmTestSequentialMessages atomic.Int64
 
-// gdmTestUIModel is an override of [UIModel] used for testing the module with gdm.
+// gdmTestUIModel is an override of [uiModel] used for testing the module with gdm.
 type gdmTestUIModel struct {
-	UIModel
+	uiModel
 
 	mu sync.Mutex
 
@@ -94,8 +94,8 @@ func (m *gdmTestUIModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 	commands := []tea.Cmd{}
 
-	uiModel, cmd := m.UIModel.Update(msg)
-	m.UIModel = convertTo[UIModel](uiModel)
+	um, cmd := m.uiModel.Update(msg)
+	m.uiModel = convertTo[uiModel](um)
 	commands = append(commands, cmd)
 
 	switch msg := msg.(type) {
@@ -175,5 +175,5 @@ func (m *gdmTestUIModel) filterFunc(model tea.Model, msg tea.Msg) tea.Msg {
 		}
 	}
 
-	return m.MsgFilter(model, msg)
+	return MsgFilter(m.uiModel, msg)
 }

--- a/pam/internal/adapter/model.go
+++ b/pam/internal/adapter/model.go
@@ -8,7 +8,6 @@ import (
 	"encoding/base64"
 	"fmt"
 	"strings"
-	"sync/atomic"
 	"time"
 
 	tea "github.com/charmbracelet/bubbletea"
@@ -72,7 +71,7 @@ type UIModel struct {
 
 	// ExitStatus is a pointer to the [PamReturnStatus] value where the
 	// exit status will be written to.
-	ExitStatus atomic.Pointer[PamReturnStatus]
+	ExitStatus *PamReturnStatus
 }
 
 /* global events */
@@ -120,8 +119,8 @@ type ChangeStage struct {
 func (m *UIModel) Init() tea.Cmd {
 	var cmds []tea.Cmd
 
-	if es := m.ExitStatus.Load(); es != nil {
-		*es = errNoExitStatus
+	if m.ExitStatus != nil {
+		*m.ExitStatus = errNoExitStatus
 	}
 
 	if m.Conn != nil {
@@ -233,11 +232,10 @@ func (m UIModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	// Exit cases
 	case PamReturnStatus:
 		log.Debugf(context.TODO(), "%#v", msg)
-		es := m.ExitStatus.Load()
-		if es == nil {
+		if m.ExitStatus == nil {
 			return &m, m.quit()
 		}
-		*es = msg
+		*m.ExitStatus = msg
 		return &m, m.quit()
 
 	// Events

--- a/pam/internal/adapter/model.go
+++ b/pam/internal/adapter/model.go
@@ -136,7 +136,7 @@ func (m *UIModel) Init() tea.Cmd {
 		if m.Conn != nil && isSSHSession(m.PamMTx) {
 			nssClient = authd.NewNSSClient(m.Conn)
 		}
-		m.nativeModel = nativeModel{pamMTx: m.PamMTx, nssClient: nssClient}
+		m.nativeModel = newNativeModel(m.PamMTx, nssClient)
 		cmds = append(cmds, m.nativeModel.Init())
 	}
 

--- a/pam/internal/adapter/nativemodel.go
+++ b/pam/internal/adapter/nativemodel.go
@@ -80,8 +80,9 @@ var errGoBack = errors.New("request to go back")
 var errEmptyResponse = errors.New("empty response received")
 var errNotAnInteger = errors.New("parsed value is not an integer")
 
-// Init initializes the main model orchestrator.
-func (m *nativeModel) Init() tea.Cmd {
+func newNativeModel(mTx pam.ModuleTransaction, nssClient authd.NSSClient) nativeModel {
+	m := nativeModel{pamMTx: mTx, nssClient: nssClient}
+
 	var err error
 	m.serviceName, err = m.pamMTx.GetItem(pam.Service)
 	if err != nil {
@@ -89,6 +90,12 @@ func (m *nativeModel) Init() tea.Cmd {
 	}
 
 	m.interactive = isSSHSession(m.pamMTx) || IsTerminalTTY(m.pamMTx)
+
+	return m
+}
+
+// Init initializes the native model orchestrator.
+func (m nativeModel) Init() tea.Cmd {
 	rendersQrCode := m.isQrcodeRenderingSupported()
 	supportsQrCode := m.serviceName != polkitServiceName
 

--- a/pam/internal/adapter/newpasswordmodel.go
+++ b/pam/internal/adapter/newpasswordmodel.go
@@ -4,11 +4,9 @@ import (
 	"context"
 	"slices"
 
-	"github.com/charmbracelet/bubbles/textinput"
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
 	"github.com/ubuntu/authd/internal/brokers/layouts"
-	"github.com/ubuntu/authd/internal/brokers/layouts/entries"
 	"github.com/ubuntu/authd/internal/proto/authd"
 	"github.com/ubuntu/authd/log"
 )
@@ -33,12 +31,9 @@ func newNewPasswordModel(label, entryType, buttonLabel string) newPasswordModel 
 
 	// TODO: add digits and force validation.
 	for range []int{0, 1} {
-		entry := &textinputModel{Model: textinput.New()}
-		if entryType == entries.CharsPassword {
-			entry.EchoMode = textinput.EchoPassword
-		}
-		passwordEntries = append(passwordEntries, entry)
-		focusableModels = append(focusableModels, entry)
+		entry := newTextInputModel(entryType)
+		passwordEntries = append(passwordEntries, &entry)
+		focusableModels = append(focusableModels, &entry)
 	}
 
 	if buttonLabel != "" {
@@ -61,9 +56,6 @@ func newNewPasswordModel(label, entryType, buttonLabel string) newPasswordModel 
 func (m newPasswordModel) Init() tea.Cmd {
 	var commands []tea.Cmd
 	for _, c := range m.focusableModels {
-		commands = append(commands, c.Init())
-	}
-	for _, c := range m.passwordEntries {
 		commands = append(commands, c.Init())
 	}
 	return tea.Batch(commands...)

--- a/pam/internal/adapter/newpasswordmodel.go
+++ b/pam/internal/adapter/newpasswordmodel.go
@@ -144,8 +144,18 @@ func (m *newPasswordModel) updateFocusModel(msg tea.Msg) tea.Cmd {
 	if m.focusIndex >= len(m.focusableModels) {
 		return nil
 	}
-	model, cmd := m.focusableModels[m.focusIndex].Update(msg)
+
+	focusedModel := m.focusableModels[m.focusIndex]
+	model, cmd := focusedModel.Update(msg)
 	m.focusableModels[m.focusIndex] = convertTo[authenticationComponent](model)
+
+	focusedInput, ok := focusedModel.(*textinputModel)
+	if !ok {
+		return cmd
+	}
+	if idx := slices.Index(m.passwordEntries, focusedInput); idx >= 0 {
+		m.passwordEntries[idx] = convertTo[*textinputModel](model)
+	}
 
 	return cmd
 }

--- a/pam/internal/adapter/qrcodemodel.go
+++ b/pam/internal/adapter/qrcodemodel.go
@@ -69,7 +69,8 @@ func (m qrcodeModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	}
 
 	model, cmd := m.buttonModel.Update(msg)
-	m.buttonModel = convertTo[*authReselectButtonModel](model)
+	buttonModel := convertTo[authReselectButtonModel](model)
+	m.buttonModel = &buttonModel
 
 	return m, cmd
 }

--- a/pam/internal/adapter/reselectbuttonmodel.go
+++ b/pam/internal/adapter/reselectbuttonmodel.go
@@ -25,7 +25,7 @@ func (b authReselectButtonModel) Init() tea.Cmd {
 }
 
 // Update handles events and actions.
-func (b *authReselectButtonModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+func (b authReselectButtonModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	switch msg := msg.(type) {
 	case buttonSelectionEvent:
 		log.Debugf(context.TODO(), "%#v: %#v", b, msg)

--- a/pam/internal/adapter/textinputmodel.go
+++ b/pam/internal/adapter/textinputmodel.go
@@ -23,13 +23,13 @@ func newTextInputModel(entryType string) textinputModel {
 }
 
 // Init initializes textinputModel.
-func (m *textinputModel) Init() tea.Cmd {
+func (m textinputModel) Init() tea.Cmd {
 	return nil
 }
 
 // Update handles events and actions.
-func (m *textinputModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+func (m textinputModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	var cmd tea.Cmd
 	m.Model, cmd = m.Model.Update(msg)
-	return m, cmd
+	return &m, cmd
 }

--- a/pam/internal/adapter/userselection.go
+++ b/pam/internal/adapter/userselection.go
@@ -58,7 +58,7 @@ func newUserSelectionModel(pamMTx pam.ModuleTransaction, clientType PamClientTyp
 }
 
 // Init initializes userSelectionModel.
-func (m *userSelectionModel) Init() tea.Cmd {
+func (m userSelectionModel) Init() tea.Cmd {
 	return nil
 }
 

--- a/pam/internal/pam_test/pam-client-dummy.go
+++ b/pam/internal/pam_test/pam-client-dummy.go
@@ -18,6 +18,7 @@ import (
 	"github.com/ubuntu/authd/internal/brokers/layouts"
 	"github.com/ubuntu/authd/internal/brokers/layouts/entries"
 	"github.com/ubuntu/authd/internal/proto/authd"
+	"github.com/ubuntu/authd/internal/testutils"
 	"github.com/ubuntu/authd/log"
 	"golang.org/x/exp/maps"
 	"google.golang.org/grpc"
@@ -431,7 +432,7 @@ func (dc *DummyClient) IsAuthenticated(ctx context.Context, in *authd.IARequest,
 			return nil, errors.New("no wanted wait provided")
 		}
 		select {
-		case <-time.After(dc.isAuthenticatedWantWait):
+		case <-time.After(time.Duration(testutils.SleepMultiplier() * float64(dc.isAuthenticatedWantWait))):
 		case <-ctx.Done():
 			return &authd.IAResponse{
 				Access: auth.Cancelled,

--- a/pam/pam.go
+++ b/pam/pam.go
@@ -313,15 +313,14 @@ func (h *pamModule) handleAuthRequest(mode authd.SessionMode, mTx pam.ModuleTran
 	}
 	defer closeConn()
 
+	var exitStatus adapter.PamReturnStatus
 	appState := adapter.UIModel{
 		PamMTx:      mTx,
 		Conn:        conn,
 		ClientType:  pamClientType,
 		SessionMode: mode,
+		ExitStatus:  &exitStatus,
 	}
-
-	var exitStatus adapter.PamReturnStatus
-	appState.ExitStatus.Store(&exitStatus)
 
 	if err := mTx.SetData(authenticationBrokerIDKey, nil); err != nil {
 		return err

--- a/pam/pam.go
+++ b/pam/pam.go
@@ -313,21 +313,14 @@ func (h *pamModule) handleAuthRequest(mode authd.SessionMode, mTx pam.ModuleTran
 	}
 	defer closeConn()
 
-	var exitStatus adapter.PamReturnStatus
-	appState := adapter.UIModel{
-		PamMTx:      mTx,
-		Conn:        conn,
-		ClientType:  pamClientType,
-		SessionMode: mode,
-		ExitStatus:  &exitStatus,
-	}
-
 	if err := mTx.SetData(authenticationBrokerIDKey, nil); err != nil {
 		return err
 	}
 
+	var exitStatus adapter.PamReturnStatus
+	appState := adapter.NewUIModel(mTx, pamClientType, mode, conn, &exitStatus)
 	teaOpts = append(teaOpts, tea.WithFilter(appState.MsgFilter))
-	p := tea.NewProgram(&appState, teaOpts...)
+	p := tea.NewProgram(appState, teaOpts...)
 	if _, err := p.Run(); err != nil {
 		log.Errorf(context.TODO(), "Cancelled authentication: %v", err)
 		return pam.ErrAbort

--- a/pam/pam.go
+++ b/pam/pam.go
@@ -320,6 +320,9 @@ func (h *pamModule) handleAuthRequest(mode authd.SessionMode, mTx pam.ModuleTran
 		SessionMode: mode,
 	}
 
+	var exitStatus adapter.PamReturnStatus
+	appState.ExitStatus.Store(&exitStatus)
+
 	if err := mTx.SetData(authenticationBrokerIDKey, nil); err != nil {
 		return err
 	}
@@ -331,9 +334,9 @@ func (h *pamModule) handleAuthRequest(mode authd.SessionMode, mTx pam.ModuleTran
 		return pam.ErrAbort
 	}
 
-	sendReturnMessageToPam(mTx, appState.ExitStatus())
+	sendReturnMessageToPam(mTx, exitStatus)
 
-	switch exitStatus := appState.ExitStatus().(type) {
+	switch exitStatus := exitStatus.(type) {
 	case adapter.PamSuccess:
 		if err := mTx.SetData(authenticationBrokerIDKey, exitStatus.BrokerID); err != nil {
 			return err

--- a/pam/pam.go
+++ b/pam/pam.go
@@ -319,7 +319,7 @@ func (h *pamModule) handleAuthRequest(mode authd.SessionMode, mTx pam.ModuleTran
 
 	var exitStatus adapter.PamReturnStatus
 	appState := adapter.NewUIModel(mTx, pamClientType, mode, conn, &exitStatus)
-	teaOpts = append(teaOpts, tea.WithFilter(appState.MsgFilter))
+	teaOpts = append(teaOpts, tea.WithFilter(adapter.MsgFilter))
 	p := tea.NewProgram(appState, teaOpts...)
 	if _, err := p.Run(); err != nil {
 		log.Errorf(context.TODO(), "Cancelled authentication: %v", err)


### PR DESCRIPTION
See commits for details, but basically lots of cleanups to ensure that the races are properly monitored and that the artifacts saved in CI, then I decided to tackle the root cause of https://github.com/charmbracelet/bubbletea/issues/909 that was mostly due to the fact that we were, in various cases, updating the models with pointer receivers, instead of relying on the returned and modified value.

Coming with various cleanups.

UDENG-6474