### PR TITLE
Log UserPreCheck errors

### DIFF
--- a/examplebroker/broker.go
+++ b/examplebroker/broker.go
@@ -853,6 +853,7 @@ func (b *Broker) cancelIsAuthenticatedUnlocked(_ context.Context, sessionID stri
 }
 
 // UserPreCheck checks if the user is known to the broker.
+// It returns the user info in JSON format if the user is valid, or an empty string if the user is not allowed.
 func (b *Broker) UserPreCheck(ctx context.Context, username string) (string, error) {
 	if strings.HasPrefix(username, "user-") && strings.Contains(username, "integration") &&
 		strings.Contains(username, fmt.Sprintf("-%s-", UserIntegrationPreCheckValue)) {
@@ -862,7 +863,8 @@ func (b *Broker) UserPreCheck(ctx context.Context, username string) (string, err
 	exampleUsersMu.Lock()
 	defer exampleUsersMu.Unlock()
 	if _, exists := exampleUsers[username]; !exists {
-		return "", fmt.Errorf("user %q does not exist", username)
+		// The username does not match any of the allowed suffixes.
+		return "", nil
 	}
 	return userInfoFromName(username), nil
 }

--- a/internal/services/user/user.go
+++ b/internal/services/user/user.go
@@ -216,12 +216,17 @@ func (s Service) userPreCheck(ctx context.Context, username string) (types.UserE
 
 		userinfo, err = b.UserPreCheck(ctx, username)
 		if err != nil {
+			// An unexpected error occurred while checking the user.
+			log.Errorf(ctx, "UserPreCheck: %v", err)
+			continue
+		}
+		if userinfo == "" {
+			// The broker does not permit the user to log in via SSH for the first time.
+			// This is an expected error, so we only log it at debug level.
 			log.Debugf(ctx, "UserPreCheck: %v", err)
 			continue
 		}
-		if userinfo != "" {
-			break
-		}
+		break
 	}
 
 	if err != nil || userinfo == "" {


### PR DESCRIPTION
We used to silently ignore errors returned by the call to the broker's UserPreCheck method.

We now differentiate between "user not permitted to log in via SSH for the first time", which we log with debug level, and unexpected errors, which we log with error level.