### PR TITLE
Fix bug report template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -92,7 +92,7 @@ body:
 
         #### Logs
         \`\`\`
-        $(journalctl -o short-monotonic --lines 500  _SYSTEMD_UNIT=authd.service \+ UNIT=authd.service \+ \
+        $(sudo journalctl -o short-monotonic --lines 500  _SYSTEMD_UNIT=authd.service \+ UNIT=authd.service \+ \
           _SYSTEMD_UNIT=snap.authd-msentraid.authd-msentraid.service \+ UNIT=snap.authd-msentraid.authd-msentraid.service \+ SYSLOG_IDENTIFIER=authd-msentraid \+ \
           _SYSTEMD_UNIT=snap.authd-google.authd-google.service \+ UNIT=snap.authd-google.authd-google.service \+ SYSLOG_IDENTIFIER=authd-google \+ \
           '_CMDLINE="gdm-session-worker [pam/gdm-authd]"' | sed -E 's/[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}/<UUID redacted>/g')


### PR DESCRIPTION
* Fix sudo password prompt not visible
    
    When using sudo in the subshells of the command substitutions in the
    heredoc, the password prompt is not visible, so the command seems to
    hang, while actually it's waiting for the user to input their password.
    
    To work around that, use `sudo -v` before the heredoc, so that the
    user's credentials are cached and sudo doesn't ask for them again
    (assuming that credential caching hasn't been disabled).


* Use journalctl with sudo
    
    Non-privileged users are not allowed to read journal messages from
    system services such as authd.
