### PR TITLE
docs: add doc contribution guidelines

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -26,6 +26,10 @@ These are mostly guidelines, not rules. Use your best judgment and feel free to 
     - [About the test suite](#about-the-testsuite)
       - [Tests with dependencies](#tests-with-dependencies)
     - [Code style](#code-style)
+  - [Contributing to the documentation](#contributing-to-the-documentation)
+    - [Building the documentation](#building-the-documentation)
+    - [Testing the documentation](#testing-the-documentation)
+    - [Open Documentation Academy](#open-documentation-academy)
   - [Contributor License Agreement](#contributor-license-agreement)
   - [Getting help](#getting-help)
 
@@ -48,7 +52,7 @@ Contributions are made to this project via Issues and Pull Requests (PRs). These
 
 Issues can be used to report problems with the software, request a new feature or discuss potential changes before a PR is created. When you [create a new Issue](https://github.com/ubuntu/authd/issues), a template will be loaded that will guide you through collecting and providing the information that we need to investigate.
 
-If you find an Issue that addresses the problem you're having, please add your own reproduction information to the existing issue rather than creating a new one. Adding a [reaction](https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) can also help be indicating to our maintainers that a particular problem is affecting more than just the reporter.
+If you find an Issue that addresses the problem you're having, please add your own reproduction information to the existing issue rather than creating a new one. Adding a [reaction](https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) can also help by indicating to our maintainers that a particular problem is affecting more than just the reporter.
 
 ### Pull Requests
 
@@ -57,7 +61,7 @@ PRs to our project are always welcome and can be a quick way to get your fix or 
 * Only fix/add the functionality in question **OR** address wide-spread whitespace/style issues, not both.
 * Add unit or integration tests for fixed or changed functionality.
 * Address a single concern in the least possible number of changed lines.
-* Include documentation in the repo or on our [docs site](https://github.com/ubuntu/authd/wiki).
+* Include documentation in the repo or on our [docs site](https://documentation.ubuntu.com/authd/stable/).
 * Be accompanied by a complete Pull Request template (loaded automatically when a PR is created).
 
 For changes that address core functionality or that would require breaking changes (e.g. a major release), it's best to open an Issue to discuss your proposal first. This is not required but can save time when creating and reviewing changes.
@@ -189,6 +193,87 @@ Information about these tools and their usage will be linked below:
 ### Code style
 
 This project follow the Go code-style. For more detailed information about the code style in use, please check <https://google.github.io/styleguide/go/>.
+
+## Contributing to the documentation
+
+You can contribute to the documentation in various ways.
+
+At the top of each page in the documentation, there is a **Give feedback**
+button. If you find an issue in the documentation, clicking this button will
+open an Issue submission on GitHub for the specific page.
+
+For minor changes, such as fixing a single typo, you can click the **pencil**
+icon at the top right of any page. This will open up the source file in GitHub so
+that you can make edits directly.
+
+For more significant changes to the content or organization of the
+documentation, you should create your own fork and follow the steps
+outlined in the section on [pull requests](#pull-requests).
+
+### Building the documentation
+
+After cloning your fork, change into the `/docs/` directory.
+The documentation is written in markdown files grouped under
+[Diátaxis](https://diataxis.fr/) categories.
+
+A makefile is used to preview and test the documentation locally.
+To view all the possible commands, run `make` without arguments.
+
+The command `make run` will serve the documentation at port `8000` on
+`localhost`. You can then preview the documentation in your browser and the
+preview will automatically update with each change that you make.
+
+To clean the build environment at any point, run `make clean`.
+
+When you submit a PR, there are automated checks for typos and broken links.
+Please run the tests locally before submitting the PR to save yourself and your
+reviewers time.
+
+### Testing the documentation
+
+Automatic checks will be run on any PR relating to documentation to verify
+spelling and the validity of links. Before submitting a PR, you can check for
+any issues locally:
+
+- Check the spelling: `make spelling`
+- Check the validity of links: `make linkcheck`
+
+Doing these checks locally is good practice. You are less likely to run into
+failed CI checks after your PR is submitted and the reviewer of your PR can
+more quickly focus on the substance of your contribution.
+
+If the documentation builds, your PR will generate a preview of the
+documentation on Read the Docs. This preview appears as a check in the CI.
+Click on the check to open the preview and confirm that your changes have been
+applied successfully.
+
+### Open Documentation Academy
+
+authd is a proud member of the [Canonical Open Documentation
+Academy](https://github.com/canonical/open-documentation-academy) (CODA).
+
+CODA is an initiative to encourage open source contributions from the
+community, and to provide help, advice and mentorship to people making their
+first contributions.
+
+A key aim of the initiative is to lower the barrier to successful open-source
+software contributions by making documentation into the gateway, and it’s a
+great way to make your first open source contributions to projects like authd.
+
+The best way to get started is to take a look at our [project-related
+documentation
+tasks](https://github.com/canonical/open-documentation-academy/issues) and read
+our [Getting started
+guide](https://discourse.ubuntu.com/t/getting-started/42769). Tasks typically
+include testing and fixing documentation pages, updating outdated content, and
+restructuring large documents. We'll help you see those tasks through to
+completion.
+
+You can get involved the with the CODA community through:
+
+* The [discussion forum](https://discourse.ubuntu.com/c/community/open-documentation-academy/166) on the Ubuntu Community Hub
+* The [Matrix channel](https://matrix.to/#/#documentation:ubuntu.com) for interactive chat
+* [Fosstodon](https://fosstodon.org/@CanonicalDocumentation) for the latest updates and events
 
 ## Contributor License Agreement
 

--- a/docs/.custom_wordlist.txt
+++ b/docs/.custom_wordlist.txt
@@ -8,6 +8,7 @@ Center
 DBus
 entra
 filesystem
+Fosstodon
 fstab
 ESC
 GDM
@@ -27,6 +28,7 @@ Keytab
 Keytabs
 libpwquality
 linux
+makefile
 MDM
 mountpoint
 msentraid

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -217,7 +217,10 @@ redirects = {}
 #
 # TODO: Remove or adjust the ACME entry after you update the contributing guide
 
-linkcheck_ignore = ["http://127.0.0.1:8000"]
+linkcheck_ignore = [
+    "http://127.0.0.1:8000",
+    "https://matrix.to/#/#documentation:ubuntu.com",  # the linkchecker struggles with hashes
+]
 
 
 # A regex list of URLs where anchors are ignored by 'make linkcheck'


### PR DESCRIPTION
The contributing guidelines should include guidance relating to docs contributions (ways to contribute, building, testing).

The Open Documentation Academy should also be referenced, as authd is now a participating project, and new contributors to open source may want to get involved through that channel.

Other changes: fixed a link and a typo.

> [!NOTE]
> The changes are also trancluded to the relevant section of the docs
> See [relevant section in the preview](https://canonical-ubuntu-documentation-library--1015.com.readthedocs.build/authd/1015/howto/contributing/#contributing-to-the-documentation) 

UDENG-7330