### PR TITLE
Fix error message "GetUserByName: no result matching  in"

### DIFF
--- a/internal/users/db/db.go
+++ b/internal/users/db/db.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strconv"
 	"sync"
 	"syscall"
 
@@ -175,6 +176,26 @@ func RemoveDB(dbDir string) error {
 	return os.Remove(filepath.Join(dbDir, consts.DefaultDatabaseFileName))
 }
 
+// NewUIDNotFoundError returns a NoDataFoundError for the given user ID.
+func NewUIDNotFoundError(uid uint32) NoDataFoundError {
+	return NoDataFoundError{key: strconv.FormatUint(uint64(uid), 10), table: "users"}
+}
+
+// NewGIDNotFoundError returns a NoDataFoundError for the given group ID.
+func NewGIDNotFoundError(gid uint32) NoDataFoundError {
+	return NoDataFoundError{key: strconv.FormatUint(uint64(gid), 10), table: "groups"}
+}
+
+// NewUserNotFoundError returns a NoDataFoundError for the given user name.
+func NewUserNotFoundError(name string) NoDataFoundError {
+	return NoDataFoundError{key: name, table: "users"}
+}
+
+// NewGroupNotFoundError returns a NoDataFoundError for the given group name.
+func NewGroupNotFoundError(name string) NoDataFoundError {
+	return NoDataFoundError{key: name, table: "groups"}
+}
+
 // NoDataFoundError is returned when we didn’t find a matching entry.
 type NoDataFoundError struct {
 	key   string
@@ -183,7 +204,7 @@ type NoDataFoundError struct {
 
 // Error implements the error interface.
 func (err NoDataFoundError) Error() string {
-	return fmt.Sprintf("no result matching %v in %v", err.key, err.table)
+	return fmt.Sprintf("no result matching %q in %q", err.key, err.table)
 }
 
 // Is makes this error insensitive to the key and table names.

--- a/internal/users/db/groups.go
+++ b/internal/users/db/groups.go
@@ -4,7 +4,6 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
-	"strconv"
 )
 
 // GroupRow represents a group in the database.
@@ -46,7 +45,7 @@ func groupByID(db queryable, gid uint32) (GroupRow, error) {
 	var g GroupRow
 	err := row.Scan(&g.Name, &g.GID, &g.UGID)
 	if errors.Is(err, sql.ErrNoRows) {
-		return GroupRow{}, NoDataFoundError{key: strconv.FormatUint(uint64(gid), 10), table: "groups"}
+		return GroupRow{}, NewGIDNotFoundError(gid)
 	}
 	if err != nil {
 		return GroupRow{}, fmt.Errorf("query error: %w", err)
@@ -93,7 +92,7 @@ func groupByName(db queryable, name string) (GroupRow, error) {
 	var g GroupRow
 	err := row.Scan(&g.Name, &g.GID, &g.UGID)
 	if errors.Is(err, sql.ErrNoRows) {
-		return GroupRow{}, NoDataFoundError{key: name, table: "groups"}
+		return GroupRow{}, NewGroupNotFoundError(name)
 	}
 	if err != nil {
 		return GroupRow{}, fmt.Errorf("query error: %w", err)
@@ -140,7 +139,7 @@ func groupByUGID(db queryable, ugid string) (GroupRow, error) {
 	var g GroupRow
 	err := row.Scan(&g.Name, &g.GID, &g.UGID)
 	if errors.Is(err, sql.ErrNoRows) {
-		return GroupRow{}, NoDataFoundError{key: ugid, table: "groups"}
+		return GroupRow{}, NewGroupNotFoundError(ugid)
 	}
 	if err != nil {
 		return GroupRow{}, fmt.Errorf("query error: %w", err)

--- a/internal/users/db/update.go
+++ b/internal/users/db/update.go
@@ -174,7 +174,7 @@ func (m *Manager) UpdateBrokerForUser(username, brokerID string) error {
 		return fmt.Errorf("failed to get rows affected: %w", err)
 	}
 	if rowsAffected == 0 {
-		return NoDataFoundError{table: "users", key: username}
+		return NewUserNotFoundError(username)
 	}
 
 	return nil

--- a/internal/users/db/usergroups.go
+++ b/internal/users/db/usergroups.go
@@ -43,7 +43,7 @@ func userGroups(db queryable, uid uint32) ([]GroupRow, error) {
 	}
 
 	if len(groups) == 0 {
-		return nil, NoDataFoundError{key: strconv.FormatUint(uint64(uid), 10), table: "users_to_groups"}
+		return nil, NewUIDNotFoundError(uid)
 	}
 
 	return groups, nil

--- a/internal/users/db/users.go
+++ b/internal/users/db/users.go
@@ -5,7 +5,6 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
-	"strconv"
 	"strings"
 
 	"github.com/ubuntu/authd/log"
@@ -52,7 +51,7 @@ func userByID(db queryable, uid uint32) (UserRow, error) {
 	var u UserRow
 	err := row.Scan(&u.Name, &u.UID, &u.GID, &u.Gecos, &u.Dir, &u.Shell, &u.BrokerID)
 	if errors.Is(err, sql.ErrNoRows) {
-		return UserRow{}, NoDataFoundError{key: strconv.FormatUint(uint64(uid), 10), table: "users"}
+		return UserRow{}, NewUIDNotFoundError(uid)
 	}
 	if err != nil {
 		return UserRow{}, fmt.Errorf("query error: %w", err)
@@ -72,7 +71,7 @@ func (m *Manager) UserByName(name string) (UserRow, error) {
 	var u UserRow
 	err := row.Scan(&u.Name, &u.UID, &u.GID, &u.Gecos, &u.Dir, &u.Shell, &u.BrokerID)
 	if errors.Is(err, sql.ErrNoRows) {
-		return UserRow{}, NoDataFoundError{key: name, table: "users"}
+		return UserRow{}, NewUserNotFoundError(name)
 	}
 	if err != nil {
 		return UserRow{}, fmt.Errorf("query error: %w", err)
@@ -181,7 +180,7 @@ func (m *Manager) DeleteUser(uid uint32) error {
 		return fmt.Errorf("failed to get rows affected: %w", err)
 	}
 	if rowsAffected == 0 {
-		return NoDataFoundError{table: "users", key: strconv.FormatUint(uint64(uid), 10)}
+		return NewUIDNotFoundError(uid)
 	}
 
 	return nil

--- a/internal/users/manager.go
+++ b/internal/users/manager.go
@@ -324,10 +324,6 @@ func checkHomeDirOwnership(home string, uid, gid uint32) error {
 // BrokerForUser returns the broker ID for the given user.
 func (m *Manager) BrokerForUser(username string) (string, error) {
 	u, err := m.db.UserByName(username)
-	if err != nil && errors.Is(err, db.NoDataFoundError{}) {
-		// User not in db.
-		return "", NoDataFoundError{}
-	}
 	if err != nil {
 		return "", err
 	}

--- a/internal/users/tempentries/groups.go
+++ b/internal/users/tempentries/groups.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"sync"
 
+	"github.com/ubuntu/authd/internal/users/db"
 	"github.com/ubuntu/authd/internal/users/localentries"
 	"github.com/ubuntu/authd/internal/users/types"
 	"github.com/ubuntu/authd/log"
@@ -43,7 +44,7 @@ func (r *temporaryGroupRecords) GroupByID(gid uint32) (types.GroupEntry, error) 
 
 	group, ok := r.groups[gid]
 	if !ok {
-		return types.GroupEntry{}, NoDataFoundError{}
+		return types.GroupEntry{}, db.NewGIDNotFoundError(gid)
 	}
 
 	return groupEntry(group), nil
@@ -56,7 +57,7 @@ func (r *temporaryGroupRecords) GroupByName(name string) (types.GroupEntry, erro
 
 	gid, ok := r.gidByName[name]
 	if !ok {
-		return types.GroupEntry{}, NoDataFoundError{}
+		return types.GroupEntry{}, db.NewGroupNotFoundError(name)
 	}
 
 	return r.GroupByID(gid)

--- a/internal/users/tempentries/preauth.go
+++ b/internal/users/tempentries/preauth.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"sync"
 
+	"github.com/ubuntu/authd/internal/users/db"
 	"github.com/ubuntu/authd/internal/users/localentries"
 	"github.com/ubuntu/authd/internal/users/types"
 	"github.com/ubuntu/authd/log"
@@ -58,7 +59,7 @@ func (r *preAuthUserRecords) userByID(uid uint32) (types.UserEntry, error) {
 
 	user, ok := r.users[uid]
 	if !ok {
-		return types.UserEntry{}, NoDataFoundError{}
+		return types.UserEntry{}, db.NewUIDNotFoundError(uid)
 	}
 
 	return preAuthUserEntry(user), nil
@@ -71,7 +72,7 @@ func (r *preAuthUserRecords) userByName(name string) (types.UserEntry, error) {
 
 	uid, ok := r.uidByName[name]
 	if !ok {
-		return types.UserEntry{}, NoDataFoundError{}
+		return types.UserEntry{}, db.NewUserNotFoundError(name)
 	}
 
 	return r.userByID(uid)
@@ -83,7 +84,7 @@ func (r *preAuthUserRecords) userByLogin(loginName string) (types.UserEntry, err
 
 	uid, ok := r.uidByLogin[loginName]
 	if !ok {
-		return types.UserEntry{}, NoDataFoundError{}
+		return types.UserEntry{}, db.NewUserNotFoundError(loginName)
 	}
 
 	return r.userByID(uid)

--- a/internal/users/tempentries/users.go
+++ b/internal/users/tempentries/users.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"sync"
 
+	"github.com/ubuntu/authd/internal/users/db"
 	"github.com/ubuntu/authd/internal/users/localentries"
 	"github.com/ubuntu/authd/internal/users/types"
 	"github.com/ubuntu/authd/log"
@@ -42,7 +43,7 @@ func (r *temporaryUserRecords) userByID(uid uint32) (types.UserEntry, error) {
 
 	user, ok := r.users[uid]
 	if !ok {
-		return types.UserEntry{}, NoDataFoundError{}
+		return types.UserEntry{}, db.NewUIDNotFoundError(uid)
 	}
 
 	return userEntry(user), nil
@@ -55,7 +56,7 @@ func (r *temporaryUserRecords) userByName(name string) (types.UserEntry, error) 
 
 	uid, ok := r.uidByName[name]
 	if !ok {
-		return types.UserEntry{}, NoDataFoundError{}
+		return types.UserEntry{}, db.NewUserNotFoundError(name)
 	}
 
 	return r.userByID(uid)


### PR DESCRIPTION
The functions of the tempentries package returned empty `NoDataFoundError{}` instances, which are converted to the string "no result matching  in".
    
This PR extracts exported functions to create instances of a `NoDataFoundError` which are now used both in the `db` package and the `tempentries` package.