### PR TITLE
Do not release Debian packages for tags on non-main branches

### DIFF
--- a/.github/workflows/build-deb.yaml
+++ b/.github/workflows/build-deb.yaml
@@ -130,10 +130,8 @@ jobs:
 
     # Run only on:
     #  - Push events to main
-    #  - On new tags
     #  - On github release
     if: ${{ (github.event_name == 'push' && github.ref == 'refs/heads/main') ||
-       startsWith(github.ref, 'refs/tags/') ||
        github.event_name == 'release' }}
 
     steps:


### PR DESCRIPTION
Pushing a tag to a feature branch should not result in Debian package being automatically published to the edge PPA.