### PR TITLE
qa: Install all the packages from launchpad if repositories fail

### DIFF
--- a/.github/workflows/qa.yaml
+++ b/.github/workflows/qa.yaml
@@ -161,7 +161,9 @@ jobs:
           # Load the apparmor profile for bubblewrap.
           sudo ln -s /usr/share/apparmor/extra-profiles/bwrap-userns-restrict /etc/apparmor.d/
           sudo apparmor_parser /etc/apparmor.d/bwrap-userns-restrict
+
       - name: Install PAM and GLib debug symbols
+        continue-on-error: true
         run: |
           set -eu
           sudo apt-get install ubuntu-dbgsym-keyring -y


### PR DESCRIPTION
In case the repositories ddebs are not in sync we are getting the ddebs from launchpad, but again they could be newer.

So let's just get everything from launchpad in case

See: https://github.com/ubuntu/authd/actions/runs/15580229563/job/43873519694