### PR TITLE
Improve error messages

### DIFF
--- a/internal/users/db/db.go
+++ b/internal/users/db/db.go
@@ -9,7 +9,6 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"strconv"
 	"sync"
 	"syscall"
 
@@ -178,33 +177,32 @@ func RemoveDB(dbDir string) error {
 
 // NewUIDNotFoundError returns a NoDataFoundError for the given user ID.
 func NewUIDNotFoundError(uid uint32) NoDataFoundError {
-	return NoDataFoundError{key: strconv.FormatUint(uint64(uid), 10), table: "users"}
+	return NoDataFoundError{fmt.Sprintf("user with UID %d not found", uid)}
 }
 
 // NewGIDNotFoundError returns a NoDataFoundError for the given group ID.
 func NewGIDNotFoundError(gid uint32) NoDataFoundError {
-	return NoDataFoundError{key: strconv.FormatUint(uint64(gid), 10), table: "groups"}
+	return NoDataFoundError{fmt.Sprintf("group with GID %d not found", gid)}
 }
 
 // NewUserNotFoundError returns a NoDataFoundError for the given user name.
 func NewUserNotFoundError(name string) NoDataFoundError {
-	return NoDataFoundError{key: name, table: "users"}
+	return NoDataFoundError{fmt.Sprintf("user %q not found", name)}
 }
 
 // NewGroupNotFoundError returns a NoDataFoundError for the given group name.
 func NewGroupNotFoundError(name string) NoDataFoundError {
-	return NoDataFoundError{key: name, table: "groups"}
+	return NoDataFoundError{fmt.Sprintf("group %q not found", name)}
 }
 
 // NoDataFoundError is returned when we didn’t find a matching entry.
 type NoDataFoundError struct {
-	key   string
-	table string
+	msg string
 }
 
 // Error implements the error interface.
 func (err NoDataFoundError) Error() string {
-	return fmt.Sprintf("no result matching %q in %q", err.key, err.table)
+	return err.msg
 }
 
 // Is makes this error insensitive to the key and table names.

--- a/internal/users/db/usergroups.go
+++ b/internal/users/db/usergroups.go
@@ -3,7 +3,6 @@ package db
 import (
 	"context"
 	"fmt"
-	"strconv"
 
 	"github.com/ubuntu/authd/log"
 )
@@ -122,7 +121,7 @@ func removeUserFromAllGroups(db queryable, uid uint32) error {
 		return fmt.Errorf("failed to get rows affected: %w", err)
 	}
 	if rowsAffected == 0 {
-		return NoDataFoundError{table: "users_to_groups", key: strconv.FormatUint(uint64(uid), 10)}
+		return NoDataFoundError{fmt.Sprintf("no groups found for user with UID %d", uid)}
 	}
 
 	return nil


### PR DESCRIPTION
authctl will show these errors messages, so let's improve them. For example, instead of:

    no result matching "foo" in "users"

use:

    user "foo" not found