### PR TITLE
docs: reorganise troubleshooting content

### DIFF
--- a/docs/howto/changing-versions.md
+++ b/docs/howto/changing-versions.md
@@ -1,0 +1,96 @@
+---
+myst:
+  html_meta:
+    "description lang=en": "Change to the edge release of authd to test new features and bug fixes."
+---
+
+(ref::changing-versions)=
+# Changing authd versions
+
+To test new features or check if a bug has been fixed in a new version,
+you can switch to edge releases of authd and its brokers.
+
+```{warning}
+Do not use the edge PPA in a production system, because it may apply changes to
+the authd database in a non-reversible way, which can make it difficult to roll
+back to the stable version of authd.
+```
+
+## Switch authd to the edge PPA
+
+The [edge
+PPA](https://launchpad.net/~ubuntu-enterprise-desktop/+archive/ubuntu/authd-edge) contains
+the latest fixes and features for authd, in addition to its GNOME Shell (GDM)
+counterpart.
+
+```shell
+sudo add-apt-repository ppa:ubuntu-enterprise-desktop/authd-edge
+sudo apt update
+sudo apt install authd gnome-shell
+```
+
+Keep in mind that this version is not tested and may be incompatible with the current released version of the brokers.
+
+To switch back to the stable version of authd:
+
+```shell
+sudo apt install ppa-purge
+sudo ppa-purge ppa:ubuntu-enterprise-desktop/authd-edge
+```
+
+## Switch broker snap to the edge channel
+
+You can also switch to the edge channel of the broker snap:
+
+::::{tab-set}
+:sync-group: broker
+
+:::{tab-item} Google IAM
+:sync: google
+
+```shell
+sudo snap switch authd-google --edge
+sudo snap refresh authd-google
+```
+:::
+
+:::{tab-item} MS Entra ID
+:sync: msentraid
+
+```shell
+sudo snap switch authd-msentraid --edge
+sudo snap refresh authd-msentraid
+```
+:::
+::::
+
+Keep in mind that this version is not tested and may be incompatible with the current released version of authd.
+
+To switch back to stable after trying the edge channel:
+
+::::{tab-set}
+:sync-group: broker
+
+:::{tab-item} Google IAM
+:sync: google
+
+```shell
+sudo snap switch authd-google --stable
+sudo snap refresh authd-google
+```
+:::
+
+:::{tab-item} MS Entra ID
+:sync: msentraid
+
+```shell
+sudo snap switch authd-msentraid --stable
+sudo snap refresh authd-msentraid
+```
+:::
+::::
+
+```{note}
+If using an edge release, you can read the
+[latest development version of the documentation](https://canonical-authd.readthedocs-hosted.com/en/latest/)
+```

--- a/docs/howto/configure-authd.md
+++ b/docs/howto/configure-authd.md
@@ -4,6 +4,7 @@ myst:
     "description lang=en": "Configure authd and its identity brokers to enable authentication of Ubuntu devices with multiple cloud identity providers, including Google IAM and Microsoft Entra ID."
 ---
 
+(ref::config)=
 # Configure authd for cloud identity providers
 
 This guide shows how to configure identity brokers to support authentication of
@@ -237,6 +238,42 @@ in `allowed_users`:
 ```text
 owner = ""
 ```
+
+:::::{admonition} Only my first logged-in user has access to the machine?
+:class: important
+By default, the first logged-in user is defined as the "owner" and only the
+owner can log in.
+To allow more users to log in, update the list of allowed users.
+
+If an administrator is the first to log in to a machine and becomes the owner,
+they can ensure that the next user to log in becomes the owner by removing the
+`20-owner-autoregistration.conf` file:
+
+::::{tab-set}
+:sync-group: broker
+
+:::{tab-item} Google IAM
+:sync: google
+
+```shell
+sudo rm /var/snap/authd-google/current/broker.conf.d/20-owner-autoregistration.conf
+```
+:::
+
+:::{tab-item} MS Entra ID
+:sync: msentraid
+
+```shell
+sudo rm /var/snap/authd-msentraid/current/broker.conf.d/20-owner-autoregistration.conf
+```
+:::
+::::
+
+
+This file is generated when a user logs in and becomes the owner. If it is
+removed, it will be regenerated on the next successful login.
+
+:::::
 
 (ref::config-user-groups)=
 ## Configure user groups

--- a/docs/howto/enter-recovery-mode.md
+++ b/docs/howto/enter-recovery-mode.md
@@ -1,0 +1,32 @@
+---
+myst:
+  html_meta:
+    "description lang=en": "Guide on entering recovery mode after a failed login attempt with authd."
+---
+
+# How to enter recovery mode after failed login
+
+If authd and/or the broker are missing, corrupted, or broken in any way, a user may
+be prevented from logging in.
+
+To get access to the system for modifying configurations and installations in
+such cases, there are two main options:
+
+1. Log in as root user or another local user with administrator privileges
+2. Boot into recovery mode to get root access
+
+The steps required for entering recovery mode are included below.
+
+## Boot into recovery mode
+
+If it is not possible to log in with the root user account or another local
+user account with administrator privileges, the user can boot into recovery
+mode:
+
+1. Reboot the device
+2. During the reboot, press and hold the right <kbd>SHIFT</kbd> key
+3. When the Grub menu appears, select `advanced options for Ubuntu`
+4. Choose `recovery mode` for the correct kernel version
+5. Select `drop to root shell prompt`
+
+The user then has access to the root filesystem and can proceed with debugging.

--- a/docs/howto/index.md
+++ b/docs/howto/index.md
@@ -10,8 +10,8 @@ provider.
 ```{toctree}
 :titlesonly:
 
-Install authd <install-authd>
-Configure authd <configure-authd>
+Installing authd <install-authd>
+Configuring authd <configure-authd>
 ```
 
 ## Login and authentication
@@ -19,12 +19,11 @@ Configure authd <configure-authd>
 Read about how users can authenticate when
 logging into Ubuntu Desktop or Server.
 
-
 ```{toctree}
 :titlesonly:
 
-Log in with GDM <login-gdm>
-Log in with SSH <login-ssh>
+Logging in with GDM <login-gdm>
+Logging in with SSH <login-ssh>
 ```
 
 ## Network file systems
@@ -34,8 +33,30 @@ Learn how to use authd with different network file systems.
 ```{toctree}
 :titlesonly:
 
-Use authd with NFS <use-with-nfs>
-Use authd with Samba <use-with-samba>
+Using authd with NFS <use-with-nfs>
+Using authd with Samba <use-with-samba>
+```
+
+## Debugging and troubleshooting
+
+Actions you can take if something goes wrong.
+
+```{toctree}
+:titlesonly:
+
+Accessing and configuring logs <logging>
+Entering recovery mode on failed login <enter-recovery-mode>
+```
+
+## Updating and upgrading
+
+authd and its brokers can currently be switched between
+stable and edge releases.
+
+```{toctree}
+:titlesonly:
+
+Changing authd versions <changing-versions>
 ```
 
 ## Contributing to authd

--- a/docs/howto/logging.md
+++ b/docs/howto/logging.md
@@ -1,0 +1,168 @@
+---
+myst:
+  html_meta:
+    "description lang=en": "Get logs from authd and configure logging behavior."
+---
+
+(ref::logging)=
+# Accessing and configuring logs
+
+Logs are generated for authd and its brokers, which can help when
+troubleshooting and reporting bugs.
+
+## authd
+
+`authd` logs to the system journal.
+
+For `authd` entries, run:
+
+```shell
+sudo journalctl -u authd.service
+```
+
+If you want logs for authd and all brokers on the system, run:
+
+```shell
+sudo journalctl -u authd.service -u "snap.authd-*.service"
+```
+
+For specific broker entries run the command for your chosen broker:
+
+::::{tab-set}
+:sync-group: broker
+
+:::{tab-item} Google IAM
+:sync: google
+
+```shell
+sudo journalctl -u snap.authd-google.authd-google.service
+```
+:::
+
+:::{tab-item} MS Entra ID
+:sync: msentraid
+
+```shell
+sudo journalctl -u snap.authd-msentraid.authd-msentraid.service
+```
+:::
+::::
+
+For the GDM integration:
+
+```shell
+sudo journalctl /usr/bin/gnome-shell
+```
+
+For anything else or more broader investigation, use `sudo journalctl`.
+
+## Configure logging verbosity
+
+You can increase the verbosity of the logs in different ways.
+
+### PAM module
+
+Append `debug=true` to all the lines with `pam_authd_exec.so` or `pam_authd.so` in the PAM configuration files (`common-auth`, `gdm-authd`...) in `/etc/pam.d/` to increase the verbosity of the PAM messages.
+
+### NSS module
+
+Export `AUTHD_NSS_INFO=stderr` environment variable on any program using the authd NSS module to get more info on NSS requests to authd.
+
+### authd service
+
+To increase the verbosity of the service itself, edit the service file:
+
+```shell
+sudo systemctl edit authd.service
+```
+
+Add the following lines to the override file and make sure to add `-vv` at the end of the `authd` command:
+
+```ini
+[Service]
+ExecStart=
+ExecStart=/usr/libexec/authd -vv
+```
+
+Then you need to restart the service with `sudo systemctl restart authd`.
+
+### GDM
+
+Ensure the lines in `/etc/gdm3/custom.conf` are not commented:
+
+```ini
+[debug]
+# Uncomment the line below to turn on debugging
+# More verbose logs
+# Additionally lets the X server dump core if it crashes
+Enable=true
+```
+
+Then you need to restart the service with `sudo systemctl restart gdm`.
+
+### authd broker service
+
+To increase the verbosity of the broker service, edit the service file:
+
+::::{tab-set}
+:sync-group: broker
+
+:::{tab-item} Google IAM
+:sync: google
+
+```shell
+sudo systemctl edit snap.authd-google.authd-google.service
+```
+:::
+
+:::{tab-item} MS Entra ID
+:sync: msentraid
+
+```shell
+sudo systemctl edit snap.authd-msentraid.authd-msentraid.service
+```
+:::
+::::
+
+Add the following lines to the override file and make sure to add `-vv` to the exec command:
+
+::::{tab-set}
+:sync-group: broker
+
+:::{tab-item} Google IAM
+:sync: google
+
+```ini
+[Service]
+ExecStart=
+ExecStart=/usr/bin/snap run authd-google -vv
+```
+:::
+
+:::{tab-item} MS Entra ID
+:sync: msentraid
+
+```ini
+[Service]
+ExecStart=
+ExecStart=/usr/bin/snap run authd-msentraid -vv
+```
+::::
+
+You will then need to restart the service with:
+
+::::{tab-set}
+:sync-group: broker
+
+:::{tab-item} Google IAM
+:sync: google
+
+`sudo snap restart authd-google`.
+:::
+
+:::{tab-item} MS Entra ID
+:sync: msentraid
+
+`sudo snap restart authd-msentraid`.
+:::
+::::

--- a/docs/reference/troubleshooting.md
+++ b/docs/reference/troubleshooting.md
@@ -6,313 +6,46 @@ myst:
 
 # Troubleshooting
 
-This page includes tips for troubleshooting authd and the identity
-brokers for different cloud providers.
+This page includes links to authd documentation that may be helpful when
+troubleshooting.
 
 ## Logging
 
-### authd
+Logs are generated for authd and its brokers, which can be useful when
+troubleshooting and reporting bugs.
 
-`authd` logs to the system journal.
+To learn how to get logs and configure logging behavior, read the dedicated
+[guide on logging](ref::logging).
 
-For `authd` entries, run:
+## Changing versions
 
-```shell
-sudo journalctl -u authd.service
-```
+To test new features or check if a bug has been fixed in a new version,
+you can switch to edge releases for authd and its brokers.
 
-If you want logs for authd and all brokers on the system, run:
+This is described in the [guide on changing
+versions](ref::changing-versions).
 
-```shell
-sudo journalctl -u authd.service -u "snap.authd-*.service"
-```
+## Only the first logged-in user can get access
 
-For specific broker entries run the command for your chosen broker:
+This is the expected behavior, as the first logged-in user becomes the owner
+and only the owner has access by default.
 
-::::{tab-set}
-:sync-group: broker
+To change access you can make the next logged-in user the owner or add more
+allowed users.
 
-:::{tab-item} Google IAM
-:sync: google
+Guidelines on [configuring allowed users](ref::config-allowed-users) are
+outlined in the [configuring authd guide](ref::config).
 
-```shell
-sudo journalctl -u snap.authd-google.authd-google.service
-```
-:::
-
-:::{tab-item} MS Entra ID
-:sync: msentraid
-
-```shell
-sudo journalctl -u snap.authd-msentraid.authd-msentraid.service
-```
-:::
-::::
-
-
-For the GDM integration:
-
-```shell
-sudo journalctl /usr/bin/gnome-shell
-```
-
-For anything else or more broader investigation, use `sudo journalctl`.
-
-### Logging verbosity
-
-You can increase the verbosity of the logs in different ways.
-
-#### PAM module
-
-Append `debug=true` to all the lines with `pam_authd_exec.so` or `pam_authd.so` in the PAM configuration files (`common-auth`, `gdm-authd`...) in `/etc/pam.d/` to increase the verbosity of the PAM messages.
-
-#### NSS module
-
-Export `AUTHD_NSS_INFO=stderr` environment variable on any program using the authd NSS module to get more info on NSS requests to authd.
-
-#### authd service
-
-To increase the verbosity of the service itself, edit the service file:
-
-```shell
-sudo systemctl edit authd.service
-```
-
-Add the following lines to the override file and make sure to add `-vv` at the end of the `authd` command:
-
-```ini
-[Service]
-ExecStart=
-ExecStart=/usr/libexec/authd -vv
-```
-
-Then you need to restart the service with `sudo systemctl restart authd`.
-
-#### GDM
-
-Ensure the lines in `/etc/gdm3/custom.conf` are not commented:
-
-```ini
-[debug]
-# Uncomment the line below to turn on debugging
-# More verbose logs
-# Additionally lets the X server dump core if it crashes
-Enable=true
-```
-
-Then you need to restart the service with `sudo systemctl restart gdm`.
-
-#### authd broker service
-
-To increase the verbosity of the broker service, edit the service file:
-
-::::{tab-set}
-:sync-group: broker
-
-:::{tab-item} Google IAM
-:sync: google
-
-```shell
-sudo systemctl edit snap.authd-google.authd-google.service
-```
-:::
-
-:::{tab-item} MS Entra ID
-:sync: msentraid
-
-```shell
-sudo systemctl edit snap.authd-msentraid.authd-msentraid.service
-```
-:::
-::::
-
-Add the following lines to the override file and make sure to add `-vv` to the exec command:
-
-::::{tab-set}
-:sync-group: broker
-
-:::{tab-item} Google IAM
-:sync: google
-
-```ini
-[Service]
-ExecStart=
-ExecStart=/usr/bin/snap run authd-google -vv
-```
-:::
-
-:::{tab-item} MS Entra ID
-:sync: msentraid
-
-```ini
-[Service]
-ExecStart=
-ExecStart=/usr/bin/snap run authd-msentraid -vv
-```
-::::
-
-You will then need to restart the service with:
-
-::::{tab-set}
-:sync-group: broker
-
-:::{tab-item} Google IAM
-:sync: google
-
-`sudo snap restart authd-google`.
-:::
-
-:::{tab-item} MS Entra ID
-:sync: msentraid
-
-`sudo snap restart authd-msentraid`.
-:::
-::::
-
-## Switch authd to the edge PPA
-
-Maybe your issue is already fixed! You can try switching to the [edge PPA](https://launchpad.net/~ubuntu-enterprise-desktop/+archive/ubuntu/authd-edge), which contains the
-latest fixes and features for authd, in addition to its GNOME Shell (GDM)
-counterpart.
-
-```{warning}
-Do not use the edge PPA in a production system, because it may apply changes to
-the authd database in a non-reversible way, which can make it difficult to roll
-back to the stable version of authd.
-```
-
-```shell
-sudo add-apt-repository ppa:ubuntu-enterprise-desktop/authd-edge
-sudo apt update
-sudo apt install authd gnome-shell
-```
-
-Keep in mind that this version is not tested and may be incompatible with the current released version of the brokers.
-
-To switch back to the stable version of authd:
-
-```shell
-sudo apt install ppa-purge
-sudo ppa-purge ppa:ubuntu-enterprise-desktop/authd-edge
-```
-
-```{note}
-If using an edge release, you can read the
-[latest development version of the documentation](https://canonical-authd.readthedocs-hosted.com/en/latest/)
-```
-
-## Switch broker snap to the edge channel
-
-Maybe your issue is already fixed! You should try switching to the edge channel of the broker snap. You can easily do that with:
-
-::::{tab-set}
-:sync-group: broker
-
-:::{tab-item} Google IAM
-:sync: google
-
-```shell
-sudo snap switch authd-google --edge
-sudo snap refresh authd-google
-```
-:::
-
-:::{tab-item} MS Entra ID
-:sync: msentraid
-
-```shell
-sudo snap switch authd-msentraid --edge
-sudo snap refresh authd-msentraid
-```
-:::
-::::
-
-Keep in mind that this version is not tested and may be incompatible with the current released version of authd. You should switch back to stable after trying the edge channel:
-
-::::{tab-set}
-:sync-group: broker
-
-:::{tab-item} Google IAM
-:sync: google
-
-```shell
-sudo snap switch authd-google --stable
-sudo snap refresh authd-google
-```
-:::
-
-:::{tab-item} MS Entra ID
-:sync: msentraid
-
-```shell
-sudo snap switch authd-msentraid --stable
-sudo snap refresh authd-msentraid
-```
-:::
-::::
-
-```{note}
-If using an edge release, you can read the
-[latest development version of the documentation](https://canonical-authd.readthedocs-hosted.com/en/latest/)
-```
-
-## Common issues
-
-### Only the first logged-in user can get access to a machine
-
-This is the expected behavior.
-
-By default, the first logged-in user is defined as the "owner" and only the
-owner can log in.
-
-For other users to gain access after authentication, they must be added to
-`allowed_users` in the `broker.conf` file.
-This is outlined in the [guide for configuring authd](ref::config-allowed-users).
-
-See below the relevant line in the configuration, showing both the owner and
-an additional user:
-
-```ini
-[users]
-allowed_users = OWNER,additionaluser1@example.com
-```
-
-If an administrator is the first to log in to a machine and becomes the owner,
-they can ensure that the next user to log in becomes the owner by removing the
-`20-owner-autoregistration.conf` file:
-
-::::{tab-set}
-:sync-group: broker
-
-:::{tab-item} Google IAM
-:sync: google
-
-```shell
-sudo rm /var/snap/authd-google/current/broker.conf.d/20-owner-autoregistration.conf
-```
-:::
-
-:::{tab-item} MS Entra ID
-:sync: msentraid
-
-```shell
-sudo rm /var/snap/authd-msentraid/current/broker.conf.d/20-owner-autoregistration.conf
-```
-:::
-::::
-
-
-This file is generated when a user logs in and becomes the owner. If it is
-removed, it will be regenerated on the next successful login.
-
-### File ownership on shared network resources (e.g. NFS, Samba)
+## File ownership on shared network resources (NFS, Samba)
 
 The user identifiers (UIDs) and group identifiers (GIDs) assigned by authd are
 unique to each machine. This means that when using authd with NFS or Samba, the
 UIDs and GIDs of users and groups on the server will not match those on the
 client machines, which leads to permission issues.
 
-To avoid these issues, you can use ID mapping. For more information, see
+To avoid these issues, you can use ID mapping. For more information, see the
+dedicated guides on NFS and Samba:
+
 * [Using authd with NFS](../howto/use-with-nfs)
 * [Using authd with Samba](../howto/use-with-samba)
 
@@ -321,24 +54,5 @@ To avoid these issues, you can use ID mapping. For more information, see
 If authd and/or the broker are missing, corrupted, or broken in any way, a user may
 be prevented from logging in.
 
-To get access to the system for modifying configurations and installations in
-such cases, there are two main options:
-
-1. Log in as root user or another local user with administrator privileges
-2. Boot into recovery mode to get root access
-
-The steps required for entering recovery mode are included below.
-
-### Boot into recovery mode
-
-If it is not possible to log in with the root user account or another local
-user account with administrator privileges, the user can boot into recovery
-mode:
-
-1. Reboot the device
-2. During the reboot, press and hold the right <kbd>SHIFT</kbd> key
-3. When the Grub menu appears, select `advanced options for Ubuntu`
-4. Choose `recovery mode` for the correct kernel version
-5. Select `drop to root shell prompt`
-
-The user then has access to the root filesystem and can proceed with debugging.
+When this occurs, you can [boot into recovery mode](../howto/enter-recovery-mode.md) to
+access to the system for modifying configurations and installations.


### PR DESCRIPTION
The Troubleshooting reference contains good information but is getting complex and hard-to-follow. Some of the information, such as switching versions, is also not necessarily restricted to troubleshooting and could be more generally useful. Lastly, the content largely consists of step-by-step guides, so is more appropriate under the how-to section of the docs.

Major changes:

* Specific troubleshooting content (logging, changing versions, recovery)  that was sufficiently developed and useful was moved to standalone pages.
* Guidance on configuring users (only the first logged-in user has access) was moved to the dedicated configuration guide where it is most relevant and discoverable.
* The Troubleshooting page remains as a reference, but was rewritten to primarily link out to relevant material. It can be developed further in this way. This also means that no redirects should be necessary.

Minor changes:

* Minor fixups after reorganisation of content: update header levels; update how-to index; typographical fixes.
* More consistent verb form in side-nav TOC

UDENG-7325