### PR TITLE
docs: add information on configuring ID ranges for LXD

### DIFF
--- a/docs/.custom_wordlist.txt
+++ b/docs/.custom_wordlist.txt
@@ -10,6 +10,7 @@ filesystem
 fstab
 ESC
 GDM
+GID
 GIDs
 gRPC
 github

--- a/docs/.sphinx/spellingcheck.yaml
+++ b/docs/.sphinx/spellingcheck.yaml
@@ -28,3 +28,4 @@ matrix:
             - img
             - a.p-navigation__link
             - a.contributor
+            - div.code-block-caption

--- a/docs/howto/configure-authd.md
+++ b/docs/howto/configure-authd.md
@@ -273,6 +273,23 @@ sudo snap restart authd-msentraid
 ::::
 :::::
 
-## System configuration
+## Configure login timeout
 
-By default on Ubuntu, the login timeout is 60s. This may be too brief for a device code flow authentication. It can be set to a different value by changing the value of `LOGIN_TIMEOUT` in `/etc/login.defs`
+By default on Ubuntu, the login timeout is 60s.
+
+This may be too brief for a device code flow authentication.
+
+It can be modified by changing the value of `LOGIN_TIMEOUT` in `/etc/login.defs`.
+
+## Configure the authd service
+
+The authd service is configured in `/etc/authd/authd.yaml`.
+
+This provides configuration options for logging verbosity and UID/GID ranges.
+
+```{admonition} Additional configuration for LXD
+:class: tip
+If you are using authd inside LXD containers, read our short guide on [how to
+use authd with LXD](howto::use-with-lxd), which outlines additional steps for
+configuring appropriate UID/GID ranges.
+```

--- a/docs/howto/index.md
+++ b/docs/howto/index.md
@@ -12,6 +12,7 @@ provider.
 
 Install authd <install-authd>
 Configure authd <configure-authd>
+Use authd with LXD <use-with-lxd>
 ```
 
 ## Login and authentication

--- a/docs/howto/use-with-lxd.md
+++ b/docs/howto/use-with-lxd.md
@@ -1,0 +1,60 @@
+---
+myst:
+  html_meta:
+    "description lang=en": "To use authd with LXD, you need to configure the UID and GID ranges."
+---
+
+(howto::use-with-lxd)=
+# Use authd in LXD containers
+
+Running authd inside a LXD container requires the configuration of UID and GID
+ranges.
+
+```{important}
+These steps are in addition to the general installation and configuration steps
+outlined in the [configuring authd guide](configure-authd.md).
+```
+## Default ID map ranges
+
+The ID map range for LXD is: `1000000:1000000000`.
+
+The default range for authd exceeds those values: `1000000000:1999999999`.
+
+This causes errors when authenticating from LXD containers.
+
+## Configuration options for using authd with LXD
+
+Two options for configuring the ID ranges are outlined below.
+
+### 1. Configure ID ranges for the authd service
+
+Change the default ranges so that they don't exceed those from the user namespace mappings, for example:
+
+```{code-block} diff
+:caption: /etc/authd/authd.yaml
+
+-#UID_MIN: 1000000000
++#UID_MIN: 100000
+-#UID_MAX: 1999999999
++#UID_MAX: 1000000000
+-#GID_MIN: 1000000000
++#GID_MIN: 100000
+-#GID_MAX: 1999999999
++#GID_MAX: 1000000000
+
+```
+
+### 2. Configure subordinate ID ranges on the host
+
+The mappings that apply to LXD containers can be found in the following files on the host:
+
+* `/etc/subuid`
+* `/etc/subgid`
+
+Configure the subordinate ID range in each file to include the default authd ID range (`1000000000:1999999999`), for example:
+
+```{code-block} diff
+:caption: /etc/subuid
+-<your-user>:100000:65536
++<your-user>:1000000000:1999999999
+```

--- a/docs/reference/troubleshooting.md
+++ b/docs/reference/troubleshooting.md
@@ -342,3 +342,11 @@ mode:
 5. Select `drop to root shell prompt`
 
 The user then has access to the root filesystem and can proceed with debugging.
+
+## Using authd in LXD containers
+
+If you are using authd in a LXD container, you may encounter errors during authentication.
+
+To fix these errors, you need to configure UID and GID ranges.
+
+The configuration steps are outlined in this guide on [using authd with LXD](howto::use-with-lxd).


### PR DESCRIPTION
A user reported issues authenticating with authd from LXD containers: https://github.com/ubuntu/authd/issues/819

This PR is based on the solutions offered in response. It adds:

* A brief and self-contained how-to guide **Use authd with LXD** on configuring UID/GID ranges for LXD. _I considered adding this to the general installation and configuration guide, but it seemed too specific and could distract users interested in more conventional use-cases._
* A brief section on the LXD issue in the **Troubleshooting** reference that points to the new guide. _This helps increase the probability that people looking for the solution will find it._
* A reference to the file for configuring the authd service to the **Configure authd** guide. _There might be other contexts in which users want to change the ID ranges, so it's good to mention the file here in this general configuration guide. It also provides a natural lead-in to a link pointing to the LXD guide_

Other minor changes:

* Added some fixes for the spellchecker
* Made a change to a heading `System configuration -> Configure login timeout` in the config guide to be more specific and also separated sentences in that section for better readability

UDENG-6740