### PR TITLE
Bump Go toolchain version to 1.23.8

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/ubuntu/authd
 
 go 1.23.0
 
-toolchain go1.23.6
+toolchain go1.23.8
 
 require (
 	github.com/charmbracelet/bubbles v0.20.0


### PR DESCRIPTION
govulncheck reports the following vulnerability in go1.23.6

```
Vulnerability #1: GO-2025-3563
    Request smuggling due to acceptance of invalid chunked data in net/http
  More info: https://pkg.go.dev/vuln/GO-2025-3563
  Standard library
    Found in: net/http/internal@go1.23.6
    Fixed in: net/http/internal@go1.23.8
```