### PR TITLE
users/localentries/get{pw,gr}ent: Use safer *_r implementations

### DIFF
--- a/internal/users/localentries/getgrent_test.go
+++ b/internal/users/localentries/getgrent_test.go
@@ -1,6 +1,8 @@
 package localentries
 
 import (
+	"fmt"
+	"slices"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -9,24 +11,47 @@ import (
 func TestGetGroupEntries(t *testing.T) {
 	t.Parallel()
 
-	got, err := GetGroupEntries()
-	require.NoError(t, err, "GetGroupEntries should never return an error")
-	require.NotEmpty(t, got, "GetGroupEntries should never return an empty list")
+	// Ensure the requests can be parallelized
+	for idx := range 10 {
+		t.Run(fmt.Sprintf("iteration_%d", idx), func(t *testing.T) {
+			t.Parallel()
+
+			got, err := GetGroupEntries()
+			require.NoError(t, err, "GetGroupEntries should never return an error")
+			require.NotEmpty(t, got, "GetGroupEntries should never return an empty list")
+			require.True(t, slices.ContainsFunc(got, func(g Group) bool {
+				return g.Name == "root" && g.GID == 0
+			}), "GetGroupEntries should return root")
+		})
+	}
 }
 
 func TestGetGroupByName(t *testing.T) {
 	t.Parallel()
 
-	got, err := GetGroupByName("root")
-	require.NoError(t, err, "GetGroupByName should not return an error")
-	require.Equal(t, got.Name, "root")
-	require.Equal(t, got.GID, uint32(0))
+	for idx := range 10 {
+		t.Run(fmt.Sprintf("iteration_%d", idx), func(t *testing.T) {
+			t.Parallel()
+
+			got, err := GetGroupByName("root")
+			require.NoError(t, err, "GetGroupByName should not return an error")
+			require.Equal(t, got.Name, "root")
+			require.Equal(t, got.GID, uint32(0))
+			require.Equal(t, got.Passwd, "x")
+		})
+	}
 }
 
 func TestGetGroupByName_NotFound(t *testing.T) {
 	t.Parallel()
 
-	got, err := GetGroupByName("nonexistent")
-	require.ErrorIs(t, err, ErrGroupNotFound)
-	require.Equal(t, got.Name, "")
+	for idx := range 10 {
+		t.Run(fmt.Sprintf("iteration_%d", idx), func(t *testing.T) {
+			t.Parallel()
+
+			got, err := GetGroupByName(fmt.Sprintf("nonexistent-really-%d", idx))
+			require.ErrorIs(t, err, ErrGroupNotFound)
+			require.Equal(t, got.Name, "")
+		})
+	}
 }

--- a/internal/users/localentries/getpwent_c.go
+++ b/internal/users/localentries/getpwent_c.go
@@ -7,16 +7,17 @@ package localentries
 #include <stdlib.h>
 #include <pwd.h>
 #include <grp.h>
-#include <errno.h>
 */
 import "C"
 
 import (
 	"errors"
-	"fmt"
+	"runtime"
 	"sync"
+	"syscall"
+	"unsafe"
 
-	"github.com/ubuntu/authd/internal/errno"
+	"github.com/ubuntu/decorate"
 )
 
 // Passwd represents a passwd entry.
@@ -28,81 +29,98 @@ type Passwd struct {
 
 var getpwentMu sync.Mutex
 
-func getPasswdEntry() (*C.struct_passwd, error) {
-	errno.Lock()
-	defer errno.Unlock()
-
-	cPasswd := C.getpwent()
-	if cPasswd != nil {
-		return cPasswd, nil
-	}
-
-	err := errno.Get()
-	// It's not documented in the man page, but apparently getpwent sets errno to ENOENT when there are no more
-	// entries in the passwd database.
-	if errors.Is(err, errno.ErrNoEnt) {
-		return nil, nil
-	}
-	if err != nil {
-		return nil, fmt.Errorf("getpwent: %v", err)
-	}
-	return cPasswd, nil
-}
-
 // GetPasswdEntries returns all passwd entries.
-func GetPasswdEntries() ([]Passwd, error) {
-	// This function repeatedly calls getpwent, which iterates over the records in the passwd database.
+func GetPasswdEntries() (entries []Passwd, err error) {
+	decorate.OnError(&err, "getpwent_r")
+
+	// This function repeatedly calls getpwent_r, which iterates over the records in the passwd database.
 	// Use a mutex to avoid that parallel calls to this function interfere with each other.
+	// It would be nice to use fgetpwent_r, that is thread safe, but it can only
+	// iterate over a stream, while we want to iterate over all the NSS sources too.
 	getpwentMu.Lock()
 	defer getpwentMu.Unlock()
 
 	C.setpwent()
 	defer C.endpwent()
 
-	var entries []Passwd
+	var passwd C.struct_passwd
+	var passwdPtr *C.struct_passwd
+	buf := make([]C.char, 1024)
+
+	pinner := runtime.Pinner{}
+	defer pinner.Unpin()
+
+	pinner.Pin(&passwd)
+	pinner.Pin(&buf[0])
+
 	for {
-		cPasswd, err := getPasswdEntry()
-		if err != nil {
-			return nil, err
+		ret := C.getpwent_r(&passwd, &buf[0], C.size_t(len(buf)), &passwdPtr)
+		errno := syscall.Errno(ret)
+
+		if errors.Is(errno, syscall.ERANGE) {
+			buf = make([]C.char, len(buf)*2)
+			pinner.Pin(&buf[0])
+			continue
 		}
-		if cPasswd == nil {
-			// No more entries in the passwd database.
-			break
+		if errors.Is(errno, syscall.ENOENT) {
+			return entries, nil
+		}
+		if !errors.Is(errno, syscall.Errno(0)) {
+			return nil, errno
 		}
 
 		entries = append(entries, Passwd{
-			Name:  C.GoString(cPasswd.pw_name),
-			UID:   uint32(cPasswd.pw_uid),
-			Gecos: C.GoString(cPasswd.pw_gecos),
+			Name:  C.GoString(passwdPtr.pw_name),
+			UID:   uint32(passwdPtr.pw_uid),
+			Gecos: C.GoString(passwdPtr.pw_gecos),
 		})
 	}
-
-	return entries, nil
 }
 
 // ErrUserNotFound is returned when a user is not found.
 var ErrUserNotFound = errors.New("user not found")
 
 // GetPasswdByName returns the user with the given name.
-func GetPasswdByName(name string) (Passwd, error) {
-	errno.Lock()
-	defer errno.Unlock()
+func GetPasswdByName(name string) (p Passwd, err error) {
+	decorate.OnError(&err, "getgrnam_r")
 
-	cPasswd := C.getpwnam(C.CString(name))
-	if cPasswd == nil {
-		err := errno.Get()
-		if err == nil ||
-			errors.Is(err, errno.ErrNoEnt) ||
-			errors.Is(err, errno.ErrSrch) ||
-			errors.Is(err, errno.ErrBadf) ||
-			errors.Is(err, errno.ErrPerm) {
+	var passwd C.struct_passwd
+	var passwdPtr *C.struct_passwd
+	buf := make([]C.char, 256)
+
+	pinner := runtime.Pinner{}
+	defer pinner.Unpin()
+
+	pinner.Pin(&passwd)
+	pinner.Pin(&buf[0])
+
+	cName := C.CString(name)
+	defer C.free(unsafe.Pointer(cName))
+
+	for {
+		ret := C.getpwnam_r(cName, &passwd, &buf[0], C.size_t(len(buf)), &passwdPtr)
+		errno := syscall.Errno(ret)
+
+		if errors.Is(errno, syscall.ERANGE) {
+			buf = make([]C.char, len(buf)*2)
+			pinner.Pin(&buf[0])
+			continue
+		}
+		if (errors.Is(errno, syscall.Errno(0)) && passwdPtr == nil) ||
+			errors.Is(errno, syscall.ENOENT) ||
+			errors.Is(errno, syscall.ESRCH) ||
+			errors.Is(errno, syscall.EBADF) ||
+			errors.Is(errno, syscall.EPERM) {
 			return Passwd{}, ErrUserNotFound
 		}
-		return Passwd{}, fmt.Errorf("getpwnam: %v", err)
-	}
+		if !errors.Is(errno, syscall.Errno(0)) {
+			return Passwd{}, errno
+		}
 
-	return Passwd{
-		Name: C.GoString(cPasswd.pw_name),
-		UID:  uint32(cPasswd.pw_uid),
-	}, nil
+		return Passwd{
+			Name:  C.GoString(passwdPtr.pw_name),
+			UID:   uint32(passwdPtr.pw_uid),
+			Gecos: C.GoString(passwdPtr.pw_gecos),
+		}, nil
+	}
 }

--- a/internal/users/localentries/getpwent_test.go
+++ b/internal/users/localentries/getpwent_test.go
@@ -1,6 +1,7 @@
 package localentries
 
 import (
+	"fmt"
 	"slices"
 	"testing"
 
@@ -10,30 +11,49 @@ import (
 func TestGetPasswdEntries(t *testing.T) {
 	t.Parallel()
 
-	got, err := GetPasswdEntries()
-	require.NoError(t, err, "GetPasswdEntries should never return an error")
-	require.NotEmpty(t, got, "GetPasswdEntries should never return an empty list")
+	for idx := range 10 {
+		t.Run(fmt.Sprintf("iteration_%d", idx), func(t *testing.T) {
+			t.Parallel()
 
-	// Check if the root user is present in the list
-	rootFound := slices.ContainsFunc(got, func(entry Passwd) bool {
-		return entry.Name == "root"
-	})
-	require.True(t, rootFound, "GetPasswdEntries should always return root")
+			got, err := GetPasswdEntries()
+			require.NoError(t, err, "GetPasswdEntries should never return an error")
+			require.NotEmpty(t, got, "GetPasswdEntries should never return an empty list")
+
+			// Check if the root user is present in the list
+			rootFound := slices.ContainsFunc(got, func(entry Passwd) bool {
+				return entry.Name == "root" && entry.UID == 0
+			})
+			require.True(t, rootFound, "GetPasswdEntries should always return root")
+		})
+	}
 }
 
 func TestGetPasswdByName(t *testing.T) {
 	t.Parallel()
 
-	got, err := GetPasswdByName("root")
-	require.NoError(t, err, "GetPasswdByName should not return an error")
-	require.Equal(t, got.Name, "root")
-	require.Equal(t, got.UID, uint32(0))
+	for idx := range 10 {
+		t.Run(fmt.Sprintf("iteration_%d", idx), func(t *testing.T) {
+			t.Parallel()
+
+			got, err := GetPasswdByName("root")
+			require.NoError(t, err, "GetPasswdByName should not return an error")
+			require.Equal(t, "root", got.Name, "Name does not match")
+			require.Equal(t, uint32(0), got.UID, "UID does not match")
+			require.Equal(t, "root", got.Gecos, "Gecos does not match")
+		})
+	}
 }
 
 func TestGetPasswdByName_NotFound(t *testing.T) {
 	t.Parallel()
 
-	got, err := GetPasswdByName("nonexistent")
-	require.ErrorIs(t, err, ErrUserNotFound)
-	require.Equal(t, got.Name, "")
+	for idx := range 10 {
+		t.Run(fmt.Sprintf("iteration_%d", idx), func(t *testing.T) {
+			t.Parallel()
+
+			got, err := GetPasswdByName(fmt.Sprintf("nonexistent-really-%d", idx))
+			require.ErrorIs(t, err, ErrUserNotFound)
+			require.Empty(t, got, "Entry should be empty, but is not")
+		})
+	}
 }


### PR DESCRIPTION
We are getting some races for the way we handle the errno, which is by
design unsafe, especially in a multi-threading context.

glibc provides some safer implementations that instead of setting errno,
they actually return the error we got.

Use them instead, to avoid having races.

Also, while `get*ent_r` are not thread safe, `get*nam_r` are, thus
we don't need any more an errno implicit lock.

Test both working in parallel to.

Ideally this should avoid us in troubles as per #991

UDENG-7209