### PR TITLE
Start authd.socket before accounts-daemon.service

### DIFF
--- a/debian/authd.socket
+++ b/debian/authd.socket
@@ -4,6 +4,8 @@ Description=Socket activation for Authd daemon
 DefaultDependencies=No
 Wants=dbus.service
 After=dbus.service
+Before=nss-user-lookup.target
+Wants=nss-user-lookup.target
 
 [Socket]
 ListenStream=/run/authd.sock


### PR DESCRIPTION
If the accounts service is started first, it doesn't find any authd users.

Closes #965 