### PR TITLE
Remove the completion subcommand

### DIFF
--- a/cmd/authd/daemon/daemon.go
+++ b/cmd/authd/daemon/daemon.go
@@ -102,6 +102,10 @@ func New() *App {
 		},
 		// We display usage error ourselves
 		SilenceErrors: true,
+		// Don't add a completion subcommand, authd is not a CLI tool.
+		CompletionOptions: cobra.CompletionOptions{
+			DisableDefaultCmd: true,
+		},
 	}
 	viper := viper.New()
 

--- a/cmd/authd/daemon/daemon_test.go
+++ b/cmd/authd/daemon/daemon_test.go
@@ -29,15 +29,6 @@ func TestHelp(t *testing.T) {
 	require.NoErrorf(t, err, "Run should not return an error with argument --help. Stdout: %v", getStdout())
 }
 
-func TestCompletion(t *testing.T) {
-	a := daemon.NewForTests(t, nil, "completion", "bash")
-
-	getStdout := captureStdout(t)
-
-	err := a.Run()
-	require.NoError(t, err, "Completion should not start the daemon. Stdout: %v", getStdout())
-}
-
 func TestVersion(t *testing.T) {
 	a := daemon.NewForTests(t, nil, "version")
 
@@ -58,7 +49,7 @@ func TestVersion(t *testing.T) {
 }
 
 func TestNoUsageError(t *testing.T) {
-	a := daemon.NewForTests(t, nil, "completion", "bash")
+	a := daemon.NewForTests(t, nil, "version")
 
 	getStdout := captureStdout(t)
 	err := a.Run()


### PR DESCRIPTION
authd is not a CLI tool, so there is no need to generate shell completion scripts.