### PR TITLE
authmodeselection: Actually mark list as focused on focus request

### DIFF
--- a/pam/internal/adapter/list.go
+++ b/pam/internal/adapter/list.go
@@ -15,20 +15,20 @@ import (
 	"github.com/ubuntu/authd/log"
 )
 
-var listIDs atomic.Int32
+var listIDs atomic.Uint32
 
 // List is a [tea_list.Model] implementation for authd list views.
 type List struct {
 	tea_list.Model
 
 	clientType PamClientType
-	id         int32
+	id         uint32
 	focused    bool
 }
 
 // listFocused is the internal event to signal that the list view is focused.
 type listFocused struct {
-	id int32
+	id uint32
 }
 
 // listItemSelected is the internal event to signal that the a list item has been selected.

--- a/pam/internal/adapter/nativemodel.go
+++ b/pam/internal/adapter/nativemodel.go
@@ -279,7 +279,7 @@ func (m nativeModel) Update(msg tea.Msg) (nativeModel, tea.Cmd) {
 		}
 
 		if len(m.authModes) == 1 {
-			return m, sendEvent(authModeSelected{id: m.authModes[0].Id})
+			return m, selectAuthMode(m.authModes[0].Id)
 		}
 
 		return m.startAsyncOp(m.authModeSelection)
@@ -552,7 +552,7 @@ func (m nativeModel) authModeSelection() tea.Cmd {
 		})
 	}
 
-	return sendEvent(authModeSelected{id: id})
+	return selectAuthMode(id)
 }
 
 func (m nativeModel) startChallenge() tea.Cmd {


### PR DESCRIPTION
If the list gets focused we were doing the authentication mode selection
but we didn't properly mark the list as focused (as per not properly
overriding the listFocused message), thus breaking the focus model,
since at global level the user selection was instead considered
focused.

This can break the auto-selection (as seen in some GDM tests), because
on further focus requests the autoSelectedAuthModeID value was set set
again (even if unnecessary) causing further focus calls to lazily using
it.

This should help fixing the gdm [tests failure](https://github.com/ubuntu/authd/actions/runs/14884282528/attempts/1) we got recently due to too-early authentication mode selection.

I still have further improvements ready for that, but let's go simpler first.