### PR TITLE
debian/gbp.conf: Use cargo-vendor-filterer from path during build

### DIFF
--- a/debian/gbp.conf
+++ b/debian/gbp.conf
@@ -5,5 +5,9 @@ debian-branch=main
 [buildpackage]
 export=INDEX
 
+# This is required only for noble, we can drop it once cargo-vendor-filterer
+# will be in the archive for all the versions we're targetting.
+prebuild=env PATH=$PATH:${CARGO_HOME:-$HOME/.cargo}/bin debian/rules clean
+
 [dch]
 multimaint-merge=True


### PR DESCRIPTION
Ensure that gbp buildpackage works by using the locally-installed cargo-vendor-filterer, if any.

So trigger the package cleanup before the build with the proper PATH value, to ensure that we can have a properly working gbp buildpackage in all the versions we support.

As per this, building a _clean_ source package is as easy as doing (or binaries can be built in a similar way):

    gbp buildpackage -S