### PR TITLE
pam: Use safer handler for debugging bubble tea messages without disclosing information

### DIFF
--- a/pam/internal/adapter/authentication.go
+++ b/pam/internal/adapter/authentication.go
@@ -196,32 +196,32 @@ func (m authenticationModel) Update(msg tea.Msg) (authModel authenticationModel,
 		if msg.Stage != pam_proto.Stage_challenge {
 			return m, nil
 		}
-		log.Debugf(context.TODO(), "%#v, in progress %v, focused: %v",
-			msg, m.inProgress, m.Focused())
+		safeMessageDebug(msg, "in progress %v, focused: %v",
+			m.inProgress, m.Focused())
 		if m.inProgress || !m.Focused() {
 			return m, nil
 		}
 		return m, sendEvent(startAuthentication{})
 
 	case startAuthentication:
-		log.Debugf(context.TODO(), "%#v: current model %v, focused %v",
-			msg, m.currentModel, m.Focused())
+		safeMessageDebug(msg, "current model %v, focused %v",
+			m.currentModel, m.Focused())
 		if !m.Focused() {
 			return m, nil
 		}
 		m.inProgress = true
 
 	case stopAuthentication:
-		log.Debugf(context.TODO(), "%#v: current model %v, focused %v",
-			msg, m.currentModel, m.Focused())
+		safeMessageDebug(msg, "current model %v, focused %v",
+			m.currentModel, m.Focused())
 		m.inProgress = false
 
 	case reselectAuthMode:
-		log.Debugf(context.TODO(), "%#v", msg)
+		safeMessageDebug(msg)
 		return m, tea.Sequence(m.cancelIsAuthenticated(), sendEvent(AuthModeSelected{}))
 
 	case newPasswordCheck:
-		log.Debugf(context.TODO(), "%T", msg)
+		safeMessageDebug(msg)
 		currentSecret := m.currentSecret
 		return m, func() tea.Msg {
 			res := newPasswordCheckResult{ctx: msg.ctx, password: msg.password}
@@ -232,7 +232,7 @@ func (m authenticationModel) Update(msg tea.Msg) (authModel authenticationModel,
 		}
 
 	case newPasswordCheckResult:
-		log.Debugf(msg.ctx, "%T: %s", msg, msg.msg)
+		safeMessageDebug(msg)
 		if m.clientType != Gdm {
 			// This may be handled by the current model, so don't return early.
 			break
@@ -261,7 +261,7 @@ func (m authenticationModel) Update(msg tea.Msg) (authModel authenticationModel,
 		})
 
 	case isAuthenticatedRequested:
-		log.Debugf(context.TODO(), "%#v", msg)
+		safeMessageDebug(msg)
 
 		authTracker := m.authTracker
 
@@ -294,7 +294,7 @@ func (m authenticationModel) Update(msg tea.Msg) (authModel authenticationModel,
 		}
 
 	case isAuthenticatedRequestedSend:
-		log.Debugf(context.TODO(), "%#v", msg)
+		safeMessageDebug(msg)
 		// no password value, pass it as is
 		plainTextSecret, err := msg.encryptSecretIfPresent(m.encryptionKey)
 		if err != nil {
@@ -304,11 +304,11 @@ func (m authenticationModel) Update(msg tea.Msg) (authModel authenticationModel,
 		return m, sendIsAuthenticated(msg.ctx, m.client, m.currentSessionID, &authd.IARequest_AuthenticationData{Item: msg.item}, plainTextSecret)
 
 	case isAuthenticatedCancelled:
-		log.Debugf(context.TODO(), "%#v", msg)
+		safeMessageDebug(msg)
 		return m, m.cancelIsAuthenticated()
 
 	case isAuthenticatedResultReceived:
-		log.Debugf(context.TODO(), "%#v", msg)
+		safeMessageDebug(msg)
 
 		// Resets password if the authentication wasn't successful.
 		defer func() {

--- a/pam/internal/adapter/authmodeselection.go
+++ b/pam/internal/adapter/authmodeselection.go
@@ -108,7 +108,7 @@ func (m authModeSelectionModel) Update(msg tea.Msg) (authModeSelectionModel, tea
 			return m, nil
 		}
 
-		log.Debugf(context.TODO(), "%#v, autoselect: %q", msg, m.autoSelectedAuthModeID)
+		safeMessageDebug(msg, "autoselect: %q", m.autoSelectedAuthModeID)
 
 		if m.autoSelectedAuthModeID != "" {
 			authMode := m.autoSelectedAuthModeID
@@ -117,7 +117,7 @@ func (m authModeSelectionModel) Update(msg tea.Msg) (authModeSelectionModel, tea
 		}
 
 	case supportedUILayoutsReceived:
-		log.Debugf(context.TODO(), "%#v", msg)
+		safeMessageDebug(msg)
 		if len(msg.layouts) == 0 {
 			return m, sendEvent(pamError{
 				status: pam.ErrCredUnavail,
@@ -128,7 +128,7 @@ func (m authModeSelectionModel) Update(msg tea.Msg) (authModeSelectionModel, tea
 		return m, sendEvent(supportedUILayoutsSet{})
 
 	case authModesReceived:
-		log.Debugf(context.TODO(), "%#v", msg)
+		safeMessageDebug(msg)
 		m.availableAuthModes = msg.authModes
 
 		var allAuthModes []tea_list.Item
@@ -159,12 +159,12 @@ func (m authModeSelectionModel) Update(msg tea.Msg) (authModeSelectionModel, tea
 			return m, nil
 		}
 
-		log.Debugf(context.TODO(), "%#v", msg)
+		safeMessageDebug(msg)
 		authMode := convertTo[authModeItem](msg.item)
 		return m, selectAuthMode(authMode.id)
 
 	case authModeSelected:
-		log.Debugf(context.TODO(), "%#v", msg)
+		safeMessageDebug(msg)
 		// Ensure auth mode id is valid
 		if !validAuthModeID(msg.id, m.availableAuthModes) {
 			log.Infof(context.TODO(), "authentication mode %q is not part of currently available authentication mode", msg.id)

--- a/pam/internal/adapter/brokerselection.go
+++ b/pam/internal/adapter/brokerselection.go
@@ -63,7 +63,7 @@ func (m brokerSelectionModel) Update(msg tea.Msg) (brokerSelectionModel, tea.Cmd
 		return m, getAvailableBrokers(m.client)
 
 	case brokersListReceived:
-		log.Debugf(context.TODO(), "%#v", msg)
+		safeMessageDebug(msg)
 		if len(msg.brokers) == 0 {
 			return m, sendEvent(pamError{
 				status: pam.ErrAuthinfoUnavail,
@@ -86,7 +86,7 @@ func (m brokerSelectionModel) Update(msg tea.Msg) (brokerSelectionModel, tea.Cmd
 		return m, tea.Batch(cmds...)
 
 	case brokerSelectionRequired:
-		log.Debugf(context.TODO(), "%#v", msg)
+		safeMessageDebug(msg)
 		return m, sendEvent(ChangeStage{Stage: proto.Stage_brokerSelection})
 
 	case listItemSelected:
@@ -94,12 +94,12 @@ func (m brokerSelectionModel) Update(msg tea.Msg) (brokerSelectionModel, tea.Cmd
 			return m, nil
 		}
 
-		log.Debugf(context.TODO(), "%#v", msg)
+		safeMessageDebug(msg)
 		broker := convertTo[brokerItem](msg.item)
 		return m, selectBroker(broker.id)
 
 	case brokerSelected:
-		log.Debugf(context.TODO(), "%#v", msg)
+		safeMessageDebug(msg)
 		broker := brokerFromID(msg.brokerID, m.availableBrokers)
 		if broker == nil {
 			log.Infof(context.TODO(), "broker %q is not part of current active brokers", msg.brokerID)

--- a/pam/internal/adapter/debug.go
+++ b/pam/internal/adapter/debug.go
@@ -1,0 +1,7 @@
+//go:build pam_debug
+
+package adapter
+
+func init() {
+	debugMessageFormatter = testMessageFormatter
+}

--- a/pam/internal/adapter/export_test.go
+++ b/pam/internal/adapter/export_test.go
@@ -1,0 +1,5 @@
+package adapter
+
+func init() {
+	debugMessageFormatter = testMessageFormatter
+}

--- a/pam/internal/adapter/gdmmodel_uimodel_test.go
+++ b/pam/internal/adapter/gdmmodel_uimodel_test.go
@@ -102,7 +102,7 @@ func (m *gdmTestUIModel) maybeHandleWantMessageUnlocked(msg tea.Msg) {
 func (m *gdmTestUIModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	if log.IsLevelEnabled(log.DebugLevel) &&
 		reflect.TypeOf(msg).PkgPath() == currentPkg {
-		log.Debugf(context.TODO(), "%#v", msg)
+		safeMessageDebug(msg)
 	}
 
 	m.mu.Lock()

--- a/pam/internal/adapter/list.go
+++ b/pam/internal/adapter/list.go
@@ -112,7 +112,7 @@ func (m List) Update(msg tea.Msg) (List, tea.Cmd) {
 			return m, nil
 		}
 
-		log.Debugf(context.TODO(), "%#v", msg)
+		safeMessageDebug(msg)
 		m.focused = true
 		return m, nil
 	}

--- a/pam/internal/adapter/nativemodel.go
+++ b/pam/internal/adapter/nativemodel.go
@@ -153,7 +153,19 @@ func (m nativeModel) requestStageChange(stage proto.Stage) tea.Cmd {
 }
 
 func (m nativeModel) Update(msg tea.Msg) (nativeModel, tea.Cmd) {
-	log.Debugf(context.TODO(), "Native model update: %#v", msg)
+	if log.IsLevelEnabled(log.DebugLevel) {
+		const prefix = "Native model update"
+		switch msg := msg.(type) {
+		case newPasswordCheck:
+			log.Debugf(context.TODO(), "%s: %#v", prefix,
+				newPasswordCheck{password: "***********", ctx: msg.ctx})
+		case newPasswordCheckResult:
+			log.Debugf(context.TODO(), "%s: %#v", prefix,
+				newPasswordCheckResult{password: "***********", msg: msg.msg, ctx: msg.ctx})
+		default:
+			log.Debugf(context.TODO(), "%s: %#v", prefix, msg)
+		}
+	}
 
 	switch msg := msg.(type) {
 	case StageChanged:

--- a/pam/internal/adapter/nativemodel.go
+++ b/pam/internal/adapter/nativemodel.go
@@ -153,19 +153,7 @@ func (m nativeModel) requestStageChange(stage proto.Stage) tea.Cmd {
 }
 
 func (m nativeModel) Update(msg tea.Msg) (nativeModel, tea.Cmd) {
-	if log.IsLevelEnabled(log.DebugLevel) {
-		const prefix = "Native model update"
-		switch msg := msg.(type) {
-		case newPasswordCheck:
-			log.Debugf(context.TODO(), "%s: %#v", prefix,
-				newPasswordCheck{password: "***********", ctx: msg.ctx})
-		case newPasswordCheckResult:
-			log.Debugf(context.TODO(), "%s: %#v", prefix,
-				newPasswordCheckResult{password: "***********", msg: msg.msg, ctx: msg.ctx})
-		default:
-			log.Debugf(context.TODO(), "%s: %#v", prefix, msg)
-		}
-	}
+	safeMessageDebugWithPrefix("Native model update", msg)
 
 	switch msg := msg.(type) {
 	case StageChanged:

--- a/pam/internal/adapter/reselectbuttonmodel.go
+++ b/pam/internal/adapter/reselectbuttonmodel.go
@@ -1,10 +1,7 @@
 package adapter
 
 import (
-	"context"
-
 	tea "github.com/charmbracelet/bubbletea"
-	"github.com/ubuntu/authd/log"
 )
 
 type authReselectButtonModel struct {
@@ -28,7 +25,7 @@ func (b authReselectButtonModel) Init() tea.Cmd {
 func (b authReselectButtonModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	switch msg := msg.(type) {
 	case buttonSelectionEvent:
-		log.Debugf(context.TODO(), "%#v: %#v", b, msg)
+		safeMessageDebug(msg, "button: %#v", b)
 		if msg.model == b.buttonModel {
 			return b, sendEvent(reselectAuthMode{})
 		}

--- a/pam/internal/adapter/userselection.go
+++ b/pam/internal/adapter/userselection.go
@@ -78,7 +78,7 @@ func (m userSelectionModel) SelectUser() tea.Cmd {
 func (m userSelectionModel) Update(msg tea.Msg) (userSelectionModel, tea.Cmd) {
 	switch msg := msg.(type) {
 	case userSelected:
-		log.Debugf(context.TODO(), "%#v", msg)
+		safeMessageDebug(msg)
 		currentUser, err := m.pamMTx.GetItem(pam.User)
 		if cmd := maybeSendPamError(err); cmd != nil {
 			return m, cmd
@@ -106,7 +106,7 @@ func (m userSelectionModel) Update(msg tea.Msg) (userSelectionModel, tea.Cmd) {
 		return m, sendEvent(UsernameSelected{})
 
 	case userRequired:
-		log.Debugf(context.TODO(), "%#v", msg)
+		safeMessageDebug(msg)
 		m.enabled = true
 		return m, sendEvent(ChangeStage{Stage: proto.Stage_userSelection})
 	}

--- a/pam/internal/adapter/utils.go
+++ b/pam/internal/adapter/utils.go
@@ -161,6 +161,14 @@ func defaultSafeMessageFormatter(msg tea.Msg) string {
 	case isAuthenticatedRequestedSend:
 		return fmt.Sprintf("%T{%s}", msg,
 			defaultSafeMessageFormatter(msg.isAuthenticatedRequested))
+	case UILayoutReceived:
+		return fmt.Sprintf("%T{%#v}", msg, msg.layout)
+	case ChangeStage:
+		return fmt.Sprintf("%T{Stage:%q}", msg, msg.Stage)
+	case StageChanged:
+		return fmt.Sprintf("%T{Stage:%q}", msg, msg.Stage)
+	case nativeStageChangeRequest:
+		return fmt.Sprintf("%T{Stage:%q}", msg, msg.Stage)
 	case tea.KeyMsg:
 		if msg.Type != tea.KeyRunes {
 			return fmt.Sprintf("%T{%s}", msg, msg)

--- a/pam/internal/adapter/utils.go
+++ b/pam/internal/adapter/utils.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"math"
 	"os"
+	"strings"
 	"sync"
 
 	tea "github.com/charmbracelet/bubbletea"
@@ -133,4 +134,72 @@ func maybeSendPamError(err error) tea.Cmd {
 		return sendEvent(pamError{status: errPam, msg: err.Error()})
 	}
 	return sendEvent(pamError{status: pam.ErrSystem, msg: err.Error()})
+}
+
+var debugMessageFormatter = defaultSafeMessageFormatter
+
+func defaultSafeMessageFormatter(msg tea.Msg) string {
+	switch msg := msg.(type) {
+	case newPasswordCheck:
+		return fmt.Sprintf("%#v",
+			newPasswordCheck{password: "***********", ctx: msg.ctx})
+	case newPasswordCheckResult:
+		return fmt.Sprintf("%#v",
+			newPasswordCheckResult{password: "***********", msg: msg.msg, ctx: msg.ctx})
+	case tea.KeyMsg:
+		if msg.Type != tea.KeyRunes {
+			return fmt.Sprintf("%T{%s}", msg, msg)
+		}
+	case nil:
+		return ""
+	default:
+		return fmt.Sprintf("%#v", msg)
+	}
+
+	return ""
+}
+
+func testMessageFormatter(msg tea.Msg) string {
+	switch msg := msg.(type) {
+	case newPasswordCheck:
+	case newPasswordCheckResult:
+	case tea.KeyMsg:
+		return fmt.Sprintf("%T{%s}", msg, msg)
+	default:
+		return defaultSafeMessageFormatter(msg)
+	}
+
+	return fmt.Sprintf("%#v", msg)
+}
+
+func safeMessageDebug(msg tea.Msg, formatAndArgs ...any) {
+	safeMessageDebugWithPrefix("", msg, formatAndArgs...)
+}
+
+func safeMessageDebugWithPrefix(prefix string, msg tea.Msg, formatAndArgs ...any) {
+	if !log.IsLevelEnabled(log.DebugLevel) {
+		return
+	}
+
+	m := debugMessageFormatter(msg)
+	if m == "" {
+		return
+	}
+	if prefix != "" {
+		m = fmt.Sprintf("%s: %s", prefix, m)
+	}
+
+	if len(formatAndArgs) == 0 {
+		log.Debug(context.Background(), m)
+		return
+	}
+
+	format, ok := formatAndArgs[0].(string)
+	if !ok || !strings.Contains(format, "%") {
+		log.Debug(context.Background(), append([]any{m, ", "}, formatAndArgs...)...)
+		return
+	}
+
+	args := formatAndArgs[1:]
+	log.Debugf(context.Background(), "%s, %s", m, fmt.Sprintf(format, args...))
 }

--- a/pam/internal/adapter/utils_test.go
+++ b/pam/internal/adapter/utils_test.go
@@ -24,7 +24,15 @@ func TestDebugMessageFormatter(t *testing.T) {
 		"Empty_msg": {},
 		"StageChanged_message": {
 			msg:            StageChanged{proto.Stage_brokerSelection},
-			wantSafeString: "adapter.StageChanged{Stage:1}",
+			wantSafeString: `adapter.StageChanged{Stage:"brokerSelection"}`,
+		},
+		"ChangeStage_message": {
+			msg:            ChangeStage{Stage: proto.Stage_authModeSelection},
+			wantSafeString: `adapter.ChangeStage{Stage:"authModeSelection"}`,
+		},
+		"nativeStageChangeRequest_message": {
+			msg:            ChangeStage{Stage: proto.Stage_authModeSelection},
+			wantSafeString: `adapter.ChangeStage{Stage:"authModeSelection"}`,
 		},
 		"New_password_check": {
 			msg:             newPasswordCheck{password: "Super secret password!"},
@@ -137,7 +145,7 @@ func TestSafeMessageDebug(t *testing.T) {
 		},
 		"StageChanged_message": {
 			msg:            StageChanged{proto.Stage_brokerSelection},
-			wantSafeString: "adapter.StageChanged{Stage:1}",
+			wantSafeString: `adapter.StageChanged{Stage:"brokerSelection"}`,
 		},
 		"startAuthentication_message_with_prefix": {
 			msg:            startAuthentication{},

--- a/pam/internal/adapter/utils_test.go
+++ b/pam/internal/adapter/utils_test.go
@@ -1,0 +1,202 @@
+package adapter
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/stretchr/testify/require"
+	"github.com/ubuntu/authd/log"
+	"github.com/ubuntu/authd/pam/internal/proto"
+)
+
+func TestDebugMessageFormatter(t *testing.T) {
+	t.Parallel()
+
+	tests := map[string]struct {
+		msg tea.Msg
+
+		wantSafeString  string
+		wantDebugString string
+	}{
+		"Empty_msg": {},
+		"StageChanged_message": {
+			msg:            StageChanged{proto.Stage_brokerSelection},
+			wantSafeString: "adapter.StageChanged{Stage:1}",
+		},
+		"New_password_check": {
+			msg:             newPasswordCheck{password: "Super secret password!"},
+			wantSafeString:  `adapter.newPasswordCheck{ctx:context.Context(nil), password:"***********"}`,
+			wantDebugString: `adapter.newPasswordCheck{ctx:context.Context(nil), password:"Super secret password!"}`,
+		},
+		"New_password_check_result": {
+			msg:             newPasswordCheckResult{password: "Super secret password!", msg: "Some message"},
+			wantSafeString:  `adapter.newPasswordCheckResult{ctx:context.Context(nil), password:"***********", msg:"Some message"}`,
+			wantDebugString: `adapter.newPasswordCheckResult{ctx:context.Context(nil), password:"Super secret password!", msg:"Some message"}`,
+		},
+		"Key_rune_message": {
+			msg:             tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'p', 'a', 's', 's'}},
+			wantSafeString:  ``,
+			wantDebugString: `tea.KeyMsg{pass}`,
+		},
+		"Key_modifier_message": {
+			msg:            tea.KeyMsg{Type: tea.KeyTab, Runes: []rune{'p', 'a', 's', 's'}},
+			wantSafeString: `tea.KeyMsg{tab}`,
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			require.Equal(t, tc.wantSafeString, defaultSafeMessageFormatter(tc.msg),
+				"MessageFormatter safe result mismatches expected")
+
+			if tc.wantDebugString == "" {
+				tc.wantDebugString = tc.wantSafeString
+			}
+
+			require.Equal(t, tc.wantDebugString, debugMessageFormatter(tc.msg),
+				"MessageFormatter debug result mismatches expected")
+		})
+	}
+}
+
+func TestSafeMessageDebug(t *testing.T) {
+	// This cannot be parallel
+
+	tests := map[string]struct {
+		prefix        string
+		msg           tea.Msg
+		formatAndArgs []any
+
+		wantSafeString  string
+		wantDebugString string
+	}{
+		"Empty_msg": {},
+		"Empty_msg_with_prefix": {
+			prefix: "prefix",
+		},
+		"Empty_msg_with_prefix_and_suffix": {
+			prefix:        "prefix",
+			formatAndArgs: []any{"suffix"},
+		},
+		"StageChanged_message": {
+			msg:            StageChanged{proto.Stage_brokerSelection},
+			wantSafeString: "adapter.StageChanged{Stage:1}",
+		},
+		"startAuthentication_message_with_prefix": {
+			msg:            startAuthentication{},
+			prefix:         "prefix",
+			wantSafeString: "prefix: adapter.startAuthentication{}",
+		},
+		"startAuthentication_message_with_prefix_and_single_value_suffix": {
+			msg:            startAuthentication{},
+			prefix:         "prefix",
+			formatAndArgs:  []any{true},
+			wantSafeString: "prefix: adapter.startAuthentication{}, true",
+		},
+		"startAuthentication_message_with_prefix_and_multiple_value_suffix": {
+			msg:            startAuthentication{},
+			prefix:         "prefix",
+			formatAndArgs:  []any{true, false},
+			wantSafeString: "prefix: adapter.startAuthentication{}, true false",
+		},
+		"startAuthentication_message_with_prefix_and_single_string_suffix": {
+			msg:            startAuthentication{},
+			prefix:         "prefix",
+			formatAndArgs:  []any{"suffix"},
+			wantSafeString: "prefix: adapter.startAuthentication{}, suffix",
+		},
+		"startAuthentication_message_with_prefix_and_format_suffix": {
+			msg:            startAuthentication{},
+			prefix:         "prefix",
+			formatAndArgs:  []any{"suffix is %#v and %q", stopAuthentication{}, "suffix"},
+			wantSafeString: `prefix: adapter.startAuthentication{}, suffix is adapter.stopAuthentication{} and "suffix"`,
+		},
+		"New_password_check": {
+			msg:             newPasswordCheck{password: "Super secret password!"},
+			wantSafeString:  `adapter.newPasswordCheck{ctx:context.Context(nil), password:"***********"}`,
+			wantDebugString: `adapter.newPasswordCheck{ctx:context.Context(nil), password:"Super secret password!"}`,
+		},
+		"New_password_check_result": {
+			msg:             newPasswordCheckResult{password: "Super secret password!", msg: "Some message"},
+			wantSafeString:  `adapter.newPasswordCheckResult{ctx:context.Context(nil), password:"***********", msg:"Some message"}`,
+			wantDebugString: `adapter.newPasswordCheckResult{ctx:context.Context(nil), password:"Super secret password!", msg:"Some message"}`,
+		},
+		"Key_rune_message": {
+			msg:             tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'p', 'a', 's', 's'}},
+			wantSafeString:  ``,
+			wantDebugString: `tea.KeyMsg{pass}`,
+		},
+		"Key_modifier_message": {
+			msg:            tea.KeyMsg{Type: tea.KeyTab, Runes: []rune{'p', 'a', 's', 's'}},
+			wantSafeString: `tea.KeyMsg{tab}`,
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			handlerCalled := false
+			wantCtx := context.Background()
+			log.SetLevelHandler(log.DebugLevel, func(ctx context.Context, l log.Level, format string, args ...interface{}) {
+				t.Logf(format, args...)
+				handlerCalled = true
+				require.Equal(t, wantCtx, ctx, "Context should match expected")
+				require.Equal(t, tc.wantSafeString, fmt.Sprintf(format, args...),
+					"Format should match")
+			})
+
+			initialLogLevel := log.GetLevel()
+			log.SetLevel(log.DebugLevel)
+			t.Cleanup(func() { log.SetLevel(initialLogLevel) })
+
+			initialFormatter := debugMessageFormatter
+			debugMessageFormatter = defaultSafeMessageFormatter
+			t.Cleanup(func() { debugMessageFormatter = initialFormatter })
+
+			if tc.prefix == "" {
+				safeMessageDebug(tc.msg, tc.formatAndArgs...)
+			} else {
+				safeMessageDebugWithPrefix(tc.prefix, tc.msg, tc.formatAndArgs...)
+			}
+			require.Equal(t, tc.wantSafeString != "", handlerCalled,
+				"Handler should have been called")
+		})
+
+		t.Run(fmt.Sprintf("%s_debug_mode", name), func(t *testing.T) {
+			if tc.wantDebugString == "" {
+				tc.wantDebugString = tc.wantSafeString
+			}
+
+			handlerCalled := false
+			wantCtx := context.Background()
+			log.SetLevelHandler(log.DebugLevel, func(ctx context.Context, l log.Level, format string, args ...interface{}) {
+				t.Logf(format, args...)
+				handlerCalled = true
+				t.Logf("Called with %q", format)
+				t.Logf("Atgs are %#v", args)
+				require.Equal(t, wantCtx, ctx, "Context should match expected")
+				require.Equal(t, tc.wantDebugString, fmt.Sprintf(format, args...),
+					"Format should match")
+			})
+
+			initialLogLevel := log.GetLevel()
+			log.SetLevel(log.DebugLevel)
+			t.Cleanup(func() { log.SetLevel(initialLogLevel) })
+
+			initialFormatter := debugMessageFormatter
+			debugMessageFormatter = testMessageFormatter
+			t.Cleanup(func() { debugMessageFormatter = initialFormatter })
+
+			if tc.prefix == "" {
+				safeMessageDebug(tc.msg, tc.formatAndArgs...)
+			} else {
+				safeMessageDebugWithPrefix(tc.prefix, tc.msg, tc.formatAndArgs...)
+			}
+			require.Equal(t, tc.wantDebugString != "", handlerCalled,
+				"Handler should have been called")
+		})
+	}
+}

--- a/pam/internal/adapter/utils_test.go
+++ b/pam/internal/adapter/utils_test.go
@@ -7,6 +7,7 @@ import (
 
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/stretchr/testify/require"
+	"github.com/ubuntu/authd/internal/proto/authd"
 	"github.com/ubuntu/authd/log"
 	"github.com/ubuntu/authd/pam/internal/proto"
 )
@@ -43,6 +44,58 @@ func TestDebugMessageFormatter(t *testing.T) {
 		"Key_modifier_message": {
 			msg:            tea.KeyMsg{Type: tea.KeyTab, Runes: []rune{'p', 'a', 's', 's'}},
 			wantSafeString: `tea.KeyMsg{tab}`,
+		},
+		"isAuthenticatedRequested_empty": {
+			msg:            isAuthenticatedRequested{},
+			wantSafeString: `adapter.isAuthenticatedRequested{<nil>{}}`,
+		},
+		"isAuthenticatedRequested_with_secret": {
+			msg: isAuthenticatedRequested{
+				item: &authd.IARequest_AuthenticationData_Secret{Secret: "super-secret!"},
+			},
+			wantSafeString:  `adapter.isAuthenticatedRequested{*authd.IARequest_AuthenticationData_Secret{Secret:"***********"}}`,
+			wantDebugString: `adapter.isAuthenticatedRequested{*authd.IARequest_AuthenticationData_Secret{Secret:"super-secret!"}}`,
+		},
+		"isAuthenticatedRequested_with_wait": {
+			msg: isAuthenticatedRequested{
+				item: &authd.IARequest_AuthenticationData_Wait{Wait: "wait!"},
+			},
+			wantSafeString: `adapter.isAuthenticatedRequested{*authd.IARequest_AuthenticationData_Wait{Wait:"wait!"}}`,
+		},
+		"isAuthenticatedRequested_with_skip": {
+			msg: isAuthenticatedRequested{
+				item: &authd.IARequest_AuthenticationData_Skip{Skip: "skip!"},
+			},
+			wantSafeString: `adapter.isAuthenticatedRequested{*authd.IARequest_AuthenticationData_Skip{Skip:"skip!"}}`,
+		},
+		"isAuthenticatedRequestedSend_empty": {
+			msg:            isAuthenticatedRequestedSend{},
+			wantSafeString: `adapter.isAuthenticatedRequestedSend{adapter.isAuthenticatedRequested{<nil>{}}}`,
+		},
+		"isAuthenticatedRequestedSend_with_secret": {
+			msg: isAuthenticatedRequestedSend{
+				isAuthenticatedRequested: isAuthenticatedRequested{
+					item: &authd.IARequest_AuthenticationData_Secret{Secret: "super-secret!"},
+				},
+			},
+			wantSafeString:  `adapter.isAuthenticatedRequestedSend{adapter.isAuthenticatedRequested{*authd.IARequest_AuthenticationData_Secret{Secret:"***********"}}}`,
+			wantDebugString: `adapter.isAuthenticatedRequestedSend{adapter.isAuthenticatedRequested{*authd.IARequest_AuthenticationData_Secret{Secret:"super-secret!"}}}`,
+		},
+		"isAuthenticatedRequestedSend_with_wait": {
+			msg: isAuthenticatedRequestedSend{
+				isAuthenticatedRequested: isAuthenticatedRequested{
+					item: &authd.IARequest_AuthenticationData_Wait{Wait: "wait!"},
+				},
+			},
+			wantSafeString: `adapter.isAuthenticatedRequestedSend{adapter.isAuthenticatedRequested{*authd.IARequest_AuthenticationData_Wait{Wait:"wait!"}}}`,
+		},
+		"isAuthenticatedRequestedSend_with_skip": {
+			msg: isAuthenticatedRequestedSend{
+				isAuthenticatedRequested: isAuthenticatedRequested{
+					item: &authd.IARequest_AuthenticationData_Skip{Skip: "skip!"},
+				},
+			},
+			wantSafeString: `adapter.isAuthenticatedRequestedSend{adapter.isAuthenticatedRequested{*authd.IARequest_AuthenticationData_Skip{Skip:"skip!"}}}`,
 		},
 	}
 
@@ -133,6 +186,58 @@ func TestSafeMessageDebug(t *testing.T) {
 		"Key_modifier_message": {
 			msg:            tea.KeyMsg{Type: tea.KeyTab, Runes: []rune{'p', 'a', 's', 's'}},
 			wantSafeString: `tea.KeyMsg{tab}`,
+		},
+		"isAuthenticatedRequested_empty": {
+			msg:            isAuthenticatedRequested{},
+			wantSafeString: `adapter.isAuthenticatedRequested{<nil>{}}`,
+		},
+		"isAuthenticatedRequested_with_secret": {
+			msg: isAuthenticatedRequested{
+				item: &authd.IARequest_AuthenticationData_Secret{Secret: "super-secret!"},
+			},
+			wantSafeString:  `adapter.isAuthenticatedRequested{*authd.IARequest_AuthenticationData_Secret{Secret:"***********"}}`,
+			wantDebugString: `adapter.isAuthenticatedRequested{*authd.IARequest_AuthenticationData_Secret{Secret:"super-secret!"}}`,
+		},
+		"isAuthenticatedRequested_with_wait": {
+			msg: isAuthenticatedRequested{
+				item: &authd.IARequest_AuthenticationData_Wait{Wait: "wait!"},
+			},
+			wantSafeString: `adapter.isAuthenticatedRequested{*authd.IARequest_AuthenticationData_Wait{Wait:"wait!"}}`,
+		},
+		"isAuthenticatedRequested_with_skip": {
+			msg: isAuthenticatedRequested{
+				item: &authd.IARequest_AuthenticationData_Skip{Skip: "skip!"},
+			},
+			wantSafeString: `adapter.isAuthenticatedRequested{*authd.IARequest_AuthenticationData_Skip{Skip:"skip!"}}`,
+		},
+		"isAuthenticatedRequestedSend_empty": {
+			msg:            isAuthenticatedRequestedSend{},
+			wantSafeString: `adapter.isAuthenticatedRequestedSend{adapter.isAuthenticatedRequested{<nil>{}}}`,
+		},
+		"isAuthenticatedRequestedSend_with_secret": {
+			msg: isAuthenticatedRequestedSend{
+				isAuthenticatedRequested: isAuthenticatedRequested{
+					item: &authd.IARequest_AuthenticationData_Secret{Secret: "super-secret!"},
+				},
+			},
+			wantSafeString:  `adapter.isAuthenticatedRequestedSend{adapter.isAuthenticatedRequested{*authd.IARequest_AuthenticationData_Secret{Secret:"***********"}}}`,
+			wantDebugString: `adapter.isAuthenticatedRequestedSend{adapter.isAuthenticatedRequested{*authd.IARequest_AuthenticationData_Secret{Secret:"super-secret!"}}}`,
+		},
+		"isAuthenticatedRequestedSend_with_wait": {
+			msg: isAuthenticatedRequestedSend{
+				isAuthenticatedRequested: isAuthenticatedRequested{
+					item: &authd.IARequest_AuthenticationData_Wait{Wait: "wait!"},
+				},
+			},
+			wantSafeString: `adapter.isAuthenticatedRequestedSend{adapter.isAuthenticatedRequested{*authd.IARequest_AuthenticationData_Wait{Wait:"wait!"}}}`,
+		},
+		"isAuthenticatedRequestedSend_with_skip": {
+			msg: isAuthenticatedRequestedSend{
+				isAuthenticatedRequested: isAuthenticatedRequested{
+					item: &authd.IARequest_AuthenticationData_Skip{Skip: "skip!"},
+				},
+			},
+			wantSafeString: `adapter.isAuthenticatedRequestedSend{adapter.isAuthenticatedRequested{*authd.IARequest_AuthenticationData_Skip{Skip:"skip!"}}}`,
 		},
 	}
 


### PR DESCRIPTION
When debug mode is enabled, during ssh sessions we are disclosing some new-password information.

So avoid this to happen, but also take the occasion to make the messages logging safer and more helpful in debug and test builds so that we can show all the information when it's safe, while not expose anything relevant in release builds.

UDENG-6647