### PR TITLE
Make errors when checking home dir owner non-fatal

### DIFF
--- a/internal/users/manager.go
+++ b/internal/users/manager.go
@@ -231,7 +231,7 @@ func (m *Manager) UpdateUser(u types.UserInfo) (err error) {
 	}
 
 	if err = checkHomeDirOwnership(userRow.Dir, userRow.UID, userRow.GID); err != nil {
-		return fmt.Errorf("failed to check home directory owner and group: %w", err)
+		log.Warningf(context.Background(), "Failed to check home directory ownership: %v", err)
 	}
 
 	return nil


### PR DESCRIPTION
We only do this check to display a warning in case that the home directory is not owned by the correct UID/GID. Let's not block login if we can't do this check.

I encountered this case myself, when I bind-mounted another directory via bindfs, which caused a "transport endpoint is not connected" error when trying to access the home directory. It doesn't make sense to lock the user out in that case, lets log them in and let them deal with the fact that they can't access the home directory.