### PR TITLE
pam/nativemodel: Do not show "go back" info message if not supported

### DIFF
--- a/pam/integration-tests/testdata/golden/TestNativeAuthenticate/Authenticate_user_successfully_with_password_only_supported_method_in_polkit
+++ b/pam/integration-tests/testdata/golden/TestNativeAuthenticate/Authenticate_user_successfully_with_password_only_supported_method_in_polkit
@@ -1,12 +1,10 @@
 > ./pam_authd login socket=${AUTHD_TEST_TAPE_SOCKET} force_native_client=true
 == Password authentication ==
-Enter 'r' to cancel the request and go back to user selection
 Gimme your password:
 >
 ────────────────────────────────────────────────────────────────────────────────
 > ./pam_authd login socket=${AUTHD_TEST_TAPE_SOCKET} force_native_client=true
 == Password authentication ==
-Enter 'r' to cancel the request and go back to user selection
 Gimme your password:
 >
 PAM Authenticate()

--- a/pam/integration-tests/testdata/golden/TestNativeChangeAuthTok/Change_password_successfully_and_authenticate_with_new_one_with_single_broker_and_password_only_supported_method
+++ b/pam/integration-tests/testdata/golden/TestNativeChangeAuthTok/Change_password_successfully_and_authenticate_with_new_one_with_single_broker_and_password_only_supported_method
@@ -1,0 +1,61 @@
+> ./pam_authd passwd socket=${AUTHD_TEST_TAPE_SOCKET} force_native_client=true
+== Password authentication ==
+Gimme your password:
+>
+────────────────────────────────────────────────────────────────────────────────
+> ./pam_authd passwd socket=${AUTHD_TEST_TAPE_SOCKET} force_native_client=true
+== Password authentication ==
+Gimme your password:
+>
+== Password reset ==
+Enter your new password:
+>
+────────────────────────────────────────────────────────────────────────────────
+> ./pam_authd passwd socket=${AUTHD_TEST_TAPE_SOCKET} force_native_client=true
+== Password authentication ==
+Gimme your password:
+>
+== Password reset ==
+Enter your new password:
+>
+Confirm Password:
+>
+────────────────────────────────────────────────────────────────────────────────
+> ./pam_authd passwd socket=${AUTHD_TEST_TAPE_SOCKET} force_native_client=true
+== Password authentication ==
+Gimme your password:
+>
+== Password reset ==
+Enter your new password:
+>
+Confirm Password:
+>
+PAM ChangeAuthTok()
+  User: "user-auth-modes-password,mandatoryreset-integration-polkit-testnativechangeauthtok"
+  Result: success
+PAM AcctMgmt()
+  User: "user-auth-modes-password,mandatoryreset-integration-polkit-testnativechangeauthtok"
+  Result: success
+>
+────────────────────────────────────────────────────────────────────────────────
+>
+────────────────────────────────────────────────────────────────────────────────
+> ./pam_authd login socket=${AUTHD_TEST_TAPE_SOCKET} force_native_client=true
+== Password authentication ==
+Enter 'r' to cancel the request and go back to select the authentication method
+Gimme your password:
+>
+────────────────────────────────────────────────────────────────────────────────
+> ./pam_authd login socket=${AUTHD_TEST_TAPE_SOCKET} force_native_client=true
+== Password authentication ==
+Enter 'r' to cancel the request and go back to select the authentication method
+Gimme your password:
+>
+PAM Authenticate()
+  User: "user-auth-modes-password,mandatoryreset-integration-polkit-testnativechangeauthtok"
+  Result: success
+PAM AcctMgmt()
+  User: "user-auth-modes-password,mandatoryreset-integration-polkit-testnativechangeauthtok"
+  Result: success
+>
+────────────────────────────────────────────────────────────────────────────────

--- a/pam/integration-tests/testdata/tapes/native/passwd_simple_one_broker_only.tape
+++ b/pam/integration-tests/testdata/tapes/native/passwd_simple_one_broker_only.tape
@@ -1,0 +1,37 @@
+Hide
+TypeInPrompt+Shell "${AUTHD_TEST_TAPE_COMMAND}"
+Enter
+Wait+Prompt /Gimme your password/
+Show
+
+Hide
+Type "goodpass"
+Enter
+Wait+Prompt /Enter your new password/
+Show
+
+Hide
+Type "authd2404"
+Enter
+Wait+Prompt /Confirm Password/
+Show
+
+Hide
+Type "authd2404"
+Enter
+${AUTHD_TEST_TAPE_COMMAND_PASSWD_FINAL_WAIT}
+Show
+
+ClearTerminal
+
+Hide
+TypeInPrompt+Shell "${AUTHD_TEST_TAPE_LOGIN_COMMAND}"
+Enter
+Wait+Prompt /Gimme your password/
+Show
+
+Hide
+Type "authd2404"
+Enter
+${AUTHD_TEST_TAPE_COMMAND_AUTH_FINAL_WAIT}
+Show


### PR DESCRIPTION
During the challenge phase a "go back" message may have been shown even
if we had no multiple authentication methods or brokers available.

So fix this by actually checking if we can go back

Depends on #914 (as noticed when tuning tests there :))