### PR TITLE
locking: Return ErrLockTimeout on EINTR

### DIFF
--- a/internal/errno/errno_c.go
+++ b/internal/errno/errno_c.go
@@ -36,6 +36,8 @@ const (
 	ErrBadf Error = C.EBADF
 	// ErrPerm is the errno EPERM.
 	ErrPerm Error = C.EPERM
+	// ErrIntr is the errno EINTR.
+	ErrIntr Error = C.EINTR
 )
 
 // All these functions are expected to be called while this mutex is locked.

--- a/internal/users/locking/locking_bwrap_test.go
+++ b/internal/users/locking/locking_bwrap_test.go
@@ -4,7 +4,6 @@ package userslocking_test
 
 import (
 	"context"
-	"math"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -14,7 +13,6 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/require"
-	"github.com/ubuntu/authd/internal/testutils"
 	userslocking "github.com/ubuntu/authd/internal/users/locking"
 )
 
@@ -121,7 +119,7 @@ func TestLockAndLockAgainGroupFileOverridden(t *testing.T) {
 	}()
 
 	select {
-	case <-time.After(sleepDuration(3 * time.Second)):
+	case <-time.After(3 * time.Second):
 		// If we're time-outing: it's fine, it means we were locked!
 	case err := <-gPasswdExited:
 		require.ErrorIs(t, err, userslocking.ErrLock, "GPasswd should fail")
@@ -191,7 +189,7 @@ func TestLockingLockedDatabase(t *testing.T) {
 	}()
 
 	select {
-	case <-time.After(sleepDuration(1 * time.Second)):
+	case <-time.After(1 * time.Second):
 		t.Cleanup(func() { cmd.Process.Kill() })
 		// If we're time-outing: it's fine, it means the test-locker process is running
 	case err := <-lockerExited:
@@ -205,7 +203,7 @@ func TestLockingLockedDatabase(t *testing.T) {
 	}()
 
 	select {
-	case <-time.After(sleepDuration(3 * time.Second)):
+	case <-time.After(3 * time.Second):
 		// If we're time-outing: it's fine, it means we were locked!
 	case err := <-gPasswdExited:
 		require.ErrorIs(t, err, userslocking.ErrLock, "GPasswd should fail")
@@ -216,7 +214,7 @@ func TestLockingLockedDatabase(t *testing.T) {
 	}()
 
 	select {
-	case <-time.After(sleepDuration(3 * time.Second)):
+	case <-time.After(3 * time.Second):
 		// If we're time-outing: it's fine, it means the test-locker process is
 		// still running and holding the lock.
 	case err := <-writeLockExited:
@@ -247,7 +245,7 @@ func TestLockingLockedDatabaseFailsAfterTimeout(t *testing.T) {
 	}()
 
 	select {
-	case <-time.After(sleepDuration(1 * time.Second)):
+	case <-time.After(2 * time.Second):
 		t.Cleanup(func() { cmd.Process.Kill() })
 		// If we're time-outing: it's fine, it means the test-locker process is running
 	case err := <-lockerExited:
@@ -283,7 +281,7 @@ func TestLockingLockedDatabaseWorksAfterUnlock(t *testing.T) {
 	}()
 
 	select {
-	case <-time.After(sleepDuration(1 * time.Second)):
+	case <-time.After(1 * time.Second):
 		// If we're time-outing: it's fine, it means the test-locker process is
 		// still running and holding the lock.
 		t.Cleanup(func() { lockerCmd.Process.Kill() })
@@ -297,7 +295,7 @@ func TestLockingLockedDatabaseWorksAfterUnlock(t *testing.T) {
 	}()
 
 	select {
-	case <-time.After(sleepDuration(3 * time.Second)):
+	case <-time.After(3 * time.Second):
 		// If we're time-outing: it's fine, it means the test-locker process is
 		// still running and holding the lock.
 	case err := <-writeLockExited:
@@ -310,7 +308,7 @@ func TestLockingLockedDatabaseWorksAfterUnlock(t *testing.T) {
 	}()
 
 	select {
-	case <-time.After(sleepDuration(1 * time.Second)):
+	case <-time.After(1 * time.Second):
 		// If we're time-outing: it's fine, it means the test-locker process is
 		// still running and holding the lock.
 	case err := <-writeUnLockExited:
@@ -352,8 +350,4 @@ func runGPasswd(t *testing.T, args ...string) (string, error) {
 	t.Helper()
 
 	return runCmd(t, "gpasswd", args...)
-}
-
-func sleepDuration(in time.Duration) time.Duration {
-	return time.Duration(math.Round(float64(in) * testutils.SleepMultiplier()))
 }


### PR DESCRIPTION
We've seen the test fail in the CI with:

    Error Trace: /home/runner/work/authd/authd/internal/users/locking/locking_bwrap_test.go:266
    Error:       Target error should be in err chain:
                 expected: "failed to lock the shadow password database: timeout"
                 in chain: "failed to lock the shadow password database: Interrupted system call"
    Test:        TestLockingLockedDatabaseFailsAfterTimeout

The reason is probably that the alarm set by lckpwdf does sometimes work in the CI, so lckpwdf returns an error before our own 16 second timeout is reached, resulting in a different error to be returned.

Return a ErrLockTimeout when that happens.