### PR TITLE
testutils: Get current effective UID via os.Geteuid

### DIFF
--- a/internal/services/permissions/testutils.go
+++ b/internal/services/permissions/testutils.go
@@ -6,8 +6,7 @@ package permissions
 import (
 	"fmt"
 	"math"
-	"os/user"
-	"strconv"
+	"os"
 	"strings"
 
 	"github.com/ubuntu/authd/internal/testsdetection"
@@ -29,15 +28,13 @@ func Z_ForTests_WithCurrentUserAsRoot() Option {
 func currentUserUID() uint32 {
 	testsdetection.MustBeTesting()
 
-	u, err := user.Current()
-	if err != nil {
-		panic(fmt.Sprintf("could not get current user: %v", err))
-	}
-	uid, err := strconv.ParseUint(u.Uid, 10, 0)
-	if err != nil || uid > math.MaxUint32 {
-		panic(fmt.Sprintf("current uid is not an uint32 (%v): %v", u.Uid, err))
+	uid := os.Geteuid()
+
+	if uid < 0 || uint64(uid) > math.MaxUint32 {
+		panic(fmt.Sprintf("current uid is not a valid uint32: %v", uid))
 	}
 
+	//nolint:gosec // G115 we checked for an integer overflow above.
 	return uint32(uid)
 }
 


### PR DESCRIPTION
It's more efficient to use `os.Getuid` (or `os.Geteuid`) than `user.Current()`, because the latter uses `getpwuid` which sends an NSS request while the former just retrieves the UID of the current process from the kernel via the `getuid` (or `geteuid`) syscall.

We want `geteuid` instead of `getuid` because this is used for permission checking (in tests, but still).