### PR TITLE
authd/daemon: Fix parsing users config if was not defined

### DIFF
--- a/cmd/authd/daemon/daemon_test.go
+++ b/cmd/authd/daemon/daemon_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/ubuntu/authd/internal/consts"
 	"github.com/ubuntu/authd/internal/fileutils"
 	"github.com/ubuntu/authd/internal/testutils"
+	"github.com/ubuntu/authd/internal/users"
 	"github.com/ubuntu/authd/log"
 )
 
@@ -265,10 +266,12 @@ func TestAppGetRootCmd(t *testing.T) {
 }
 
 func TestConfigLoad(t *testing.T) {
+	wantUsersConfig := &users.Config{UIDMin: 10001, UIDMax: 19000, GIDMax: 9999}
 	customizedSocketPath := filepath.Join(t.TempDir(), "mysocket")
 	var config daemon.DaemonConfig
 	config.Verbosity = 1
 	config.Paths.Socket = customizedSocketPath
+	config.UsersConfig = wantUsersConfig
 
 	a, wait := startDaemon(t, &config)
 	defer wait()
@@ -277,6 +280,7 @@ func TestConfigLoad(t *testing.T) {
 	_, err := os.Stat(customizedSocketPath)
 	require.NoError(t, err, "Socket should exist")
 	require.Equal(t, 1, a.Config().Verbosity, "Verbosity is set from config")
+	require.Equal(t, wantUsersConfig, a.Config().UsersConfig, "Unexpected users config")
 }
 
 func TestAutoDetectConfig(t *testing.T) {
@@ -310,6 +314,7 @@ func TestAutoDetectConfig(t *testing.T) {
 	_, err = os.Stat(customizedSocketPath)
 	require.NoError(t, err, "Socket should exist")
 	require.Equal(t, 1, a.Config().Verbosity, "Verbosity is set from config")
+	require.Equal(t, &users.DefaultConfig, a.Config().UsersConfig, "Default Users Config")
 }
 
 func TestNoConfigSetDefaults(t *testing.T) {
@@ -323,6 +328,7 @@ func TestNoConfigSetDefaults(t *testing.T) {
 	require.Equal(t, 0, a.Config().Verbosity, "Default Verbosity")
 	require.Equal(t, consts.DefaultBrokersConfPath, a.Config().Paths.BrokersConf, "Default brokers configuration path")
 	require.Equal(t, consts.DefaultDatabaseDir, a.Config().Paths.Database, "Default database directory")
+	require.Equal(t, &users.DefaultConfig, a.Config().UsersConfig, "Default Users Config")
 	require.Equal(t, "", a.Config().Paths.Socket, "No socket address as default")
 }
 

--- a/cmd/authd/daemon/export_test.go
+++ b/cmd/authd/daemon/export_test.go
@@ -50,6 +50,7 @@ func GenerateTestConfig(t *testing.T, origConf *daemonConfig) string {
 	d, err := yaml.Marshal(conf)
 	require.NoError(t, err, "Setup: could not marshal configuration for tests")
 
+	t.Logf("Test config file is\n%s", d)
 	confPath := filepath.Join(t.TempDir(), "testconfig.yaml")
 	err = os.WriteFile(confPath, d, 0600)
 	require.NoError(t, err, "Setup: could not create configuration for tests")

--- a/internal/users/manager.go
+++ b/internal/users/manager.go
@@ -22,10 +22,10 @@ import (
 
 // Config is the configuration for the user manager.
 type Config struct {
-	UIDMin uint32 `mapstructure:"uid_min"`
-	UIDMax uint32 `mapstructure:"uid_max"`
-	GIDMin uint32 `mapstructure:"gid_min"`
-	GIDMax uint32 `mapstructure:"gid_max"`
+	UIDMin uint32 `mapstructure:"uid_min" yaml:"uid_min"`
+	UIDMax uint32 `mapstructure:"uid_max" yaml:"uid_max"`
+	GIDMin uint32 `mapstructure:"gid_min" yaml:"gid_min"`
+	GIDMax uint32 `mapstructure:"gid_max" yaml:"gid_max"`
 }
 
 // DefaultConfig is the default configuration for the user manager.


### PR DESCRIPTION
In case the users config was not set we ended up with an invalid one, since by default we were initializing a zeroed pam.UsersConfig value instead of the default one.

This is likely not an issue in reality, but be consistent with what we do for other configuration parameters and add tests to ensure that the user parameters behave as expected