### PR TITLE
Fix `version` command trying to migrate

### DIFF
--- a/cmd/authd/daemon/daemon.go
+++ b/cmd/authd/daemon/daemon.go
@@ -56,12 +56,14 @@ func New() *App {
 		Short:/*i18n.G(*/ "Authentication daemon",                                           /*)*/
 		Long:/*i18n.G(*/ "Authentication daemon bridging the system with external brokers.", /*)*/
 		Args:                                                                                cobra.NoArgs,
-		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
+		PersistentPreRun: func(cmd *cobra.Command, args []string) {
 			// First thing, initialize the journal handler
 			log.InitJournalHandler(false)
 
 			// Command parsing has been successful. Returns to not print usage anymore.
 			a.rootCmd.SilenceUsage = true
+		},
+		PreRunE: func(cmd *cobra.Command, args []string) error {
 			// TODO: before or after?  cmd.LocalFlags()
 
 			// Set config defaults

--- a/cmd/authd/daemon/daemon_test.go
+++ b/cmd/authd/daemon/daemon_test.go
@@ -314,8 +314,8 @@ func TestAutoDetectConfig(t *testing.T) {
 
 func TestNoConfigSetDefaults(t *testing.T) {
 	a := daemon.New()
-	// Use version to still run preExec to load no config but without running server
-	a.SetArgs("version")
+
+	a.SetArgs("--check-config")
 
 	err := a.Run()
 	require.NoError(t, err, "Run should not return an error")
@@ -328,8 +328,7 @@ func TestNoConfigSetDefaults(t *testing.T) {
 
 func TestBadConfigReturnsError(t *testing.T) {
 	a := daemon.New()
-	// Use version to still run preExec to load no config but without running server
-	a.SetArgs("version", "--config", "/does/not/exist.yaml")
+	a.SetArgs("--check-config", "--config", "/does/not/exist.yaml")
 
 	err := a.Run()
 	require.Error(t, err, "Run should return an error on config file")


### PR DESCRIPTION
The `PersistentPreRunE` method did things which should not be done for subcommands like `version`. We don't need to parse the config file to print the authd version, and we definitely don't need to migrate the database.

Also add a `--check-config` flag which can be used in tests which check config parsing instead of the `version` command.