### PR TITLE
Try fixing flaky TestUserByIDAndName/Successfully_get_a_user_by_ID

### DIFF
--- a/internal/users/tempentries/tempentries_test.go
+++ b/internal/users/tempentries/tempentries_test.go
@@ -95,8 +95,6 @@ func TestRegisterUser(t *testing.T) {
 }
 
 func TestUserByIDAndName(t *testing.T) {
-	t.Parallel()
-
 	userName := "authd-temp-users-test"
 	uidToGenerate := uint32(12345)
 
@@ -127,8 +125,6 @@ func TestUserByIDAndName(t *testing.T) {
 
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
-			t.Parallel()
-
 			idGeneratorMock := &idgenerator.IDGeneratorMock{UIDsToGenerate: []uint32{uidToGenerate}}
 			records := NewTemporaryRecords(idGeneratorMock)
 			userRecords := records.temporaryUserRecords


### PR DESCRIPTION
The test was flaky, it sometimes failed with:

    ❌ TestUserByIDAndName/Successfully_get_a_user_by_ID (10ms)
          tempentries_test.go:138:
              	Error Trace:	/home/runner/work/authd-private/authd-private/internal/users/tempentries/tempentries_test.go:138
              	Error:      	Received unexpected error:
              	            	checking UID and name uniqueness: getpwent: Invalid argument
              	Test:       	TestUserByIDAndName/Successfully_get_a_user_by_ID
              	Messages:   	RegisterUser should not return an error, but did

We suspect that's because something else is writing errno. Let's try if running the test non-parallel fixes it.

UDENG-7209