### PR TITLE
More readable logs of pam integration tests

### DIFF
--- a/log/handler.go
+++ b/log/handler.go
@@ -1,0 +1,63 @@
+package log
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"log/slog"
+)
+
+// SimpleHandler writes logs in the format: <timestamp> <level> <message>.
+type SimpleHandler struct {
+	slog.TextHandler
+	w io.Writer
+}
+
+// NewSimpleHandler creates a new SimpleHandler that writes to the provided io.Writer.
+func NewSimpleHandler(w io.Writer, level slog.Level) slog.Handler {
+	opts := &slog.HandlerOptions{
+		Level: level,
+	}
+	return &SimpleHandler{
+		TextHandler: *slog.NewTextHandler(w, opts),
+		w:           w,
+	}
+}
+
+// Handle implements the slog.Handler interface.
+func (h *SimpleHandler) Handle(ctx context.Context, r slog.Record) error {
+	t := r.Time.Format("15:04:05")
+	_, err := fmt.Fprintf(h.w, "%s %s %s\n", t, r.Level.String(), r.Message)
+	return err
+}
+
+// Enabled checks if the handler is enabled for the given log level.
+func (h *SimpleHandler) Enabled(ctx context.Context, level slog.Level) bool {
+	return h.TextHandler.Enabled(ctx, level)
+}
+
+// WithAttrs returns a new SimpleHandler with the specified attributes.
+func (h *SimpleHandler) WithAttrs(attrs []slog.Attr) slog.Handler {
+	textHandler, ok := h.TextHandler.WithAttrs(attrs).(*slog.TextHandler)
+	if !ok {
+		panic("WithAttrs did not return a *slog.TextHandler")
+	}
+
+	return &SimpleHandler{
+		TextHandler: *textHandler,
+		w:           h.w,
+	}
+}
+
+// WithGroup returns a new SimpleHandler with the specified group name.
+func (h *SimpleHandler) WithGroup(name string) slog.Handler {
+	textHandler, ok := h.TextHandler.WithGroup(name).(*slog.TextHandler)
+	if !ok {
+		panic("WithGroup did not return a *slog.TextHandler")
+	}
+
+	return &SimpleHandler{
+		TextHandler: *textHandler,
+		w:           h.w,
+	}
+}

--- a/log/log.go
+++ b/log/log.go
@@ -96,9 +96,7 @@ func SetLevel(level Level) (oldLevel Level) {
 // SetOutput sets the log output.
 func SetOutput(out io.Writer) {
 	hasCustomOutput.Store(&out)
-	slog.SetDefault(slog.New(slog.NewTextHandler(out, &slog.HandlerOptions{
-		Level: GetLevel(),
-	})))
+	slog.SetDefault(slog.New(NewSimpleHandler(out, GetLevel())))
 }
 
 // SetLevelHandler allows to define the default handler function for a given level.


### PR DESCRIPTION
SetOutput used the slog.TextHandler instead of the default slog.defaultHandler.

That produced output like this:

    time=2025-06-23T16:48:23.615+02:00 level=DEBUG msg="Sending to GDM: {\"type\":\"request\",\"request\":{\"type\":\"uiLayoutCapabilities\",\"uiLayoutCapabilities\":{}}}"

This commit uses a custom handler which produces output similar to the slog.defaultHandler (which we can't use because it's not exported), except that it omits the date and only prints the time instead (because we're generally not interested in the date when looking at test logs).

It produces output like this:

    16:48:09 DEBUG Sending to GDM: {"type":"request","request":{"type":"uiLayoutCapabilities","uiLayoutCapabilities":{}}}