### PR TITLE
Run `cargo fmt`

### DIFF
--- a/nss/src/passwd/mod.rs
+++ b/nss/src/passwd/mod.rs
@@ -115,7 +115,11 @@ fn get_entry_by_name(name: String) -> Response<Passwd> {
         }
 
         #[cfg(feature = "integration_tests")]
-        info!("Get entry by name '{}' (pre-check: {})", name, should_pre_check());
+        info!(
+            "Get entry by name '{}' (pre-check: {})",
+            name,
+            should_pre_check()
+        );
 
         let mut req = Request::new(authd::GetPasswdByNameRequest {
             name: name.clone(),


### PR DESCRIPTION
https://github.com/ubuntu/authd/pull/864 introduced some Rust formatting which does not adhere to the rustfmt style.

That was not caught by the "Rust: Code sanity" job, which should be fixed by  https://github.com/canonical/desktop-engineering/pull/67.