### PR TITLE
localentries: Remove unused functions

### DIFF
--- a/internal/users/localentries/getgrent_c.go
+++ b/internal/users/localentries/getgrent_c.go
@@ -73,55 +73,6 @@ func getGroupEntries() (entries []types.GroupEntry, err error) {
 	}
 }
 
-// ErrGroupNotFound is returned when a group is not found.
-var ErrGroupNotFound = errors.New("group not found")
-
-// GetGroupByName returns the group with the given name.
-func GetGroupByName(name string) (g types.GroupEntry, err error) {
-	decorate.OnError(&err, "getgrnam_r")
-
-	var group C.struct_group
-	var groupPtr *C.struct_group
-	buf := make([]C.char, 256)
-
-	pinner := runtime.Pinner{}
-	defer pinner.Unpin()
-
-	pinner.Pin(&group)
-	pinner.Pin(&buf[0])
-
-	cName := C.CString(name)
-	defer C.free(unsafe.Pointer(cName))
-
-	for {
-		ret := C.getgrnam_r(cName, &group, &buf[0], C.size_t(len(buf)), &groupPtr)
-		errno := syscall.Errno(ret)
-
-		if errors.Is(errno, syscall.ERANGE) {
-			buf = make([]C.char, len(buf)*2)
-			pinner.Pin(&buf[0])
-			continue
-		}
-		if (errors.Is(errno, syscall.Errno(0)) && groupPtr == nil) ||
-			errors.Is(errno, syscall.ENOENT) ||
-			errors.Is(errno, syscall.ESRCH) ||
-			errors.Is(errno, syscall.EBADF) ||
-			errors.Is(errno, syscall.EPERM) {
-			return types.GroupEntry{}, ErrGroupNotFound
-		}
-		if !errors.Is(errno, syscall.Errno(0)) {
-			return types.GroupEntry{}, errno
-		}
-
-		return types.GroupEntry{
-			Name:   C.GoString(groupPtr.gr_name),
-			GID:    uint32(groupPtr.gr_gid),
-			Passwd: C.GoString(groupPtr.gr_passwd),
-			Users:  strvToSlice(groupPtr.gr_mem),
-		}, nil
-	}
-}
-
 func strvToSlice(strv **C.char) []string {
 	var users []string
 	for i := C.uint(0); ; i++ {

--- a/internal/users/localentries/getgrent_test.go
+++ b/internal/users/localentries/getgrent_test.go
@@ -30,34 +30,3 @@ func TestGetGroupEntries(t *testing.T) {
 		})
 	}
 }
-
-func TestGetGroupByName(t *testing.T) {
-	t.Parallel()
-
-	for idx := range 10 {
-		t.Run(fmt.Sprintf("iteration_%d", idx), func(t *testing.T) {
-			t.Parallel()
-
-			got, err := GetGroupByName("root")
-			require.NoError(t, err, "GetGroupByName should not return an error")
-			require.Equal(t, got.Name, "root", "Name does not match")
-			require.Equal(t, got.GID, uint32(0), "GID does not match")
-			require.Equal(t, got.Passwd, "x", "Passwd does not match")
-			require.Empty(t, got.Users)
-		})
-	}
-}
-
-func TestGetGroupByName_NotFound(t *testing.T) {
-	t.Parallel()
-
-	for idx := range 10 {
-		t.Run(fmt.Sprintf("iteration_%d", idx), func(t *testing.T) {
-			t.Parallel()
-
-			got, err := GetGroupByName(fmt.Sprintf("nonexistent-really-%d", idx))
-			require.ErrorIs(t, err, ErrGroupNotFound)
-			require.Empty(t, got, "Entry should be empty, but is not")
-		})
-	}
-}

--- a/internal/users/localentries/getpwent_c.go
+++ b/internal/users/localentries/getpwent_c.go
@@ -13,7 +13,6 @@ import (
 	"runtime"
 	"sync"
 	"syscall"
-	"unsafe"
 
 	"github.com/ubuntu/authd/internal/users/types"
 	"github.com/ubuntu/decorate"
@@ -69,56 +68,5 @@ func getUserEntries() (entries []types.UserEntry, err error) {
 			Dir:   C.GoString(passwdPtr.pw_dir),
 			Shell: C.GoString(passwdPtr.pw_shell),
 		})
-	}
-}
-
-// ErrUserNotFound is returned when a user is not found.
-var ErrUserNotFound = errors.New("user not found")
-
-// GetPasswdByName returns the user with the given name.
-func GetPasswdByName(name string) (p types.UserEntry, err error) {
-	decorate.OnError(&err, "getgrnam_r")
-
-	var passwd C.struct_passwd
-	var passwdPtr *C.struct_passwd
-	buf := make([]C.char, 256)
-
-	pinner := runtime.Pinner{}
-	defer pinner.Unpin()
-
-	pinner.Pin(&passwd)
-	pinner.Pin(&buf[0])
-
-	cName := C.CString(name)
-	defer C.free(unsafe.Pointer(cName))
-
-	for {
-		ret := C.getpwnam_r(cName, &passwd, &buf[0], C.size_t(len(buf)), &passwdPtr)
-		errno := syscall.Errno(ret)
-
-		if errors.Is(errno, syscall.ERANGE) {
-			buf = make([]C.char, len(buf)*2)
-			pinner.Pin(&buf[0])
-			continue
-		}
-		if (errors.Is(errno, syscall.Errno(0)) && passwdPtr == nil) ||
-			errors.Is(errno, syscall.ENOENT) ||
-			errors.Is(errno, syscall.ESRCH) ||
-			errors.Is(errno, syscall.EBADF) ||
-			errors.Is(errno, syscall.EPERM) {
-			return types.UserEntry{}, ErrUserNotFound
-		}
-		if !errors.Is(errno, syscall.Errno(0)) {
-			return types.UserEntry{}, errno
-		}
-
-		return types.UserEntry{
-			Name:  C.GoString(passwdPtr.pw_name),
-			UID:   uint32(passwdPtr.pw_uid),
-			GID:   uint32(passwdPtr.pw_gid),
-			Gecos: C.GoString(passwdPtr.pw_gecos),
-			Dir:   C.GoString(passwdPtr.pw_dir),
-			Shell: C.GoString(passwdPtr.pw_shell),
-		}, nil
 	}
 }

--- a/internal/users/localentries/getpwent_test.go
+++ b/internal/users/localentries/getpwent_test.go
@@ -28,36 +28,3 @@ func TestGetPasswdEntries(t *testing.T) {
 		})
 	}
 }
-
-func TestGetPasswdByName(t *testing.T) {
-	t.Parallel()
-
-	for idx := range 10 {
-		t.Run(fmt.Sprintf("iteration_%d", idx), func(t *testing.T) {
-			t.Parallel()
-
-			got, err := GetPasswdByName("root")
-			require.NoError(t, err, "GetPasswdByName should not return an error")
-			require.Equal(t, "root", got.Name, "Name does not match")
-			require.Equal(t, uint32(0), got.UID, "UID does not match")
-			require.Equal(t, uint32(0), got.GID, "GID does not match")
-			require.Equal(t, "root", got.Gecos, "Gecos does not match")
-			require.NotEmpty(t, got.Shell, "Shell is not empty")
-			require.Equal(t, "/root", got.Dir, "Dir does not match")
-		})
-	}
-}
-
-func TestGetPasswdByName_NotFound(t *testing.T) {
-	t.Parallel()
-
-	for idx := range 10 {
-		t.Run(fmt.Sprintf("iteration_%d", idx), func(t *testing.T) {
-			t.Parallel()
-
-			got, err := GetPasswdByName(fmt.Sprintf("nonexistent-really-%d", idx))
-			require.ErrorIs(t, err, ErrUserNotFound)
-			require.Empty(t, got, "Entry should be empty, but is not")
-		})
-	}
-}


### PR DESCRIPTION
These functions were never used. On https://github.com/ubuntu/authd/pull/993 we had a use case for them, but then decided to use `user.Lookup`/`user.LookupGroup` instead, so let's remove them.