### PR TITLE
docs: change github_folder to repo_folder

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -144,7 +144,7 @@ html_context = {
     # Docs location in the repo; used in links for viewing the source files
     #
     # TODO: To customise the directory, uncomment and update as needed.
-    "github_folder": "/docs/",
+    "repo_folder": "/docs/",
 
     # TODO: To enable or disable the Previous / Next buttons at the bottom of pages
     # Valid options: none, prev, next, both


### PR DESCRIPTION
`github_folder` was deprecated in a recent update to the starter pack and is now replaced with the more generic `repo_folder`.

The change caused failed builds on Read the Docs, which should be fixed by this PR.