### PR TITLE
pam/tests: Fix failures due to timing issues as per recent go updates

### DIFF
--- a/pam/integration-tests/ssh_test.go
+++ b/pam/integration-tests/ssh_test.go
@@ -36,6 +36,8 @@ import (
 var (
 	sshEnvVariablesRegex *regexp.Regexp
 	sshHostPortRegex     *regexp.Regexp
+
+	sshDefaultFinalWaitTimeout = sleepDuration(3 * defaultSleepValues[authdWaitDefault])
 )
 
 func TestSSHAuthenticate(t *testing.T) {
@@ -240,8 +242,9 @@ func testSSHAuthenticate(t *testing.T, sharedSSHd bool) {
 			tape:                "max_attempts",
 			wantNotLoggedInUser: true,
 			tapeVariables: map[string]string{
-				vhsCommandFinalAuthWaitVariable: `Wait+Screen /Too many authentication failures/
-Wait`,
+				vhsCommandFinalAuthWaitVariable: fmt.Sprintf(
+					`Wait+Screen /Too many authentication failures/
+Wait@%dms`, sshDefaultFinalWaitTimeout),
 			},
 		},
 		"Deny_authentication_if_user_does_not_exist": {

--- a/pam/integration-tests/ssh_test.go
+++ b/pam/integration-tests/ssh_test.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"io"
 	"net"
 	"net/http"
 	"net/http/httptest"
@@ -17,7 +16,6 @@ import (
 	"slices"
 	"strconv"
 	"strings"
-	"sync"
 	"syscall"
 	"testing"
 	"time"
@@ -594,37 +592,6 @@ func sshdCommand(t *testing.T, port, hostKey, forcedCommand string, env []string
 	return sshd, pidFile, logFile
 }
 
-// safeBuffer is used to buffer the sshd output, since we may read this from
-// cleanup sub-functions (that run as different goroutines than the command's exec)
-// we need to use locked read/writes on bytes.Buffer to avoid read/write races when
-// running the tests in race mode.
-// We only override the methods we require in the tests.
-type safeBuffer struct {
-	bytes.Buffer
-	mu sync.RWMutex
-}
-
-func (sb *safeBuffer) Write(p []byte) (n int, err error) {
-	sb.mu.Lock()
-	defer sb.mu.Unlock()
-
-	return sb.Buffer.Write(p)
-}
-
-func (sb *safeBuffer) ReadFrom(r io.Reader) (n int64, err error) {
-	sb.mu.Lock()
-	defer sb.mu.Unlock()
-
-	return sb.Buffer.ReadFrom(r)
-}
-
-func (sb *safeBuffer) String() string {
-	sb.mu.RLock()
-	defer sb.mu.RUnlock()
-
-	return sb.Buffer.String()
-}
-
 func startSSHd(t *testing.T, hostKey, forcedCommand string, env []string, daemonize bool) string {
 	t.Helper()
 
@@ -636,7 +603,7 @@ func startSSHd(t *testing.T, hostKey, forcedCommand string, env []string, daemon
 	server.Close()
 
 	sshd, sshdPidFile, sshdLogFile := sshdCommand(t, sshdPort, hostKey, forcedCommand, env, daemonize)
-	sshdStderr := safeBuffer{}
+	sshdStderr := bytes.Buffer{}
 	sshd.Stderr = &sshdStderr
 	if testing.Verbose() {
 		sshd.Stdout = os.Stdout
@@ -653,7 +620,7 @@ func startSSHd(t *testing.T, hostKey, forcedCommand string, env []string, daemon
 			return
 		}
 		sshdLog := filepath.Join(t.TempDir(), "sshd.log")
-		require.NoError(t, os.WriteFile(sshdLog, []byte(sshdStderr.String()), 0600),
+		require.NoError(t, os.WriteFile(sshdLog, sshdStderr.Bytes(), 0600),
 			"TearDown: Saving sshd log")
 		saveArtifactsForDebug(t, []string{sshdLog})
 	})

--- a/pam/integration-tests/testdata/tapes/cli/form_with_button.tape
+++ b/pam/integration-tests/testdata/tapes/cli/form_with_button.tape
@@ -27,7 +27,7 @@ Show
 
 Hide
 Type "7"
-Wait+CLIPrompt /Enter your one time credential/ /\[ Resend SMS \(1 sent\) \]/
+Wait+CLIPrompt@${AUTHD_WAIT_DEFAULT}*2 /Enter your one time credential/ /\[ Resend SMS \(1 sent\) \]/
 Show
 
 Hide
@@ -36,7 +36,7 @@ Show
 
 Hide
 Enter
-Wait+CLIPrompt /Enter your one time credential/ /\[ Resend SMS \(2 sent\) \]/
+Wait+CLIPrompt@${AUTHD_WAIT_DEFAULT}*2 /Enter your one time credential/ /\[ Resend SMS \(2 sent\) \]/
 Show
 
 Hide

--- a/pam/integration-tests/testdata/tapes/cli/mfa_reset_pwquality_auth.tape
+++ b/pam/integration-tests/testdata/tapes/cli/mfa_reset_pwquality_auth.tape
@@ -40,7 +40,7 @@ Show
 
 Hide
 Enter
-Wait+CLIPrompt /New password/ /\[ Skip \]/ /The password is the same as the old one/
+Wait+CLIPrompt@${AUTHD_WAIT_DEFAULT}*2 /New password/ /\[ Skip \]/ /The password is the same as the old one/
 Show
 
 Hide
@@ -49,7 +49,7 @@ Show
 
 Hide
 Enter
-Wait+CLIPrompt /New password/ /\[ Skip \]\nThe password fails the dictionary check[^\n]+/
+Wait+CLIPrompt@${AUTHD_WAIT_DEFAULT}*2 /New password/ /\[ Skip \]\nThe password fails the dictionary check[^\n]+/
 Show
 
 Hide
@@ -58,7 +58,7 @@ Show
 
 Hide
 Enter
-Wait+CLIPrompt /New password/ /\[ Skip \]\nThe password is the same as the old one/
+Wait+CLIPrompt@${AUTHD_WAIT_DEFAULT}*2 /New password/ /\[ Skip \]\nThe password is the same as the old one/
 Show
 
 Hide
@@ -67,7 +67,7 @@ Show
 
 Hide
 Enter
-Wait+CLIPrompt /New password/ /\[ Skip \]\nThe password is shorter than \d+ characters/
+Wait+CLIPrompt@${AUTHD_WAIT_DEFAULT}*2 /New password/ /\[ Skip \]\nThe password is shorter than \d+ characters/
 Show
 
 Hide
@@ -76,7 +76,7 @@ Show
 
 Hide
 Enter
-Wait+CLIPrompt /Confirm password/ /\[ Skip \]/
+Wait+CLIPrompt@${AUTHD_WAIT_DEFAULT}*2 /Confirm password/ /\[ Skip \]/
 Show
 
 Hide

--- a/pam/integration-tests/testdata/tapes/cli/optional_password_reset_skip.tape
+++ b/pam/integration-tests/testdata/tapes/cli/optional_password_reset_skip.tape
@@ -25,7 +25,7 @@ Show
 
 Hide
 Enter
-Wait+CLIPrompt /New password/ /\[ Skip \]/
+Wait+CLIPrompt@${AUTHD_WAIT_DEFAULT}*2 /New password/ /\[ Skip \]/
 Show
 
 Hide

--- a/pam/integration-tests/testdata/tapes/cli/remember_broker_and_mode.tape
+++ b/pam/integration-tests/testdata/tapes/cli/remember_broker_and_mode.tape
@@ -24,7 +24,7 @@ Show
 
 Hide
 Type "7"
-Wait+CLIPrompt /Enter your one time credential/ /\[ Resend SMS \(1 sent\) \]/
+Wait+CLIPrompt@${AUTHD_WAIT_DEFAULT}*2 /Enter your one time credential/ /\[ Resend SMS \(1 sent\) \]/
 Show
 
 Hide
@@ -47,7 +47,7 @@ Show
 
 Hide
 Enter
-Wait+CLIPrompt /Enter your one time credential/ /\[ Resend SMS \(1 sent\) \]/
+Wait+CLIPrompt@${AUTHD_WAIT_DEFAULT}*2 /Enter your one time credential/ /\[ Resend SMS \(1 sent\) \]/
 Show
 
 Hide

--- a/pam/integration-tests/testdata/tapes/ssh/simple_auth_with_shell.tape
+++ b/pam/integration-tests/testdata/tapes/ssh/simple_auth_with_shell.tape
@@ -13,7 +13,7 @@ Show
 Hide
 Type "goodpass"
 Enter
-Wait /\$\n/
+Wait@${AUTHD_WAIT_DEFAULT}*3 /\$\n/
 Show
 
 Hide

--- a/pam/integration-tests/vhs-helpers_test.go
+++ b/pam/integration-tests/vhs-helpers_test.go
@@ -629,20 +629,25 @@ func evaluateTapeVariables(t *testing.T, tapeString string, td tapeData, testTyp
 }
 
 func finalWaitCommands(testType vhsTestType, sessionMode authd.SessionMode) string {
-	if testType == vhsTestTypeSSH {
-		return `Wait+Suffix /Connection to localhost closed\.\n>/`
-	}
+	var firstResult, secondResult pam_test.RunnerResultAction
+	switch testType {
+	case vhsTestTypeSSH:
+		firstResult = pam_test.RunnerResultActionAuthenticate
+		secondResult = pam_test.RunnerResultActionAcctMgmt
 
-	firstResult := pam_test.RunnerResultActionAuthenticate
-	if sessionMode == authd.SessionMode_CHANGE_PASSWORD {
-		firstResult = pam_test.RunnerResultActionChangeAuthTok
+	default:
+		firstResult = pam_test.RunnerResultActionAuthenticate
+		if sessionMode == authd.SessionMode_CHANGE_PASSWORD {
+			firstResult = pam_test.RunnerResultActionChangeAuthTok
+		}
+		secondResult = pam_test.RunnerResultActionAcctMgmt
 	}
 
 	return fmt.Sprintf(`Wait+Screen /%s[^\n]*/
 Wait+Screen /%s[^\n]*/
 Wait`,
 		regexp.QuoteMeta(firstResult.String()),
-		regexp.QuoteMeta(pam_test.RunnerResultActionAcctMgmt.String()),
+		regexp.QuoteMeta(secondResult.String()),
 	)
 }
 

--- a/pam/integration-tests/vhs-helpers_test.go
+++ b/pam/integration-tests/vhs-helpers_test.go
@@ -114,8 +114,8 @@ var (
 
 	defaultConnectionTimeout = sleepDuration(3*time.Second) / time.Millisecond
 
-	vhsSleepRegex = regexp.MustCompile(
-		`(?m)\$\{?(AUTHD_SLEEP_[A-Z_]+)\}?(\s?([*/]+)\s?([\d.]+))?(.*)$`)
+	vhsSleepOrWaitRegex = regexp.MustCompile(
+		`(?m)\$\{?(AUTHD_(?:SLEEP|WAIT)_[A-Z_]+)\}?(\s?([*/]+)\s?([\d.]+))?(.*)$`)
 
 	vhsEmptyTrailingLinesRegex = regexp.MustCompile(`(?m)\s+\z`)
 	vhsUnixTargetRegex         = regexp.MustCompile(fmt.Sprintf(`unix://%s/(\S*)\b`,
@@ -483,7 +483,7 @@ func (td tapeData) PrepareTape(t *testing.T, testType vhsTestType, outputPath st
 func evaluateTapeVariables(t *testing.T, tapeString string, td tapeData, testType vhsTestType) string {
 	t.Helper()
 
-	for _, m := range vhsSleepRegex.FindAllStringSubmatch(tapeString, -1) {
+	for _, m := range vhsSleepOrWaitRegex.FindAllStringSubmatch(tapeString, -1) {
 		fullMatch, sleepKind, op, arg, rest := m[0], m[1], m[3], m[4], m[5]
 		sleep, ok := defaultSleepValues[sleepKind]
 		require.True(t, ok, "Setup: unknown sleep kind: %q", sleepKind)

--- a/pam/internal/adapter/gdmmodel_test.go
+++ b/pam/internal/adapter/gdmmodel_test.go
@@ -1281,7 +1281,7 @@ func TestGdmModel(t *testing.T) {
 			wantExitStatus: PamSuccess{BrokerID: firstBrokerInfo.Id},
 		},
 		"Authenticated_with_qrcode_regenerated_after_auth_selection_stage_from_client_after_client_side_broker_and_auth_mode_selection": {
-			timeout: 20 * time.Second,
+			timeout: 30 * time.Second,
 			supportedLayouts: []*authd.UILayout{
 				pam_test.FormUILayout(pam_test.WithWait(true)),
 				pam_test.QrCodeUILayout(),


### PR DESCRIPTION
As per #882 SSH tests take way more to return back to the terminal, and this leads to random failures in CI.

So give these tests more time to wait for being completed, sadly.

It's also weird that a minor upgrade has such performances implications, but not something we can easily track.