### PR TITLE
docs: build sitemap for docs site

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -169,6 +169,24 @@ html_theme_options = {
 
 slug = "authd"
 
+#######################
+# Sitemap configuration: https://sphinx-sitemap.readthedocs.io/
+#######################
+
+# Base URL of RTD hosted project
+
+html_baseurl = "https://documentation.ubuntu.com/authd/"
+
+# URL scheme. Add language and version scheme elements manually e.g. '{0}/{1}/{{link}}'.format(os.environ['READTHEDOCS_LANGUAGE'], os.environ['READTHEDOCS_VERSION'])
+
+# When configured with RTD variables, check for RTD environment so manual runs succeed:
+
+if "READTHEDOCS_VERSION" in os.environ:
+    version = os.environ["READTHEDOCS_VERSION"]
+    sitemap_url_scheme = "{version}{link}"
+else:
+    sitemap_url_scheme = "stable/{link}"
+
 # Template and asset locations
 
 # html_static_path = [".sphinx/_static"]
@@ -250,6 +268,7 @@ extensions = [
     "sphinxcontrib.cairosvgconverter",
     "sphinx_last_updated_by_git",
     "sphinx.ext.intersphinx",
+    "sphinx_sitemap",
 ]
 
 

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,3 +1,4 @@
 canonical-sphinx[full]
 sphinxcontrib-svg2pdfconverter[CairoSVG]
 sphinx-last-updated-by-git
+sphinx-sitemap


### PR DESCRIPTION
Generating a sitemap for the authd documentation should improve search engine performance.

These changes generate a `sitemap.xml` when the site is built.

![sitemap-authd](https://github.com/user-attachments/assets/a763bcdf-fff1-467d-8d6a-50c4406a26f1)

This can be previewed here: https://canonical-ubuntu-documentation-library--962.com.readthedocs.build/authd/962/sitemap.xml and it can be accessed at `https://documentation.ubuntu.com/authd/{version}/sitemap.xml` after the PR is merged (note: won't be available in stable until next release).

Similar changes are to be applied across all Canonical product documentation sites.

UDENG-7163