### PR TITLE
pam/adapter/model: Show an info message to explain how to go back

### DIFF
--- a/pam/integration-tests/testdata/golden/TestCLIAuthenticate/Authenticate_user_and_add_it_to_local_group
+++ b/pam/integration-tests/testdata/golden/TestCLIAuthenticate/Authenticate_user_and_add_it_to_local_group
@@ -9,14 +9,20 @@ Username: user-local-groups-integration-auth-native
 
 > 1. local
   2. ExampleBroker
+
+  Press escape key to go back to user selection
 ────────────────────────────────────────────────────────────────────────────────
 > ./pam_authd login socket=${AUTHD_TEST_TAPE_SOCKET}
 Gimme your password:
 >
+
+  Press escape key to go back to select the authentication method
 ────────────────────────────────────────────────────────────────────────────────
 > ./pam_authd login socket=${AUTHD_TEST_TAPE_SOCKET}
 Gimme your password:
 > ********
+
+  Press escape key to go back to select the authentication method
 ────────────────────────────────────────────────────────────────────────────────
 > ./pam_authd login socket=${AUTHD_TEST_TAPE_SOCKET}
 PAM Authenticate()

--- a/pam/integration-tests/testdata/golden/TestCLIAuthenticate/Authenticate_user_and_offer_password_reset
+++ b/pam/integration-tests/testdata/golden/TestCLIAuthenticate/Authenticate_user_and_offer_password_reset
@@ -9,19 +9,27 @@ Username: user-can-reset
 
 > 1. local
   2. ExampleBroker
+
+  Press escape key to go back to user selection
 ────────────────────────────────────────────────────────────────────────────────
 > ./pam_authd login socket=${AUTHD_TEST_TAPE_SOCKET}
 Gimme your password:
 >
+
+  Press escape key to go back to select the authentication method
 ────────────────────────────────────────────────────────────────────────────────
 > ./pam_authd login socket=${AUTHD_TEST_TAPE_SOCKET}
 Gimme your password:
 > ********
+
+  Press escape key to go back to select the authentication method
 ────────────────────────────────────────────────────────────────────────────────
 > ./pam_authd login socket=${AUTHD_TEST_TAPE_SOCKET}
 Gimme your password:
 > ********
 Password reset, 1 step(s) missing
+
+  Press escape key to go back to select the authentication method
 ────────────────────────────────────────────────────────────────────────────────
 > ./pam_authd login socket=${AUTHD_TEST_TAPE_SOCKET}
 Enter your new password (3 days until mandatory)
@@ -30,6 +38,8 @@ New password:
 >
 
   [ Skip ]
+
+  Press escape key to go back to choose the provider
 ────────────────────────────────────────────────────────────────────────────────
 > ./pam_authd login socket=${AUTHD_TEST_TAPE_SOCKET}
 PAM Authenticate()

--- a/pam/integration-tests/testdata/golden/TestCLIAuthenticate/Authenticate_user_and_reset_password_while_enforcing_policy
+++ b/pam/integration-tests/testdata/golden/TestCLIAuthenticate/Authenticate_user_and_reset_password_while_enforcing_policy
@@ -9,31 +9,43 @@ Username: user-needs-reset-integration-mandatory
 
 > 1. local
   2. ExampleBroker
+
+  Press escape key to go back to user selection
 ────────────────────────────────────────────────────────────────────────────────
 > ./pam_authd login socket=${AUTHD_TEST_TAPE_SOCKET}
 Gimme your password:
 >
+
+  Press escape key to go back to select the authentication method
 ────────────────────────────────────────────────────────────────────────────────
 > ./pam_authd login socket=${AUTHD_TEST_TAPE_SOCKET}
 Gimme your password:
 > ********
+
+  Press escape key to go back to select the authentication method
 ────────────────────────────────────────────────────────────────────────────────
 > ./pam_authd login socket=${AUTHD_TEST_TAPE_SOCKET}
 Gimme your password:
 > ********
 Password reset, 1 step(s) missing
+
+  Press escape key to go back to select the authentication method
 ────────────────────────────────────────────────────────────────────────────────
 > ./pam_authd login socket=${AUTHD_TEST_TAPE_SOCKET}
 Enter your new password
 
 New password:
 >
+
+  Press escape key to go back to choose the provider
 ────────────────────────────────────────────────────────────────────────────────
 > ./pam_authd login socket=${AUTHD_TEST_TAPE_SOCKET}
 Enter your new password
 
 New password:
 > *********
+
+  Press escape key to go back to choose the provider
 ────────────────────────────────────────────────────────────────────────────────
 > ./pam_authd login socket=${AUTHD_TEST_TAPE_SOCKET}
 Enter your new password
@@ -42,6 +54,8 @@ New password:
 > *********
 Confirm password:
 > *********
+
+  Press escape key to go back to choose the provider
 ────────────────────────────────────────────────────────────────────────────────
 > ./pam_authd login socket=${AUTHD_TEST_TAPE_SOCKET}
 PAM Authenticate()

--- a/pam/integration-tests/testdata/golden/TestCLIAuthenticate/Authenticate_user_and_reset_password_with_case_insensitive_user_selection
+++ b/pam/integration-tests/testdata/golden/TestCLIAuthenticate/Authenticate_user_and_reset_password_with_case_insensitive_user_selection
@@ -9,26 +9,36 @@ Username: user-needs-reset-integration-case-insensitive-testcliauthenticate
 
 > 1. local
   2. ExampleBroker
+
+  Press escape key to go back to user selection
 ────────────────────────────────────────────────────────────────────────────────
 > ./pam_authd login socket=${AUTHD_TEST_TAPE_SOCKET}
 Gimme your password:
 >
+
+  Press escape key to go back to select the authentication method
 ────────────────────────────────────────────────────────────────────────────────
 > ./pam_authd login socket=${AUTHD_TEST_TAPE_SOCKET}
 Gimme your password:
 > ********
+
+  Press escape key to go back to select the authentication method
 ────────────────────────────────────────────────────────────────────────────────
 > ./pam_authd login socket=${AUTHD_TEST_TAPE_SOCKET}
 Enter your new password
 
 New password:
 >
+
+  Press escape key to go back to choose the provider
 ────────────────────────────────────────────────────────────────────────────────
 > ./pam_authd login socket=${AUTHD_TEST_TAPE_SOCKET}
 Enter your new password
 
 New password:
 > *********
+
+  Press escape key to go back to choose the provider
 ────────────────────────────────────────────────────────────────────────────────
 > ./pam_authd login socket=${AUTHD_TEST_TAPE_SOCKET}
 Enter your new password
@@ -37,6 +47,8 @@ New password:
 > *********
 Confirm password:
 > *********
+
+  Press escape key to go back to choose the provider
 ────────────────────────────────────────────────────────────────────────────────
 > ./pam_authd login socket=${AUTHD_TEST_TAPE_SOCKET}
 PAM Authenticate()
@@ -58,10 +70,14 @@ Username: USER-NEEDS-RESET-INTEGRATION-CASE-INSENSITIVE-TESTCLIAUTHENTICATE
 > ./pam_authd login socket=${AUTHD_TEST_TAPE_SOCKET}
 Gimme your password:
 >
+
+  Press escape key to go back to select the authentication method
 ────────────────────────────────────────────────────────────────────────────────
 > ./pam_authd login socket=${AUTHD_TEST_TAPE_SOCKET}
 Gimme your password:
 > *********
+
+  Press escape key to go back to select the authentication method
 ────────────────────────────────────────────────────────────────────────────────
 > ./pam_authd login socket=${AUTHD_TEST_TAPE_SOCKET}
 PAM Authenticate()
@@ -83,10 +99,14 @@ Username: user-needs-reset-integration-Case-INSENSITIVE-testcliauthenticate
 > ./pam_authd login socket=${AUTHD_TEST_TAPE_SOCKET}
 Gimme your password:
 >
+
+  Press escape key to go back to select the authentication method
 ────────────────────────────────────────────────────────────────────────────────
 > ./pam_authd login socket=${AUTHD_TEST_TAPE_SOCKET}
 Gimme your password:
 > *********
+
+  Press escape key to go back to select the authentication method
 ────────────────────────────────────────────────────────────────────────────────
 > ./pam_authd login socket=${AUTHD_TEST_TAPE_SOCKET}
 PAM Authenticate()

--- a/pam/integration-tests/testdata/golden/TestCLIAuthenticate/Authenticate_user_successfully
+++ b/pam/integration-tests/testdata/golden/TestCLIAuthenticate/Authenticate_user_successfully
@@ -9,14 +9,20 @@ Username: user-integration-simple-testcliauthenticate
 
 > 1. local
   2. ExampleBroker
+
+  Press escape key to go back to user selection
 ────────────────────────────────────────────────────────────────────────────────
 > ./pam_authd login socket=${AUTHD_TEST_TAPE_SOCKET}
 Gimme your password:
 >
+
+  Press escape key to go back to select the authentication method
 ────────────────────────────────────────────────────────────────────────────────
 > ./pam_authd login socket=${AUTHD_TEST_TAPE_SOCKET}
 Gimme your password:
 > ********
+
+  Press escape key to go back to select the authentication method
 ────────────────────────────────────────────────────────────────────────────────
 > ./pam_authd login socket=${AUTHD_TEST_TAPE_SOCKET}
 PAM Authenticate()

--- a/pam/integration-tests/testdata/golden/TestCLIAuthenticate/Authenticate_user_successfully_after_db_migration
+++ b/pam/integration-tests/testdata/golden/TestCLIAuthenticate/Authenticate_user_successfully_after_db_migration
@@ -1,10 +1,14 @@
 > ./pam_authd login socket=${AUTHD_TEST_TAPE_SOCKET}
 Gimme your password:
 >
+
+  Press escape key to go back to select the authentication method
 ────────────────────────────────────────────────────────────────────────────────
 > ./pam_authd login socket=${AUTHD_TEST_TAPE_SOCKET}
 Gimme your password:
 > ********
+
+  Press escape key to go back to select the authentication method
 ────────────────────────────────────────────────────────────────────────────────
 > ./pam_authd login socket=${AUTHD_TEST_TAPE_SOCKET}
 PAM Authenticate()

--- a/pam/integration-tests/testdata/golden/TestCLIAuthenticate/Authenticate_user_successfully_after_trying_empty_user
+++ b/pam/integration-tests/testdata/golden/TestCLIAuthenticate/Authenticate_user_successfully_after_trying_empty_user
@@ -15,10 +15,14 @@ Username: user-integration-was-empty
 
 > 1. local
   2. ExampleBroker
+
+  Press escape key to go back to user selection
 ────────────────────────────────────────────────────────────────────────────────
 > ./pam_authd login socket=${AUTHD_TEST_TAPE_SOCKET}
 Gimme your password:
 >
+
+  Press escape key to go back to select the authentication method
 ────────────────────────────────────────────────────────────────────────────────
 > ./pam_authd login socket=${AUTHD_TEST_TAPE_SOCKET}
 PAM Authenticate()

--- a/pam/integration-tests/testdata/golden/TestCLIAuthenticate/Authenticate_user_successfully_with_invalid_connection_timeout
+++ b/pam/integration-tests/testdata/golden/TestCLIAuthenticate/Authenticate_user_successfully_with_invalid_connection_timeout
@@ -9,14 +9,20 @@ Username: user-integration-invalid-timeout-testcliauthenticate
 
 > 1. local
   2. ExampleBroker
+
+  Press escape key to go back to user selection
 ────────────────────────────────────────────────────────────────────────────────
 > ./pam_authd login socket=${AUTHD_TEST_TAPE_SOCKET}
 Gimme your password:
 >
+
+  Press escape key to go back to select the authentication method
 ────────────────────────────────────────────────────────────────────────────────
 > ./pam_authd login socket=${AUTHD_TEST_TAPE_SOCKET}
 Gimme your password:
 > ********
+
+  Press escape key to go back to select the authentication method
 ────────────────────────────────────────────────────────────────────────────────
 > ./pam_authd login socket=${AUTHD_TEST_TAPE_SOCKET}
 PAM Authenticate()

--- a/pam/integration-tests/testdata/golden/TestCLIAuthenticate/Authenticate_user_successfully_with_password_only_supported_method
+++ b/pam/integration-tests/testdata/golden/TestCLIAuthenticate/Authenticate_user_successfully_with_password_only_supported_method
@@ -9,14 +9,20 @@ Username: user-auth-modes-password-integration-cli
 
 > 1. local
   2. ExampleBroker
+
+  Press escape key to go back to user selection
 ────────────────────────────────────────────────────────────────────────────────
 > ./pam_authd login socket=${AUTHD_TEST_TAPE_SOCKET}
 Gimme your password:
 >
+
+  Press escape key to go back to choose the provider
 ────────────────────────────────────────────────────────────────────────────────
 > ./pam_authd login socket=${AUTHD_TEST_TAPE_SOCKET}
 Gimme your password:
 > ********
+
+  Press escape key to go back to choose the provider
 ────────────────────────────────────────────────────────────────────────────────
 > ./pam_authd login socket=${AUTHD_TEST_TAPE_SOCKET}
 PAM Authenticate()

--- a/pam/integration-tests/testdata/golden/TestCLIAuthenticate/Authenticate_user_successfully_with_preset_user
+++ b/pam/integration-tests/testdata/golden/TestCLIAuthenticate/Authenticate_user_successfully_with_preset_user
@@ -7,10 +7,14 @@
 > ./pam_authd login socket=${AUTHD_TEST_TAPE_SOCKET}
 Gimme your password:
 >
+
+  Press escape key to go back to select the authentication method
 ────────────────────────────────────────────────────────────────────────────────
 > ./pam_authd login socket=${AUTHD_TEST_TAPE_SOCKET}
 Gimme your password:
 > ********
+
+  Press escape key to go back to select the authentication method
 ────────────────────────────────────────────────────────────────────────────────
 > ./pam_authd login socket=${AUTHD_TEST_TAPE_SOCKET}
 PAM Authenticate()

--- a/pam/integration-tests/testdata/golden/TestCLIAuthenticate/Authenticate_user_successfully_with_upper_case
+++ b/pam/integration-tests/testdata/golden/TestCLIAuthenticate/Authenticate_user_successfully_with_upper_case
@@ -9,14 +9,20 @@ Username: user-integration-upper-case-testcliauthenticate
 
 > 1. local
   2. ExampleBroker
+
+  Press escape key to go back to user selection
 ────────────────────────────────────────────────────────────────────────────────
 > ./pam_authd login socket=${AUTHD_TEST_TAPE_SOCKET}
 Gimme your password:
 >
+
+  Press escape key to go back to select the authentication method
 ────────────────────────────────────────────────────────────────────────────────
 > ./pam_authd login socket=${AUTHD_TEST_TAPE_SOCKET}
 Gimme your password:
 > ********
+
+  Press escape key to go back to select the authentication method
 ────────────────────────────────────────────────────────────────────────────────
 > ./pam_authd login socket=${AUTHD_TEST_TAPE_SOCKET}
 PAM Authenticate()

--- a/pam/integration-tests/testdata/golden/TestCLIAuthenticate/Authenticate_user_successfully_with_upper_case_preset_user
+++ b/pam/integration-tests/testdata/golden/TestCLIAuthenticate/Authenticate_user_successfully_with_upper_case_preset_user
@@ -7,10 +7,14 @@
 > ./pam_authd login socket=${AUTHD_TEST_TAPE_SOCKET}
 Gimme your password:
 >
+
+  Press escape key to go back to select the authentication method
 ────────────────────────────────────────────────────────────────────────────────
 > ./pam_authd login socket=${AUTHD_TEST_TAPE_SOCKET}
 Gimme your password:
 > ********
+
+  Press escape key to go back to select the authentication method
 ────────────────────────────────────────────────────────────────────────────────
 > ./pam_authd login socket=${AUTHD_TEST_TAPE_SOCKET}
 PAM Authenticate()

--- a/pam/integration-tests/testdata/golden/TestCLIAuthenticate/Authenticate_user_switching_auth_mode
+++ b/pam/integration-tests/testdata/golden/TestCLIAuthenticate/Authenticate_user_switching_auth_mode
@@ -9,10 +9,14 @@ Username: user-integration-switch-mode
 
 > 1. local
   2. ExampleBroker
+
+  Press escape key to go back to user selection
 ────────────────────────────────────────────────────────────────────────────────
 > ./pam_authd login socket=${AUTHD_TEST_TAPE_SOCKET}
 Gimme your password:
 >
+
+  Press escape key to go back to select the authentication method
 ────────────────────────────────────────────────────────────────────────────────
 > ./pam_authd login socket=${AUTHD_TEST_TAPE_SOCKET}
   Select your authentication method
@@ -24,10 +28,14 @@ Gimme your password:
   5. Use your phone +1...
   6. Use a QR code
   7. Authentication code
+
+  Press escape key to go back to choose the provider
 ────────────────────────────────────────────────────────────────────────────────
 > ./pam_authd login socket=${AUTHD_TEST_TAPE_SOCKET}
 Click on the link received at user-integration-switch-mode@gmail.com or enter the code:
 >
+
+  Press escape key to go back to select the authentication method
 ────────────────────────────────────────────────────────────────────────────────
 > ./pam_authd login socket=${AUTHD_TEST_TAPE_SOCKET}
   Select your authentication method
@@ -39,9 +47,13 @@ Click on the link received at user-integration-switch-mode@gmail.com or enter th
   5. Use your phone +1...
   6. Use a QR code
   7. Authentication code
+
+  Press escape key to go back to choose the provider
 ────────────────────────────────────────────────────────────────────────────────
 > ./pam_authd login socket=${AUTHD_TEST_TAPE_SOCKET}
 Plug your fido device and press with your thumb
+
+  Press escape key to go back to select the authentication method
 ────────────────────────────────────────────────────────────────────────────────
 > ./pam_authd login socket=${AUTHD_TEST_TAPE_SOCKET}
   Select your authentication method
@@ -53,14 +65,20 @@ Plug your fido device and press with your thumb
   5. Use your phone +1...
   6. Use a QR code
   7. Authentication code
+
+  Press escape key to go back to choose the provider
 ────────────────────────────────────────────────────────────────────────────────
 > ./pam_authd login socket=${AUTHD_TEST_TAPE_SOCKET}
 Gimme your password:
 >
+
+  Press escape key to go back to select the authentication method
 ────────────────────────────────────────────────────────────────────────────────
 > ./pam_authd login socket=${AUTHD_TEST_TAPE_SOCKET}
 Gimme your password:
 > ********
+
+  Press escape key to go back to select the authentication method
 ────────────────────────────────────────────────────────────────────────────────
 > ./pam_authd login socket=${AUTHD_TEST_TAPE_SOCKET}
 PAM Authenticate()

--- a/pam/integration-tests/testdata/golden/TestCLIAuthenticate/Authenticate_user_switching_to_local_broker
+++ b/pam/integration-tests/testdata/golden/TestCLIAuthenticate/Authenticate_user_switching_to_local_broker
@@ -9,10 +9,14 @@ Username: user-integration-switch-broker
 
 > 1. local
   2. ExampleBroker
+
+  Press escape key to go back to user selection
 ────────────────────────────────────────────────────────────────────────────────
 > ./pam_authd login socket=${AUTHD_TEST_TAPE_SOCKET}
 Gimme your password:
 >
+
+  Press escape key to go back to select the authentication method
 ────────────────────────────────────────────────────────────────────────────────
 > ./pam_authd login socket=${AUTHD_TEST_TAPE_SOCKET}
   Select your authentication method
@@ -24,17 +28,23 @@ Gimme your password:
   5. Use your phone +1...
   6. Use a QR code
   7. Authentication code
+
+  Press escape key to go back to choose the provider
 ────────────────────────────────────────────────────────────────────────────────
 > ./pam_authd login socket=${AUTHD_TEST_TAPE_SOCKET}
   Select your provider
 
   1. local
 > 2. ExampleBroker
+
+  Press escape key to go back to user selection
 ────────────────────────────────────────────────────────────────────────────────
 > ./pam_authd login socket=${AUTHD_TEST_TAPE_SOCKET}
   Select your provider
 
 > 1. local
+  2. ExampleBroker
+
 PAM Info Message: auth=incomplete
 PAM Authenticate()
   User: "user-integration-switch-broker"

--- a/pam/integration-tests/testdata/golden/TestCLIAuthenticate/Authenticate_user_switching_username
+++ b/pam/integration-tests/testdata/golden/TestCLIAuthenticate/Authenticate_user_switching_username
@@ -9,6 +9,8 @@ Username: user-integration-switch-username
 
 > 1. local
   2. ExampleBroker
+
+  Press escape key to go back to user selection
 ────────────────────────────────────────────────────────────────────────────────
 > ./pam_authd login socket=${AUTHD_TEST_TAPE_SOCKET}
 Username: user-integration-username-switched
@@ -18,14 +20,20 @@ Username: user-integration-username-switched
 
 > 1. local
   2. ExampleBroker
+
+  Press escape key to go back to user selection
 ────────────────────────────────────────────────────────────────────────────────
 > ./pam_authd login socket=${AUTHD_TEST_TAPE_SOCKET}
 Gimme your password:
 >
+
+  Press escape key to go back to select the authentication method
 ────────────────────────────────────────────────────────────────────────────────
 > ./pam_authd login socket=${AUTHD_TEST_TAPE_SOCKET}
 Gimme your password:
 > ********
+
+  Press escape key to go back to select the authentication method
 ────────────────────────────────────────────────────────────────────────────────
 > ./pam_authd login socket=${AUTHD_TEST_TAPE_SOCKET}
 PAM Authenticate()

--- a/pam/integration-tests/testdata/golden/TestCLIAuthenticate/Authenticate_user_with_form_mode_with_button
+++ b/pam/integration-tests/testdata/golden/TestCLIAuthenticate/Authenticate_user_with_form_mode_with_button
@@ -9,10 +9,14 @@ Username: user-integration-form-w-button
 
 > 1. local
   2. ExampleBroker
+
+  Press escape key to go back to user selection
 ────────────────────────────────────────────────────────────────────────────────
 > ./pam_authd login socket=${AUTHD_TEST_TAPE_SOCKET}
 Gimme your password:
 >
+
+  Press escape key to go back to select the authentication method
 ────────────────────────────────────────────────────────────────────────────────
 > ./pam_authd login socket=${AUTHD_TEST_TAPE_SOCKET}
   Select your authentication method
@@ -24,18 +28,24 @@ Gimme your password:
   5. Use your phone +1...
   6. Use a QR code
   7. Authentication code
+
+  Press escape key to go back to choose the provider
 ────────────────────────────────────────────────────────────────────────────────
 > ./pam_authd login socket=${AUTHD_TEST_TAPE_SOCKET}
 Enter your one time credential:
 >
 
   [ Resend SMS (1 sent) ]
+
+  Press escape key to go back to select the authentication method
 ────────────────────────────────────────────────────────────────────────────────
 > ./pam_authd login socket=${AUTHD_TEST_TAPE_SOCKET}
 Enter your one time credential:
 >
 
   [ Resend SMS (2 sent) ]
+
+  Press escape key to go back to select the authentication method
 ────────────────────────────────────────────────────────────────────────────────
 > ./pam_authd login socket=${AUTHD_TEST_TAPE_SOCKET}
 PAM Authenticate()

--- a/pam/integration-tests/testdata/golden/TestCLIAuthenticate/Authenticate_user_with_mfa
+++ b/pam/integration-tests/testdata/golden/TestCLIAuthenticate/Authenticate_user_with_mfa
@@ -9,10 +9,14 @@ Username: user-mfa
 
 > 1. local
   2. ExampleBroker
+
+  Press escape key to go back to user selection
 ────────────────────────────────────────────────────────────────────────────────
 > ./pam_authd login socket=${AUTHD_TEST_TAPE_SOCKET}
 Gimme your password:
 >
+
+  Press escape key to go back to select the authentication method
 ────────────────────────────────────────────────────────────────────────────────
 > ./pam_authd login socket=${AUTHD_TEST_TAPE_SOCKET}
   Select your authentication method
@@ -24,17 +28,25 @@ Gimme your password:
   5. Use your phone +1...
   6. Use a QR code
   7. Authentication code
+
+  Press escape key to go back to choose the provider
 ────────────────────────────────────────────────────────────────────────────────
 > ./pam_authd login socket=${AUTHD_TEST_TAPE_SOCKET}
 Gimme your password:
 >
+
+  Press escape key to go back to select the authentication method
 ────────────────────────────────────────────────────────────────────────────────
 > ./pam_authd login socket=${AUTHD_TEST_TAPE_SOCKET}
 Gimme your password:
 > ********
+
+  Press escape key to go back to select the authentication method
 ────────────────────────────────────────────────────────────────────────────────
 > ./pam_authd login socket=${AUTHD_TEST_TAPE_SOCKET}
 Plug your fido device and press with your thumb
+
+  Press escape key to go back to select the authentication method
 ────────────────────────────────────────────────────────────────────────────────
 > ./pam_authd login socket=${AUTHD_TEST_TAPE_SOCKET}
   Select your authentication method
@@ -42,21 +54,31 @@ Plug your fido device and press with your thumb
 > 1. Use your fido device foo
   2. Use your phone +33...
   3. Authentication code
+
+  Press escape key to go back to choose the provider
 ────────────────────────────────────────────────────────────────────────────────
 > ./pam_authd login socket=${AUTHD_TEST_TAPE_SOCKET}
 Plug your fido device and press with your thumb
+
+  Press escape key to go back to select the authentication method
 ────────────────────────────────────────────────────────────────────────────────
 > ./pam_authd login socket=${AUTHD_TEST_TAPE_SOCKET}
 Unlock your phone +33... or accept request on web interface
+
+  Press escape key to go back to select the authentication method
 ────────────────────────────────────────────────────────────────────────────────
 > ./pam_authd login socket=${AUTHD_TEST_TAPE_SOCKET}
   Select your authentication method
 
 > 1. Use your phone +33...
   2. Authentication code
+
+  Press escape key to go back to choose the provider
 ────────────────────────────────────────────────────────────────────────────────
 > ./pam_authd login socket=${AUTHD_TEST_TAPE_SOCKET}
 Unlock your phone +33... or accept request on web interface
+
+  Press escape key to go back to select the authentication method
 ────────────────────────────────────────────────────────────────────────────────
 > ./pam_authd login socket=${AUTHD_TEST_TAPE_SOCKET}
 PAM Authenticate()

--- a/pam/integration-tests/testdata/golden/TestCLIAuthenticate/Authenticate_user_with_mfa_and_reset_password_while_enforcing_policy
+++ b/pam/integration-tests/testdata/golden/TestCLIAuthenticate/Authenticate_user_with_mfa_and_reset_password_while_enforcing_policy
@@ -9,26 +9,38 @@ Username: user-mfa-with-reset
 
 > 1. local
   2. ExampleBroker
+
+  Press escape key to go back to user selection
 ────────────────────────────────────────────────────────────────────────────────
 > ./pam_authd login socket=${AUTHD_TEST_TAPE_SOCKET}
 Gimme your password:
 >
+
+  Press escape key to go back to select the authentication method
 ────────────────────────────────────────────────────────────────────────────────
 > ./pam_authd login socket=${AUTHD_TEST_TAPE_SOCKET}
 Gimme your password:
 > ********
+
+  Press escape key to go back to select the authentication method
 ────────────────────────────────────────────────────────────────────────────────
 > ./pam_authd login socket=${AUTHD_TEST_TAPE_SOCKET}
 Gimme your password:
 > ********
 Password reset, 2 step(s) missing
+
+  Press escape key to go back to select the authentication method
 ────────────────────────────────────────────────────────────────────────────────
 > ./pam_authd login socket=${AUTHD_TEST_TAPE_SOCKET}
 Plug your fido device and press with your thumb
+
+  Press escape key to go back to select the authentication method
 ────────────────────────────────────────────────────────────────────────────────
 > ./pam_authd login socket=${AUTHD_TEST_TAPE_SOCKET}
 Plug your fido device and press with your thumb
 Password reset, 1 step(s) missing
+
+  Press escape key to go back to select the authentication method
 ────────────────────────────────────────────────────────────────────────────────
 > ./pam_authd login socket=${AUTHD_TEST_TAPE_SOCKET}
 Enter your new password (3 days until mandatory)
@@ -37,6 +49,8 @@ New password:
 >
 
   [ Skip ]
+
+  Press escape key to go back to choose the provider
 ────────────────────────────────────────────────────────────────────────────────
 > ./pam_authd login socket=${AUTHD_TEST_TAPE_SOCKET}
 Enter your new password (3 days until mandatory)
@@ -45,6 +59,8 @@ New password:
 > ********
 
   [ Skip ]
+
+  Press escape key to go back to choose the provider
 ────────────────────────────────────────────────────────────────────────────────
 > ./pam_authd login socket=${AUTHD_TEST_TAPE_SOCKET}
 Enter your new password (3 days until mandatory)
@@ -54,6 +70,8 @@ New password:
 
   [ Skip ]
 The password is the same as the old one
+
+  Press escape key to go back to choose the provider
 ────────────────────────────────────────────────────────────────────────────────
 > ./pam_authd login socket=${AUTHD_TEST_TAPE_SOCKET}
 Enter your new password (3 days until mandatory)
@@ -63,6 +81,8 @@ New password:
 
   [ Skip ]
 The password is the same as the old one
+
+  Press escape key to go back to choose the provider
 ────────────────────────────────────────────────────────────────────────────────
 > ./pam_authd login socket=${AUTHD_TEST_TAPE_SOCKET}
 Enter your new password (3 days until mandatory)
@@ -72,6 +92,8 @@ New password:
 
   [ Skip ]
 The password fails the dictionary check - it is based on a dictionary word
+
+  Press escape key to go back to choose the provider
 ────────────────────────────────────────────────────────────────────────────────
 > ./pam_authd login socket=${AUTHD_TEST_TAPE_SOCKET}
 Enter your new password (3 days until mandatory)
@@ -81,6 +103,8 @@ New password:
 
   [ Skip ]
 The password fails the dictionary check - it is based on a dictionary word
+
+  Press escape key to go back to choose the provider
 ────────────────────────────────────────────────────────────────────────────────
 > ./pam_authd login socket=${AUTHD_TEST_TAPE_SOCKET}
 Enter your new password (3 days until mandatory)
@@ -90,6 +114,8 @@ New password:
 
   [ Skip ]
 The password is the same as the old one
+
+  Press escape key to go back to choose the provider
 ────────────────────────────────────────────────────────────────────────────────
 > ./pam_authd login socket=${AUTHD_TEST_TAPE_SOCKET}
 Enter your new password (3 days until mandatory)
@@ -99,6 +125,8 @@ New password:
 
   [ Skip ]
 The password is the same as the old one
+
+  Press escape key to go back to choose the provider
 ────────────────────────────────────────────────────────────────────────────────
 > ./pam_authd login socket=${AUTHD_TEST_TAPE_SOCKET}
 Enter your new password (3 days until mandatory)
@@ -108,6 +136,8 @@ New password:
 
   [ Skip ]
 The password is shorter than 8 characters
+
+  Press escape key to go back to choose the provider
 ────────────────────────────────────────────────────────────────────────────────
 > ./pam_authd login socket=${AUTHD_TEST_TAPE_SOCKET}
 Enter your new password (3 days until mandatory)
@@ -117,6 +147,8 @@ New password:
 
   [ Skip ]
 The password is shorter than 8 characters
+
+  Press escape key to go back to choose the provider
 ────────────────────────────────────────────────────────────────────────────────
 > ./pam_authd login socket=${AUTHD_TEST_TAPE_SOCKET}
 Enter your new password (3 days until mandatory)
@@ -127,6 +159,8 @@ Confirm password:
 >
 
   [ Skip ]
+
+  Press escape key to go back to choose the provider
 ────────────────────────────────────────────────────────────────────────────────
 > ./pam_authd login socket=${AUTHD_TEST_TAPE_SOCKET}
 Enter your new password (3 days until mandatory)
@@ -137,6 +171,8 @@ Confirm password:
 > *********
 
   [ Skip ]
+
+  Press escape key to go back to choose the provider
 ────────────────────────────────────────────────────────────────────────────────
 > ./pam_authd login socket=${AUTHD_TEST_TAPE_SOCKET}
 PAM Authenticate()

--- a/pam/integration-tests/testdata/golden/TestCLIAuthenticate/Authenticate_user_with_mixed_case_after_db_migration
+++ b/pam/integration-tests/testdata/golden/TestCLIAuthenticate/Authenticate_user_with_mixed_case_after_db_migration
@@ -1,10 +1,14 @@
 > ./pam_authd login socket=${AUTHD_TEST_TAPE_SOCKET}
 Gimme your password:
 >
+
+  Press escape key to go back to select the authentication method
 ────────────────────────────────────────────────────────────────────────────────
 > ./pam_authd login socket=${AUTHD_TEST_TAPE_SOCKET}
 Gimme your password:
 > ********
+
+  Press escape key to go back to select the authentication method
 ────────────────────────────────────────────────────────────────────────────────
 > ./pam_authd login socket=${AUTHD_TEST_TAPE_SOCKET}
 PAM Authenticate()

--- a/pam/integration-tests/testdata/golden/TestCLIAuthenticate/Authenticate_user_with_qr_code
+++ b/pam/integration-tests/testdata/golden/TestCLIAuthenticate/Authenticate_user_with_qr_code
@@ -7,6 +7,8 @@
 > ./pam_authd login socket=${AUTHD_TEST_TAPE_SOCKET}
 Gimme your password:
 >
+
+  Press escape key to go back to select the authentication method
 ────────────────────────────────────────────────────────────────────────────────
 > ./pam_authd login socket=${AUTHD_TEST_TAPE_SOCKET}
   Select your authentication method
@@ -18,6 +20,8 @@ Gimme your password:
   5. Use your phone +1...
   6. Use a QR code
   7. Authentication code
+
+  Press escape key to go back to choose the provider
 ────────────────────────────────────────────────────────────────────────────────
 > ./pam_authd login socket=${AUTHD_TEST_TAPE_SOCKET}
 Scan the qrcode or enter the code in the login page
@@ -43,6 +47,8 @@ Scan the qrcode or enter the code in the login page
               1337
 
         [ Regenerate code ]
+
+  Press escape key to go back to select the authentication method
 ────────────────────────────────────────────────────────────────────────────────
 > ./pam_authd login socket=${AUTHD_TEST_TAPE_SOCKET}
 Scan the qrcode or enter the code in the login page
@@ -68,6 +74,8 @@ Scan the qrcode or enter the code in the login page
               1338
 
         [ Regenerate code ]
+
+  Press escape key to go back to select the authentication method
 ────────────────────────────────────────────────────────────────────────────────
 > ./pam_authd login socket=${AUTHD_TEST_TAPE_SOCKET}
 Scan the qrcode or enter the code in the login page
@@ -95,6 +103,8 @@ Scan the qrcode or enter the code in the login page
                 1339
 
           [ Regenerate code ]
+
+  Press escape key to go back to select the authentication method
 ────────────────────────────────────────────────────────────────────────────────
 > ./pam_authd login socket=${AUTHD_TEST_TAPE_SOCKET}
 Scan the qrcode or enter the code in the login page
@@ -120,6 +130,8 @@ Scan the qrcode or enter the code in the login page
               1340
 
         [ Regenerate code ]
+
+  Press escape key to go back to select the authentication method
 ────────────────────────────────────────────────────────────────────────────────
 > ./pam_authd login socket=${AUTHD_TEST_TAPE_SOCKET}
 Scan the qrcode or enter the code in the login page
@@ -145,6 +157,8 @@ Scan the qrcode or enter the code in the login page
               1341
 
         [ Regenerate code ]
+
+  Press escape key to go back to select the authentication method
 ────────────────────────────────────────────────────────────────────────────────
 > ./pam_authd login socket=${AUTHD_TEST_TAPE_SOCKET}
 PAM Authenticate()

--- a/pam/integration-tests/testdata/golden/TestCLIAuthenticate/Authenticate_user_with_qr_code_after_many_regenerations
+++ b/pam/integration-tests/testdata/golden/TestCLIAuthenticate/Authenticate_user_with_qr_code_after_many_regenerations
@@ -9,10 +9,14 @@ Username: user-integration-qrcode-static-regenerate
 
 > 1. local
   2. ExampleBroker
+
+  Press escape key to go back to user selection
 ────────────────────────────────────────────────────────────────────────────────
 > ./pam_authd login socket=${AUTHD_TEST_TAPE_SOCKET}
 Gimme your password:
 >
+
+  Press escape key to go back to select the authentication method
 ────────────────────────────────────────────────────────────────────────────────
 > ./pam_authd login socket=${AUTHD_TEST_TAPE_SOCKET}
   Select your authentication method
@@ -24,6 +28,8 @@ Gimme your password:
   5. Use your phone +1...
   6. Use a QR code
   7. Authentication code
+
+  Press escape key to go back to choose the provider
 ────────────────────────────────────────────────────────────────────────────────
 > ./pam_authd login socket=${AUTHD_TEST_TAPE_SOCKET}
 Scan the qrcode or enter the code in the login page
@@ -49,6 +55,8 @@ Scan the qrcode or enter the code in the login page
               1337
 
         [ Regenerate code ]
+
+  Press escape key to go back to select the authentication method
 ────────────────────────────────────────────────────────────────────────────────
 > ./pam_authd login socket=${AUTHD_TEST_TAPE_SOCKET}
 PAM Authenticate()

--- a/pam/integration-tests/testdata/golden/TestCLIAuthenticate/Authenticate_user_with_qr_code_in_a_TTY
+++ b/pam/integration-tests/testdata/golden/TestCLIAuthenticate/Authenticate_user_with_qr_code_in_a_TTY
@@ -7,6 +7,8 @@
 > ./pam_authd login socket=${AUTHD_TEST_TAPE_SOCKET}
 Gimme your password:
 >
+
+  Press escape key to go back to select the authentication method
 ────────────────────────────────────────────────────────────────────────────────
 > ./pam_authd login socket=${AUTHD_TEST_TAPE_SOCKET}
   Select your authentication method
@@ -18,6 +20,8 @@ Gimme your password:
   5. Use your phone +1...
   6. Use a QR code
   7. Authentication code
+
+  Press escape key to go back to choose the provider
 ────────────────────────────────────────────────────────────────────────────────
 > ./pam_authd login socket=${AUTHD_TEST_TAPE_SOCKET}
 Scan the qrcode or enter the code in the login page
@@ -59,6 +63,8 @@ Scan the qrcode or enter the code in the login page
                                1337
 
                         [ Regenerate code ]
+
+  Press escape key to go back to select the authentication method
 ────────────────────────────────────────────────────────────────────────────────
 > ./pam_authd login socket=${AUTHD_TEST_TAPE_SOCKET}
 Scan the qrcode or enter the code in the login page
@@ -100,6 +106,8 @@ Scan the qrcode or enter the code in the login page
                                1338
 
                         [ Regenerate code ]
+
+  Press escape key to go back to select the authentication method
 ────────────────────────────────────────────────────────────────────────────────
 > ./pam_authd login socket=${AUTHD_TEST_TAPE_SOCKET}
 Scan the qrcode or enter the code in the login page
@@ -145,6 +153,8 @@ Scan the qrcode or enter the code in the login page
                                    1339
 
                             [ Regenerate code ]
+
+  Press escape key to go back to select the authentication method
 ────────────────────────────────────────────────────────────────────────────────
 > ./pam_authd login socket=${AUTHD_TEST_TAPE_SOCKET}
 Scan the qrcode or enter the code in the login page
@@ -186,6 +196,8 @@ Scan the qrcode or enter the code in the login page
                                1340
 
                         [ Regenerate code ]
+
+  Press escape key to go back to select the authentication method
 ────────────────────────────────────────────────────────────────────────────────
 > ./pam_authd login socket=${AUTHD_TEST_TAPE_SOCKET}
 Scan the qrcode or enter the code in the login page
@@ -227,6 +239,8 @@ Scan the qrcode or enter the code in the login page
                                1341
 
                         [ Regenerate code ]
+
+  Press escape key to go back to select the authentication method
 ────────────────────────────────────────────────────────────────────────────────
 > ./pam_authd login socket=${AUTHD_TEST_TAPE_SOCKET}
 PAM Authenticate()

--- a/pam/integration-tests/testdata/golden/TestCLIAuthenticate/Authenticate_user_with_qr_code_in_a_TTY_session
+++ b/pam/integration-tests/testdata/golden/TestCLIAuthenticate/Authenticate_user_with_qr_code_in_a_TTY_session
@@ -7,6 +7,8 @@
 > ./pam_authd login socket=${AUTHD_TEST_TAPE_SOCKET}
 Gimme your password:
 >
+
+  Press escape key to go back to select the authentication method
 ────────────────────────────────────────────────────────────────────────────────
 > ./pam_authd login socket=${AUTHD_TEST_TAPE_SOCKET}
   Select your authentication method
@@ -18,6 +20,8 @@ Gimme your password:
   5. Use your phone +1...
   6. Use a QR code
   7. Authentication code
+
+  Press escape key to go back to choose the provider
 ────────────────────────────────────────────────────────────────────────────────
 > ./pam_authd login socket=${AUTHD_TEST_TAPE_SOCKET}
 Scan the qrcode or enter the code in the login page
@@ -59,6 +63,8 @@ Scan the qrcode or enter the code in the login page
                                1337
 
                         [ Regenerate code ]
+
+  Press escape key to go back to select the authentication method
 ────────────────────────────────────────────────────────────────────────────────
 > ./pam_authd login socket=${AUTHD_TEST_TAPE_SOCKET}
 Scan the qrcode or enter the code in the login page
@@ -100,6 +106,8 @@ Scan the qrcode or enter the code in the login page
                                1338
 
                         [ Regenerate code ]
+
+  Press escape key to go back to select the authentication method
 ────────────────────────────────────────────────────────────────────────────────
 > ./pam_authd login socket=${AUTHD_TEST_TAPE_SOCKET}
 Scan the qrcode or enter the code in the login page
@@ -145,6 +153,8 @@ Scan the qrcode or enter the code in the login page
                                    1339
 
                             [ Regenerate code ]
+
+  Press escape key to go back to select the authentication method
 ────────────────────────────────────────────────────────────────────────────────
 > ./pam_authd login socket=${AUTHD_TEST_TAPE_SOCKET}
 Scan the qrcode or enter the code in the login page
@@ -186,6 +196,8 @@ Scan the qrcode or enter the code in the login page
                                1340
 
                         [ Regenerate code ]
+
+  Press escape key to go back to select the authentication method
 ────────────────────────────────────────────────────────────────────────────────
 > ./pam_authd login socket=${AUTHD_TEST_TAPE_SOCKET}
 Scan the qrcode or enter the code in the login page
@@ -227,6 +239,8 @@ Scan the qrcode or enter the code in the login page
                                1341
 
                         [ Regenerate code ]
+
+  Press escape key to go back to select the authentication method
 ────────────────────────────────────────────────────────────────────────────────
 > ./pam_authd login socket=${AUTHD_TEST_TAPE_SOCKET}
 PAM Authenticate()

--- a/pam/integration-tests/testdata/golden/TestCLIAuthenticate/Authenticate_user_with_qr_code_in_screen
+++ b/pam/integration-tests/testdata/golden/TestCLIAuthenticate/Authenticate_user_with_qr_code_in_screen
@@ -7,6 +7,8 @@
 > ./pam_authd login socket=${AUTHD_TEST_TAPE_SOCKET}
 Gimme your password:
 >
+
+  Press escape key to go back to select the authentication method
 ────────────────────────────────────────────────────────────────────────────────
 > ./pam_authd login socket=${AUTHD_TEST_TAPE_SOCKET}
   Select your authentication method
@@ -18,6 +20,8 @@ Gimme your password:
   5. Use your phone +1...
   6. Use a QR code
   7. Authentication code
+
+  Press escape key to go back to choose the provider
 ────────────────────────────────────────────────────────────────────────────────
 > ./pam_authd login socket=${AUTHD_TEST_TAPE_SOCKET}
 Scan the qrcode or enter the code in the login page
@@ -59,6 +63,8 @@ Scan the qrcode or enter the code in the login page
                                1337
 
                         [ Regenerate code ]
+
+  Press escape key to go back to select the authentication method
 ────────────────────────────────────────────────────────────────────────────────
 > ./pam_authd login socket=${AUTHD_TEST_TAPE_SOCKET}
 Scan the qrcode or enter the code in the login page
@@ -100,6 +106,8 @@ Scan the qrcode or enter the code in the login page
                                1338
 
                         [ Regenerate code ]
+
+  Press escape key to go back to select the authentication method
 ────────────────────────────────────────────────────────────────────────────────
 > ./pam_authd login socket=${AUTHD_TEST_TAPE_SOCKET}
 Scan the qrcode or enter the code in the login page
@@ -145,6 +153,8 @@ Scan the qrcode or enter the code in the login page
                                    1339
 
                             [ Regenerate code ]
+
+  Press escape key to go back to select the authentication method
 ────────────────────────────────────────────────────────────────────────────────
 > ./pam_authd login socket=${AUTHD_TEST_TAPE_SOCKET}
 Scan the qrcode or enter the code in the login page
@@ -186,6 +196,8 @@ Scan the qrcode or enter the code in the login page
                                1340
 
                         [ Regenerate code ]
+
+  Press escape key to go back to select the authentication method
 ────────────────────────────────────────────────────────────────────────────────
 > ./pam_authd login socket=${AUTHD_TEST_TAPE_SOCKET}
 Scan the qrcode or enter the code in the login page
@@ -227,6 +239,8 @@ Scan the qrcode or enter the code in the login page
                                1341
 
                         [ Regenerate code ]
+
+  Press escape key to go back to select the authentication method
 ────────────────────────────────────────────────────────────────────────────────
 > ./pam_authd login socket=${AUTHD_TEST_TAPE_SOCKET}
 PAM Authenticate()

--- a/pam/integration-tests/testdata/golden/TestCLIAuthenticate/Authenticate_user_with_upper_case_using_lower_case_after_db_migration
+++ b/pam/integration-tests/testdata/golden/TestCLIAuthenticate/Authenticate_user_with_upper_case_using_lower_case_after_db_migration
@@ -1,10 +1,14 @@
 > ./pam_authd login socket=${AUTHD_TEST_TAPE_SOCKET}
 Gimme your password:
 >
+
+  Press escape key to go back to select the authentication method
 ────────────────────────────────────────────────────────────────────────────────
 > ./pam_authd login socket=${AUTHD_TEST_TAPE_SOCKET}
 Gimme your password:
 > ********
+
+  Press escape key to go back to select the authentication method
 ────────────────────────────────────────────────────────────────────────────────
 > ./pam_authd login socket=${AUTHD_TEST_TAPE_SOCKET}
 PAM Authenticate()

--- a/pam/integration-tests/testdata/golden/TestCLIAuthenticate/Authenticate_with_warnings_on_unsupported_arguments
+++ b/pam/integration-tests/testdata/golden/TestCLIAuthenticate/Authenticate_with_warnings_on_unsupported_arguments
@@ -9,14 +9,20 @@ Username: user2
 
 > 1. local
   2. ExampleBroker
+
+  Press escape key to go back to user selection
 ────────────────────────────────────────────────────────────────────────────────
 > ./pam_authd login socket=${AUTHD_TEST_TAPE_SOCKET} invalid_flag=foo bar
 Gimme your password:
 >
+
+  Press escape key to go back to select the authentication method
 ────────────────────────────────────────────────────────────────────────────────
 > ./pam_authd login socket=${AUTHD_TEST_TAPE_SOCKET} invalid_flag=foo bar
 Gimme your password:
 > ********
+
+  Press escape key to go back to select the authentication method
 ────────────────────────────────────────────────────────────────────────────────
 > ./pam_authd login socket=${AUTHD_TEST_TAPE_SOCKET} invalid_flag=foo bar
 PAM Authenticate()

--- a/pam/integration-tests/testdata/golden/TestCLIAuthenticate/Deny_authentication_if_max_attempts_reached
+++ b/pam/integration-tests/testdata/golden/TestCLIAuthenticate/Deny_authentication_if_max_attempts_reached
@@ -9,54 +9,76 @@ Username: user-integration-max-attempts
 
 > 1. local
   2. ExampleBroker
+
+  Press escape key to go back to user selection
 ────────────────────────────────────────────────────────────────────────────────
 > ./pam_authd login socket=${AUTHD_TEST_TAPE_SOCKET}
 Gimme your password:
 >
+
+  Press escape key to go back to select the authentication method
 ────────────────────────────────────────────────────────────────────────────────
 > ./pam_authd login socket=${AUTHD_TEST_TAPE_SOCKET}
 Gimme your password:
 > *********
-────────────────────────────────────────────────────────────────────────────────
-> ./pam_authd login socket=${AUTHD_TEST_TAPE_SOCKET}
-Gimme your password:
->
-invalid password 'wrongpass', should be 'goodpass'
-────────────────────────────────────────────────────────────────────────────────
-> ./pam_authd login socket=${AUTHD_TEST_TAPE_SOCKET}
-Gimme your password:
-> *********
-invalid password 'wrongpass', should be 'goodpass'
+
+  Press escape key to go back to select the authentication method
 ────────────────────────────────────────────────────────────────────────────────
 > ./pam_authd login socket=${AUTHD_TEST_TAPE_SOCKET}
 Gimme your password:
 >
 invalid password 'wrongpass', should be 'goodpass'
+
+  Press escape key to go back to select the authentication method
 ────────────────────────────────────────────────────────────────────────────────
 > ./pam_authd login socket=${AUTHD_TEST_TAPE_SOCKET}
 Gimme your password:
 > *********
 invalid password 'wrongpass', should be 'goodpass'
+
+  Press escape key to go back to select the authentication method
 ────────────────────────────────────────────────────────────────────────────────
 > ./pam_authd login socket=${AUTHD_TEST_TAPE_SOCKET}
 Gimme your password:
 >
 invalid password 'wrongpass', should be 'goodpass'
+
+  Press escape key to go back to select the authentication method
 ────────────────────────────────────────────────────────────────────────────────
 > ./pam_authd login socket=${AUTHD_TEST_TAPE_SOCKET}
 Gimme your password:
 > *********
 invalid password 'wrongpass', should be 'goodpass'
+
+  Press escape key to go back to select the authentication method
 ────────────────────────────────────────────────────────────────────────────────
 > ./pam_authd login socket=${AUTHD_TEST_TAPE_SOCKET}
 Gimme your password:
 >
 invalid password 'wrongpass', should be 'goodpass'
+
+  Press escape key to go back to select the authentication method
 ────────────────────────────────────────────────────────────────────────────────
 > ./pam_authd login socket=${AUTHD_TEST_TAPE_SOCKET}
 Gimme your password:
 > *********
 invalid password 'wrongpass', should be 'goodpass'
+
+  Press escape key to go back to select the authentication method
+────────────────────────────────────────────────────────────────────────────────
+> ./pam_authd login socket=${AUTHD_TEST_TAPE_SOCKET}
+Gimme your password:
+>
+invalid password 'wrongpass', should be 'goodpass'
+
+  Press escape key to go back to select the authentication method
+────────────────────────────────────────────────────────────────────────────────
+> ./pam_authd login socket=${AUTHD_TEST_TAPE_SOCKET}
+Gimme your password:
+> *********
+invalid password 'wrongpass', should be 'goodpass'
+
+  Press escape key to go back to select the authentication method
 ────────────────────────────────────────────────────────────────────────────────
 > ./pam_authd login socket=${AUTHD_TEST_TAPE_SOCKET}
 PAM Error Message: invalid password 'wrongpass', should be 'goodpass'

--- a/pam/integration-tests/testdata/golden/TestCLIAuthenticate/Deny_authentication_if_newpassword_does_not_match_required_criteria
+++ b/pam/integration-tests/testdata/golden/TestCLIAuthenticate/Deny_authentication_if_newpassword_does_not_match_required_criteria
@@ -9,25 +9,35 @@ Username: user-needs-reset
 
 > 1. local
   2. ExampleBroker
+
+  Press escape key to go back to user selection
 ────────────────────────────────────────────────────────────────────────────────
 > ./pam_authd login socket=${AUTHD_TEST_TAPE_SOCKET}
 Gimme your password:
 >
+
+  Press escape key to go back to select the authentication method
 ────────────────────────────────────────────────────────────────────────────────
 > ./pam_authd login socket=${AUTHD_TEST_TAPE_SOCKET}
 Gimme your password:
 > ********
+
+  Press escape key to go back to select the authentication method
 ────────────────────────────────────────────────────────────────────────────────
 > ./pam_authd login socket=${AUTHD_TEST_TAPE_SOCKET}
 Gimme your password:
 > ********
 Password reset, 1 step(s) missing
+
+  Press escape key to go back to select the authentication method
 ────────────────────────────────────────────────────────────────────────────────
 > ./pam_authd login socket=${AUTHD_TEST_TAPE_SOCKET}
 Enter your new password
 
 New password:
 >
+
+  Press escape key to go back to choose the provider
 ────────────────────────────────────────────────────────────────────────────────
 > ./pam_authd login socket=${AUTHD_TEST_TAPE_SOCKET}
 Enter your new password
@@ -35,6 +45,8 @@ Enter your new password
 New password:
 >
 No password supplied
+
+  Press escape key to go back to choose the provider
 ────────────────────────────────────────────────────────────────────────────────
 > ./pam_authd login socket=${AUTHD_TEST_TAPE_SOCKET}
 Enter your new password
@@ -42,6 +54,8 @@ Enter your new password
 New password:
 > ****
 No password supplied
+
+  Press escape key to go back to choose the provider
 ────────────────────────────────────────────────────────────────────────────────
 > ./pam_authd login socket=${AUTHD_TEST_TAPE_SOCKET}
 Enter your new password
@@ -49,6 +63,8 @@ Enter your new password
 New password:
 >
 The password is shorter than 8 characters
+
+  Press escape key to go back to choose the provider
 ────────────────────────────────────────────────────────────────────────────────
 > ./pam_authd login socket=${AUTHD_TEST_TAPE_SOCKET}
 Enter your new password
@@ -56,6 +72,8 @@ Enter your new password
 New password:
 > ********
 The password is shorter than 8 characters
+
+  Press escape key to go back to choose the provider
 ────────────────────────────────────────────────────────────────────────────────
 > ./pam_authd login socket=${AUTHD_TEST_TAPE_SOCKET}
 Enter your new password
@@ -63,6 +81,8 @@ Enter your new password
 New password:
 >
 The password fails the dictionary check - it is too simplistic/systematic
+
+  Press escape key to go back to choose the provider
 ────────────────────────────────────────────────────────────────────────────────
 > ./pam_authd login socket=${AUTHD_TEST_TAPE_SOCKET}
 Enter your new password
@@ -70,6 +90,8 @@ Enter your new password
 New password:
 > *********
 The password fails the dictionary check - it is too simplistic/systematic
+
+  Press escape key to go back to choose the provider
 ────────────────────────────────────────────────────────────────────────────────
 > ./pam_authd login socket=${AUTHD_TEST_TAPE_SOCKET}
 Enter your new password
@@ -78,6 +100,8 @@ New password:
 > *********
 Confirm password:
 >
+
+  Press escape key to go back to choose the provider
 ────────────────────────────────────────────────────────────────────────────────
 > ./pam_authd login socket=${AUTHD_TEST_TAPE_SOCKET}
 Enter your new password
@@ -86,6 +110,8 @@ New password:
 > *********
 Confirm password:
 > *********
+
+  Press escape key to go back to choose the provider
 ────────────────────────────────────────────────────────────────────────────────
 > ./pam_authd login socket=${AUTHD_TEST_TAPE_SOCKET}
 Enter your new password
@@ -93,6 +119,8 @@ Enter your new password
 New password:
 >
 Password entries don't match
+
+  Press escape key to go back to choose the provider
 ────────────────────────────────────────────────────────────────────────────────
 > ./pam_authd login socket=${AUTHD_TEST_TAPE_SOCKET}
 Enter your new password
@@ -100,6 +128,8 @@ Enter your new password
 New password:
 > *********
 Password entries don't match
+
+  Press escape key to go back to choose the provider
 ────────────────────────────────────────────────────────────────────────────────
 > ./pam_authd login socket=${AUTHD_TEST_TAPE_SOCKET}
 Enter your new password
@@ -108,6 +138,8 @@ New password:
 > *********
 Confirm password:
 >
+
+  Press escape key to go back to choose the provider
 ────────────────────────────────────────────────────────────────────────────────
 > ./pam_authd login socket=${AUTHD_TEST_TAPE_SOCKET}
 Enter your new password
@@ -116,6 +148,8 @@ New password:
 > *********
 Confirm password:
 > *********
+
+  Press escape key to go back to choose the provider
 ────────────────────────────────────────────────────────────────────────────────
 > ./pam_authd login socket=${AUTHD_TEST_TAPE_SOCKET}
 PAM Authenticate()

--- a/pam/integration-tests/testdata/golden/TestCLIAuthenticate/Deny_authentication_if_user_does_not_exist
+++ b/pam/integration-tests/testdata/golden/TestCLIAuthenticate/Deny_authentication_if_user_does_not_exist
@@ -9,11 +9,15 @@ Username: user-unexistent
 
 > 1. local
   2. ExampleBroker
+
+  Press escape key to go back to user selection
 ────────────────────────────────────────────────────────────────────────────────
 > ./pam_authd login socket=${AUTHD_TEST_TAPE_SOCKET}
   Select your provider
 
   1. local
+> 2. ExampleBroker
+
 PAM Error Message: can't select broker: user "user-unexistent" does not exist
 PAM Authenticate()
   User: "user-unexistent"

--- a/pam/integration-tests/testdata/golden/TestCLIAuthenticate/Exit_authd_if_local_broker_is_selected
+++ b/pam/integration-tests/testdata/golden/TestCLIAuthenticate/Exit_authd_if_local_broker_is_selected
@@ -9,11 +9,15 @@ Username: user-local-broker
 
 > 1. local
   2. ExampleBroker
+
+  Press escape key to go back to user selection
 ────────────────────────────────────────────────────────────────────────────────
 > ./pam_authd login socket=${AUTHD_TEST_TAPE_SOCKET}
   Select your provider
 
 > 1. local
+  2. ExampleBroker
+
 PAM Info Message: auth=incomplete
 PAM Authenticate()
   User: "user-local-broker"

--- a/pam/integration-tests/testdata/golden/TestCLIAuthenticate/Exit_authd_if_user_sigints
+++ b/pam/integration-tests/testdata/golden/TestCLIAuthenticate/Exit_authd_if_user_sigints
@@ -9,13 +9,19 @@ Username: user-integration-sigint
 
 > 1. local
   2. ExampleBroker
+
+  Press escape key to go back to user selection
 ────────────────────────────────────────────────────────────────────────────────
 > ./pam_authd login socket=${AUTHD_TEST_TAPE_SOCKET}
 Gimme your password:
 >
+
+  Press escape key to go back to select the authentication method
 ────────────────────────────────────────────────────────────────────────────────
 > ./pam_authd login socket=${AUTHD_TEST_TAPE_SOCKET}
 Gimme your password:
+>
+
 PAM Error Message: cancel requested
 PAM Authenticate()
   User: "user-integration-sigint"

--- a/pam/integration-tests/testdata/golden/TestCLIAuthenticate/Prevent_user_from_switching_username
+++ b/pam/integration-tests/testdata/golden/TestCLIAuthenticate/Prevent_user_from_switching_username
@@ -13,6 +13,8 @@
 > ./pam_authd login socket=${AUTHD_TEST_TAPE_SOCKET}
 Gimme your password:
 >
+
+  Press escape key to go back to select the authentication method
 ────────────────────────────────────────────────────────────────────────────────
 > ./pam_authd login socket=${AUTHD_TEST_TAPE_SOCKET}
   Select your authentication method
@@ -24,6 +26,8 @@ Gimme your password:
   5. Use your phone +1...
   6. Use a QR code
   7. Authentication code
+
+  Press escape key to go back to choose the provider
 ────────────────────────────────────────────────────────────────────────────────
 > ./pam_authd login socket=${AUTHD_TEST_TAPE_SOCKET}
   Select your provider
@@ -34,10 +38,14 @@ Gimme your password:
 > ./pam_authd login socket=${AUTHD_TEST_TAPE_SOCKET}
 Gimme your password:
 >
+
+  Press escape key to go back to select the authentication method
 ────────────────────────────────────────────────────────────────────────────────
 > ./pam_authd login socket=${AUTHD_TEST_TAPE_SOCKET}
 Gimme your password:
 > ********
+
+  Press escape key to go back to select the authentication method
 ────────────────────────────────────────────────────────────────────────────────
 > ./pam_authd login socket=${AUTHD_TEST_TAPE_SOCKET}
 PAM Authenticate()

--- a/pam/integration-tests/testdata/golden/TestCLIAuthenticate/Remember_last_successful_broker_and_mode
+++ b/pam/integration-tests/testdata/golden/TestCLIAuthenticate/Remember_last_successful_broker_and_mode
@@ -9,6 +9,8 @@ Username: user-integration-remember-mode
 
 > 1. local
   2. ExampleBroker
+
+  Press escape key to go back to user selection
 ────────────────────────────────────────────────────────────────────────────────
 > ./pam_authd login socket=${AUTHD_TEST_TAPE_SOCKET}
   Select your authentication method
@@ -20,12 +22,16 @@ Username: user-integration-remember-mode
   5. Use your phone +1...
   6. Use a QR code
   7. Authentication code
+
+  Press escape key to go back to choose the provider
 ────────────────────────────────────────────────────────────────────────────────
 > ./pam_authd login socket=${AUTHD_TEST_TAPE_SOCKET}
 Enter your one time credential:
 >
 
   [ Resend SMS (1 sent) ]
+
+  Press escape key to go back to select the authentication method
 ────────────────────────────────────────────────────────────────────────────────
 > ./pam_authd login socket=${AUTHD_TEST_TAPE_SOCKET}
 PAM Authenticate()
@@ -49,6 +55,8 @@ Enter your one time credential:
 >
 
   [ Resend SMS (1 sent) ]
+
+  Press escape key to go back to select the authentication method
 ────────────────────────────────────────────────────────────────────────────────
 > ./pam_authd login socket=${AUTHD_TEST_TAPE_SOCKET}
 PAM Authenticate()

--- a/pam/integration-tests/testdata/golden/TestCLIChangeAuthTok/Change_passwd_after_MFA_auth
+++ b/pam/integration-tests/testdata/golden/TestCLIChangeAuthTok/Change_passwd_after_MFA_auth
@@ -9,10 +9,14 @@ Username: user-mfa-integration-cli-passwd
 
 > 1. local
   2. ExampleBroker
+
+  Press escape key to go back to user selection
 ────────────────────────────────────────────────────────────────────────────────
 > ./pam_authd passwd socket=${AUTHD_TEST_TAPE_SOCKET}
 Gimme your password:
 >
+
+  Press escape key to go back to select the authentication method
 ────────────────────────────────────────────────────────────────────────────────
 > ./pam_authd passwd socket=${AUTHD_TEST_TAPE_SOCKET}
   Select your authentication method
@@ -24,17 +28,25 @@ Gimme your password:
   5. Use your phone +1...
   6. Use a QR code
   7. Authentication code
+
+  Press escape key to go back to choose the provider
 ────────────────────────────────────────────────────────────────────────────────
 > ./pam_authd passwd socket=${AUTHD_TEST_TAPE_SOCKET}
 Gimme your password:
 >
+
+  Press escape key to go back to select the authentication method
 ────────────────────────────────────────────────────────────────────────────────
 > ./pam_authd passwd socket=${AUTHD_TEST_TAPE_SOCKET}
 Gimme your password:
 > ********
+
+  Press escape key to go back to select the authentication method
 ────────────────────────────────────────────────────────────────────────────────
 > ./pam_authd passwd socket=${AUTHD_TEST_TAPE_SOCKET}
 Plug your fido device and press with your thumb
+
+  Press escape key to go back to select the authentication method
 ────────────────────────────────────────────────────────────────────────────────
 > ./pam_authd passwd socket=${AUTHD_TEST_TAPE_SOCKET}
   Select your authentication method
@@ -42,33 +54,47 @@ Plug your fido device and press with your thumb
 > 1. Use your fido device foo
   2. Use your phone +33...
   3. Authentication code
+
+  Press escape key to go back to choose the provider
 ────────────────────────────────────────────────────────────────────────────────
 > ./pam_authd passwd socket=${AUTHD_TEST_TAPE_SOCKET}
 Plug your fido device and press with your thumb
+
+  Press escape key to go back to select the authentication method
 ────────────────────────────────────────────────────────────────────────────────
 > ./pam_authd passwd socket=${AUTHD_TEST_TAPE_SOCKET}
 Unlock your phone +33... or accept request on web interface
+
+  Press escape key to go back to select the authentication method
 ────────────────────────────────────────────────────────────────────────────────
 > ./pam_authd passwd socket=${AUTHD_TEST_TAPE_SOCKET}
   Select your authentication method
 
 > 1. Use your phone +33...
   2. Authentication code
+
+  Press escape key to go back to choose the provider
 ────────────────────────────────────────────────────────────────────────────────
 > ./pam_authd passwd socket=${AUTHD_TEST_TAPE_SOCKET}
 Unlock your phone +33... or accept request on web interface
+
+  Press escape key to go back to select the authentication method
 ────────────────────────────────────────────────────────────────────────────────
 > ./pam_authd passwd socket=${AUTHD_TEST_TAPE_SOCKET}
 Enter your new password
 
 New password:
 >
+
+  Press escape key to go back to choose the provider
 ────────────────────────────────────────────────────────────────────────────────
 > ./pam_authd passwd socket=${AUTHD_TEST_TAPE_SOCKET}
 Enter your new password
 
 New password:
 > *********
+
+  Press escape key to go back to choose the provider
 ────────────────────────────────────────────────────────────────────────────────
 > ./pam_authd passwd socket=${AUTHD_TEST_TAPE_SOCKET}
 Enter your new password
@@ -77,6 +103,8 @@ New password:
 > *********
 Confirm password:
 > *********
+
+  Press escape key to go back to choose the provider
 ────────────────────────────────────────────────────────────────────────────────
 > ./pam_authd passwd socket=${AUTHD_TEST_TAPE_SOCKET}
 PAM ChangeAuthTok()

--- a/pam/integration-tests/testdata/golden/TestCLIChangeAuthTok/Change_password_successfully_and_authenticate_with_new_one
+++ b/pam/integration-tests/testdata/golden/TestCLIChangeAuthTok/Change_password_successfully_and_authenticate_with_new_one
@@ -9,26 +9,36 @@ Username: user-integration-simple-testclichangeauthtok
 
 > 1. local
   2. ExampleBroker
+
+  Press escape key to go back to user selection
 ────────────────────────────────────────────────────────────────────────────────
 > ./pam_authd passwd socket=${AUTHD_TEST_TAPE_SOCKET}
 Gimme your password:
 >
+
+  Press escape key to go back to select the authentication method
 ────────────────────────────────────────────────────────────────────────────────
 > ./pam_authd passwd socket=${AUTHD_TEST_TAPE_SOCKET}
 Gimme your password:
 > ********
+
+  Press escape key to go back to select the authentication method
 ────────────────────────────────────────────────────────────────────────────────
 > ./pam_authd passwd socket=${AUTHD_TEST_TAPE_SOCKET}
 Enter your new password
 
 New password:
 >
+
+  Press escape key to go back to choose the provider
 ────────────────────────────────────────────────────────────────────────────────
 > ./pam_authd passwd socket=${AUTHD_TEST_TAPE_SOCKET}
 Enter your new password
 
 New password:
 > *********
+
+  Press escape key to go back to choose the provider
 ────────────────────────────────────────────────────────────────────────────────
 > ./pam_authd passwd socket=${AUTHD_TEST_TAPE_SOCKET}
 Enter your new password
@@ -37,6 +47,8 @@ New password:
 > *********
 Confirm password:
 > *********
+
+  Press escape key to go back to choose the provider
 ────────────────────────────────────────────────────────────────────────────────
 > ./pam_authd passwd socket=${AUTHD_TEST_TAPE_SOCKET}
 PAM ChangeAuthTok()
@@ -58,6 +70,8 @@ Username: user-integration-simple-testclichangeauthtok
 > ./pam_authd login socket=${AUTHD_TEST_TAPE_SOCKET}
 Gimme your password:
 >
+
+  Press escape key to go back to select the authentication method
 ────────────────────────────────────────────────────────────────────────────────
 > ./pam_authd login socket=${AUTHD_TEST_TAPE_SOCKET}
 PAM Authenticate()

--- a/pam/integration-tests/testdata/golden/TestCLIChangeAuthTok/Change_password_successfully_and_authenticate_with_new_one_with_different_case
+++ b/pam/integration-tests/testdata/golden/TestCLIChangeAuthTok/Change_password_successfully_and_authenticate_with_new_one_with_different_case
@@ -9,26 +9,36 @@ Username: USER-INTEGRATION-CASE-INSENSITIVE-TESTCLICHANGEAUTHTOK
 
 > 1. local
   2. ExampleBroker
+
+  Press escape key to go back to user selection
 ────────────────────────────────────────────────────────────────────────────────
 > ./pam_authd passwd socket=${AUTHD_TEST_TAPE_SOCKET}
 Gimme your password:
 >
+
+  Press escape key to go back to select the authentication method
 ────────────────────────────────────────────────────────────────────────────────
 > ./pam_authd passwd socket=${AUTHD_TEST_TAPE_SOCKET}
 Gimme your password:
 > ********
+
+  Press escape key to go back to select the authentication method
 ────────────────────────────────────────────────────────────────────────────────
 > ./pam_authd passwd socket=${AUTHD_TEST_TAPE_SOCKET}
 Enter your new password
 
 New password:
 >
+
+  Press escape key to go back to choose the provider
 ────────────────────────────────────────────────────────────────────────────────
 > ./pam_authd passwd socket=${AUTHD_TEST_TAPE_SOCKET}
 Enter your new password
 
 New password:
 > *********
+
+  Press escape key to go back to choose the provider
 ────────────────────────────────────────────────────────────────────────────────
 > ./pam_authd passwd socket=${AUTHD_TEST_TAPE_SOCKET}
 Enter your new password
@@ -37,6 +47,8 @@ New password:
 > *********
 Confirm password:
 > *********
+
+  Press escape key to go back to choose the provider
 ────────────────────────────────────────────────────────────────────────────────
 > ./pam_authd passwd socket=${AUTHD_TEST_TAPE_SOCKET}
 PAM ChangeAuthTok()
@@ -58,6 +70,8 @@ Username: user-integration-case-insensitive-testclichangeauthtok
 > ./pam_authd login socket=${AUTHD_TEST_TAPE_SOCKET}
 Gimme your password:
 >
+
+  Press escape key to go back to select the authentication method
 ────────────────────────────────────────────────────────────────────────────────
 > ./pam_authd login socket=${AUTHD_TEST_TAPE_SOCKET}
 PAM Authenticate()

--- a/pam/integration-tests/testdata/golden/TestCLIChangeAuthTok/Exit_authd_if_local_broker_is_selected
+++ b/pam/integration-tests/testdata/golden/TestCLIChangeAuthTok/Exit_authd_if_local_broker_is_selected
@@ -9,11 +9,15 @@ Username: user-integration-cli-passwd-exit-authd-if-local-broker-is-selected
 
 > 1. local
   2. ExampleBroker
+
+  Press escape key to go back to user selection
 ────────────────────────────────────────────────────────────────────────────────
 > ./pam_authd passwd socket=${AUTHD_TEST_TAPE_SOCKET}
   Select your provider
 
 > 1. local
+  2. ExampleBroker
+
 PAM Info Message: chauthtok=incomplete
 PAM ChangeAuthTok()
   User: "user-integration-cli-passwd-exit-authd-if-local-broker-is-selected"

--- a/pam/integration-tests/testdata/golden/TestCLIChangeAuthTok/Exit_authd_if_user_sigints
+++ b/pam/integration-tests/testdata/golden/TestCLIChangeAuthTok/Exit_authd_if_user_sigints
@@ -9,13 +9,19 @@ Username: user-integration-cli-passwd-exit-authd-if-user-sigints
 
 > 1. local
   2. ExampleBroker
+
+  Press escape key to go back to user selection
 ────────────────────────────────────────────────────────────────────────────────
 > ./pam_authd passwd socket=${AUTHD_TEST_TAPE_SOCKET}
 Gimme your password:
 >
+
+  Press escape key to go back to select the authentication method
 ────────────────────────────────────────────────────────────────────────────────
 > ./pam_authd passwd socket=${AUTHD_TEST_TAPE_SOCKET}
 Gimme your password:
+>
+
 PAM Error Message: cancel requested
 PAM ChangeAuthTok()
   User: "user-integration-cli-passwd-exit-authd-if-user-sigints"

--- a/pam/integration-tests/testdata/golden/TestCLIChangeAuthTok/Prevent_change_password_if_auth_fails
+++ b/pam/integration-tests/testdata/golden/TestCLIChangeAuthTok/Prevent_change_password_if_auth_fails
@@ -9,54 +9,76 @@ Username: user-integration-cli-passwd-prevent-change-password-if-auth-fails
 
 > 1. local
   2. ExampleBroker
+
+  Press escape key to go back to user selection
 ────────────────────────────────────────────────────────────────────────────────
 > ./pam_authd passwd socket=${AUTHD_TEST_TAPE_SOCKET}
 Gimme your password:
 >
+
+  Press escape key to go back to select the authentication method
 ────────────────────────────────────────────────────────────────────────────────
 > ./pam_authd passwd socket=${AUTHD_TEST_TAPE_SOCKET}
 Gimme your password:
 > *********
-────────────────────────────────────────────────────────────────────────────────
-> ./pam_authd passwd socket=${AUTHD_TEST_TAPE_SOCKET}
-Gimme your password:
->
-invalid password 'wrongpass', should be 'goodpass'
-────────────────────────────────────────────────────────────────────────────────
-> ./pam_authd passwd socket=${AUTHD_TEST_TAPE_SOCKET}
-Gimme your password:
-> *********
-invalid password 'wrongpass', should be 'goodpass'
+
+  Press escape key to go back to select the authentication method
 ────────────────────────────────────────────────────────────────────────────────
 > ./pam_authd passwd socket=${AUTHD_TEST_TAPE_SOCKET}
 Gimme your password:
 >
 invalid password 'wrongpass', should be 'goodpass'
+
+  Press escape key to go back to select the authentication method
 ────────────────────────────────────────────────────────────────────────────────
 > ./pam_authd passwd socket=${AUTHD_TEST_TAPE_SOCKET}
 Gimme your password:
 > *********
 invalid password 'wrongpass', should be 'goodpass'
+
+  Press escape key to go back to select the authentication method
 ────────────────────────────────────────────────────────────────────────────────
 > ./pam_authd passwd socket=${AUTHD_TEST_TAPE_SOCKET}
 Gimme your password:
 >
 invalid password 'wrongpass', should be 'goodpass'
+
+  Press escape key to go back to select the authentication method
 ────────────────────────────────────────────────────────────────────────────────
 > ./pam_authd passwd socket=${AUTHD_TEST_TAPE_SOCKET}
 Gimme your password:
 > *********
 invalid password 'wrongpass', should be 'goodpass'
+
+  Press escape key to go back to select the authentication method
 ────────────────────────────────────────────────────────────────────────────────
 > ./pam_authd passwd socket=${AUTHD_TEST_TAPE_SOCKET}
 Gimme your password:
 >
 invalid password 'wrongpass', should be 'goodpass'
+
+  Press escape key to go back to select the authentication method
 ────────────────────────────────────────────────────────────────────────────────
 > ./pam_authd passwd socket=${AUTHD_TEST_TAPE_SOCKET}
 Gimme your password:
 > *********
 invalid password 'wrongpass', should be 'goodpass'
+
+  Press escape key to go back to select the authentication method
+────────────────────────────────────────────────────────────────────────────────
+> ./pam_authd passwd socket=${AUTHD_TEST_TAPE_SOCKET}
+Gimme your password:
+>
+invalid password 'wrongpass', should be 'goodpass'
+
+  Press escape key to go back to select the authentication method
+────────────────────────────────────────────────────────────────────────────────
+> ./pam_authd passwd socket=${AUTHD_TEST_TAPE_SOCKET}
+Gimme your password:
+> *********
+invalid password 'wrongpass', should be 'goodpass'
+
+  Press escape key to go back to select the authentication method
 ────────────────────────────────────────────────────────────────────────────────
 > ./pam_authd passwd socket=${AUTHD_TEST_TAPE_SOCKET}
 PAM Error Message: invalid password 'wrongpass', should be 'goodpass'

--- a/pam/integration-tests/testdata/golden/TestCLIChangeAuthTok/Prevent_change_password_if_user_does_not_exist
+++ b/pam/integration-tests/testdata/golden/TestCLIChangeAuthTok/Prevent_change_password_if_user_does_not_exist
@@ -9,11 +9,15 @@ Username: user-unexistent
 
 > 1. local
   2. ExampleBroker
+
+  Press escape key to go back to user selection
 ────────────────────────────────────────────────────────────────────────────────
 > ./pam_authd passwd socket=${AUTHD_TEST_TAPE_SOCKET}
   Select your provider
 
   1. local
+> 2. ExampleBroker
+
 PAM Error Message: can't select broker: user "user-unexistent" does not exist
 PAM ChangeAuthTok()
   User: "user-unexistent"

--- a/pam/integration-tests/testdata/golden/TestCLIChangeAuthTok/Retry_if_new_password_does_not_match_quality_criteria
+++ b/pam/integration-tests/testdata/golden/TestCLIChangeAuthTok/Retry_if_new_password_does_not_match_quality_criteria
@@ -9,20 +9,28 @@ Username: user-integration-cli-passwd-retry-if-new-password-does-not-match-quali
 
 > 1. local
   2. ExampleBroker
+
+  Press escape key to go back to user selection
 ────────────────────────────────────────────────────────────────────────────────
 > ./pam_authd passwd socket=${AUTHD_TEST_TAPE_SOCKET}
 Gimme your password:
 >
+
+  Press escape key to go back to select the authentication method
 ────────────────────────────────────────────────────────────────────────────────
 > ./pam_authd passwd socket=${AUTHD_TEST_TAPE_SOCKET}
 Gimme your password:
 > ********
+
+  Press escape key to go back to select the authentication method
 ────────────────────────────────────────────────────────────────────────────────
 > ./pam_authd passwd socket=${AUTHD_TEST_TAPE_SOCKET}
 Enter your new password
 
 New password:
 >
+
+  Press escape key to go back to choose the provider
 ────────────────────────────────────────────────────────────────────────────────
 > ./pam_authd passwd socket=${AUTHD_TEST_TAPE_SOCKET}
 Enter your new password
@@ -30,6 +38,8 @@ Enter your new password
 New password:
 >
 No password supplied
+
+  Press escape key to go back to choose the provider
 ────────────────────────────────────────────────────────────────────────────────
 > ./pam_authd passwd socket=${AUTHD_TEST_TAPE_SOCKET}
 Enter your new password
@@ -37,6 +47,8 @@ Enter your new password
 New password:
 >
 The password is shorter than 8 characters
+
+  Press escape key to go back to choose the provider
 ────────────────────────────────────────────────────────────────────────────────
 > ./pam_authd passwd socket=${AUTHD_TEST_TAPE_SOCKET}
 Enter your new password
@@ -44,6 +56,8 @@ Enter your new password
 New password:
 >
 The password fails the dictionary check - it is too simplistic/systematic
+
+  Press escape key to go back to choose the provider
 ────────────────────────────────────────────────────────────────────────────────
 > ./pam_authd passwd socket=${AUTHD_TEST_TAPE_SOCKET}
 Enter your new password
@@ -52,6 +66,8 @@ New password:
 > *********
 Confirm password:
 >
+
+  Press escape key to go back to choose the provider
 ────────────────────────────────────────────────────────────────────────────────
 > ./pam_authd passwd socket=${AUTHD_TEST_TAPE_SOCKET}
 Enter your new password
@@ -60,6 +76,8 @@ New password:
 > *********
 Confirm password:
 > *********
+
+  Press escape key to go back to choose the provider
 ────────────────────────────────────────────────────────────────────────────────
 > ./pam_authd passwd socket=${AUTHD_TEST_TAPE_SOCKET}
 Enter your new password
@@ -67,6 +85,8 @@ Enter your new password
 New password:
 >
 Password entries don't match
+
+  Press escape key to go back to choose the provider
 ────────────────────────────────────────────────────────────────────────────────
 > ./pam_authd passwd socket=${AUTHD_TEST_TAPE_SOCKET}
 Enter your new password
@@ -75,6 +95,8 @@ New password:
 > *********
 Confirm password:
 >
+
+  Press escape key to go back to choose the provider
 ────────────────────────────────────────────────────────────────────────────────
 > ./pam_authd passwd socket=${AUTHD_TEST_TAPE_SOCKET}
 Enter your new password
@@ -83,6 +105,8 @@ New password:
 > *********
 Confirm password:
 > *********
+
+  Press escape key to go back to choose the provider
 ────────────────────────────────────────────────────────────────────────────────
 > ./pam_authd passwd socket=${AUTHD_TEST_TAPE_SOCKET}
 PAM ChangeAuthTok()

--- a/pam/integration-tests/testdata/golden/TestCLIChangeAuthTok/Retry_if_new_password_is_rejected_by_broker
+++ b/pam/integration-tests/testdata/golden/TestCLIChangeAuthTok/Retry_if_new_password_is_rejected_by_broker
@@ -9,26 +9,36 @@ Username: user-integration-cli-passwd-retry-if-new-password-is-rejected-by-broke
 
 > 1. local
   2. ExampleBroker
+
+  Press escape key to go back to user selection
 ────────────────────────────────────────────────────────────────────────────────
 > ./pam_authd passwd socket=${AUTHD_TEST_TAPE_SOCKET}
 Gimme your password:
 >
+
+  Press escape key to go back to select the authentication method
 ────────────────────────────────────────────────────────────────────────────────
 > ./pam_authd passwd socket=${AUTHD_TEST_TAPE_SOCKET}
 Gimme your password:
 > ********
+
+  Press escape key to go back to select the authentication method
 ────────────────────────────────────────────────────────────────────────────────
 > ./pam_authd passwd socket=${AUTHD_TEST_TAPE_SOCKET}
 Enter your new password
 
 New password:
 >
+
+  Press escape key to go back to choose the provider
 ────────────────────────────────────────────────────────────────────────────────
 > ./pam_authd passwd socket=${AUTHD_TEST_TAPE_SOCKET}
 Enter your new password
 
 New password:
 > *********
+
+  Press escape key to go back to choose the provider
 ────────────────────────────────────────────────────────────────────────────────
 > ./pam_authd passwd socket=${AUTHD_TEST_TAPE_SOCKET}
 Enter your new password
@@ -37,6 +47,8 @@ New password:
 > *********
 Confirm password:
 > *********
+
+  Press escape key to go back to choose the provider
 ────────────────────────────────────────────────────────────────────────────────
 > ./pam_authd passwd socket=${AUTHD_TEST_TAPE_SOCKET}
 Enter your new password
@@ -44,6 +56,8 @@ Enter your new password
 New password:
 >
 new password does not match criteria: must be 'authd2404'
+
+  Press escape key to go back to choose the provider
 ────────────────────────────────────────────────────────────────────────────────
 > ./pam_authd passwd socket=${AUTHD_TEST_TAPE_SOCKET}
 Enter your new password
@@ -51,6 +65,8 @@ Enter your new password
 New password:
 > *********
 new password does not match criteria: must be 'authd2404'
+
+  Press escape key to go back to choose the provider
 ────────────────────────────────────────────────────────────────────────────────
 > ./pam_authd passwd socket=${AUTHD_TEST_TAPE_SOCKET}
 Enter your new password
@@ -59,6 +75,8 @@ New password:
 > *********
 Confirm password:
 > *********
+
+  Press escape key to go back to choose the provider
 ────────────────────────────────────────────────────────────────────────────────
 > ./pam_authd passwd socket=${AUTHD_TEST_TAPE_SOCKET}
 PAM ChangeAuthTok()
@@ -80,18 +98,24 @@ Username: user-integration-cli-passwd-retry-if-new-password-is-rejected-by-broke
 > ./pam_authd passwd socket=${AUTHD_TEST_TAPE_SOCKET}
 Gimme your password:
 >
+
+  Press escape key to go back to select the authentication method
 ────────────────────────────────────────────────────────────────────────────────
 > ./pam_authd passwd socket=${AUTHD_TEST_TAPE_SOCKET}
 Enter your new password
 
 New password:
 >
+
+  Press escape key to go back to choose the provider
 ────────────────────────────────────────────────────────────────────────────────
 > ./pam_authd passwd socket=${AUTHD_TEST_TAPE_SOCKET}
 Enter your new password
 
 New password:
 > *********
+
+  Press escape key to go back to choose the provider
 ────────────────────────────────────────────────────────────────────────────────
 > ./pam_authd passwd socket=${AUTHD_TEST_TAPE_SOCKET}
 Enter your new password
@@ -100,6 +124,8 @@ New password:
 > *********
 Confirm password:
 > *********
+
+  Press escape key to go back to choose the provider
 ────────────────────────────────────────────────────────────────────────────────
 > ./pam_authd passwd socket=${AUTHD_TEST_TAPE_SOCKET}
 Enter your new password
@@ -107,6 +133,8 @@ Enter your new password
 New password:
 >
 new password does not match criteria: must be 'goodpass'
+
+  Press escape key to go back to choose the provider
 ────────────────────────────────────────────────────────────────────────────────
 > ./pam_authd passwd socket=${AUTHD_TEST_TAPE_SOCKET}
 Enter your new password
@@ -114,6 +142,8 @@ Enter your new password
 New password:
 > ********
 new password does not match criteria: must be 'goodpass'
+
+  Press escape key to go back to choose the provider
 ────────────────────────────────────────────────────────────────────────────────
 > ./pam_authd passwd socket=${AUTHD_TEST_TAPE_SOCKET}
 Enter your new password
@@ -122,6 +152,8 @@ New password:
 > ********
 Confirm password:
 > ********
+
+  Press escape key to go back to choose the provider
 ────────────────────────────────────────────────────────────────────────────────
 > ./pam_authd passwd socket=${AUTHD_TEST_TAPE_SOCKET}
 PAM ChangeAuthTok()

--- a/pam/integration-tests/testdata/golden/TestCLIChangeAuthTok/Retry_if_new_password_is_same_of_previous
+++ b/pam/integration-tests/testdata/golden/TestCLIChangeAuthTok/Retry_if_new_password_is_same_of_previous
@@ -9,26 +9,36 @@ Username: user-integration-cli-passwd-retry-if-new-password-is-same-of-previous
 
 > 1. local
   2. ExampleBroker
+
+  Press escape key to go back to user selection
 ────────────────────────────────────────────────────────────────────────────────
 > ./pam_authd passwd socket=${AUTHD_TEST_TAPE_SOCKET}
 Gimme your password:
 >
+
+  Press escape key to go back to select the authentication method
 ────────────────────────────────────────────────────────────────────────────────
 > ./pam_authd passwd socket=${AUTHD_TEST_TAPE_SOCKET}
 Gimme your password:
 > ********
+
+  Press escape key to go back to select the authentication method
 ────────────────────────────────────────────────────────────────────────────────
 > ./pam_authd passwd socket=${AUTHD_TEST_TAPE_SOCKET}
 Enter your new password
 
 New password:
 >
+
+  Press escape key to go back to choose the provider
 ────────────────────────────────────────────────────────────────────────────────
 > ./pam_authd passwd socket=${AUTHD_TEST_TAPE_SOCKET}
 Enter your new password
 
 New password:
 > ********
+
+  Press escape key to go back to choose the provider
 ────────────────────────────────────────────────────────────────────────────────
 > ./pam_authd passwd socket=${AUTHD_TEST_TAPE_SOCKET}
 Enter your new password
@@ -36,6 +46,8 @@ Enter your new password
 New password:
 >
 The password is the same as the old one
+
+  Press escape key to go back to choose the provider
 ────────────────────────────────────────────────────────────────────────────────
 > ./pam_authd passwd socket=${AUTHD_TEST_TAPE_SOCKET}
 Enter your new password
@@ -43,6 +55,8 @@ Enter your new password
 New password:
 > *********
 The password is the same as the old one
+
+  Press escape key to go back to choose the provider
 ────────────────────────────────────────────────────────────────────────────────
 > ./pam_authd passwd socket=${AUTHD_TEST_TAPE_SOCKET}
 Enter your new password
@@ -51,6 +65,8 @@ New password:
 > *********
 Confirm password:
 > *********
+
+  Press escape key to go back to choose the provider
 ────────────────────────────────────────────────────────────────────────────────
 > ./pam_authd passwd socket=${AUTHD_TEST_TAPE_SOCKET}
 PAM ChangeAuthTok()

--- a/pam/integration-tests/testdata/golden/TestCLIChangeAuthTok/Retry_if_password_confirmation_is_not_the_same
+++ b/pam/integration-tests/testdata/golden/TestCLIChangeAuthTok/Retry_if_password_confirmation_is_not_the_same
@@ -9,26 +9,36 @@ Username: user-integration-cli-passwd-retry-if-password-confirmation-is-not-the-
 
 > 1. local
   2. ExampleBroker
+
+  Press escape key to go back to user selection
 ────────────────────────────────────────────────────────────────────────────────
 > ./pam_authd passwd socket=${AUTHD_TEST_TAPE_SOCKET}
 Gimme your password:
 >
+
+  Press escape key to go back to select the authentication method
 ────────────────────────────────────────────────────────────────────────────────
 > ./pam_authd passwd socket=${AUTHD_TEST_TAPE_SOCKET}
 Gimme your password:
 > ********
+
+  Press escape key to go back to select the authentication method
 ────────────────────────────────────────────────────────────────────────────────
 > ./pam_authd passwd socket=${AUTHD_TEST_TAPE_SOCKET}
 Enter your new password
 
 New password:
 >
+
+  Press escape key to go back to choose the provider
 ────────────────────────────────────────────────────────────────────────────────
 > ./pam_authd passwd socket=${AUTHD_TEST_TAPE_SOCKET}
 Enter your new password
 
 New password:
 > *********
+
+  Press escape key to go back to choose the provider
 ────────────────────────────────────────────────────────────────────────────────
 > ./pam_authd passwd socket=${AUTHD_TEST_TAPE_SOCKET}
 Enter your new password
@@ -37,6 +47,8 @@ New password:
 > *********
 Confirm password:
 > *******
+
+  Press escape key to go back to choose the provider
 ────────────────────────────────────────────────────────────────────────────────
 > ./pam_authd passwd socket=${AUTHD_TEST_TAPE_SOCKET}
 Enter your new password
@@ -44,6 +56,8 @@ Enter your new password
 New password:
 >
 Password entries don't match
+
+  Press escape key to go back to choose the provider
 ────────────────────────────────────────────────────────────────────────────────
 > ./pam_authd passwd socket=${AUTHD_TEST_TAPE_SOCKET}
 Enter your new password
@@ -51,6 +65,8 @@ Enter your new password
 New password:
 > *********
 Password entries don't match
+
+  Press escape key to go back to choose the provider
 ────────────────────────────────────────────────────────────────────────────────
 > ./pam_authd passwd socket=${AUTHD_TEST_TAPE_SOCKET}
 Enter your new password
@@ -59,6 +75,8 @@ New password:
 > *********
 Confirm password:
 > *********
+
+  Press escape key to go back to choose the provider
 ────────────────────────────────────────────────────────────────────────────────
 > ./pam_authd passwd socket=${AUTHD_TEST_TAPE_SOCKET}
 PAM ChangeAuthTok()

--- a/pam/integration-tests/testdata/tapes/cli/bad_password.tape
+++ b/pam/integration-tests/testdata/tapes/cli/bad_password.tape
@@ -16,7 +16,7 @@ Show
 
 Hide
 Type "2"
-Wait+Prompt /Gimme your password/
+Wait+CLIPrompt /Gimme your password/ /Press escape key to go back to select the authentication method/
 Show
 
 Hide
@@ -25,11 +25,12 @@ Show
 
 Hide
 Enter
-Wait /Password reset, 1 step\(s\) missing/
+Wait+Screen /Password reset, 1 step\(s\) missing/
+Wait /Press escape key to go back to select the authentication method/
 Show
 
 Hide
-Wait+Prompt /New password/
+Wait+CLIPrompt /New password/ /Press escape key to go back to choose the provider/
 Show
 
 Hide
@@ -38,7 +39,7 @@ Show
 
 Hide
 Enter
-Wait+CLIPrompt /New password/ /No password supplied/
+Wait+CLIPrompt /New password/ /No password supplied/ /[ ]*Press escape key to go back to choose the provider/
 Show
 
 Hide
@@ -47,7 +48,7 @@ Show
 
 Hide
 Enter
-Wait+CLIPrompt /New password/ /The password is shorter than \d+ characters/
+Wait+CLIPrompt /New password/ /The password is shorter than \d+ characters/ /[ ]*Press escape key to go back to choose the provider/
 Show
 
 Hide
@@ -56,7 +57,7 @@ Show
 
 Hide
 Enter
-Wait+CLIPrompt /New password/ /The password fails the dictionary check[^\n]*/
+Wait+CLIPrompt /New password/ /The password fails the dictionary check[^\n]*/ /[ ]*Press escape key to go back to choose the provider/
 Show
 
 Hide
@@ -65,7 +66,7 @@ Show
 
 Hide
 Enter
-Wait+Prompt /Confirm password/
+Wait+CLIPrompt /Confirm password/ /Press escape key to go back to choose the provider/
 Show
 
 Hide
@@ -74,7 +75,7 @@ Show
 
 Hide
 Enter
-Wait+CLIPrompt /New password/ /Password entries don't match/
+Wait+CLIPrompt /New password/ /Password entries don't match/ /[ ]*Press escape key to go back to choose the provider/
 Show
 
 Hide
@@ -83,7 +84,7 @@ Show
 
 Hide
 Enter
-Wait+Prompt /Confirm password/
+Wait+CLIPrompt /Confirm password/ /Press escape key to go back to choose the provider/
 Show
 
 Hide

--- a/pam/integration-tests/testdata/tapes/cli/form_with_button.tape
+++ b/pam/integration-tests/testdata/tapes/cli/form_with_button.tape
@@ -16,7 +16,7 @@ Show
 
 Hide
 Type "2"
-Wait+Prompt /Gimme your password/
+Wait+CLIPrompt /Gimme your password/ /Press escape key to go back to select the authentication method/
 Show
 
 Hide
@@ -27,7 +27,7 @@ Show
 
 Hide
 Type "7"
-Wait+CLIPrompt@${AUTHD_WAIT_DEFAULT}*2 /Enter your one time credential/ /\[ Resend SMS \(1 sent\) \]/
+Wait+CLIPrompt@${AUTHD_WAIT_DEFAULT}*2 /Enter your one time credential/ /\[ Resend SMS \(1 sent\) \][\n]+[ ]*Press escape key to go back to select the authentication method/
 Show
 
 Hide
@@ -36,7 +36,7 @@ Show
 
 Hide
 Enter
-Wait+CLIPrompt@${AUTHD_WAIT_DEFAULT}*2 /Enter your one time credential/ /\[ Resend SMS \(2 sent\) \]/
+Wait+CLIPrompt@${AUTHD_WAIT_DEFAULT}*2 /Enter your one time credential/ /\[ Resend SMS \(2 sent\) \][\n]+[ ]*Press escape key to go back to select the authentication method/
 Show
 
 Hide

--- a/pam/integration-tests/testdata/tapes/cli/local_group.tape
+++ b/pam/integration-tests/testdata/tapes/cli/local_group.tape
@@ -16,7 +16,7 @@ Show
 
 Hide
 Type "2"
-Wait+Prompt /Gimme your password/
+Wait+CLIPrompt /Gimme your password/ /Press escape key to go back to select the authentication method/
 Show
 
 Hide

--- a/pam/integration-tests/testdata/tapes/cli/mandatory_password_reset.tape
+++ b/pam/integration-tests/testdata/tapes/cli/mandatory_password_reset.tape
@@ -16,20 +16,22 @@ Show
 
 Hide
 Type "2"
-Wait+Prompt /Gimme your password/
+Wait+CLIPrompt /Gimme your password/ /Press escape key to go back to select the authentication method/
 Show
 
 Hide
 TypeCLIPassword "goodpass"
+Wait /Press escape key to go back to select the authentication method/
 Show
 
 Hide
 Enter
-Wait /Password reset, 1 step\(s\) missing/
+Wait+Screen /Password reset, 1 step\(s\) missing/
+Wait /Press escape key to go back to select the authentication method/
 Show
 
 Hide
-Wait+Prompt /New password/
+Wait+CLIPrompt /New password/ /Press escape key to go back to choose the provider/
 Show
 
 Hide
@@ -38,7 +40,7 @@ Show
 
 Hide
 Enter
-Wait+Prompt /Confirm password/
+Wait+CLIPrompt /Confirm password/ /Press escape key to go back to choose the provider/
 TypeCLIPassword "authd2404"
 Show
 

--- a/pam/integration-tests/testdata/tapes/cli/mandatory_password_reset_case_insensitive.tape
+++ b/pam/integration-tests/testdata/tapes/cli/mandatory_password_reset_case_insensitive.tape
@@ -16,7 +16,7 @@ Show
 
 Hide
 Type "2"
-Wait+Prompt /Gimme your password/
+Wait+CLIPrompt /Gimme your password/ /Press escape key to go back to select the authentication method/
 Show
 
 Hide
@@ -27,7 +27,7 @@ Show
 
 Hide
 Enter
-Wait+Prompt /New password/
+Wait+CLIPrompt /New password/ /Press escape key to go back to choose the provider/
 Show
 
 Hide
@@ -36,7 +36,7 @@ Show
 
 Hide
 Enter
-Wait+Prompt /Confirm password/
+Wait+CLIPrompt /Confirm password/ /Press escape key to go back to choose the provider/
 TypeCLIPassword "authd2404"
 Show
 
@@ -61,7 +61,7 @@ Show
 
 Hide
 Enter
-Wait+Prompt /Gimme your password/
+Wait+CLIPrompt /Gimme your password/ /Press escape key to go back to select the authentication method/
 Show
 
 Hide
@@ -89,7 +89,7 @@ Show
 
 Hide
 Enter
-Wait+Prompt /Gimme your password/
+Wait+CLIPrompt /Gimme your password/ /Press escape key to go back to select the authentication method/
 Show
 
 Hide

--- a/pam/integration-tests/testdata/tapes/cli/max_attempts.tape
+++ b/pam/integration-tests/testdata/tapes/cli/max_attempts.tape
@@ -16,7 +16,7 @@ Show
 
 Hide
 Type "2"
-Wait+Prompt /Gimme your password/
+Wait+CLIPrompt /Gimme your password/ /Press escape key to go back to select the authentication method/
 Show
 
 Hide
@@ -25,7 +25,7 @@ Show
 
 Hide
 Enter
-Wait+CLIPrompt /Gimme your password/ /invalid password '.+', should be[^\n]+/
+Wait+CLIPrompt /Gimme your password/ /invalid password '.+', should be[^\n]+[\n]+[ ]*Press escape key to go back to select the authentication method/
 Show
 
 Hide
@@ -34,7 +34,7 @@ Show
 
 Hide
 Enter
-Wait+CLIPrompt /Gimme your password/ /invalid password '.+', should be[^\n]+/
+Wait+CLIPrompt /Gimme your password/ /invalid password '.+', should be[^\n]+[\n]+[ ]*Press escape key to go back to select the authentication method/
 Show
 
 Hide
@@ -43,7 +43,7 @@ Show
 
 Hide
 Enter
-Wait+CLIPrompt /Gimme your password/ /invalid password '.+', should be[^\n]+/
+Wait+CLIPrompt /Gimme your password/ /invalid password '.+', should be[^\n]+[\n]+[ ]*Press escape key to go back to select the authentication method/
 Show
 
 Hide
@@ -52,7 +52,7 @@ Show
 
 Hide
 Enter
-Wait+CLIPrompt /Gimme your password/ /invalid password '.+', should be[^\n]+/
+Wait+CLIPrompt /Gimme your password/ /invalid password '.+', should be[^\n]+[\n]+[ ]*Press escape key to go back to select the authentication method/
 Show
 
 Hide

--- a/pam/integration-tests/testdata/tapes/cli/mfa_auth.tape
+++ b/pam/integration-tests/testdata/tapes/cli/mfa_auth.tape
@@ -16,7 +16,7 @@ Show
 
 Hide
 Type "2"
-Wait+Prompt /Gimme your password/
+Wait+CLIPrompt /Gimme your password/ /Press escape key to go back to select the authentication method/
 Show
 
 Hide
@@ -27,7 +27,7 @@ Show
 
 Hide
 Type "1"
-Wait+Prompt /Gimme your password/
+Wait+CLIPrompt /Gimme your password/ /Press escape key to go back to select the authentication method/
 Show
 
 Hide
@@ -36,7 +36,7 @@ Show
 
 Hide
 Enter
-Wait@${AUTHD_SLEEP_EXAMPLE_BROKER_MFA_WAIT}/2 /Plug your fido device and press with your thumb/
+Wait+Screen@${AUTHD_SLEEP_EXAMPLE_BROKER_MFA_WAIT}/2 /Plug your fido device and press with your thumb/
 Show
 
 Hide
@@ -47,11 +47,13 @@ Show
 
 Hide
 Enter
-Wait@${AUTHD_SLEEP_EXAMPLE_BROKER_MFA_WAIT}/2 /Plug your fido device and press with your thumb/
+Wait+Screen@${AUTHD_SLEEP_EXAMPLE_BROKER_MFA_WAIT}/2 /Plug your fido device and press with your thumb/
+Wait /Press escape key to go back to select the authentication method/
 Show
 
 Hide
-Wait@${AUTHD_SLEEP_EXAMPLE_BROKER_MFA_WAIT}*1.2 /Unlock your phone \+33\.\.\. or accept request on web interface/
+Wait+Screen@${AUTHD_SLEEP_EXAMPLE_BROKER_MFA_WAIT}*1.2 /Unlock your phone \+33\.\.\. or accept request on web interface/
+Wait /Press escape key to go back to select the authentication method/
 Show
 
 Hide
@@ -62,7 +64,8 @@ Show
 
 Hide
 Enter
-Wait@${AUTHD_SLEEP_EXAMPLE_BROKER_MFA_WAIT}/2 /Unlock your phone \+33\.\.\. or accept request on web interface/
+Wait+Screen@${AUTHD_SLEEP_EXAMPLE_BROKER_MFA_WAIT}/2 /Unlock your phone \+33\.\.\. or accept request on web interface/
+Wait /Press escape key to go back to select the authentication method/
 Show
 
 Hide

--- a/pam/integration-tests/testdata/tapes/cli/mfa_reset_pwquality_auth.tape
+++ b/pam/integration-tests/testdata/tapes/cli/mfa_reset_pwquality_auth.tape
@@ -16,7 +16,7 @@ Show
 
 Hide
 Type "2"
-Wait+Prompt /Gimme your password/
+Wait+CLIPrompt /Gimme your password/ /Press escape key to go back to select the authentication method/
 Show
 
 Hide
@@ -25,21 +25,24 @@ Show
 
 Hide
 Enter
-Wait@${AUTHD_SLEEP_EXAMPLE_BROKER_MFA_WAIT} * 1.2 /Password reset, 2 step\(s\) missing/
+Wait+Screen@${AUTHD_SLEEP_EXAMPLE_BROKER_MFA_WAIT} * 1.2 /Password reset, 2 step\(s\) missing/
+Wait /Press escape key to go back to select the authentication method/
 Show
 
 Hide
-Wait /Plug your fido device and press with your thumb/
+Wait+Screen /Plug your fido device and press with your thumb/
+Wait /Press escape key to go back to select the authentication method/
 Show
 
 Hide
-Wait@${AUTHD_SLEEP_EXAMPLE_BROKER_MFA_WAIT} * 1.2 /Password reset, 1 step\(s\) missing/
+Wait+Screen@${AUTHD_SLEEP_EXAMPLE_BROKER_MFA_WAIT} * 1.2 /Password reset, 1 step\(s\) missing/
+Wait /Press escape key to go back to select the authentication method/
 Show
 
 # Wait for MFA auth to happen
 Hide
 Wait+Screen /Enter your new password \(3 days until mandatory\)\n/
-Wait+CLIPrompt@${AUTHD_SLEEP_EXAMPLE_BROKER_MFA_WAIT} * 1.2 /New password/ /\[ Skip \]/
+Wait+CLIPrompt@${AUTHD_SLEEP_EXAMPLE_BROKER_MFA_WAIT} * 1.2 /New password/ /\[ Skip \]/ /[ ]*Press escape key to go back to choose the provider/
 Show
 
 Hide
@@ -48,7 +51,7 @@ Show
 
 Hide
 Enter
-Wait+CLIPrompt@${AUTHD_WAIT_DEFAULT}*2 /New password/ /\[ Skip \]/ /The password is the same as the old one/
+Wait+CLIPrompt@${AUTHD_WAIT_DEFAULT}*2 /New password/ /\[ Skip \]/ /The password is the same as the old one[\n]+[ ]*Press escape key to go back to choose the provider/
 Show
 
 Hide
@@ -57,7 +60,7 @@ Show
 
 Hide
 Enter
-Wait+CLIPrompt@${AUTHD_WAIT_DEFAULT}*2 /New password/ /\[ Skip \]\nThe password fails the dictionary check[^\n]+/
+Wait+CLIPrompt@${AUTHD_WAIT_DEFAULT}*2 /New password/ /\[ Skip \]\nThe password fails the dictionary check[^\n]+[\n]+[ ]*Press escape key to go back to choose the provider/
 Show
 
 Hide
@@ -66,7 +69,7 @@ Show
 
 Hide
 Enter
-Wait+CLIPrompt@${AUTHD_WAIT_DEFAULT}*2 /New password/ /\[ Skip \]\nThe password is the same as the old one/
+Wait+CLIPrompt@${AUTHD_WAIT_DEFAULT}*2 /New password/ /\[ Skip \]\nThe password is the same as the old one[\n]+[ ]*Press escape key to go back to choose the provider/
 Show
 
 Hide
@@ -75,7 +78,7 @@ Show
 
 Hide
 Enter
-Wait+CLIPrompt@${AUTHD_WAIT_DEFAULT}*2 /New password/ /\[ Skip \]\nThe password is shorter than \d+ characters/
+Wait+CLIPrompt@${AUTHD_WAIT_DEFAULT}*2 /New password/ /\[ Skip \]\nThe password is shorter than \d+ characters[\n]+[ ]*Press escape key to go back to choose the provider/
 Show
 
 Hide
@@ -84,7 +87,7 @@ Show
 
 Hide
 Enter
-Wait+CLIPrompt@${AUTHD_WAIT_DEFAULT}*2 /Confirm password/ /\[ Skip \]/
+Wait+CLIPrompt@${AUTHD_WAIT_DEFAULT}*2 /Confirm password/ /\[ Skip \]/ /[ ]*Press escape key to go back to choose the provider/
 Show
 
 Hide

--- a/pam/integration-tests/testdata/tapes/cli/optional_password_reset_skip.tape
+++ b/pam/integration-tests/testdata/tapes/cli/optional_password_reset_skip.tape
@@ -16,20 +16,22 @@ Show
 
 Hide
 Type "2"
-Wait+Prompt /Gimme your password/
+Wait+CLIPrompt /Gimme your password/ /Press escape key to go back to select the authentication method/
 Show
 
 Hide
 TypeCLIPassword "goodpass"
+Wait /Press escape key to go back to select the authentication method/
 Show
 
 Hide
 Enter
-Wait /Password reset, 1 step\(s\) missing/
+Wait+Screen /Password reset, 1 step\(s\) missing/
+Wait /Press escape key to go back to select the authentication method/
 Show
 
 Hide
-Wait+CLIPrompt@${AUTHD_WAIT_DEFAULT}*2 /New password/ /\[ Skip \]/
+Wait+CLIPrompt@${AUTHD_WAIT_DEFAULT}*2 /New password/ /\[ Skip \][\n]+[ ]*Press escape key to go back to choose the provider/
 Show
 
 Hide

--- a/pam/integration-tests/testdata/tapes/cli/passwd_auth_fail.tape
+++ b/pam/integration-tests/testdata/tapes/cli/passwd_auth_fail.tape
@@ -16,7 +16,7 @@ Show
 
 Hide
 Type "2"
-Wait+Prompt /Gimme your password/
+Wait+CLIPrompt /Gimme your password/ /Press escape key to go back to select the authentication method/
 Show
 
 Hide
@@ -25,7 +25,7 @@ Show
 
 Hide
 Enter
-Wait+CLIPrompt /Gimme your password/ /invalid password '.+', should be[^\n]+/
+Wait+CLIPrompt /Gimme your password/ /invalid password '.+', should be[^\n]+[\n]+[ ]*Press escape key to go back to select the authentication method/
 Show
 
 Hide
@@ -34,7 +34,7 @@ Show
 
 Hide
 Enter
-Wait+CLIPrompt /Gimme your password/ /invalid password '.+', should be[^\n]+/
+Wait+CLIPrompt /Gimme your password/ /invalid password '.+', should be[^\n]+[\n]+[ ]*Press escape key to go back to select the authentication method/
 Show
 
 Hide
@@ -43,7 +43,7 @@ Show
 
 Hide
 Enter
-Wait+CLIPrompt /Gimme your password/ /invalid password '.+', should be[^\n]+/
+Wait+CLIPrompt /Gimme your password/ /invalid password '.+', should be[^\n]+[\n]+[ ]*Press escape key to go back to select the authentication method/
 Show
 
 Hide
@@ -52,7 +52,7 @@ Show
 
 Hide
 Enter
-Wait+CLIPrompt /Gimme your password/ /invalid password '.+', should be[^\n]+/
+Wait+CLIPrompt /Gimme your password/ /invalid password '.+', should be[^\n]+[\n]+[ ]*Press escape key to go back to select the authentication method/
 Show
 
 Hide

--- a/pam/integration-tests/testdata/tapes/cli/passwd_bad_password.tape
+++ b/pam/integration-tests/testdata/tapes/cli/passwd_bad_password.tape
@@ -16,7 +16,7 @@ Show
 
 Hide
 Type "2"
-Wait+Prompt /Gimme your password/
+Wait+CLIPrompt /Gimme your password/ /Press escape key to go back to select the authentication method/
 Show
 
 Hide
@@ -25,30 +25,30 @@ Show
 
 Hide
 Enter
-Wait+CLIPrompt /New password/
+Wait+CLIPrompt /New password/ /Press escape key to go back to choose the provider/
 Show
 
 Hide
 Enter
-Wait+CLIPrompt /New password/ /No password supplied/
+Wait+CLIPrompt /New password/ /No password supplied[\n]+[ ]*Press escape key to go back to choose the provider/
 Show
 
 Hide
 TypeCLIPassword "1234"
 Enter
-Wait+CLIPrompt /New password/ /The password is shorter than \d+ characters/
+Wait+CLIPrompt /New password/ /The password is shorter than \d+ characters[\n]+[ ]*Press escape key to go back to choose the provider/
 Show
 
 Hide
 TypeCLIPassword "12345678"
 Enter
-Wait+CLIPrompt /New password/ /The password fails the dictionary check[^\n]*/
+Wait+CLIPrompt /New password/ /The password fails the dictionary check[^\n]*[\n]+[ ]*Press escape key to go back to choose the provider/
 Show
 
 Hide
 TypeCLIPassword "authd2404"
 Enter
-Wait+Prompt /Confirm password/
+Wait+CLIPrompt /Confirm password/ /Press escape key to go back to choose the provider/
 Show
 
 Hide
@@ -57,13 +57,13 @@ Show
 
 Hide
 Enter
-Wait+CLIPrompt /New password/ /Password entries don't match/
+Wait+CLIPrompt /New password/ /Password entries don't match[\n]+[ ]*Press escape key to go back to choose the provider/
 Show
 
 Hide
 TypeCLIPassword "authd2404"
 Enter
-Wait+Prompt /Confirm password/
+Wait+CLIPrompt /Confirm password/ /Press escape key to go back to choose the provider/
 Show
 
 Hide

--- a/pam/integration-tests/testdata/tapes/cli/passwd_mfa.tape
+++ b/pam/integration-tests/testdata/tapes/cli/passwd_mfa.tape
@@ -16,7 +16,7 @@ Show
 
 Hide
 Type "2"
-Wait+Prompt /Gimme your password/
+Wait+CLIPrompt /Gimme your password/ /Press escape key to go back to select the authentication method/
 Show
 
 Hide
@@ -27,7 +27,7 @@ Show
 
 Hide
 Type "1"
-Wait+Prompt /Gimme your password/
+Wait+CLIPrompt /Gimme your password/ /Press escape key to go back to select the authentication method/
 Show
 
 Hide
@@ -36,7 +36,8 @@ Show
 
 Hide
 Enter
-Wait@${AUTHD_SLEEP_EXAMPLE_BROKER_MFA_WAIT}/2 /Plug your fido device and press with your thumb/
+Wait+Screen@${AUTHD_SLEEP_EXAMPLE_BROKER_MFA_WAIT}/2 /Plug your fido device and press with your thumb/
+Wait /Press escape key to go back to select the authentication method/
 Show
 
 Hide
@@ -47,11 +48,13 @@ Show
 
 Hide
 Enter
-Wait@${AUTHD_SLEEP_EXAMPLE_BROKER_MFA_WAIT}/2 /Plug your fido device and press with your thumb/
+Wait+Screen@${AUTHD_SLEEP_EXAMPLE_BROKER_MFA_WAIT}/2 /Plug your fido device and press with your thumb/
+Wait /Press escape key to go back to select the authentication method/
 Show
 
 Hide
-Wait@${AUTHD_SLEEP_EXAMPLE_BROKER_MFA_WAIT}*1.2 /Unlock your phone \+33\.\.\. or accept request on web interface/
+Wait+Screen@${AUTHD_SLEEP_EXAMPLE_BROKER_MFA_WAIT}*1.2 /Unlock your phone \+33\.\.\. or accept request on web interface/
+Wait /Press escape key to go back to select the authentication method/
 Show
 
 Hide
@@ -62,11 +65,12 @@ Show
 
 Hide
 Enter
-Wait@${AUTHD_SLEEP_EXAMPLE_BROKER_MFA_WAIT}/2 /Unlock your phone \+33\.\.\. or accept request on web interface/
+Wait+Screen@${AUTHD_SLEEP_EXAMPLE_BROKER_MFA_WAIT}/2 /Unlock your phone \+33\.\.\. or accept request on web interface/
+Wait /Press escape key to go back to select the authentication method/
 Show
 
 Hide
-Wait+Prompt@${AUTHD_SLEEP_EXAMPLE_BROKER_MFA_WAIT}*1.2 /New password/
+Wait+CLIPrompt@${AUTHD_SLEEP_EXAMPLE_BROKER_MFA_WAIT}*1.2 /New password/ /Press escape key to go back to choose the provider/
 Show
 
 Hide
@@ -75,7 +79,7 @@ Show
 
 Hide
 Enter
-Wait+Prompt /Confirm password/
+Wait+CLIPrompt /Confirm password/ /Press escape key to go back to choose the provider/
 TypeCLIPassword "authd2404"
 Show
 

--- a/pam/integration-tests/testdata/tapes/cli/passwd_not_changed.tape
+++ b/pam/integration-tests/testdata/tapes/cli/passwd_not_changed.tape
@@ -16,7 +16,7 @@ Show
 
 Hide
 Type "2"
-Wait+Prompt /Gimme your password/
+Wait+CLIPrompt /Gimme your password/ /Press escape key to go back to select the authentication method/
 Show
 
 Hide
@@ -25,7 +25,7 @@ Show
 
 Hide
 Enter
-Wait+Prompt /New password/
+Wait+CLIPrompt /New password/ /Press escape key to go back to choose the provider/
 Show
 
 Hide
@@ -34,7 +34,7 @@ Show
 
 Hide
 Enter
-Wait+CLIPrompt /New password/ /The password is the same as the old one/
+Wait+CLIPrompt /New password/ /The password is the same as the old one[\n]+[ ]*Press escape key to go back to choose the provider/
 Show
 
 Hide
@@ -43,7 +43,7 @@ Show
 
 Hide
 Enter
-Wait+Prompt /Confirm password/
+Wait+CLIPrompt /Confirm password/ /Press escape key to go back to choose the provider/
 TypeCLIPassword "authd2404"
 Show
 

--- a/pam/integration-tests/testdata/tapes/cli/passwd_not_confirmed.tape
+++ b/pam/integration-tests/testdata/tapes/cli/passwd_not_confirmed.tape
@@ -16,7 +16,7 @@ Show
 
 Hide
 Type "2"
-Wait+Prompt /Gimme your password/
+Wait+CLIPrompt /Gimme your password/ /Press escape key to go back to select the authentication method/
 Show
 
 Hide
@@ -25,7 +25,7 @@ Show
 
 Hide
 Enter
-Wait+Prompt /New password/
+Wait+CLIPrompt /New password/ /Press escape key to go back to choose the provider/
 Show
 
 Hide
@@ -34,13 +34,13 @@ Show
 
 Hide
 Enter
-Wait+Prompt /Confirm password/
+Wait+CLIPrompt /Confirm password/ /Press escape key to go back to choose the provider/
 TypeCLIPassword "badpass"
 Show
 
 Hide
 Enter
-Wait+CLIPrompt /New password/ /Password entries don't match/
+Wait+CLIPrompt /New password/ /Password entries don't match[\n]+[ ]*Press escape key to go back to choose the provider/
 Show
 
 Hide
@@ -49,7 +49,7 @@ Show
 
 Hide
 Enter
-Wait+Prompt /Confirm password/
+Wait+CLIPrompt /Confirm password/ /Press escape key to go back to choose the provider/
 TypeCLIPassword "authd2404"
 Show
 

--- a/pam/integration-tests/testdata/tapes/cli/passwd_rejected.tape
+++ b/pam/integration-tests/testdata/tapes/cli/passwd_rejected.tape
@@ -16,7 +16,7 @@ Show
 
 Hide
 Type "2"
-Wait+Prompt /Gimme your password/
+Wait+CLIPrompt /Gimme your password/ /Press escape key to go back to select the authentication method/
 Show
 
 Hide
@@ -25,7 +25,7 @@ Show
 
 Hide
 Enter
-Wait+Prompt /New password/
+Wait+CLIPrompt /New password/ /Press escape key to go back to choose the provider/
 Show
 
 Hide
@@ -34,13 +34,13 @@ Show
 
 Hide
 Enter
-Wait+Prompt /Confirm password/
+Wait+CLIPrompt /Confirm password/ /Press escape key to go back to choose the provider/
 TypeCLIPassword "noble2404"
 Show
 
 Hide
 Enter
-Wait+CLIPrompt /New password/ /new password does not match criteria: must be [^\n]+/
+Wait+CLIPrompt /New password/ /new password does not match criteria: must be [^\n]+[\n]+[ ]*Press escape key to go back to choose the provider/
 Show
 
 Hide
@@ -49,7 +49,7 @@ Show
 
 Hide
 Enter
-Wait+Prompt /Confirm password/
+Wait+CLIPrompt /Confirm password/ /Press escape key to go back to choose the provider/
 TypeCLIPassword "authd2404"
 Show
 
@@ -74,13 +74,13 @@ Show
 
 Hide
 Enter
-Wait+Prompt /Gimme your password/
+Wait+CLIPrompt /Gimme your password/ /Press escape key to go back to select the authentication method/
 Show
 
 Hide
 TypeCLIPassword "authd2404"
 Enter
-Wait+Prompt /New password/
+Wait+CLIPrompt /New password/ /Press escape key to go back to choose the provider/
 Show
 
 Hide
@@ -89,13 +89,13 @@ Show
 
 Hide
 Enter
-Wait+Prompt /Confirm password/
+Wait+CLIPrompt /Confirm password/ /Press escape key to go back to choose the provider/
 TypeCLIPassword "noble2404"
 Show
 
 Hide
 Enter
-Wait+CLIPrompt /New password/ /new password does not match criteria: must be [^\n]+/
+Wait+CLIPrompt /New password/ /new password does not match criteria: must be [^\n]+[\n]+[ ]*Press escape key to go back to choose the provider/
 Show
 
 Hide
@@ -104,7 +104,7 @@ Show
 
 Hide
 Enter
-Wait+Prompt /Confirm password/
+Wait+CLIPrompt /Confirm password/ /Press escape key to go back to choose the provider/
 TypeCLIPassword "goodpass"
 Show
 

--- a/pam/integration-tests/testdata/tapes/cli/passwd_sigint.tape
+++ b/pam/integration-tests/testdata/tapes/cli/passwd_sigint.tape
@@ -16,7 +16,7 @@ Show
 
 Hide
 Type "2"
-Wait+Prompt /Gimme your password/
+Wait+CLIPrompt /Gimme your password/ /Press escape key to go back to select the authentication method/
 Show
 
 Hide

--- a/pam/integration-tests/testdata/tapes/cli/passwd_simple.tape
+++ b/pam/integration-tests/testdata/tapes/cli/passwd_simple.tape
@@ -16,7 +16,7 @@ Show
 
 Hide
 Type "2"
-Wait+Prompt /Gimme your password/
+Wait+CLIPrompt /Gimme your password/ /Press escape key to go back to select the authentication method/
 Show
 
 Hide
@@ -25,7 +25,7 @@ Show
 
 Hide
 Enter
-Wait+Prompt /New password/
+Wait+CLIPrompt /New password/ /Press escape key to go back to choose the provider/
 Show
 
 Hide
@@ -34,7 +34,7 @@ Show
 
 Hide
 Enter
-Wait+Prompt /Confirm password/
+Wait+CLIPrompt /Confirm password/ /Press escape key to go back to choose the provider/
 TypeCLIPassword "authd2404"
 Show
 
@@ -57,7 +57,7 @@ Show
 
 Hide
 Enter
-Wait+Prompt /Gimme your password/
+Wait+CLIPrompt /Gimme your password/ /Press escape key to go back to select the authentication method/
 Show
 
 Hide

--- a/pam/integration-tests/testdata/tapes/cli/qr_code.tape
+++ b/pam/integration-tests/testdata/tapes/cli/qr_code.tape
@@ -15,7 +15,7 @@ Show
 
 Hide
 Type "2"
-Wait+Prompt /Gimme your password/
+Wait+CLIPrompt /Gimme your password/ /Press escape key to go back to select the authentication method/
 Show
 
 Hide

--- a/pam/integration-tests/testdata/tapes/cli/qr_code_quick_regenerate.tape
+++ b/pam/integration-tests/testdata/tapes/cli/qr_code_quick_regenerate.tape
@@ -16,7 +16,7 @@ Show
 
 Hide
 Type "2"
-Wait+Prompt /Gimme your password/
+Wait+CLIPrompt /Gimme your password/ /Press escape key to go back to select the authentication method/
 Show
 
 Hide

--- a/pam/integration-tests/testdata/tapes/cli/remember_broker_and_mode.tape
+++ b/pam/integration-tests/testdata/tapes/cli/remember_broker_and_mode.tape
@@ -16,7 +16,7 @@ Show
 
 Hide
 Type "2"
-Wait+Prompt /Gimme your password/
+Wait+CLIPrompt /Gimme your password/ /Press escape key to go back to select the authentication method/
 Escape
 Wait+Screen /Select your authentication method/
 Wait+Screen /7\. Authentication code/
@@ -24,7 +24,7 @@ Show
 
 Hide
 Type "7"
-Wait+CLIPrompt@${AUTHD_WAIT_DEFAULT}*2 /Enter your one time credential/ /\[ Resend SMS \(1 sent\) \]/
+Wait+CLIPrompt@${AUTHD_WAIT_DEFAULT}*2 /Enter your one time credential/ /\[ Resend SMS \(1 sent\) \][\n]+[ ]*Press escape key to go back to select the authentication method/
 Show
 
 Hide
@@ -47,7 +47,7 @@ Show
 
 Hide
 Enter
-Wait+CLIPrompt@${AUTHD_WAIT_DEFAULT}*2 /Enter your one time credential/ /\[ Resend SMS \(1 sent\) \]/
+Wait+CLIPrompt@${AUTHD_WAIT_DEFAULT}*2 /Enter your one time credential/ /\[ Resend SMS \(1 sent\) \][\n]+[ ]*Press escape key to go back to select the authentication method/
 Show
 
 Hide

--- a/pam/integration-tests/testdata/tapes/cli/sigint.tape
+++ b/pam/integration-tests/testdata/tapes/cli/sigint.tape
@@ -16,7 +16,7 @@ Show
 
 Hide
 Type "2"
-Wait+Prompt /Gimme your password/
+Wait+CLIPrompt /Gimme your password/ /Press escape key to go back to select the authentication method/
 Show
 
 Hide

--- a/pam/integration-tests/testdata/tapes/cli/simple_auth.tape
+++ b/pam/integration-tests/testdata/tapes/cli/simple_auth.tape
@@ -16,7 +16,7 @@ Show
 
 Hide
 Type "2"
-Wait+Prompt /Gimme your password/
+Wait+CLIPrompt /Gimme your password/ /Press escape key to go back to (select the authentication method|choose the provider)/
 Show
 
 Hide

--- a/pam/integration-tests/testdata/tapes/cli/simple_auth_empty_user.tape
+++ b/pam/integration-tests/testdata/tapes/cli/simple_auth_empty_user.tape
@@ -32,7 +32,7 @@ Show
 
 Hide
 Type "2"
-Wait+Prompt /Gimme your password/
+Wait+CLIPrompt /Gimme your password/ /Press escape key to go back to select the authentication method/
 Show
 
 Hide

--- a/pam/integration-tests/testdata/tapes/cli/simple_auth_with_auto_selected_broker.tape
+++ b/pam/integration-tests/testdata/tapes/cli/simple_auth_with_auto_selected_broker.tape
@@ -1,7 +1,7 @@
 Hide
 TypeInPrompt+Shell "${AUTHD_TEST_TAPE_COMMAND}"
 Enter
-Wait+Prompt /Gimme your password/
+Wait+CLIPrompt /Gimme your password/ /Press escape key to go back to select the authentication method/
 Show
 
 Hide

--- a/pam/integration-tests/testdata/tapes/cli/simple_auth_with_preset_user.tape
+++ b/pam/integration-tests/testdata/tapes/cli/simple_auth_with_preset_user.tape
@@ -7,7 +7,7 @@ Show
 
 Hide
 Type "2"
-Wait+Prompt /Gimme your password/
+Wait+CLIPrompt /Gimme your password/ /Press escape key to go back to select the authentication method/
 Show
 
 Hide

--- a/pam/integration-tests/testdata/tapes/cli/simple_auth_with_unsupported_args.tape
+++ b/pam/integration-tests/testdata/tapes/cli/simple_auth_with_unsupported_args.tape
@@ -16,7 +16,7 @@ Show
 
 Hide
 Type "2"
-Wait+Prompt /Gimme your password/
+Wait+CLIPrompt /Gimme your password/ /Press escape key to go back to select the authentication method/
 Show
 
 Hide

--- a/pam/integration-tests/testdata/tapes/cli/switch_auth_mode.tape
+++ b/pam/integration-tests/testdata/tapes/cli/switch_auth_mode.tape
@@ -16,7 +16,7 @@ Show
 
 Hide
 Type "2"
-Wait+Prompt /Gimme your password/
+Wait+CLIPrompt /Gimme your password/ /Press escape key to go back to select the authentication method/
 Show
 
 Hide
@@ -27,7 +27,7 @@ Show
 
 Hide
 Type "2"
-Wait+Prompt@${AUTHD_SLEEP_EXAMPLE_BROKER_MFA_WAIT}/3 /Click on the link received at .* or enter the code/
+Wait+CLIPrompt@${AUTHD_SLEEP_EXAMPLE_BROKER_MFA_WAIT}/3 /Click on the link received at .* or enter the code/ /Press escape key to go back to select the authentication method/
 Show
 
 Hide
@@ -38,7 +38,8 @@ Show
 
 Hide
 Type "3"
-Wait@${AUTHD_SLEEP_EXAMPLE_BROKER_MFA_WAIT}/3 /Plug your fido device and press with your thumb/
+Wait+Screen@${AUTHD_SLEEP_EXAMPLE_BROKER_MFA_WAIT}/3 /Plug your fido device and press with your thumb/
+Wait /Press escape key to go back to select the authentication method/
 Show
 
 Hide
@@ -49,7 +50,7 @@ Show
 
 Hide
 Type "1"
-Wait+Prompt /Gimme your password/
+Wait+CLIPrompt /Gimme your password/ /Press escape key to go back to select the authentication method/
 Show
 
 Hide

--- a/pam/integration-tests/testdata/tapes/cli/switch_local_broker.tape
+++ b/pam/integration-tests/testdata/tapes/cli/switch_local_broker.tape
@@ -16,7 +16,7 @@ Show
 
 Hide
 Type "2"
-Wait+Prompt /Gimme your password/
+Wait+CLIPrompt /Gimme your password/ /Press escape key to go back to select the authentication method/
 Show
 
 Hide

--- a/pam/integration-tests/testdata/tapes/cli/switch_preset_username.tape
+++ b/pam/integration-tests/testdata/tapes/cli/switch_preset_username.tape
@@ -11,7 +11,7 @@ Show
 
 Hide
 Type "2"
-Wait+Prompt /Gimme your password/
+Wait+CLIPrompt /Gimme your password/ /Press escape key to go back to select the authentication method/
 Show
 
 Hide
@@ -35,7 +35,7 @@ Show
 
 Hide
 Type "2"
-Wait+Prompt /Gimme your password/
+Wait+CLIPrompt /Gimme your password/ /Press escape key to go back to select the authentication method/
 Show
 
 Hide

--- a/pam/integration-tests/testdata/tapes/cli/switch_username.tape
+++ b/pam/integration-tests/testdata/tapes/cli/switch_username.tape
@@ -31,7 +31,7 @@ Show
 
 Hide
 Type "2"
-Wait+Prompt /Gimme your password/
+Wait+CLIPrompt /Gimme your password/ /Press escape key to go back to select the authentication method/
 Show
 
 Hide

--- a/pam/internal/adapter/model.go
+++ b/pam/internal/adapter/model.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
 	"github.com/msteinert/pam/v2"
 	"github.com/ubuntu/authd/internal/consts"
 	"github.com/ubuntu/authd/internal/proto/authd"
@@ -35,7 +36,14 @@ const (
 	Gdm
 )
 
-var debug string
+var (
+	debug string
+
+	infoMsgStyle = lipgloss.NewStyle().Foreground(lipgloss.AdaptiveColor{
+		Light: "#909090",
+		Dark:  "#7f7f7f",
+	}).Padding(1, 0, 0, 2)
+)
 
 // sessionInfo contains the global broker session information.
 type sessionInfo struct {
@@ -431,6 +439,12 @@ func (m uiModel) View() string {
 
 	if debug != "" {
 		view.WriteString(debug)
+	}
+
+	if view.Len() > 0 && m.canGoBack() {
+		infoMessage := infoMsgStyle.Render(fmt.Sprintf("Press escape key to %s",
+			goBackLabel(m.previousStage())))
+		return lipgloss.JoinVertical(lipgloss.Left, view.String(), infoMessage)
 	}
 
 	return view.String()

--- a/pam/internal/adapter/nativemodel.go
+++ b/pam/internal/adapter/nativemodel.go
@@ -905,17 +905,8 @@ func (m nativeModel) goBackActionLabel() string {
 	if !m.canGoBack() {
 		return ""
 	}
-	switch m.previousStage() {
-	case proto.Stage_authModeSelection:
-		return "go back to select the authentication method"
-	case proto.Stage_brokerSelection:
-		return "go back to choose the provider"
-	case proto.Stage_challenge:
-		return "go back to authentication"
-	case proto.Stage_userSelection:
-		return "go back to user selection"
-	}
-	return "go back"
+
+	return goBackLabel(m.previousStage())
 }
 
 func sendAuthWaitCommand() tea.Cmd {

--- a/pam/internal/adapter/utils.go
+++ b/pam/internal/adapter/utils.go
@@ -14,6 +14,8 @@ import (
 	"github.com/msteinert/pam/v2"
 	"github.com/ubuntu/authd/internal/proto/authd"
 	"github.com/ubuntu/authd/log"
+	"github.com/ubuntu/authd/pam/internal/proto"
+	pam_proto "github.com/ubuntu/authd/pam/internal/proto"
 )
 
 var (
@@ -235,4 +237,19 @@ func safeMessageDebugWithPrefix(prefix string, msg tea.Msg, formatAndArgs ...any
 
 	args := formatAndArgs[1:]
 	log.Debugf(context.Background(), "%s, %s", m, fmt.Sprintf(format, args...))
+}
+
+func goBackLabel(previousStage pam_proto.Stage) string {
+	switch previousStage {
+	case proto.Stage_authModeSelection:
+		return "go back to select the authentication method"
+	case proto.Stage_brokerSelection:
+		return "go back to choose the provider"
+	case proto.Stage_challenge:
+		return "go back to authentication"
+	case proto.Stage_userSelection:
+		return "go back to user selection"
+	default:
+		return ""
+	}
 }


### PR DESCRIPTION
In case the user is allowed to go back to previous view, the escape key
can be used to go to the previous view, but this is not always clear to
the users or expected.

So clearly add an info message about it.

Update VHS tests and golden files

UDENG-6321