### PR TITLE
Don't overwrite shell when updating user entry

### DIFF
--- a/internal/users/db/db_test.go
+++ b/internal/users/db/db_test.go
@@ -144,6 +144,13 @@ func TestUpdateUserEntry(t *testing.T) {
 			Dir:   "/new/home/user1",
 			Shell: "/bin/bash",
 		},
+		"user1-new-shell": {
+			Name:  "user1",
+			UID:   1111,
+			Gecos: "User1 gecos\nOn multiple lines",
+			Dir:   "/new/home/user1",
+			Shell: "/new/shell",
+		},
 		"user1-without-gecos": {
 			Name:  "user1",
 			UID:   1111,
@@ -185,6 +192,7 @@ func TestUpdateUserEntry(t *testing.T) {
 		// User and Group updates
 		"Update_user_by_changing_attributes":                      {userCase: "user1-new-attributes", dbFile: "one_user_and_group"},
 		"Update_user_does_not_change_homedir_if_it_exists":        {userCase: "user1-new-homedir", dbFile: "one_user_and_group"},
+		"Update_user_does_not_change_shell_if_it_exists":          {userCase: "user1-new-shell", dbFile: "one_user_and_group"},
 		"Update_user_by_removing_optional_gecos_field_if_not_set": {userCase: "user1-without-gecos", dbFile: "one_user_and_group"},
 
 		// Group updates

--- a/internal/users/db/testdata/golden/TestUpdateUserEntry/Update_user_by_changing_attributes
+++ b/internal/users/db/testdata/golden/TestUpdateUserEntry/Update_user_by_changing_attributes
@@ -4,7 +4,7 @@ users:
       gid: 11111
       gecos: New user1 gecos
       dir: /home/user1
-      shell: /bin/dash
+      shell: /bin/bash
 groups:
     - name: group1
       gid: 11111

--- a/internal/users/db/testdata/golden/TestUpdateUserEntry/Update_user_does_not_change_shell_if_it_exists
+++ b/internal/users/db/testdata/golden/TestUpdateUserEntry/Update_user_does_not_change_shell_if_it_exists
@@ -1,0 +1,16 @@
+users:
+    - name: user1
+      uid: 1111
+      gid: 11111
+      gecos: |-
+        User1 gecos
+        On multiple lines
+      dir: /home/user1
+      shell: /bin/bash
+groups:
+    - name: group1
+      gid: 11111
+      ugid: "12345678"
+users_to_groups:
+    - uid: 1111
+      gid: 11111


### PR DESCRIPTION
The user's shell should be configurable locally and not overwritten when the user info is being refreshed.

Closes #880 
UDENG-6659