### PR TITLE
Fix NSS integration tests

### DIFF
--- a/nss/integration-tests/integration_test.go
+++ b/nss/integration-tests/integration_test.go
@@ -107,7 +107,7 @@ func TestIntegration(t *testing.T) {
 
 			// We don't check compatibility of arguments, have noDaemon taking precedences to the others.
 			if tc.noDaemon {
-				socketPath = ""
+				socketPath = "/non-existent"
 				useAlternativeDaemon = false
 			}
 


### PR DESCRIPTION
The test was using the authd instance running on my system, causing the tests which expect authd to not be running to fail.