### PR TITLE
Improve log message

### DIFF
--- a/internal/users/localentries/localgroups.go
+++ b/internal/users/localentries/localgroups.go
@@ -246,7 +246,7 @@ func runGPasswd(cmdName string, args ...string) error {
 	out, err := cmd.CombinedOutput()
 	if err != nil {
 		if cmd.ProcessState.ExitCode() == 3 {
-			log.Infof(context.TODO(), "ignoring gpasswd error: %s", out)
+			log.Infof(context.TODO(), "gpasswd exited with code 3 (group or user does not exist); ignoring: %s", out)
 			return nil
 		}
 		return fmt.Errorf("%q returned: %v\nOutput: %s", strings.Join(cmd.Args, " "), err, out)

--- a/internal/users/localentries/localgroups.go
+++ b/internal/users/localentries/localgroups.go
@@ -246,7 +246,7 @@ func runGPasswd(cmdName string, args ...string) error {
 	out, err := cmd.CombinedOutput()
 	if err != nil {
 		if cmd.ProcessState.ExitCode() == 3 {
-			log.Infof(context.TODO(), "gpasswd exited with code 3 (group or user does not exist); ignoring: %s", out)
+			log.Noticef(context.TODO(), "gpasswd exited with code 3 (group or user does not exist); ignoring: %s", out)
 			return nil
 		}
 		return fmt.Errorf("%q returned: %v\nOutput: %s", strings.Join(cmd.Args, " "), err, out)


### PR DESCRIPTION
* Print log message with log level "notice"

   The default log level for authd is "notice", so messages with log level
"info" are not displayed by default. That caused me some confusion when
I added the user to a new "linux-" group in Entra, which the user wasn't
added to during login and nothing showed up about it in the logs.

    The reason was that the group name contained a typo, so gpasswd couldn't
find a local group of the same name. We should print a log message
that's shown in the default log level when that happens.

* Make it clearer why we're ignoring the error.