### PR TITLE
pam/integration-tests: Use authd NSS module to perform the pre-check on SSH tests

### DIFF
--- a/examplebroker/broker.go
+++ b/examplebroker/broker.go
@@ -18,6 +18,7 @@ import (
 	"maps"
 	"math"
 	"os"
+	"path/filepath"
 	"regexp"
 	"sort"
 	"strconv"
@@ -46,6 +47,11 @@ const (
 const (
 	optionalResetMode  = "optionalreset"
 	mandatoryResetMode = "mandatoryreset"
+)
+
+var (
+	homeBaseDir     string
+	homeBaseDirOnce sync.Once
 )
 
 type authMode struct {
@@ -928,6 +934,13 @@ func userInfoFromName(name string) string {
 		UGID string
 	}
 
+	homeBaseDirOnce.Do(func() {
+		homeBaseDir = os.Getenv("AUTHD_EXAMPLE_BROKER_HOME_BASE_DIR")
+		if homeBaseDir == "" {
+			homeBaseDir = "/home"
+		}
+	})
+
 	user := struct {
 		Name   string
 		UUID   string
@@ -938,7 +951,7 @@ func userInfoFromName(name string) string {
 	}{
 		Name:   name,
 		UUID:   "uuid-" + name,
-		Dir:    "/home/" + name,
+		Dir:    filepath.Join(homeBaseDir, name),
 		Shell:  "/bin/sh",
 		Groups: []groupJSONInfo{{Name: "group-" + name, UGID: "ugid-" + name}},
 		Gecos:  "gecos for " + name,

--- a/examplebroker/broker.go
+++ b/examplebroker/broker.go
@@ -939,7 +939,7 @@ func userInfoFromName(name string) string {
 		Name:   name,
 		UUID:   "uuid-" + name,
 		Dir:    "/home/" + name,
-		Shell:  "/usr/bin/bash",
+		Shell:  "/bin/sh",
 		Groups: []groupJSONInfo{{Name: "group-" + name, UGID: "ugid-" + name}},
 		Gecos:  "gecos for " + name,
 	}

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -98,7 +98,7 @@ func New(ctx context.Context, registerGRPCService GRPCServiceRegisterer, args ..
 
 	// Ensure selected socket exists.
 	if _, err := os.Stat(lis.Addr().String()); err != nil {
-		return nil, fmt.Errorf("%s can’t be acccessed: %v", lis.Addr().String(), err)
+		return nil, fmt.Errorf("%s can’t be accessed: %v", lis.Addr().String(), err)
 	}
 
 	return &Daemon{

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -132,7 +132,7 @@ func (d *Daemon) Serve(ctx context.Context) (err error) {
 // Quit gracefully quits listening loop and stops the grpc server.
 // It can drops any existing connexion is force is true.
 func (d Daemon) Quit(ctx context.Context, force bool) {
-	log.Info(ctx, "Stopping daemon requested.")
+	log.Infof(ctx, "Stopping daemon requested for socket %s.", d.lis.Addr())
 	if force {
 		d.grpcServer.Stop()
 		return

--- a/internal/testutils/daemon.go
+++ b/internal/testutils/daemon.go
@@ -57,7 +57,7 @@ func WithSocketPath(path string) DaemonOption {
 // WithEnvironment overrides the default environment of the daemon.
 func WithEnvironment(env ...string) DaemonOption {
 	return func(o *daemonOptions) {
-		o.env = env
+		o.env = append(o.env, env...)
 	}
 }
 
@@ -80,6 +80,13 @@ func WithOutputFile(outputFile string) DaemonOption {
 func WithSharedDaemon(shared bool) DaemonOption {
 	return func(o *daemonOptions) {
 		o.shared = shared
+	}
+}
+
+// WithHomeBaseDir sets the base path for the user home directories.
+func WithHomeBaseDir(baseDir string) DaemonOption {
+	return func(o *daemonOptions) {
+		o.env = append(o.env, fmt.Sprintf("AUTHD_EXAMPLE_BROKER_HOME_BASE_DIR=%s", baseDir))
 	}
 }
 

--- a/internal/testutils/rust.go
+++ b/internal/testutils/rust.go
@@ -66,7 +66,7 @@ func CanRunRustTests(coverageWanted bool) (err error) {
 }
 
 // BuildRustNSSLib builds the NSS library and links the compiled file to libPath.
-func BuildRustNSSLib(t *testing.T) (libPath string, rustCovEnv []string) {
+func BuildRustNSSLib(t *testing.T, features ...string) (libPath string, rustCovEnv []string) {
 	t.Helper()
 
 	projectRoot := ProjectRoot()
@@ -78,9 +78,12 @@ func BuildRustNSSLib(t *testing.T) (libPath string, rustCovEnv []string) {
 	rustDir := filepath.Join(projectRoot, "nss")
 	rustCovEnv, target = trackRustCoverage(t, rustDir)
 
+	features = append([]string{"integration_tests", "custom_socket"}, features...)
+
 	// Builds the nss library.
 	// #nosec:G204 - we control the command arguments in tests
-	cmd := exec.Command(cargo, "build", "--verbose", "--all-features", "--target-dir", target)
+	cmd := exec.Command(cargo, "build", "--verbose",
+		"--features", strings.Join(features, ","), "--target-dir", target)
 	cmd.Env = append(os.Environ(), rustCovEnv...)
 	cmd.Dir = projectRoot
 

--- a/nss/Cargo.toml
+++ b/nss/Cargo.toml
@@ -14,6 +14,7 @@ name = "nss_authd"
 # Allows to override the socket path used to connect to the grpc server, through the AUTHD_NSS_SOCKET env variable.
 custom_socket = []
 integration_tests = []
+should_pre_check_env = []
 
 [dependencies]
 libnss = "0.9.0"

--- a/nss/integration-tests/helper_test.go
+++ b/nss/integration-tests/helper_test.go
@@ -37,7 +37,7 @@ func buildRustNSSLib(t *testing.T) (libPath string, rustCovEnv []string) {
 	out, err := cmd.CombinedOutput()
 	require.NoError(t, err, "Setup: could not build Rust NSS library: %s", out)
 
-	// When building the crate with dh-cargo, this env is set to indicate which arquitecture the code
+	// When building the crate with dh-cargo, this env is set to indicate which architecture the code
 	// is being compiled to. When it's set, the compiled is stored under target/$(DEB_HOST_RUST_TYPE)/debug,
 	// rather than under target/debug, so we need to append at the end of target to ensure we use
 	// the right path.

--- a/nss/integration-tests/helper_test.go
+++ b/nss/integration-tests/helper_test.go
@@ -34,6 +34,7 @@ func buildRustNSSLib(t *testing.T) (libPath string, rustCovEnv []string) {
 	cmd.Env = append(os.Environ(), rustCovEnv...)
 	cmd.Dir = projectRoot
 
+	t.Log("Building NSS library...", cmd.Args)
 	out, err := cmd.CombinedOutput()
 	require.NoError(t, err, "Setup: could not build Rust NSS library: %s", out)
 

--- a/nss/integration-tests/integration_test.go
+++ b/nss/integration-tests/integration_test.go
@@ -22,7 +22,7 @@ func TestIntegration(t *testing.T) {
 	// codeNotFound is the expected exit code for the getent subprocess in case of errors.
 	const codeNotFound int = 2
 
-	libPath, rustCovEnv := buildRustNSSLib(t)
+	libPath, rustCovEnv := testutils.BuildRustNSSLib(t)
 
 	// Create a default daemon to use for most test cases.
 	defaultSocket := filepath.Join(os.TempDir(), "nss-integration-tests.sock")

--- a/nss/integration-tests/integration_test.go
+++ b/nss/integration-tests/integration_test.go
@@ -22,7 +22,7 @@ func TestIntegration(t *testing.T) {
 	// codeNotFound is the expected exit code for the getent subprocess in case of errors.
 	const codeNotFound int = 2
 
-	libPath, rustCovEnv := testutils.BuildRustNSSLib(t)
+	libPath, rustCovEnv := testutils.BuildRustNSSLib(t, "should_pre_check_env")
 
 	// Create a default daemon to use for most test cases.
 	defaultSocket := filepath.Join(os.TempDir(), "nss-integration-tests.sock")

--- a/nss/integration-tests/integration_test.go
+++ b/nss/integration-tests/integration_test.go
@@ -22,7 +22,7 @@ func TestIntegration(t *testing.T) {
 	// codeNotFound is the expected exit code for the getent subprocess in case of errors.
 	const codeNotFound int = 2
 
-	libPath, rustCovEnv := testutils.BuildRustNSSLib(t, "should_pre_check_env")
+	libPath, rustCovEnv := testutils.BuildRustNSSLib(t, false, "should_pre_check_env")
 
 	// Create a default daemon to use for most test cases.
 	defaultSocket := filepath.Join(os.TempDir(), "nss-integration-tests.sock")

--- a/nss/integration-tests/testdata/golden/TestIntegration/Check_user_with_broker_if_not_found_in_db
+++ b/nss/integration-tests/testdata/golden/TestIntegration/Check_user_with_broker_if_not_found_in_db
@@ -1,1 +1,1 @@
-user-pre-check:x:{{UID}}:0:gecos for user-pre-check:/home/user-pre-check:/usr/bin/bash
+user-pre-check:x:{{UID}}:0:gecos for user-pre-check:/home/user-pre-check:/bin/sh

--- a/nss/src/lib.rs
+++ b/nss/src/lib.rs
@@ -20,8 +20,15 @@ mod logs;
 
 mod client;
 
+#[cfg(not(feature = "integration_tests"))]
 const CONNECTION_TIMEOUT: Duration = Duration::from_secs(1);
+#[cfg(not(feature = "integration_tests"))]
 const REQUEST_TIMEOUT: Duration = Duration::from_secs(5);
+
+#[cfg(feature = "integration_tests")]
+const CONNECTION_TIMEOUT: Duration = Duration::from_secs(5);
+#[cfg(feature = "integration_tests")]
+const REQUEST_TIMEOUT: Duration = Duration::from_secs(10);
 
 /// socket_path returns the socket path to connect to the gRPC server.
 ///

--- a/nss/src/passwd/mod.rs
+++ b/nss/src/passwd/mod.rs
@@ -114,6 +114,9 @@ fn get_entry_by_name(name: String) -> Response<Passwd> {
             return Response::NotFound;
         }
 
+        #[cfg(feature = "integration_tests")]
+        info!("Get entry by name '{}' (pre-check: {})", name, should_pre_check());
+
         let mut req = Request::new(authd::GetPasswdByNameRequest {
             name: name.clone(),
             should_pre_check: should_pre_check(),
@@ -160,7 +163,12 @@ fn is_proc_matching(pid: u32, name: &str) -> bool {
         return false;
     }
 
-    matches!(exe.unwrap(), s if s == PathBuf::from(name))
+    let unwrapped_exe = exe.unwrap();
+
+    #[cfg(feature = "integration_tests")]
+    info!("Pre-check test: process '{}'", unwrapped_exe.display());
+
+    matches!(unwrapped_exe, s if s == PathBuf::from(name))
 }
 
 /// should_pre_check returns true if the current process sshd or a child of sshd.

--- a/nss/src/passwd/mod.rs
+++ b/nss/src/passwd/mod.rs
@@ -152,7 +152,7 @@ static SSHD_BINARY_PATH: &str = "/usr/sbin/sshd";
 /// should_pre_check returns true if the current process is a child of sshd.
 #[allow(unreachable_code)] // This function body is overridden in integration tests, so we need to ignore the warning.
 fn should_pre_check() -> bool {
-    #[cfg(feature = "integration_tests")]
+    #[cfg(feature = "should_pre_check_env")]
     return std::env::var("AUTHD_NSS_SHOULD_PRE_CHECK").is_ok();
 
     let parent = procfs::process::Process::new(std::os::unix::process::parent_id() as i32);

--- a/pam/integration-tests/cli_test.go
+++ b/pam/integration-tests/cli_test.go
@@ -18,8 +18,6 @@ import (
 	"github.com/ubuntu/authd/pam/internal/pam_test"
 )
 
-var daemonPath string
-
 func TestCLIAuthenticate(t *testing.T) {
 	t.Parallel()
 

--- a/pam/integration-tests/helpers_test.go
+++ b/pam/integration-tests/helpers_test.go
@@ -62,6 +62,11 @@ func runAuthdForTesting(t *testing.T, gpasswdOutput, groupsFile string, currentU
 	outputFile := filepath.Join(t.TempDir(), "authd.log")
 	args = append(args, testutils.WithOutputFile(outputFile))
 
+	homeBaseDir := filepath.Join(t.TempDir(), "homes")
+	err := os.MkdirAll(homeBaseDir, 0700)
+	require.NoError(t, err, "Setup: Creating home base dir %q", homeBaseDir)
+	args = append(args, testutils.WithHomeBaseDir(homeBaseDir))
+
 	socketPath, stopped := testutils.RunDaemon(ctx, t, daemonPath, args...)
 	saveArtifactsForDebugOnCleanup(t, []string{outputFile})
 	return socketPath, func() {

--- a/pam/integration-tests/integration_test.go
+++ b/pam/integration-tests/integration_test.go
@@ -10,6 +10,8 @@ import (
 
 const authdCurrentUserRootEnvVariableContent = "AUTHD_INTEGRATIONTESTS_CURRENT_USER_AS_ROOT=1"
 
+var daemonPath string
+
 func TestMain(m *testing.M) {
 	// Needed to skip the test setup when running the gpasswd mock.
 	if os.Getenv("GO_WANT_HELPER_PROCESS") != "" {

--- a/pam/integration-tests/pam_mkhomedir/pam_mkhomedir.c
+++ b/pam/integration-tests/pam_mkhomedir/pam_mkhomedir.c
@@ -1,0 +1,267 @@
+/* PAM Make Home Dir module
+
+   This module will create a users home directory if it does not exist
+   when the session begins. This allows users to be present in central
+   database (such as nis, kerb or ldap) without using a distributed
+   file system or pre-creating a large number of directories.
+
+   Here is a sample /etc/pam.d/login file for Debian GNU/Linux
+   2.1:
+
+   auth       requisite  pam_securetty.so
+   auth       sufficient pam_ldap.so
+   auth       required   pam_unix.so
+   auth       optional   pam_group.so
+   auth       optional   pam_mail.so
+   account    requisite  pam_time.so
+   account    sufficient pam_ldap.so
+   account    required   pam_unix.so
+   session    required   pam_mkhomedir.so skel=/etc/skel/ umask=0022
+   session    required   pam_unix.so
+   session    optional   pam_lastlog.so
+   password   required   pam_unix.so
+
+   Released under the GNU LGPL version 2 or later
+   Copyright (c) Red Hat, Inc. 2009
+   Originally written by Jason Gunthorpe <jgg@debian.org> Feb 1999
+   Structure taken from pam_lastlogin by Andrew Morgan
+     <morgan@parc.power.net> 1996
+ */
+
+/* This is a version of pam_mkhomedir with minimal modifications for testing
+ * purposes, so that we can safely enable our NSS implementation with it.
+ */
+
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <sys/time.h>
+#include <sys/resource.h>
+#include <sys/wait.h>
+#include <unistd.h>
+#include <pwd.h>
+#include <errno.h>
+#include <stdlib.h>
+#include <stdio.h>
+#include <string.h>
+#include <syslog.h>
+#include <signal.h>
+
+#include <security/pam_modules.h>
+#include <security/_pam_macros.h>
+#include <security/pam_modutil.h>
+#include <security/pam_ext.h>
+
+/*
+#include "pam_cc_compat.h"
+#include "pam_inline.h"
+#include "pam_i18n.h"
+*/
+
+#include "pam_mkhomedir_test.h"
+
+struct options_t {
+  int ctrl;
+  const char *umask;
+  const char *skeldir;
+};
+typedef struct options_t options_t;
+
+static void
+_pam_parse (const pam_handle_t *pamh, int flags, int argc, const char **argv,
+	    options_t *opt)
+{
+   opt->ctrl = 0;
+   opt->umask = NULL;
+   opt->skeldir = "/etc/skel";
+
+   /* does the application require quiet? */
+   if ((flags & PAM_SILENT) == PAM_SILENT)
+      opt->ctrl |= MKHOMEDIR_QUIET;
+
+   /* step through arguments */
+   for (; argc-- > 0; ++argv)
+   {
+      const char *str;
+
+      if (!strcmp(*argv, "silent")) {
+	 opt->ctrl |= MKHOMEDIR_QUIET;
+      } else if (!strcmp(*argv, "debug")) {
+         opt->ctrl |= MKHOMEDIR_DEBUG;
+      } else if ((str = pam_str_skip_prefix(*argv, "umask=")) != NULL) {
+	 opt->umask = str;
+      } else if ((str = pam_str_skip_prefix(*argv, "skel=")) != NULL) {
+	 opt->skeldir = str;
+      } else {
+	 pam_syslog(pamh, LOG_ERR, "unknown option: %s", *argv);
+      }
+   }
+}
+
+static char*
+_pam_conv_str_umask_to_homemode(const char *umask)
+{
+   unsigned int m = 0777 & ~strtoul(umask, NULL, 8);
+   return pam_asprintf("%#o", m);
+}
+
+/* Do the actual work of creating a home dir */
+static int
+create_homedir (pam_handle_t *pamh, options_t *opt,
+		const char *user, const char *dir)
+{
+   int retval, child;
+   struct sigaction newsa, oldsa;
+   char *login_umask = NULL;
+   char *login_homemode = NULL;
+
+   /* Mention what is happening, if the notification fails that is OK */
+   if (!(opt->ctrl & MKHOMEDIR_QUIET))
+      pam_info(pamh, _("Creating directory '%s'."), dir);
+
+
+   D(("called."));
+
+   if (opt->ctrl & MKHOMEDIR_DEBUG) {
+        pam_syslog(pamh, LOG_DEBUG, "Executing mkhomedir_helper.");
+   }
+
+   /* fetch UMASK from /etc/login.defs if not in argv */
+   if (opt->umask == NULL) {
+      login_umask = pam_modutil_search_key(pamh, LOGIN_DEFS, "UMASK");
+      login_homemode = pam_modutil_search_key(pamh, LOGIN_DEFS, "HOME_MODE");
+      if (login_homemode == NULL) {
+         if (login_umask != NULL) {
+            login_homemode = _pam_conv_str_umask_to_homemode(login_umask);
+         } else {
+            login_homemode = _pam_conv_str_umask_to_homemode(UMASK_DEFAULT);
+         }
+      }
+   } else {
+      login_homemode = _pam_conv_str_umask_to_homemode(opt->umask);
+   }
+
+   /*
+    * This code arranges that the demise of the child does not cause
+    * the application to receive a signal it is not expecting - which
+    * may kill the application or worse.
+    */
+   memset(&newsa, '\0', sizeof(newsa));
+   newsa.sa_handler = SIG_DFL;
+   sigaction(SIGCHLD, &newsa, &oldsa);
+
+   /* fork */
+   child = fork();
+   if (child == 0) {
+#ifdef AUTHD_TESTS_SSH_USE_AUTHD_NSS
+	char **envp = environ;
+#else
+	static char *envp[] = { NULL };
+#endif
+	const char *args[] = { NULL, NULL, NULL, NULL, NULL, NULL };
+
+	if (pam_modutil_sanitize_helper_fds(pamh, PAM_MODUTIL_PIPE_FD,
+					    PAM_MODUTIL_PIPE_FD,
+					    PAM_MODUTIL_PIPE_FD) < 0)
+		_exit(PAM_SYSTEM_ERR);
+
+	/* exec the mkhomedir helper */
+	args[0] = MKHOMEDIR_HELPER;
+	args[1] = user;
+	args[2] = opt->umask ? opt->umask : UMASK_DEFAULT;
+	args[3] = opt->skeldir;
+	args[4] = login_homemode;
+
+	DIAG_PUSH_IGNORE_CAST_QUAL;
+	execve(MKHOMEDIR_HELPER, (char **)args, envp);
+	DIAG_POP_IGNORE_CAST_QUAL;
+
+	/* should not get here: exit with error */
+	D(("helper binary is not available"));
+	_exit(PAM_SYSTEM_ERR);
+   } else if (child > 0) {
+	int rc;
+	while ((rc=waitpid(child, &retval, 0)) < 0 && errno == EINTR);
+	if (rc < 0) {
+	  pam_syslog(pamh, LOG_ERR, "waitpid failed: %m");
+	  retval = PAM_SYSTEM_ERR;
+	} else if (!WIFEXITED(retval)) {
+          pam_syslog(pamh, LOG_ERR, "mkhomedir_helper abnormal exit: %d", retval);
+          retval = PAM_SYSTEM_ERR;
+        } else {
+	  retval = WEXITSTATUS(retval);
+	}
+   } else {
+	D(("fork failed"));
+	pam_syslog(pamh, LOG_ERR, "fork failed: %m");
+	retval = PAM_SYSTEM_ERR;
+   }
+
+   sigaction(SIGCHLD, &oldsa, NULL);   /* restore old signal handler */
+
+   if (opt->ctrl & MKHOMEDIR_DEBUG) {
+        pam_syslog(pamh, LOG_DEBUG, "mkhomedir_helper returned %d", retval);
+   }
+
+   if (retval != PAM_SUCCESS && !(opt->ctrl & MKHOMEDIR_QUIET)) {
+	pam_error(pamh, _("Unable to create and initialize directory '%s'."),
+		  dir);
+   }
+
+   free(login_umask);
+   free(login_homemode);
+
+   D(("returning %d", retval));
+   return retval;
+}
+
+/* --- authentication management functions (only) --- */
+
+int
+pam_sm_open_session (pam_handle_t *pamh, int flags, int argc,
+		     const char **argv)
+{
+   int retval;
+   options_t opt;
+   const void *user;
+   const struct passwd *pwd;
+   struct stat St;
+
+   /* Parse the flag values */
+   _pam_parse(pamh, flags, argc, argv, &opt);
+
+   /* Determine the user name so we can get the home directory */
+   retval = pam_get_item(pamh, PAM_USER, &user);
+   if (retval != PAM_SUCCESS || user == NULL || *(const char *)user == '\0')
+   {
+      pam_syslog(pamh, LOG_NOTICE, "Cannot obtain the user name.");
+      return PAM_USER_UNKNOWN;
+   }
+
+   /* Get the password entry */
+   pwd = pam_modutil_getpwnam (pamh, user);
+   if (pwd == NULL)
+   {
+      pam_syslog(pamh, LOG_NOTICE, "User unknown.");
+      D(("couldn't identify user %s", (const char *) user));
+      return PAM_USER_UNKNOWN;
+   }
+
+   /* Stat the home directory, if something exists then we assume it is
+      correct and return a success*/
+   if (stat(pwd->pw_dir, &St) == 0) {
+      if (opt.ctrl & MKHOMEDIR_DEBUG) {
+          pam_syslog(pamh, LOG_DEBUG, "Home directory %s already exists.",
+              pwd->pw_dir);
+      }
+      return PAM_SUCCESS;
+   }
+
+   return create_homedir(pamh, &opt, user, pwd->pw_dir);
+}
+
+/* Ignore */
+int pam_sm_close_session (pam_handle_t * pamh UNUSED, int flags UNUSED,
+			  int argc UNUSED, const char **argv UNUSED)
+{
+   return PAM_SUCCESS;
+}

--- a/pam/integration-tests/pam_mkhomedir/pam_mkhomedir_test.h
+++ b/pam/integration-tests/pam_mkhomedir/pam_mkhomedir_test.h
@@ -1,0 +1,47 @@
+/* Compatibility layer with private definitions coming from upstream PAM
+ * Same license applies here.
+ */
+
+#pragma once
+
+#ifdef AUTHD_TESTS_SSH_USE_AUTHD_NSS
+#include <stdio.h>
+extern char **environ;
+#endif
+
+static inline const char *
+pam_str_skip_prefix(const char *str, const char *prefix)
+{
+  size_t prefix_len = prefix ? strlen (prefix) : 0;
+	return strncmp(str, prefix, prefix_len) ? NULL : str + prefix_len;
+}
+
+static inline char * PAM_FORMAT((printf, 1, 2)) PAM_NONNULL((1)) __attribute__((__malloc__))
+pam_asprintf(const char *fmt, ...)
+{
+	int rc;
+	char *res;
+	va_list ap;
+
+	va_start(ap, fmt);
+	rc = vasprintf(&res, fmt, ap);
+	va_end(ap);
+
+	return rc < 0 ? NULL : res;
+}
+
+#define _(V) V
+#define UNUSED __attribute__((__unused__))
+
+/* argument parsing */
+#define MKHOMEDIR_DEBUG      020	/* be verbose about things */
+#define MKHOMEDIR_QUIET      040	/* keep quiet about things */
+
+#define LOGIN_DEFS           "/etc/login.defs"
+#define UMASK_DEFAULT        "0022"
+
+# define DIAG_PUSH_IGNORE_CAST_QUAL					\
+	_Pragma("GCC diagnostic push");					\
+	_Pragma("GCC diagnostic ignored \"-Wcast-qual\"")
+# define DIAG_POP_IGNORE_CAST_QUAL					\
+	_Pragma("GCC diagnostic pop")

--- a/pam/integration-tests/ssh_test.go
+++ b/pam/integration-tests/ssh_test.go
@@ -248,7 +248,10 @@ Wait`,
 		},
 
 		"Error_if_cannot_connect_to_authd": {
-			tape:                "connection_error",
+			tape: "connection_error",
+			tapeVariables: map[string]string{
+				vhsCommandFinalAuthWaitVariable: `Wait /Password:/`,
+			},
 			socketPath:          "/some-path/not-existent-socket",
 			wantNotLoggedInUser: true,
 		},
@@ -371,13 +374,14 @@ func createSshdServiceFile(t *testing.T, module, execChild, socketPath string) s
 
 	outDir := t.TempDir()
 	pamServiceName := "authd-sshd"
-	moduleControl := "[success=ok new_authtok_reqd=done ignore=2 default=die]"
+	// Keep control values in sync with debian/pam-configs/authd.in.
+	authControl := "[success=ok default=die authinfo_unavail=2 ignore=2]"
 	notifyState := pam_test.ServiceLine{
 		Action: pam_test.Auth, Control: pam_test.Optional, Module: "pam_echo.so",
 		Args: []string{fmt.Sprintf("%s finished for user '%%u'", pam_test.RunnerResultActionAuthenticate.Message(""))},
 	}
 	serviceFile, err := pam_test.CreateService(outDir, pamServiceName, []pam_test.ServiceLine{
-		{Action: pam_test.Auth, Control: pam_test.NewControl(moduleControl), Module: module, Args: moduleArgs},
+		{Action: pam_test.Auth, Control: pam_test.NewControl(authControl), Module: module, Args: moduleArgs},
 		// Success case:
 		notifyState,
 		{Action: pam_test.Auth, Control: pam_test.Sufficient, Module: pam_test.Permit.String()},

--- a/pam/integration-tests/ssh_test.go
+++ b/pam/integration-tests/ssh_test.go
@@ -74,13 +74,12 @@ func testSSHAuthenticate(t *testing.T, sharedSSHd bool) {
 	var sshdPreloaderCFlags []string
 	err = testutils.CanRunRustTests(testutils.CoverDirForTests() != "")
 	if os.Getenv("AUTHD_TESTS_SSH_USE_DUMMY_NSS") == "" && err == nil {
-		nssLibrary, sshdEnv = testutils.BuildRustNSSLib(t, "should_pre_check_env")
+		nssLibrary, sshdEnv = testutils.BuildRustNSSLib(t)
 		sshdPreloadLibraries = append(sshdPreloadLibraries, nssLibrary)
 		sshdPreloaderCFlags = append(sshdPreloaderCFlags,
 			"-DAUTHD_TESTS_SSH_USE_AUTHD_NSS")
 		sshdEnv = append(sshdEnv,
 			"AUTHD_NSS_INFO=stderr",
-			"AUTHD_NSS_SHOULD_PRE_CHECK=true",
 			fmt.Sprintf("LD_LIBRARY_PATH=%s:%s", filepath.Dir(nssLibrary),
 				os.Getenv("LD_LIBRARY_PATH")),
 		)

--- a/pam/integration-tests/ssh_test.go
+++ b/pam/integration-tests/ssh_test.go
@@ -74,7 +74,7 @@ func testSSHAuthenticate(t *testing.T, sharedSSHd bool) {
 	var sshdPreloaderCFlags []string
 	err = testutils.CanRunRustTests(testutils.CoverDirForTests() != "")
 	if os.Getenv("AUTHD_TESTS_SSH_USE_DUMMY_NSS") == "" && err == nil {
-		nssLibrary, sshdEnv = testutils.BuildRustNSSLib(t)
+		nssLibrary, sshdEnv = testutils.BuildRustNSSLib(t, "should_pre_check_env")
 		sshdPreloadLibraries = append(sshdPreloadLibraries, nssLibrary)
 		sshdPreloaderCFlags = append(sshdPreloaderCFlags,
 			"-DAUTHD_TESTS_SSH_USE_AUTHD_NSS")

--- a/pam/integration-tests/ssh_test.go
+++ b/pam/integration-tests/ssh_test.go
@@ -83,9 +83,9 @@ func testSSHAuthenticate(t *testing.T, sharedSSHd bool) {
 	var nssLibrary string
 	var sshdPreloadLibraries []string
 	var sshdPreloaderCFlags []string
-	err = testutils.CanRunRustTests(testutils.CoverDirForTests() != "")
+	err = testutils.CanRunRustTests(false)
 	if os.Getenv("AUTHD_TESTS_SSH_USE_DUMMY_NSS") == "" && err == nil {
-		nssLibrary, sshdEnv = testutils.BuildRustNSSLib(t)
+		nssLibrary, sshdEnv = testutils.BuildRustNSSLib(t, true)
 		sshdPreloadLibraries = append(sshdPreloadLibraries, nssLibrary)
 		sshdPreloaderCFlags = append(sshdPreloaderCFlags,
 			"-DAUTHD_TESTS_SSH_USE_AUTHD_NSS")

--- a/pam/integration-tests/sshd_preloader/sshd_preloader.c
+++ b/pam/integration-tests/sshd_preloader/sshd_preloader.c
@@ -134,16 +134,15 @@ getpwnam (const char *name)
       passwd_entity->pw_shell = AUTHD_TEST_SHELL;
       passwd_entity->pw_gecos = AUTHD_TEST_GECOS;
       passwd_entity->pw_name = (char *) name;
+      passwd_entity->pw_dir = (char *) get_home_path ();
     }
 
   /* We're simulating to be the same user running the test but with another
-   * name and HOME directory, so that we won't touch the user settings, but
-   * it's still enough to trick sshd.
+   * name, so that we won't touch the user settings, but it's still enough to
+   * trick sshd.
    */
   passwd_entity->pw_uid = getuid ();
   passwd_entity->pw_gid = getgid ();
-
-  passwd_entity->pw_dir = (char *) get_home_path ();
 
   fprintf (stderr, "sshd_preloader [%d]: Simulating to be fake user %s (%d:%d)\n",
            getpid (), passwd_entity->pw_name, passwd_entity->pw_uid,

--- a/pam/integration-tests/sshd_preloader/sshd_preloader.c
+++ b/pam/integration-tests/sshd_preloader/sshd_preloader.c
@@ -62,7 +62,7 @@ is_valid_test_user (const char *name)
     return false;
 
   /* Here we accept all the users supported by the example broker */
-  if (strncmp (name, "user", 4) == 0)
+  if (strncmp (name, "user", 4) == 0 && strlen (name) > 4)
     return true;
 
   /* Further special case for the 'r' user */

--- a/pam/integration-tests/sshd_preloader/sshd_preloader.c
+++ b/pam/integration-tests/sshd_preloader/sshd_preloader.c
@@ -24,15 +24,13 @@ static struct passwd passwd_entities[512];
 __attribute__((constructor))
 void constructor (void)
 {
-  fprintf (stderr, "sshd_preloader: Library loaded (parent pid: %d)!\n",
-           getpid ());
+  fprintf (stderr, "sshd_preloader [%d]: Library loaded\n", getpid ());
 }
 
 __attribute__((destructor))
 void destructor (void)
 {
-  fprintf (stderr, "sshd_preloader: Library unloaded (parent pid: %d)!\n",
-           getpid ());
+  fprintf (stderr, "sshd_preloader [%d]: Library unloaded\n", getpid ());
 }
 
 static const char *
@@ -135,8 +133,9 @@ fopen (const char *pathname, const char *mode)
   if (strcmp (pathname, "/etc/pam.d/" AUTHD_DEFAULT_SSH_PAM_SERVICE_NAME) == 0 ||
       strcmp (pathname, "/usr/lib/pam.d/" AUTHD_DEFAULT_SSH_PAM_SERVICE_NAME) == 0)
     {
-      fprintf (stderr, "sshd_preloader: Trying to open '%s', "
-               "but redirecting instead to '%s'\n", pathname, service_path);
+      fprintf (stderr, "sshd_preloader [%d]: Trying to open '%s', "
+               "but redirecting instead to '%s'\n",
+               getpid (), pathname, service_path);
       pathname = service_path;
     }
 

--- a/pam/integration-tests/testdata/golden/TestSSHAuthenticate/Authenticate_user_and_accept_password_reset
+++ b/pam/integration-tests/testdata/golden/TestSSHAuthenticate/Authenticate_user_and_accept_password_reset
@@ -124,6 +124,7 @@ Enter 'r' to cancel the request and go back to choose the provider
 (user-can-reset-integration-pre-check-ssh-authenticate-user-and-accept-password-reset@localhost) Confirm Password:
 >
 PAM Authenticate() finished for user 'user-can-reset-integration-pre-check-ssh-authenticate-user-and-accept-password-reset'
+PAM AcctMgmt() finished for user 'user-can-reset-integration-pre-check-ssh-authenticate-user-and-accept-password-reset'
 Environment:
   USER=user-can-reset-integration-pre-check-ssh-authenticate-user-and-accept-password-reset
   LOGNAME=user-can-reset-integration-pre-check-ssh-authenticate-user-and-accept-password-reset

--- a/pam/integration-tests/testdata/golden/TestSSHAuthenticate/Authenticate_user_and_accept_password_reset_on_shared_SSHd
+++ b/pam/integration-tests/testdata/golden/TestSSHAuthenticate/Authenticate_user_and_accept_password_reset_on_shared_SSHd
@@ -124,6 +124,7 @@ Enter 'r' to cancel the request and go back to choose the provider
 (user-can-reset-integration-pre-check-ssh-authenticate-user-and-accept-password-reset-on-shared-sshd@localhost) Confirm Password:
 >
 PAM Authenticate() finished for user 'user-can-reset-integration-pre-check-ssh-authenticate-user-and-accept-password-reset-on-shared-sshd'
+PAM AcctMgmt() finished for user 'user-can-reset-integration-pre-check-ssh-authenticate-user-and-accept-password-reset-on-shared-sshd'
  SSHD: Connected to ssh via authd module! [TestSSHAuthenticate]
   HOME=${AUTHD_TEST_HOME}
   LOGNAME=user-can-reset-integration-pre-check-ssh-authenticate-user-and-accept-password-reset-on-shared-sshd

--- a/pam/integration-tests/testdata/golden/TestSSHAuthenticate/Authenticate_user_and_add_it_to_local_group
+++ b/pam/integration-tests/testdata/golden/TestSSHAuthenticate/Authenticate_user_and_add_it_to_local_group
@@ -34,6 +34,7 @@ Enter 'r' to cancel the request and go back to select the authentication method
 (user-local-groups-integration-pre-check-ssh-authenticate-user-and-add-it-to-local-group@localhost) Gimme your password:
 >
 PAM Authenticate() finished for user 'user-local-groups-integration-pre-check-ssh-authenticate-user-and-add-it-to-local-group'
+PAM AcctMgmt() finished for user 'user-local-groups-integration-pre-check-ssh-authenticate-user-and-add-it-to-local-group'
 Environment:
   USER=user-local-groups-integration-pre-check-ssh-authenticate-user-and-add-it-to-local-group
   LOGNAME=user-local-groups-integration-pre-check-ssh-authenticate-user-and-add-it-to-local-group

--- a/pam/integration-tests/testdata/golden/TestSSHAuthenticate/Authenticate_user_and_add_it_to_local_group_on_shared_SSHd
+++ b/pam/integration-tests/testdata/golden/TestSSHAuthenticate/Authenticate_user_and_add_it_to_local_group_on_shared_SSHd
@@ -34,6 +34,7 @@ Enter 'r' to cancel the request and go back to select the authentication method
 (user-local-groups-integration-pre-check-ssh-authenticate-user-and-add-it-to-local-group-on-shared-sshd@localhost) Gimme your password:
 >
 PAM Authenticate() finished for user 'user-local-groups-integration-pre-check-ssh-authenticate-user-and-add-it-to-local-group-on-shared-sshd'
+PAM AcctMgmt() finished for user 'user-local-groups-integration-pre-check-ssh-authenticate-user-and-add-it-to-local-group-on-shared-sshd'
 Environment:
   USER=user-local-groups-integration-pre-check-ssh-authenticate-user-and-add-it-to-local-group-on-shared-sshd
   LOGNAME=user-local-groups-integration-pre-check-ssh-authenticate-user-and-add-it-to-local-group-on-shared-sshd

--- a/pam/integration-tests/testdata/golden/TestSSHAuthenticate/Authenticate_user_and_offer_password_reset
+++ b/pam/integration-tests/testdata/golden/TestSSHAuthenticate/Authenticate_user_and_offer_password_reset
@@ -74,6 +74,7 @@ Or enter 'r' to go back to choose the provider
 (user-can-reset-integration-pre-check-ssh-authenticate-user-and-offer-password-reset@localhost) Choose action:
 > 2
 PAM Authenticate() finished for user 'user-can-reset-integration-pre-check-ssh-authenticate-user-and-offer-password-reset'
+PAM AcctMgmt() finished for user 'user-can-reset-integration-pre-check-ssh-authenticate-user-and-offer-password-reset'
 Environment:
   USER=user-can-reset-integration-pre-check-ssh-authenticate-user-and-offer-password-reset
   LOGNAME=user-can-reset-integration-pre-check-ssh-authenticate-user-and-offer-password-reset

--- a/pam/integration-tests/testdata/golden/TestSSHAuthenticate/Authenticate_user_and_offer_password_reset_on_shared_SSHd
+++ b/pam/integration-tests/testdata/golden/TestSSHAuthenticate/Authenticate_user_and_offer_password_reset_on_shared_SSHd
@@ -74,6 +74,7 @@ Or enter 'r' to go back to choose the provider
 (user-can-reset-integration-pre-check-ssh-authenticate-user-and-offer-password-reset-on-shared-sshd@localhost) Choose action:
 > 2
 PAM Authenticate() finished for user 'user-can-reset-integration-pre-check-ssh-authenticate-user-and-offer-password-reset-on-shared-sshd'
+PAM AcctMgmt() finished for user 'user-can-reset-integration-pre-check-ssh-authenticate-user-and-offer-password-reset-on-shared-sshd'
  SSHD: Connected to ssh via authd module! [TestSSHAuthenticate]
   HOME=${AUTHD_TEST_HOME}
   LOGNAME=user-can-reset-integration-pre-check-ssh-authenticate-user-and-offer-password-reset-on-shared-sshd

--- a/pam/integration-tests/testdata/golden/TestSSHAuthenticate/Authenticate_user_and_reset_password_while_enforcing_policy
+++ b/pam/integration-tests/testdata/golden/TestSSHAuthenticate/Authenticate_user_and_reset_password_while_enforcing_policy
@@ -72,6 +72,7 @@ Enter 'r' to cancel the request and go back to choose the provider
 (user-needs-reset-integration-pre-check-ssh-authenticate-user-and-reset-password-while-enforcing-policy@localhost) Confirm Password:
 >
 PAM Authenticate() finished for user 'user-needs-reset-integration-pre-check-ssh-authenticate-user-and-reset-password-while-enforcing-policy'
+PAM AcctMgmt() finished for user 'user-needs-reset-integration-pre-check-ssh-authenticate-user-and-reset-password-while-enforcing-policy'
 Environment:
   USER=user-needs-reset-integration-pre-check-ssh-authenticate-user-and-reset-password-while-enforcing-policy
   LOGNAME=user-needs-reset-integration-pre-check-ssh-authenticate-user-and-reset-password-while-enforcing-policy

--- a/pam/integration-tests/testdata/golden/TestSSHAuthenticate/Authenticate_user_and_reset_password_while_enforcing_policy_on_shared_SSHd
+++ b/pam/integration-tests/testdata/golden/TestSSHAuthenticate/Authenticate_user_and_reset_password_while_enforcing_policy_on_shared_SSHd
@@ -72,6 +72,7 @@ Enter 'r' to cancel the request and go back to choose the provider
 (user-needs-reset-integration-pre-check-ssh-authenticate-user-and-reset-password-while-enforcing-policy-on-shared-sshd@localhost) Confirm Password:
 >
 PAM Authenticate() finished for user 'user-needs-reset-integration-pre-check-ssh-authenticate-user-and-reset-password-while-enforcing-policy-on-shared-sshd'
+PAM AcctMgmt() finished for user 'user-needs-reset-integration-pre-check-ssh-authenticate-user-and-reset-password-while-enforcing-policy-on-shared-sshd'
  SSHD: Connected to ssh via authd module! [TestSSHAuthenticate]
   HOME=${AUTHD_TEST_HOME}
   LOGNAME=user-needs-reset-integration-pre-check-ssh-authenticate-user-and-reset-password-while-enforcing-policy-on-shared-sshd

--- a/pam/integration-tests/testdata/golden/TestSSHAuthenticate/Authenticate_user_successfully
+++ b/pam/integration-tests/testdata/golden/TestSSHAuthenticate/Authenticate_user_successfully
@@ -34,6 +34,7 @@ Enter 'r' to cancel the request and go back to select the authentication method
 (user-integration-pre-check-ssh-authenticate-user-successfully@localhost) Gimme your password:
 >
 PAM Authenticate() finished for user 'user-integration-pre-check-ssh-authenticate-user-successfully'
+PAM AcctMgmt() finished for user 'user-integration-pre-check-ssh-authenticate-user-successfully'
 Environment:
   USER=user-integration-pre-check-ssh-authenticate-user-successfully
   LOGNAME=user-integration-pre-check-ssh-authenticate-user-successfully

--- a/pam/integration-tests/testdata/golden/TestSSHAuthenticate/Authenticate_user_successfully_and_enters_shell
+++ b/pam/integration-tests/testdata/golden/TestSSHAuthenticate/Authenticate_user_successfully_and_enters_shell
@@ -27,6 +27,7 @@ Enter 'r' to cancel the request and go back to select the authentication method
 (user-integration-pre-check-ssh-authenticate-user-successfully-and-enters-shell@localhost) Gimme your password:
 >
 PAM Authenticate() finished for user 'user-integration-pre-check-ssh-authenticate-user-successfully-and-enters-shell'
+PAM AcctMgmt() finished for user 'user-integration-pre-check-ssh-authenticate-user-successfully-and-enters-shell'
 Environment:
   USER=user-integration-pre-check-ssh-authenticate-user-successfully-and-enters-shell
   LOGNAME=user-integration-pre-check-ssh-authenticate-user-successfully-and-enters-shell
@@ -49,6 +50,7 @@ Enter 'r' to cancel the request and go back to select the authentication method
 (user-integration-pre-check-ssh-authenticate-user-successfully-and-enters-shell@localhost) Gimme your password:
 >
 PAM Authenticate() finished for user 'user-integration-pre-check-ssh-authenticate-user-successfully-and-enters-shell'
+PAM AcctMgmt() finished for user 'user-integration-pre-check-ssh-authenticate-user-successfully-and-enters-shell'
 Environment:
   USER=user-integration-pre-check-ssh-authenticate-user-successfully-and-enters-shell
   LOGNAME=user-integration-pre-check-ssh-authenticate-user-successfully-and-enters-shell
@@ -73,6 +75,7 @@ Enter 'r' to cancel the request and go back to select the authentication method
 (user-integration-pre-check-ssh-authenticate-user-successfully-and-enters-shell@localhost) Gimme your password:
 >
 PAM Authenticate() finished for user 'user-integration-pre-check-ssh-authenticate-user-successfully-and-enters-shell'
+PAM AcctMgmt() finished for user 'user-integration-pre-check-ssh-authenticate-user-successfully-and-enters-shell'
 Environment:
   USER=user-integration-pre-check-ssh-authenticate-user-successfully-and-enters-shell
   LOGNAME=user-integration-pre-check-ssh-authenticate-user-successfully-and-enters-shell
@@ -99,6 +102,7 @@ Enter 'r' to cancel the request and go back to select the authentication method
 (user-integration-pre-check-ssh-authenticate-user-successfully-and-enters-shell@localhost) Gimme your password:
 >
 PAM Authenticate() finished for user 'user-integration-pre-check-ssh-authenticate-user-successfully-and-enters-shell'
+PAM AcctMgmt() finished for user 'user-integration-pre-check-ssh-authenticate-user-successfully-and-enters-shell'
 Environment:
   USER=user-integration-pre-check-ssh-authenticate-user-successfully-and-enters-shell
   LOGNAME=user-integration-pre-check-ssh-authenticate-user-successfully-and-enters-shell
@@ -127,6 +131,7 @@ Enter 'r' to cancel the request and go back to select the authentication method
 (user-integration-pre-check-ssh-authenticate-user-successfully-and-enters-shell@localhost) Gimme your password:
 >
 PAM Authenticate() finished for user 'user-integration-pre-check-ssh-authenticate-user-successfully-and-enters-shell'
+PAM AcctMgmt() finished for user 'user-integration-pre-check-ssh-authenticate-user-successfully-and-enters-shell'
 Environment:
   USER=user-integration-pre-check-ssh-authenticate-user-successfully-and-enters-shell
   LOGNAME=user-integration-pre-check-ssh-authenticate-user-successfully-and-enters-shell

--- a/pam/integration-tests/testdata/golden/TestSSHAuthenticate/Authenticate_user_successfully_and_enters_shell_on_shared_SSHd
+++ b/pam/integration-tests/testdata/golden/TestSSHAuthenticate/Authenticate_user_successfully_and_enters_shell_on_shared_SSHd
@@ -27,6 +27,7 @@ Enter 'r' to cancel the request and go back to select the authentication method
 (user-integration-pre-check-ssh-authenticate-user-successfully-and-enters-shell-on-shared-sshd@localhost) Gimme your password:
 >
 PAM Authenticate() finished for user 'user-integration-pre-check-ssh-authenticate-user-successfully-and-enters-shell-on-shared-sshd'
+PAM AcctMgmt() finished for user 'user-integration-pre-check-ssh-authenticate-user-successfully-and-enters-shell-on-shared-sshd'
 Environment:
   USER=user-integration-pre-check-ssh-authenticate-user-successfully-and-enters-shell-on-shared-sshd
   LOGNAME=user-integration-pre-check-ssh-authenticate-user-successfully-and-enters-shell-on-shared-sshd
@@ -49,6 +50,7 @@ Enter 'r' to cancel the request and go back to select the authentication method
 (user-integration-pre-check-ssh-authenticate-user-successfully-and-enters-shell-on-shared-sshd@localhost) Gimme your password:
 >
 PAM Authenticate() finished for user 'user-integration-pre-check-ssh-authenticate-user-successfully-and-enters-shell-on-shared-sshd'
+PAM AcctMgmt() finished for user 'user-integration-pre-check-ssh-authenticate-user-successfully-and-enters-shell-on-shared-sshd'
 Environment:
   USER=user-integration-pre-check-ssh-authenticate-user-successfully-and-enters-shell-on-shared-sshd
   LOGNAME=user-integration-pre-check-ssh-authenticate-user-successfully-and-enters-shell-on-shared-sshd
@@ -73,6 +75,7 @@ Enter 'r' to cancel the request and go back to select the authentication method
 (user-integration-pre-check-ssh-authenticate-user-successfully-and-enters-shell-on-shared-sshd@localhost) Gimme your password:
 >
 PAM Authenticate() finished for user 'user-integration-pre-check-ssh-authenticate-user-successfully-and-enters-shell-on-shared-sshd'
+PAM AcctMgmt() finished for user 'user-integration-pre-check-ssh-authenticate-user-successfully-and-enters-shell-on-shared-sshd'
 Environment:
   USER=user-integration-pre-check-ssh-authenticate-user-successfully-and-enters-shell-on-shared-sshd
   LOGNAME=user-integration-pre-check-ssh-authenticate-user-successfully-and-enters-shell-on-shared-sshd
@@ -99,6 +102,7 @@ Enter 'r' to cancel the request and go back to select the authentication method
 (user-integration-pre-check-ssh-authenticate-user-successfully-and-enters-shell-on-shared-sshd@localhost) Gimme your password:
 >
 PAM Authenticate() finished for user 'user-integration-pre-check-ssh-authenticate-user-successfully-and-enters-shell-on-shared-sshd'
+PAM AcctMgmt() finished for user 'user-integration-pre-check-ssh-authenticate-user-successfully-and-enters-shell-on-shared-sshd'
 Environment:
   USER=user-integration-pre-check-ssh-authenticate-user-successfully-and-enters-shell-on-shared-sshd
   LOGNAME=user-integration-pre-check-ssh-authenticate-user-successfully-and-enters-shell-on-shared-sshd
@@ -127,6 +131,7 @@ Enter 'r' to cancel the request and go back to select the authentication method
 (user-integration-pre-check-ssh-authenticate-user-successfully-and-enters-shell-on-shared-sshd@localhost) Gimme your password:
 >
 PAM Authenticate() finished for user 'user-integration-pre-check-ssh-authenticate-user-successfully-and-enters-shell-on-shared-sshd'
+PAM AcctMgmt() finished for user 'user-integration-pre-check-ssh-authenticate-user-successfully-and-enters-shell-on-shared-sshd'
 Environment:
   USER=user-integration-pre-check-ssh-authenticate-user-successfully-and-enters-shell-on-shared-sshd
   LOGNAME=user-integration-pre-check-ssh-authenticate-user-successfully-and-enters-shell-on-shared-sshd

--- a/pam/integration-tests/testdata/golden/TestSSHAuthenticate/Authenticate_user_successfully_on_shared_SSHd
+++ b/pam/integration-tests/testdata/golden/TestSSHAuthenticate/Authenticate_user_successfully_on_shared_SSHd
@@ -34,6 +34,7 @@ Enter 'r' to cancel the request and go back to select the authentication method
 (user-integration-pre-check-ssh-authenticate-user-successfully-on-shared-sshd@localhost) Gimme your password:
 >
 PAM Authenticate() finished for user 'user-integration-pre-check-ssh-authenticate-user-successfully-on-shared-sshd'
+PAM AcctMgmt() finished for user 'user-integration-pre-check-ssh-authenticate-user-successfully-on-shared-sshd'
  SSHD: Connected to ssh via authd module! [TestSSHAuthenticate]
   HOME=${AUTHD_TEST_HOME}
   LOGNAME=user-integration-pre-check-ssh-authenticate-user-successfully-on-shared-sshd

--- a/pam/integration-tests/testdata/golden/TestSSHAuthenticate/Authenticate_user_switching_auth_mode
+++ b/pam/integration-tests/testdata/golden/TestSSHAuthenticate/Authenticate_user_switching_auth_mode
@@ -3527,6 +3527,7 @@ Enter 'r' to cancel the request and go back to select the authentication method
 (user-integration-pre-check-ssh-authenticate-user-switching-auth-mode@localhost) Enter your pin code:
 > 4242
 PAM Authenticate() finished for user 'user-integration-pre-check-ssh-authenticate-user-switching-auth-mode'
+PAM AcctMgmt() finished for user 'user-integration-pre-check-ssh-authenticate-user-switching-auth-mode'
 Environment:
   USER=user-integration-pre-check-ssh-authenticate-user-switching-auth-mode
   LOGNAME=user-integration-pre-check-ssh-authenticate-user-switching-auth-mode

--- a/pam/integration-tests/testdata/golden/TestSSHAuthenticate/Authenticate_user_switching_auth_mode_on_shared_SSHd
+++ b/pam/integration-tests/testdata/golden/TestSSHAuthenticate/Authenticate_user_switching_auth_mode_on_shared_SSHd
@@ -3527,6 +3527,7 @@ Enter 'r' to cancel the request and go back to select the authentication method
 (user-integration-pre-check-ssh-authenticate-user-switching-auth-mode-on-shared-sshd@localhost) Enter your pin code:
 > 4242
 PAM Authenticate() finished for user 'user-integration-pre-check-ssh-authenticate-user-switching-auth-mode-on-shared-sshd'
+PAM AcctMgmt() finished for user 'user-integration-pre-check-ssh-authenticate-user-switching-auth-mode-on-shared-sshd'
  SSHD: Connected to ssh via authd module! [TestSSHAuthenticate]
   HOME=${AUTHD_TEST_HOME}
   LOGNAME=user-integration-pre-check-ssh-authenticate-user-switching-auth-mode-on-shared-sshd

--- a/pam/integration-tests/testdata/golden/TestSSHAuthenticate/Authenticate_user_with_form_mode_with_button
+++ b/pam/integration-tests/testdata/golden/TestSSHAuthenticate/Authenticate_user_with_form_mode_with_button
@@ -314,6 +314,7 @@ Enter 'r' to cancel the request and go back to select the authentication method
 (user-integration-pre-check-ssh-authenticate-user-with-form-mode-with-button@localhost) Enter your one time credential:
 > temporary pass00
 PAM Authenticate() finished for user 'user-integration-pre-check-ssh-authenticate-user-with-form-mode-with-button'
+PAM AcctMgmt() finished for user 'user-integration-pre-check-ssh-authenticate-user-with-form-mode-with-button'
 Environment:
   USER=user-integration-pre-check-ssh-authenticate-user-with-form-mode-with-button
   LOGNAME=user-integration-pre-check-ssh-authenticate-user-with-form-mode-with-button

--- a/pam/integration-tests/testdata/golden/TestSSHAuthenticate/Authenticate_user_with_form_mode_with_button_on_shared_SSHd
+++ b/pam/integration-tests/testdata/golden/TestSSHAuthenticate/Authenticate_user_with_form_mode_with_button_on_shared_SSHd
@@ -314,6 +314,7 @@ Enter 'r' to cancel the request and go back to select the authentication method
 (user-integration-pre-check-ssh-authenticate-user-with-form-mode-with-button-on-shared-sshd@localhost) Enter your one time credential:
 > temporary pass00
 PAM Authenticate() finished for user 'user-integration-pre-check-ssh-authenticate-user-with-form-mode-with-button-on-shared-sshd'
+PAM AcctMgmt() finished for user 'user-integration-pre-check-ssh-authenticate-user-with-form-mode-with-button-on-shared-sshd'
  SSHD: Connected to ssh via authd module! [TestSSHAuthenticate]
   HOME=${AUTHD_TEST_HOME}
   LOGNAME=user-integration-pre-check-ssh-authenticate-user-with-form-mode-with-button-on-shared-sshd

--- a/pam/integration-tests/testdata/golden/TestSSHAuthenticate/Authenticate_user_with_mfa
+++ b/pam/integration-tests/testdata/golden/TestSSHAuthenticate/Authenticate_user_with_mfa
@@ -473,6 +473,7 @@ Press Enter to wait for authentication or enter 'r' to go back to select the aut
 (user-mfa-integration-pre-check-ssh-authenticate-user-with-mfa@localhost) Plug your fido device and press with your thumb:
 >
 PAM Authenticate() finished for user 'user-mfa-integration-pre-check-ssh-authenticate-user-with-mfa'
+PAM AcctMgmt() finished for user 'user-mfa-integration-pre-check-ssh-authenticate-user-with-mfa'
 Environment:
   USER=user-mfa-integration-pre-check-ssh-authenticate-user-with-mfa
   LOGNAME=user-mfa-integration-pre-check-ssh-authenticate-user-with-mfa

--- a/pam/integration-tests/testdata/golden/TestSSHAuthenticate/Authenticate_user_with_mfa_and_reset_password_while_enforcing_policy
+++ b/pam/integration-tests/testdata/golden/TestSSHAuthenticate/Authenticate_user_with_mfa_and_reset_password_while_enforcing_policy
@@ -349,6 +349,7 @@ Enter 'r' to cancel the request and go back to choose the provider
 (user-mfa-with-reset-integration-pre-check-ssh-authenticate-user-with-mfa-and-reset-password-while-enforcing-policy@localhost) Confirm Password:
 >
 PAM Authenticate() finished for user 'user-mfa-with-reset-integration-pre-check-ssh-authenticate-user-with-mfa-and-reset-password-while-enforcing-policy'
+PAM AcctMgmt() finished for user 'user-mfa-with-reset-integration-pre-check-ssh-authenticate-user-with-mfa-and-reset-password-while-enforcing-policy'
 Environment:
   USER=user-mfa-with-reset-integration-pre-check-ssh-authenticate-user-with-mfa-and-reset-password-while-enforcing-policy
   LOGNAME=user-mfa-with-reset-integration-pre-check-ssh-authenticate-user-with-mfa-and-reset-password-while-enforcing-policy

--- a/pam/integration-tests/testdata/golden/TestSSHAuthenticate/Authenticate_user_with_mfa_and_reset_password_while_enforcing_policy_on_shared_SSHd
+++ b/pam/integration-tests/testdata/golden/TestSSHAuthenticate/Authenticate_user_with_mfa_and_reset_password_while_enforcing_policy_on_shared_SSHd
@@ -349,6 +349,7 @@ Enter 'r' to cancel the request and go back to choose the provider
 (user-mfa-with-reset-integration-pre-check-ssh-authenticate-user-with-mfa-and-reset-password-while-enforcing-policy-on-shared-sshd@localhost) Confirm Password:
 >
 PAM Authenticate() finished for user 'user-mfa-with-reset-integration-pre-check-ssh-authenticate-user-with-mfa-and-reset-password-while-enforcing-policy-on-shared-sshd'
+PAM AcctMgmt() finished for user 'user-mfa-with-reset-integration-pre-check-ssh-authenticate-user-with-mfa-and-reset-password-while-enforcing-policy-on-shared-sshd'
  SSHD: Connected to ssh via authd module! [TestSSHAuthenticate]
   HOME=${AUTHD_TEST_HOME}
   LOGNAME=user-mfa-with-reset-integration-pre-check-ssh-authenticate-user-with-mfa-and-reset-password-while-enforcing-policy-on-shared-sshd

--- a/pam/integration-tests/testdata/golden/TestSSHAuthenticate/Authenticate_user_with_mfa_on_shared_SSHd
+++ b/pam/integration-tests/testdata/golden/TestSSHAuthenticate/Authenticate_user_with_mfa_on_shared_SSHd
@@ -473,6 +473,7 @@ Press Enter to wait for authentication or enter 'r' to go back to select the aut
 (user-mfa-integration-pre-check-ssh-authenticate-user-with-mfa-on-shared-sshd@localhost) Plug your fido device and press with your thumb:
 >
 PAM Authenticate() finished for user 'user-mfa-integration-pre-check-ssh-authenticate-user-with-mfa-on-shared-sshd'
+PAM AcctMgmt() finished for user 'user-mfa-integration-pre-check-ssh-authenticate-user-with-mfa-on-shared-sshd'
  SSHD: Connected to ssh via authd module! [TestSSHAuthenticate]
   HOME=${AUTHD_TEST_HOME}
   LOGNAME=user-mfa-integration-pre-check-ssh-authenticate-user-with-mfa-on-shared-sshd

--- a/pam/integration-tests/testdata/golden/TestSSHAuthenticate/Authenticate_user_with_qr_code
+++ b/pam/integration-tests/testdata/golden/TestSSHAuthenticate/Authenticate_user_with_qr_code
@@ -672,6 +672,7 @@ Or enter 'r' to go back to select the authentication method
 (user-integration-pre-check-ssh-authenticate-user-with-qr-code@localhost) Choose action:
 > 1
 PAM Authenticate() finished for user 'user-integration-pre-check-ssh-authenticate-user-with-qr-code'
+PAM AcctMgmt() finished for user 'user-integration-pre-check-ssh-authenticate-user-with-qr-code'
 Environment:
   USER=user-integration-pre-check-ssh-authenticate-user-with-qr-code
   LOGNAME=user-integration-pre-check-ssh-authenticate-user-with-qr-code

--- a/pam/integration-tests/testdata/golden/TestSSHAuthenticate/Authenticate_user_with_qr_code_on_shared_SSHd
+++ b/pam/integration-tests/testdata/golden/TestSSHAuthenticate/Authenticate_user_with_qr_code_on_shared_SSHd
@@ -672,6 +672,7 @@ Or enter 'r' to go back to select the authentication method
 (user-integration-pre-check-ssh-authenticate-user-with-qr-code-on-shared-sshd@localhost) Choose action:
 > 1
 PAM Authenticate() finished for user 'user-integration-pre-check-ssh-authenticate-user-with-qr-code-on-shared-sshd'
+PAM AcctMgmt() finished for user 'user-integration-pre-check-ssh-authenticate-user-with-qr-code-on-shared-sshd'
  SSHD: Connected to ssh via authd module! [TestSSHAuthenticate]
   HOME=${AUTHD_TEST_HOME}
   LOGNAME=user-integration-pre-check-ssh-authenticate-user-with-qr-code-on-shared-sshd

--- a/pam/integration-tests/testdata/golden/TestSSHAuthenticate/Deny_authentication_if_newpassword_does_not_match_required_criteria
+++ b/pam/integration-tests/testdata/golden/TestSSHAuthenticate/Deny_authentication_if_newpassword_does_not_match_required_criteria
@@ -312,6 +312,7 @@ Enter 'r' to cancel the request and go back to choose the provider
 (user-needs-reset-integration-pre-check-ssh-deny-authentication-if-newpassword-does-not-match-required-criteria@localhost) Confirm Password:
 >
 PAM Authenticate() finished for user 'user-needs-reset-integration-pre-check-ssh-deny-authentication-if-newpassword-does-not-match-required-criteria'
+PAM AcctMgmt() finished for user 'user-needs-reset-integration-pre-check-ssh-deny-authentication-if-newpassword-does-not-match-required-criteria'
 Environment:
   USER=user-needs-reset-integration-pre-check-ssh-deny-authentication-if-newpassword-does-not-match-required-criteria
   LOGNAME=user-needs-reset-integration-pre-check-ssh-deny-authentication-if-newpassword-does-not-match-required-criteria

--- a/pam/integration-tests/testdata/golden/TestSSHAuthenticate/Deny_authentication_if_newpassword_does_not_match_required_criteria_on_shared_SSHd
+++ b/pam/integration-tests/testdata/golden/TestSSHAuthenticate/Deny_authentication_if_newpassword_does_not_match_required_criteria_on_shared_SSHd
@@ -312,6 +312,7 @@ Enter 'r' to cancel the request and go back to choose the provider
 (user-needs-reset-integration-pre-check-ssh-deny-authentication-if-newpassword-does-not-match-required-criteria-on-shared-sshd@localhost) Confirm Password:
 >
 PAM Authenticate() finished for user 'user-needs-reset-integration-pre-check-ssh-deny-authentication-if-newpassword-does-not-match-required-criteria-on-shared-sshd'
+PAM AcctMgmt() finished for user 'user-needs-reset-integration-pre-check-ssh-deny-authentication-if-newpassword-does-not-match-required-criteria-on-shared-sshd'
  SSHD: Connected to ssh via authd module! [TestSSHAuthenticate]
   HOME=${AUTHD_TEST_HOME}
   LOGNAME=user-needs-reset-integration-pre-check-ssh-deny-authentication-if-newpassword-does-not-match-required-criteria-on-shared-sshd

--- a/pam/integration-tests/testdata/golden/TestSSHAuthenticate/Error_if_cannot_connect_to_authd
+++ b/pam/integration-tests/testdata/golden/TestSSHAuthenticate/Error_if_cannot_connect_to_authd
@@ -2,7 +2,7 @@
 ────────────────────────────────────────────────────────────────────────────────
 > ssh ${AUTHD_PAM_SSH_USER}@localhost ${AUTHD_PAM_SSH_ARGS}
 could not connect to unix:///some-path/not-existent-socket: service took too long to respond. Disconnecting client
-Received disconnect from ${SSH_HOST} port ${SSH_PORT} Too many authentication failures
-Disconnected from ${SSH_HOST} port ${SSH_PORT}
->
+PAM Authenticate() finished for user 'user-integration-pre-check-ssh-error-if-cannot-connect-to-authd'
+SSH PAM user 'user-integration-pre-check-ssh-error-if-cannot-connect-to-authd' using local broker
+(user-integration-pre-check-ssh-error-if-cannot-connect-to-authd@localhost) Password:
 ────────────────────────────────────────────────────────────────────────────────

--- a/pam/integration-tests/testdata/golden/TestSSHAuthenticate/Error_if_cannot_connect_to_authd_on_shared_SSHd
+++ b/pam/integration-tests/testdata/golden/TestSSHAuthenticate/Error_if_cannot_connect_to_authd_on_shared_SSHd
@@ -2,7 +2,7 @@
 ────────────────────────────────────────────────────────────────────────────────
 > ssh ${AUTHD_PAM_SSH_USER}@localhost ${AUTHD_PAM_SSH_ARGS}
 could not connect to unix:///some-path/not-existent-socket: service took too long to respond. Disconnecting client
-Received disconnect from ${SSH_HOST} port ${SSH_PORT} Too many authentication failures
-Disconnected from ${SSH_HOST} port ${SSH_PORT}
->
+PAM Authenticate() finished for user 'user-integration-pre-check-ssh-error-if-cannot-connect-to-authd-on-shared-sshd'
+SSH PAM user 'user-integration-pre-check-ssh-error-if-cannot-connect-to-authd-on-shared-sshd' using local broker
+(user-integration-pre-check-ssh-error-if-cannot-connect-to-authd-on-shared-sshd@localhost) Password:
 ────────────────────────────────────────────────────────────────────────────────

--- a/pam/integration-tests/testdata/golden/TestSSHAuthenticate/Prevent_user_from_switching_username
+++ b/pam/integration-tests/testdata/golden/TestSSHAuthenticate/Prevent_user_from_switching_username
@@ -384,6 +384,7 @@ Enter 'r' to cancel the request and go back to select the authentication method
 (user-integration-pre-check-ssh-prevent-user-from-switching-username@localhost) Gimme your password:
 >
 PAM Authenticate() finished for user 'user-integration-pre-check-ssh-prevent-user-from-switching-username'
+PAM AcctMgmt() finished for user 'user-integration-pre-check-ssh-prevent-user-from-switching-username'
 Environment:
   USER=user-integration-pre-check-ssh-prevent-user-from-switching-username
   LOGNAME=user-integration-pre-check-ssh-prevent-user-from-switching-username

--- a/pam/integration-tests/testdata/golden/TestSSHAuthenticate/Prevent_user_from_switching_username_on_shared_SSHd
+++ b/pam/integration-tests/testdata/golden/TestSSHAuthenticate/Prevent_user_from_switching_username_on_shared_SSHd
@@ -384,6 +384,7 @@ Enter 'r' to cancel the request and go back to select the authentication method
 (user-integration-pre-check-ssh-prevent-user-from-switching-username-on-shared-sshd@localhost) Gimme your password:
 >
 PAM Authenticate() finished for user 'user-integration-pre-check-ssh-prevent-user-from-switching-username-on-shared-sshd'
+PAM AcctMgmt() finished for user 'user-integration-pre-check-ssh-prevent-user-from-switching-username-on-shared-sshd'
  SSHD: Connected to ssh via authd module! [TestSSHAuthenticate]
   HOME=${AUTHD_TEST_HOME}
   LOGNAME=user-integration-pre-check-ssh-prevent-user-from-switching-username-on-shared-sshd

--- a/pam/integration-tests/testdata/golden/TestSSHAuthenticate/Remember_last_successful_broker_and_mode
+++ b/pam/integration-tests/testdata/golden/TestSSHAuthenticate/Remember_last_successful_broker_and_mode
@@ -197,6 +197,7 @@ Enter 'r' to cancel the request and go back to select the authentication method
 (user-integration-pre-check-ssh-remember-last-successful-broker-and-mode@localhost) Enter your one time credential:
 > temporary pass0
 PAM Authenticate() finished for user 'user-integration-pre-check-ssh-remember-last-successful-broker-and-mode'
+PAM AcctMgmt() finished for user 'user-integration-pre-check-ssh-remember-last-successful-broker-and-mode'
  SSHD: Connected to ssh via authd module! [TestSSHAuthenticate/Remember_last_successful_broker_and_mode]
   HOME=${AUTHD_TEST_HOME}
   LOGNAME=user-integration-pre-check-ssh-remember-last-successful-broker-and-mode
@@ -259,6 +260,7 @@ Enter 'r' to cancel the request and go back to select the authentication method
 (user-integration-pre-check-ssh-remember-last-successful-broker-and-mode@localhost) Enter your one time credential:
 > temporary pass0
 PAM Authenticate() finished for user 'user-integration-pre-check-ssh-remember-last-successful-broker-and-mode'
+PAM AcctMgmt() finished for user 'user-integration-pre-check-ssh-remember-last-successful-broker-and-mode'
  SSHD: Connected to ssh via authd module! [TestSSHAuthenticate/Remember_last_successful_broker_and_mode]
   HOME=${AUTHD_TEST_HOME}
   LOGNAME=user-integration-pre-check-ssh-remember-last-successful-broker-and-mode

--- a/pam/integration-tests/testdata/golden/TestSSHAuthenticate/Remember_last_successful_broker_and_mode_on_shared_SSHd
+++ b/pam/integration-tests/testdata/golden/TestSSHAuthenticate/Remember_last_successful_broker_and_mode_on_shared_SSHd
@@ -197,6 +197,7 @@ Enter 'r' to cancel the request and go back to select the authentication method
 (user-integration-pre-check-ssh-remember-last-successful-broker-and-mode-on-shared-sshd@localhost) Enter your one time credential:
 > temporary pass0
 PAM Authenticate() finished for user 'user-integration-pre-check-ssh-remember-last-successful-broker-and-mode-on-shared-sshd'
+PAM AcctMgmt() finished for user 'user-integration-pre-check-ssh-remember-last-successful-broker-and-mode-on-shared-sshd'
  SSHD: Connected to ssh via authd module! [TestSSHAuthenticate]
   HOME=${AUTHD_TEST_HOME}
   LOGNAME=user-integration-pre-check-ssh-remember-last-successful-broker-and-mode-on-shared-sshd
@@ -259,6 +260,7 @@ Enter 'r' to cancel the request and go back to select the authentication method
 (user-integration-pre-check-ssh-remember-last-successful-broker-and-mode-on-shared-sshd@localhost) Enter your one time credential:
 > temporary pass0
 PAM Authenticate() finished for user 'user-integration-pre-check-ssh-remember-last-successful-broker-and-mode-on-shared-sshd'
+PAM AcctMgmt() finished for user 'user-integration-pre-check-ssh-remember-last-successful-broker-and-mode-on-shared-sshd'
  SSHD: Connected to ssh via authd module! [TestSSHAuthenticate]
   HOME=${AUTHD_TEST_HOME}
   LOGNAME=user-integration-pre-check-ssh-remember-last-successful-broker-and-mode-on-shared-sshd

--- a/pam/integration-tests/testdata/tapes/native/connection_error.tape
+++ b/pam/integration-tests/testdata/tapes/native/connection_error.tape
@@ -5,5 +5,5 @@ Show
 Hide
 Enter
 Wait+Screen /could not connect to unix:[^\n]+/
-Wait
+${AUTHD_TEST_TAPE_COMMAND_AUTH_FINAL_WAIT}
 Show


### PR DESCRIPTION
In our SSH integration tests we’re already quite close to check reality, but we’re currently mocking the broker behavior when it comes to perform the NSS queries.

Given that we already had most of the pieces setup, using our NSS module was an exercise for the reader.
Now it's time to implement it so that:
- The authd NSS library is used to get passwd elements from 
- The authd NSS library does precheck when sshd is the parent 
- Bonus point: user homes are created via `pam_mkhomedir.so` as we do in reality