### PR TITLE
docs: section on configuring password quality

### DIFF
--- a/docs/.custom_wordlist.txt
+++ b/docs/.custom_wordlist.txt
@@ -2,6 +2,7 @@ alice
 amd
 auth
 authd
+authd's
 biometric
 Center
 DBus
@@ -24,7 +25,9 @@ Kerberos
 keytab
 Keytab
 Keytabs
+libpwquality
 linux
+MDM
 mountpoint
 msentraid
 NFS

--- a/docs/howto/configure-authd.md
+++ b/docs/howto/configure-authd.md
@@ -320,3 +320,48 @@ If you are using authd inside LXD containers, read our short guide on [how to
 use authd with LXD](howto::use-with-lxd), which outlines additional steps for
 configuring appropriate UID/GID ranges.
 ```
+
+## Configure password quality
+
+You can change authd's local password policy to ensure that users always set
+strong passwords.
+
+If your mobile device management (MDM) solution includes a compliance check for
+the passwords of authd users, you may also need to configure authd's password
+policy so that it matches that of the MDM.
+
+authd depends on the libpwquality library, which supports configuring password
+quality.
+
+To configure the local password policy for authd, create a drop file in
+`/etc/security/pwquality.conf.d/`.
+This will override the default values in `/etc/security/pwquality.conf`.
+
+First, create a directory for the custom configuration file:
+
+```shell
+sudo mkdir -p /etc/security/pwquality.conf.d/
+```
+
+Then edit the file to add your settings.
+
+```shell
+sudoedit /etc/security/pwquality.conf.d/99_custom-options.conf
+```
+
+For example, if your policy requires that passwords have a 14 character minimum,
+edit the drop file to set the value for `minlen`:
+
+```{code-block} diff
+:caption: /etc/security/pwquality.conf.d/99_custom-options.conf
+# This file overrides the defaults set in /etc/security/pwquality.conf
+# Refer to the pwquality file for additional configuration options.
+# Minimum acceptable size for the new password (plus one if
+# credits are not disabled which is the default). (See pam_cracklib manual.)
+# Cannot be set to lower value than 6 (default is 8).
+minlen = 14
+```
+
+> The [man pages](https://manpages.ubuntu.com/manpages/noble/man5/pwquality.conf.5.html)
+provide a full list of configuration options for the libpwquality library.
+


### PR DESCRIPTION
Adds section to configuration guide on modifying the local password policy for authd, with a small example of setting the minimum password length.

Change was prompted by https://github.com/ubuntu/authd/issues/958, which outlined issues with InTune's password compliance checking.

UDENG-7210