### PR TITLE
docs: Improve code block styles

### DIFF
--- a/docs/howto/login-gdm.md
+++ b/docs/howto/login-gdm.md
@@ -7,9 +7,9 @@ In this example, we are going to use MS Entra ID as the remote provider but the 
 
 > See all the available providers: [Install brokers](./install-authd.md#install-brokers)
 
-In the login screen (greeter), select ```not listed``` below the user name field.
+In the login screen (greeter), select `not listed` below the user name field.
 
-Type your remote provider user name. The format is ```user@domain.name```
+Type your remote provider user name. The format is `user@domain.name`
 
 Select the broker `Microsoft Entra ID`
 
@@ -29,15 +29,15 @@ Upon successful authentication, the user is prompted to enter a local password. 
 
 ### authd
 
-```authd``` is socket-activated. It means that the service starts on-demand when it receives a request on a socket.
+`authd` is socket-activated. It means that the service starts on-demand when it receives a request on a socket.
 
-If you want to restart the service, you can stop it with ```sudo systemctl stop authd``` and it will restart automatically on the next message it receives.
+If you want to restart the service, you can stop it with `sudo systemctl stop authd` and it will restart automatically on the next message it receives.
 
-Run ```/usr/libexec/authd --help``` to display the entire help.
+Run `/usr/libexec/authd --help` to display the entire help.
 
 ## Broker management
 
-The broker is managed through the ```snap``` command.
+The broker is managed through the `snap` command.
 
 The main operation is to restart the broker to reload the configuration when it has changed. You can reload the broker with the command:
 

--- a/docs/howto/login-ssh.md
+++ b/docs/howto/login-ssh.md
@@ -17,7 +17,7 @@ Alternatively, you can directly set the keys in the sshd configuration file `/et
 
 Then restart the SSH server:
 
-```
+```shell
 sudo systemctl restart ssh
 ```
 
@@ -25,7 +25,7 @@ sudo systemctl restart ssh
 
 To configure the broker edit the file `/var/snap/authd-<broker_name>/current/broker.conf` and set the key `ssh_allowed_suffixes` with the list of domains that you want to allow.
 
-```
+```ini
 ...
 
 [users]
@@ -36,7 +36,7 @@ ssh_allowed_suffixes = <ALLOWED DOMAINS>
 
 You can set several domains separated by a comma. For instance:
 
-```
+```ini
 ssh_allowed_suffixes = @example.com,@ubuntu.com
 ```
 

--- a/docs/howto/use-with-nfs.md
+++ b/docs/howto/use-with-nfs.md
@@ -23,7 +23,7 @@ machine.
 
 1. **Install packages:**
    On the NFS server, run:
-   ```bash
+   ```shell
    sudo apt install -y nfs-kernel-server nfs-common rpcbind krb5-user krb5-admin-server krb5-kdc
    ```
 
@@ -57,7 +57,7 @@ machine.
 #### Step 2: Configure Kerberos
 
 1. **Create the Realm:**
-   ```bash
+   ```shell
    sudo krb5_newrealm
    ```
    Follow the prompts to set up the Kerberos realm.
@@ -68,14 +68,14 @@ machine.
    - Add a principal for the NFS server:
      This principal is used by the NFS client to authenticate when mounting an
      NFS directory.
-     ```bash
+     ```shell
      sudo kadmin.local addprinc -randkey nfs/server.example.com
      ```
 
    - Add a principal for the user `alice`:
      This principal is used for authentication when the user accesses the
      mounted NFS directory.
-     ```bash
+     ```shell
      sudo kadmin.local addprinc alice
      ```
      When prompted, set a password for the user `alice`.
@@ -87,7 +87,7 @@ machine.
    to input a password each time.
 
    - Export the keytab for the NFS server and the user `alice`:
-     ```bash
+     ```shell
      sudo kadmin.local ktadd -k /etc/krb5.keytab nfs/server.example.com
      ```
 
@@ -101,14 +101,14 @@ machine.
    directory in the `/etc/exports` file.
 
    - **Create a directory owned by `alice`:**
-     ```bash
+     ```shell
      sudo mkdir -p /srv/nfs/shared/alice
      sudo chown alice:alice /srv/nfs/shared/alice
      ```
 
    - **Configure exports:**
      Edit the `/etc/exports` file to define the shared directory:
-     ```bash
+     ```shell
      sudo editor /etc/exports
      ```
      Add this line:
@@ -118,7 +118,7 @@ machine.
 
 2. **Configure IDMAP:**
    Edit the IDMAP configuration:
-   ```bash
+   ```shell
    sudo editor /etc/idmapd.conf
    ```
    Ensure the following is set:
@@ -128,13 +128,13 @@ machine.
    ```
 
 3. **Restart services:**
-   ```bash
+   ```shell
    sudo systemctl restart nfs-kernel-server rpcbind rpc-svcgssd
    ```
 
 4. **Verify running services:**
    Check the status of the relevant services:
-   ```bash
+   ```shell
    sudo systemctl status nfs-kernel-server rpcbind rpc-svcgssd
    ```
 
@@ -146,7 +146,7 @@ machine.
 
 1. **Install packages:**
    On the NFS client, run:
-   ```bash
+   ```shell
    sudo apt install -y nfs-common krb5-user rpcbind
    ```
 
@@ -176,7 +176,7 @@ machine.
 1. **Copy keytab file:**
    Securely copy the keytab from the server to the client and set the correct
    permissions:
-   ```bash
+   ```shell
    scp root@server.example.com:/etc/krb5.keytab /tmp/krb5.keytab && \
    sudo mv /tmp/krb5.keytab /etc/krb5.keytab && \
    sudo chown root:root /etc/krb5.keytab && \
@@ -189,7 +189,7 @@ machine.
 
 1. **Configure IDMAP:**
    Edit the IDMAP configuration:
-   ```bash
+   ```shell
    sudo editor /etc/idmapd.conf
    ```
    Ensure the following is set:
@@ -199,13 +199,13 @@ machine.
    ```
 
 2. **Restart services:**
-   ```bash
+   ```shell
    sudo systemctl restart nfs-client.target rpc-gssd.service rpcbind.service
    ```
 
 3. **Verify running services:**
    Check the status of the relevant services:
-   ```bash
+   ```shell
    sudo systemctl status nfs-client.target rpc-gssd.service auth-rpcgss-module.service rpcbind.service
    ```
 
@@ -214,7 +214,7 @@ machine.
 #### Step 4: Mount the NFS share
 
 Mount the shared directory with Kerberos security:
-```bash
+```shell
 sudo -u alice mkdir /home/alice/nfs
 sudo mount -t nfs4 -o sec=krb5 server.example.com:/srv/nfs/shared/alice /home/alice/nfs
 ```
@@ -224,12 +224,12 @@ sudo mount -t nfs4 -o sec=krb5 server.example.com:/srv/nfs/shared/alice /home/al
 #### Step 5: Obtain Kerberos ticket
 
 Log in as the user `alice` and authenticate:
-```bash
+```shell
 kinit alice
 ```
 
 Verify the ticket:
-```bash
+```shell
 klist
 ```
 
@@ -239,24 +239,24 @@ klist
 
 1. **Test access to the share:**
    As the user `alice`, try accessing the share:
-   ```bash
+   ```shell
    ls -la /home/alice/nfs
    ```
 
    Create a test file to verify write access:
-   ```bash
+   ```shell
    touch /home/alice/nfs/test
    ```
 
 2. **Check logs if issues arise:**
 
    - On the server:
-     ```bash
+     ```shell
      sudo journalctl -u nfs-kernel-server -u rpcbind -u rpc-svcgssd
      ```
 
    - On the client:
-     ```bash
+     ```shell
      sudo journalctl -u rpcbind -u rpc-gssd
      ```
 
@@ -270,35 +270,35 @@ follow these steps:
 #### On the server
 
 1. **Purge installed packages:**
-   ```bash
+   ```shell
    sudo apt purge "krb*" "nfs-*"
    ```
 
 2. **Remove Kerberos configuration and data:**
-   ```bash
+   ```shell
    sudo sh -c "rm -rf /etc/krb5* /var/lib/krb5kdc/* /tmp/krb5*"
    ```
 
 3. **Remove the shared directory:**
-   ```bash
+   ```shell
    sudo rm -rf /srv/nfs/shared
    sudo rmdir /srv/nfs
    ```
 #### On the client
 
 1. **Unmount the shared directory and delete the mountpoint:**
-   ```bash
+   ```shell
    sudo umount /home/alice/nfs
    sudo rmdir /home/alice/nfs
    ```
 
 2. **Purge installed packages:**
-   ```bash
+   ```shell
    sudo apt purge nfs-common krb5-* rpcbind
    ```
 
 3. **Remove Kerberos data:**
-   ```bash
+   ```shell
    sudo rm -f /etc/krb5.keytab /tmp/krb5*
    ```
 

--- a/docs/howto/use-with-samba.md
+++ b/docs/howto/use-with-samba.md
@@ -21,7 +21,7 @@ shared directory on the server from a client machine.
 1. **Install Samba:**
    Install the Samba server package:
 
-   ```bash
+   ```shell
    sudo apt update
    sudo apt install samba
    ```
@@ -29,7 +29,7 @@ shared directory on the server from a client machine.
 2. **Create the shared directory:**
    Create the directory to be shared and set ownership to the `alice` user:
 
-   ```bash
+   ```shell
    sudo mkdir -p /srv/samba/alice
    sudo chown alice:alice /srv/samba/alice
    ```
@@ -37,7 +37,7 @@ shared directory on the server from a client machine.
 3. **Edit Samba configuration:**
    Open the Samba configuration file:
 
-   ```bash
+   ```shell
    sudo editor /etc/samba/smb.conf
    ```
 
@@ -62,7 +62,7 @@ shared directory on the server from a client machine.
 4. **Create a Samba user for `alice`:**
    Add the `alice` user to the Samba database and set a password:
 
-   ```bash
+   ```shell
    sudo smbpasswd -a alice
    ```
 
@@ -71,7 +71,7 @@ shared directory on the server from a client machine.
 5. **Restart Samba service:**
    Restart the Samba service to apply the changes:
 
-   ```bash
+   ```shell
    sudo systemctl restart smbd
    ```
 
@@ -82,7 +82,7 @@ shared directory on the server from a client machine.
 1. **Install Samba client:**
    Install the required packages for connecting to Samba shares:
 
-   ```bash
+   ```shell
    sudo apt update
    sudo apt install smbclient cifs-utils
    ```
@@ -91,7 +91,7 @@ shared directory on the server from a client machine.
    Test connectivity using `smbclient`, making sure to replace `$SERVER` with
    the Samba server's hostname or IP address:
 
-   ```bash
+   ```shell
    smbclient //$SERVER/alice -U alice
    ```
 
@@ -101,13 +101,13 @@ shared directory on the server from a client machine.
 3. **Mount the share:**
    Create a mount point for the share:
 
-   ```bash
+   ```shell
    mkdir -p /home/alice/samba
    ```
 
    Mount the share using the `cifs` filesystem type:
 
-   ```bash
+   ```shell
    sudo mount -t cifs //$SERVER/alice /home/alice/samba -o user=alice,uid=$(id -u alice),gid=$(id -g alice)
    ```
 
@@ -118,7 +118,7 @@ shared directory on the server from a client machine.
 
    - Create a credentials file:
 
-     ```bash
+     ```shell
      sudo editor /etc/samba/credentials
      ```
 
@@ -131,7 +131,7 @@ shared directory on the server from a client machine.
 
    - Secure the credentials file:
 
-     ```bash
+     ```shell
      sudo chmod 600 /etc/samba/credentials
      ```
 
@@ -144,13 +144,13 @@ shared directory on the server from a client machine.
 5. **Verify the mount:**
    As the user `alice`, try accessing the shared directory:
 
-   ```bash
+   ```shell
    ls -la /home/alice/samba
    ```
 
    Verify write access by creating a test file:
 
-   ```bash
+   ```shell
    touch /home/alice/samba/test
    ```
 
@@ -170,14 +170,14 @@ shared directory on the server from a client machine.
 
    - Create a restricted directory on the server:
 
-     ```bash
+     ```shell
      sudo mkdir /srv/samba/alice/secrets
      sudo chmod 700 /srv/samba/alice/secrets
      ```
 
    - Attempt to access it on the client:
 
-     ```bash
+     ```shell
      ls /home/alice/samba/secrets
      ```
 
@@ -197,14 +197,14 @@ shared directory on the server from a client machine.
 1. **Delete the shared directory:**
    Remove the directory used for the Samba share:
 
-   ```bash
+   ```shell
    sudo rm -rf /srv/samba/alice
    ```
 
 2. **Purge installed Samba packages:**
    If Samba is no longer needed, uninstall it completely:
 
-   ```bash
+   ```shell
    sudo apt purge samba samba-common
    sudo apt autoremove
    ```
@@ -215,20 +215,20 @@ shared directory on the server from a client machine.
 
 1. **Unmount the shared directory:**
 
-   ```bash
+   ```shell
    sudo umount /home/alice/samba
    ```
 
 2. **Delete the mount point:**
 
-   ```bash
+   ```shell
    rmdir /home/alice/samba
    ```
 
 3. **Remove fstab entry:**
    If you added the share to `/etc/fstab`, remove its entry:
 
-   ```bash
+   ```shell
    sudo editor /etc/fstab
    ```
 
@@ -237,14 +237,14 @@ shared directory on the server from a client machine.
 4. **Delete credentials file:**
    If a credentials file was used, remove it:
 
-   ```bash
+   ```shell
    sudo rm /etc/samba/credentials
    ```
 
 5. **Purge installed Samba client packages:**
    If Samba client tools are no longer needed, uninstall them:
 
-   ```bash
+   ```shell
    sudo apt purge samba-common smbclient cifs-utils
    sudo apt autoremove
    ```

--- a/docs/reference/troubleshooting.md
+++ b/docs/reference/troubleshooting.md
@@ -80,7 +80,7 @@ sudo systemctl edit authd.service
 
 Add the following lines to the override file and make sure to add `-vv` at the end of the `authd` command:
 
-```
+```ini
 [Service]
 ExecStart=
 ExecStart=/usr/libexec/authd -vv
@@ -134,7 +134,7 @@ Add the following lines to the override file and make sure to add `-vv` to the e
 :::{tab-item} Google IAM
 :sync: google
 
-```
+```ini
 [Service]
 ExecStart=
 ExecStart=/usr/bin/snap run authd-google -vv
@@ -144,7 +144,7 @@ ExecStart=/usr/bin/snap run authd-google -vv
 :::{tab-item} MS Entra ID
 :sync: msentraid
 
-```
+```ini
 [Service]
 ExecStart=
 ExecStart=/usr/bin/snap run authd-msentraid -vv

--- a/docs/reference/troubleshooting.md
+++ b/docs/reference/troubleshooting.md
@@ -13,9 +13,9 @@ brokers for different cloud providers.
 
 ### authd
 
-```authd``` logs to the system journal.
+`authd` logs to the system journal.
 
-For ```authd``` entries, run:
+For `authd` entries, run:
 
 ```shell
 sudo journalctl -u authd.service
@@ -56,7 +56,7 @@ For the GDM integration:
 sudo journalctl /usr/bin/gnome-shell
 ```
 
-For anything else or more broader investigation, use ```sudo journalctl```.
+For anything else or more broader investigation, use `sudo journalctl`.
 
 ### Logging verbosity
 
@@ -64,7 +64,7 @@ You can increase the verbosity of the logs in different ways.
 
 #### PAM module
 
-Append ```debug=true``` to all the lines with `pam_authd_exec.so` or `pam_authd.so` in the PAM configuration files (`common-auth`, `gdm-authd`...) in ```/etc/pam.d/``` to increase the verbosity of the PAM messages.
+Append `debug=true` to all the lines with `pam_authd_exec.so` or `pam_authd.so` in the PAM configuration files (`common-auth`, `gdm-authd`...) in `/etc/pam.d/` to increase the verbosity of the PAM messages.
 
 #### NSS module
 


### PR DESCRIPTION
* Use ini style code blocks for systemd unit files
    
    The plain code blocks had some strange highlighting, like highlighting
    the "bin" in `ExecStart=/usr/bin/snap run authd-google -vv`.

* Use single backticks for inline code
    
    Markdown uses single backticks for inline code and three backticks for
    code blocks.

* Add code block styles to some blocks