### PR TITLE
docs: Do not document setting option to default value

### DIFF
--- a/docs/howto/configure-authd.md
+++ b/docs/howto/configure-authd.md
@@ -144,7 +144,6 @@ To configure Google IAM, edit  `/var/snap/authd-google/current/broker.conf`:
 issuer = https://accounts.google.com
 client_id = <CLIENT_ID>
 client_secret = <CLIENT_SECRET>
-force_provider_authentication = false
 ```
 ::::
 
@@ -157,7 +156,6 @@ To configure Entra ID, edit  `/var/snap/authd-msentraid/current/broker.conf`:
 [oidc]
 issuer = https://login.microsoftonline.com/<ISSUER_ID>/v2.0
 client_id = <CLIENT_ID>
-force_provider_authentication = false
 ```
 ::::
 :::::


### PR DESCRIPTION
The force_provider_authentication option is set to false by default, and it's documented in the [default broker.conf](https://github.com/ubuntu/authd-oidc-brokers/blob/09e61b5b13138d668a392591b3d4db8bd017364a/conf/broker.conf#L20-L20) file, so users don't need to set it to false themselves.