### PR TITLE
Fix TestUsersLockingInBubbleWrap/TestReadWhileLocked

### DIFF
--- a/internal/testutils/bubblewrap.go
+++ b/internal/testutils/bubblewrap.go
@@ -139,7 +139,7 @@ func runInBubbleWrap(t *testing.T, withSudo bool, testDataPath string, env []str
 		cmd.Stdout = os.Stdout
 	}
 
-	t.Log("Running command", strings.Join(args, " "))
+	t.Log("Running command:", cmd.String())
 	err = cmd.Run()
 	output := strings.TrimSpace(b.String())
 

--- a/internal/testutils/bubblewrap.go
+++ b/internal/testutils/bubblewrap.go
@@ -144,7 +144,7 @@ func runInBubbleWrap(t *testing.T, withSudo bool, testDataPath string, env []str
 	output := strings.TrimSpace(b.String())
 
 	if !testing.Verbose() {
-		t.Log(output)
+		t.Logf("Command output\n%s", output)
 	}
 	return output, err
 }

--- a/internal/users/locking/locking_bwrap_test.go
+++ b/internal/users/locking/locking_bwrap_test.go
@@ -78,7 +78,7 @@ testgroup:x:1001:testuser`
 	require.NoError(t, err, "Locking once it is allowed")
 	t.Cleanup(func() { userslocking.WriteUnlock() })
 
-	output, err := runCmd(t, "getent", "group")
+	output, err := runCmd(t, "getent", "group", "root", "testgroup")
 	require.NoError(t, err, "Reading should be allowed")
 	require.Equal(t, groupContents, output)
 }


### PR DESCRIPTION
The test case failed on my system which has authd installed, because the `getent group` command also returned the authd groups.
    
Fix that by specifying which group entries `getent` should return.
