### PR TITLE
Do not remove local broker if no other broker is available

### DIFF
--- a/pam/internal/adapter/nativemodel.go
+++ b/pam/internal/adapter/nativemodel.go
@@ -204,7 +204,9 @@ func (m nativeModel) Update(msg tea.Msg) (nativeModel, tea.Cmd) {
 		return m.startAsyncOp(m.userSelection)
 
 	case brokersListReceived:
-		if m.serviceName == polkitServiceName {
+		// We should only handle this special case if there's more than one broker available.
+		// Otherwise, we will break polkit for local users.
+		if m.serviceName == polkitServiceName && len(msg.brokers) > 1 {
 			// Do not support using local broker in the polkit case.
 			// FIXME: This should be up to authd to keep a list of brokers based on service.
 			m.availableBrokers = slices.DeleteFunc(msg.brokers, func(b *authd.ABResponse_BrokerInfo) bool {


### PR DESCRIPTION
If we remove the local broker when no other broker is available, we will break the polkit dialog for local users, and we don't want that to happen.