### PR TITLE
Avoid polling token endpoint after login request cancelled

### DIFF
--- a/internal/brokers/broker.go
+++ b/internal/brokers/broker.go
@@ -149,7 +149,7 @@ func (b Broker) IsAuthenticated(ctx context.Context, sessionID, authenticationDa
 
 	// Validate access authentication.
 	if !slices.Contains(auth.Replies, access) {
-		return "", "", fmt.Errorf("invalid access authentication key: %v", access)
+		return "", "", fmt.Errorf("invalid authentication reply: %v", access)
 	}
 
 	if data == "" {

--- a/internal/brokers/broker_test.go
+++ b/internal/brokers/broker_test.go
@@ -213,7 +213,7 @@ func TestIsAuthenticated(t *testing.T) {
 		cancelFirstCall bool
 	}{
 		"Successfully_authenticate":                                        {sessionID: "success"},
-		"Successfully_authenticate_after_cancelling_first_call":            {sessionID: "ia_second_call", secondCall: true},
+		"Successfully_authenticate_after_cancelling_first_call":            {sessionID: "ia_second_call", secondCall: true, cancelFirstCall: true},
 		"Denies_authentication_when_broker_times_out":                      {sessionID: "ia_timeout"},
 		"Adds_default_groups_even_if_broker_did_not_set_them":              {sessionID: "ia_info_empty_groups"},
 		"No_error_when_auth.Next_and_no_data":                              {sessionID: "ia_next"},
@@ -236,7 +236,7 @@ func TestIsAuthenticated(t *testing.T) {
 		"Error_when_broker_returns_data_on_auth.Cancelled":                    {sessionID: "ia_cancelled_with_data"},
 		"Error_when_broker_returns_no_data_on_auth.Denied":                    {sessionID: "ia_denied_without_data"},
 		"Error_when_broker_returns_no_data_on_auth.Retry":                     {sessionID: "ia_retry_without_data"},
-		"Error_when_calling_IsAuthenticated_a_second_time_without_cancelling": {sessionID: "ia_second_call", secondCall: true, cancelFirstCall: true},
+		"Error_when_calling_IsAuthenticated_a_second_time_without_cancelling": {sessionID: "ia_second_call", secondCall: true},
 	}
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
@@ -264,7 +264,7 @@ func TestIsAuthenticated(t *testing.T) {
 			time.Sleep(time.Second)
 
 			if tc.secondCall {
-				if !tc.cancelFirstCall {
+				if tc.cancelFirstCall {
 					cancel()
 					<-done
 				}

--- a/internal/brokers/testdata/golden/TestIsAuthenticated/Error_when_broker_returns_invalid_access
+++ b/internal/brokers/testdata/golden/TestIsAuthenticated/Error_when_broker_returns_invalid_access
@@ -1,4 +1,4 @@
 FIRST CALL:
 	access: 
 	data: 
-	err: invalid access authentication key: invalid
+	err: invalid authentication reply: invalid

--- a/internal/services/errmessages/error.go
+++ b/internal/services/errmessages/error.go
@@ -5,6 +5,11 @@ type ToDisplayError struct {
 	error
 }
 
+// Unwrap returns the underlying error.
+func (e ToDisplayError) Unwrap() error {
+	return e.error
+}
+
 // NewToDisplayError returns a new ErrorToDisplay.
 func NewToDisplayError(err error) error {
 	return ToDisplayError{err}

--- a/internal/services/pam/testdata/golden/TestIsAuthenticated/Error_when_broker_returns_invalid_access/IsAuthenticated
+++ b/internal/services/pam/testdata/golden/TestIsAuthenticated/Error_when_broker_returns_invalid_access/IsAuthenticated
@@ -1,4 +1,4 @@
 FIRST CALL:
 	access: 
 	msg: 
-	err: can't check authentication: invalid access authentication key: invalid
+	err: can't check authentication: invalid authentication reply: invalid


### PR DESCRIPTION
If the context of the IsAuthenticated call from the PAM module to authd is cancelled, e.g. because the process of the PAM module exits, we want to automatically cancel the IsAuthenticated call to the broker, to avoid doing any further work towards authenticating the user (like sending requests to OAuth2 endpoints).