### PR TITLE
ci/build-deb: Don't merge main

### DIFF
--- a/.github/workflows/build-deb.yaml
+++ b/.github/workflows/build-deb.yaml
@@ -51,6 +51,8 @@ jobs:
     steps:
       - name: Checkout authd code
         uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
 
       - name: Build debian packages and sources
         uses: canonical/desktop-engineering/gh-actions/common/build-debian@main


### PR DESCRIPTION
When building Debian packages from the branch of a PR, we want to actually build what's on the branch, without changes from main.

That's especially important when preparing bugfix releases, which we build from the source packages from the CI. We don't want unexpected changes from main to end up in these releases.