### PR TITLE
docs: clarify initial user access

### DIFF
--- a/docs/howto/configure-authd.md
+++ b/docs/howto/configure-authd.md
@@ -9,6 +9,19 @@ myst:
 This guide shows how to configure identity brokers to support authentication of
 Ubuntu devices with authd and your chosen cloud provider.
 
+```{admonition} Logging in multiple users with authd
+:class: tip
+By default, the first user to authenticate and log in to a machine becomes the
+"owner" and only they are allowed to log in.
+
+For other authenticated users to log in, they must first be added as an
+"allowed user".
+
+The steps you need to follow when allowing more users are outlined in
+[configure allowed users](ref::config-allowed-users) on the current page.
+
+```
+
 ## Broker discovery
 
 Create the directory that will contain the declaration files of the broker(s):
@@ -167,6 +180,7 @@ force_provider_authentication = true
 In some cases, this may prevent login, such as when there are network issues.
 ```
 
+(ref::config-allowed-users)=
 ## Configure allowed users
 
 The users who are allowed to log in (after successfully authenticating via the

--- a/docs/howto/configure-authd.md
+++ b/docs/howto/configure-authd.md
@@ -30,7 +30,7 @@ Create the directory that will contain the declaration files of the broker(s):
 sudo mkdir -p /etc/authd/brokers.d/
 ```
 
-Then copy the the `.conf` file from your chosen broker snap package:
+Then copy the `.conf` file from your chosen broker snap package:
 
 :::::{tab-set}
 :sync-group: broker

--- a/docs/reference/troubleshooting.md
+++ b/docs/reference/troubleshooting.md
@@ -104,7 +104,6 @@ Then you need to restart the service with `sudo systemctl restart gdm`.
 
 #### authd broker service
 
-
 To increase the verbosity of the broker service, edit the service file:
 
 ::::{tab-set}
@@ -225,7 +224,33 @@ If using an edge release, you can read the
 [latest development version of the documentation](https://canonical-authd.readthedocs-hosted.com/en/latest/)
 ```
 
-## Common issues and limitations
+## Common issues
+
+### Only the first logged-in user can get access to a machine
+
+This is the expected behavior.
+
+By default, the first logged-in user is defined as the "owner" and only the
+owner can log in.
+
+For other users to gain access after authentication, they must be added to
+`allowed_users` in the `broker.conf` file.
+This is outlined in the [guide for configuring authd](ref::config-allowed-users).
+
+See below the relevant line in the configuration, showing both the owner and
+an additional user:
+
+```ini
+[users]
+allowed_users = OWNER,additionaluser1@example.com
+```
+
+Based on this default behavior, an example of an authentication workflow for a
+new machine could be as follows:
+
+1. An administrator logs in and becomes the owner of the machine
+2. The owner adds the intended user of the machine to `allowed_users`
+3. That user then authenticates and logs in successfully
 
 ### File ownership on shared network resources (e.g. NFS, Samba)
 


### PR DESCRIPTION
People have reported that they cannot log in with additional users after initial log in.

This is the default behavior, as the user who first authenticates and logs in is the owner, and only they can log in.

As this is a relatively common report, we can try to increase the probability that a user finds the correct configuration guidance in the docs.

To that end, this PR:

* Adds a note on the default behaviour at the top of the configuration guide, which points to the appropriate section
* Adds a troubleshooting entry for those looking to solve the problem, which points to the appropriate section

UDENG-6601