### PR TITLE
ci/build-deb: Push the debian sources to packaging branches

### DIFF
--- a/.github/workflows/build-deb.yaml
+++ b/.github/workflows/build-deb.yaml
@@ -41,6 +41,8 @@ jobs:
     outputs:
       run-id: ${{ github.run_id }}
       # FIXME: Use dynamic outputs when possible: https://github.com/actions/runner/pull/2477
+      pkg-dsc-devel:  ${{ steps.outputs.outputs.pkg-dsc-devel }}
+      pkg-dsc-noble:  ${{ steps.outputs.outputs.pkg-dsc-noble }}
       pkg-src-changes-devel: ${{ steps.outputs.outputs.pkg-src-changes-devel }}
       pkg-src-changes-noble: ${{ steps.outputs.outputs.pkg-src-changes-noble }}
 
@@ -68,6 +70,7 @@ jobs:
         id: outputs
         run: |
           (
+            echo "pkg-dsc-${{ matrix.ubuntu-version }}=${{ env.PKG_DSC }}"
             echo "pkg-src-changes-${{ matrix.ubuntu-version }}=${{ env.PKG_SOURCE_CHANGES }}"
           ) >> "${GITHUB_OUTPUT}"
 
@@ -107,6 +110,110 @@ jobs:
 
           escaped_json=$(echo "${modified_files}" | jq '.| tostring')
           echo "modified_files=${escaped_json}" >> "${GITHUB_OUTPUT}"
+
+  synchronize-packaging-branches:
+    name: Update packaging branch
+    runs-on: ubuntu-latest
+    needs:
+      - define-versions
+      - build-deb-package
+    permissions:
+      contents: write
+    strategy:
+      fail-fast: false
+      matrix:
+        ubuntu-version: ${{ fromJSON(needs.define-versions.outputs.ubuntu-versions) }}
+    env:
+        PACKAGING_BRANCH: ubuntu-packaging-${{ matrix.ubuntu-version }}
+
+    # Run only on:
+    #  - Push events to main
+    #  - On new tags
+    #  - On github release
+    if: ${{ (github.event_name == 'push' && github.ref == 'refs/heads/main') ||
+       startsWith(github.ref, 'refs/tags/') ||
+       github.event_name == 'release' }}
+
+    steps:
+    # FIXME: Use dynamic outputs when possible: https://github.com/actions/runner/pull/2477
+    - name: Setup job variables
+      run: |
+        set -exuo pipefail
+
+        json_output='${{ toJSON(needs.build-deb-package.outputs) }}'
+        for var in $(echo "${json_output}" | jq -r 'keys | .[]'); do
+          if  [[ "${var}" != *"-${{ matrix.ubuntu-version }}" ]]; then
+            continue;
+          fi
+
+          v=$(echo "${json_output}" | jq -r ".\"${var}\"")
+          var="${var%-${{ matrix.ubuntu-version }}}"
+          echo "${var//-/_}=${v}" >> "${GITHUB_ENV}"
+        done
+
+    - name: Download artifacts
+      uses: actions/download-artifact@v4
+      with:
+        run-id: ${{ needs.build-deb-package.outputs.run-id }}
+        merge-multiple: true
+
+    - name: Install dependencies
+      run: |
+        set -euo pipefail
+
+        sudo apt update -y
+        sudo apt install -y --no-install-suggests --no-install-recommends \
+          dpkg-dev devscripts
+
+    - name: Checkout code
+      uses: actions/checkout@v4
+      with:
+        fetch-depth: 100
+        path: repo
+
+    - name: Extract the debian sources
+      run: |
+        set -euo pipefail
+
+        dpkg-source -x ${{ env.pkg_dsc }} sources
+
+    - name: Commit packaging sources
+      run: |
+        set -exuo pipefail
+
+        # Create or switch to the packaging branch
+        if git -C repo fetch --depth=1 origin "${{ env.PACKAGING_BRANCH }}:${{ env.PACKAGING_BRANCH }}"; then
+          git -C repo checkout "${{ env.PACKAGING_BRANCH }}"
+        else
+          git -C repo checkout -b "${{ env.PACKAGING_BRANCH }}"
+        fi
+
+        # Replace the repository content with the package sources
+        mv repo/.git sources/
+        cd sources
+
+        # Drop the ubuntu version, as the PPA recipe will add it anyways
+        version=$(dpkg-parsechangelog -SVersion)
+        sanitized_version=$(echo "${version}" | sed "s,~[0-9.]\+\$,,")
+        perl -pe "s|\Q${version}\E|${sanitized_version}|" debian/changelog > \
+          debian/changelog.sanitized
+        mv debian/changelog.sanitized debian/changelog
+        dpkg-parsechangelog
+
+        git config --global user.name "Ubuntu Enterprise Desktop"
+        git config --global user.email "ubuntu-devel-discuss@lists.ubuntu.com"
+
+        git add --all
+        git commit \
+          --allow-empty \
+          -m "Update ubuntu ${{ matrix.ubuntu-version }} package sources" \
+          -m "Use upstream commit ${GITHUB_SHA}"
+
+    - name: Push to packaging branch
+      run: |
+        set -exuo pipefail
+
+        git -C sources push origin "${{ env.PACKAGING_BRANCH }}:${{ env.PACKAGING_BRANCH }}"
 
   run-autopkgtests:
     name: Run autopkgtests

--- a/.github/workflows/build-deb.yaml
+++ b/.github/workflows/build-deb.yaml
@@ -40,7 +40,9 @@ jobs:
         ubuntu-version: ${{ fromJSON(needs.define-versions.outputs.ubuntu-versions) }}
     outputs:
       run-id: ${{ github.run_id }}
-      pkg-src-changes: ${{ env.PKG_SOURCE_CHANGES }}
+      # FIXME: Use dynamic outputs when possible: https://github.com/actions/runner/pull/2477
+      pkg-src-changes-devel: ${{ steps.outputs.outputs.pkg-src-changes-devel }}
+      pkg-src-changes-noble: ${{ steps.outputs.outputs.pkg-src-changes-noble }}
 
     steps:
       - name: Checkout authd code
@@ -60,6 +62,14 @@ jobs:
                 cargo-vendor-filterer@${{ env.CARGO_VENDOR_FILTERER_VERSION }}
               command -v cargo-vendor-filterer
             fi
+
+        # FIXME: Use dynamic outputs when possible: https://github.com/actions/runner/pull/2477
+      - name: Generate outputs
+        id: outputs
+        run: |
+          (
+            echo "pkg-src-changes-${{ matrix.ubuntu-version }}=${{ env.PKG_SOURCE_CHANGES }}"
+          ) >> "${GITHUB_OUTPUT}"
 
   check-modified-files:
     name: Check modified files
@@ -123,6 +133,22 @@ jobs:
        github.event_name == 'release' }}
 
     steps:
+    # FIXME: Use dynamic outputs when possible: https://github.com/actions/runner/pull/2477
+    - name: Setup job variables
+      run: |
+        set -exuo pipefail
+
+        json_output='${{ toJSON(needs.build-deb-package.outputs) }}'
+        for var in $(echo "${json_output}" | jq -r 'keys | .[]'); do
+          if  [[ "${var}" != *"-${{ matrix.ubuntu-version }}" ]]; then
+            continue;
+          fi
+
+          v=$(echo "${json_output}" | jq -r ".\"${var}\"")
+          var="${var%-${{ matrix.ubuntu-version }}}"
+          echo "${var//-/_}=${v}" >> "${GITHUB_ENV}"
+        done
+
     - name: Download artifacts
       uses: actions/download-artifact@v4
       with:
@@ -133,4 +159,4 @@ jobs:
       uses: canonical/desktop-engineering/gh-actions/common/run-autopkgtest@main
       with:
         lxd-image: ubuntu:${{ matrix.ubuntu-version }}
-        source-changes: ${{ needs.build-deb-package.outputs.pkg-src-changes }}
+        source-changes: ${{ env.pkg_src_changes }}


### PR DESCRIPTION
In order to be able to build authd from launchpad recipes we need to use a synchronized repository that contains the sources in a ready-to-build form, however our sources requires vendording the dependencies and cargo filtering and this does not work in builders without an internet connection (and without very recent cargo either).

The good thing is that we're already building the sources ourselves, so we can provide launchpad just them.

While dput'ing the built sources would be an option, it would also requires having an uploader bot with its GPG key, and that's somewhat unsafer, so let's instead just put the sources in a branch that is updated at every push to main and that launchpad can fetch for creating the packages.

This will be handled by https://code.launchpad.net/~ubuntu-enterprise-desktop/+recipe/authd-edge-devel

UDENG-6396