### PR TITLE
Bump Go toolchain version to 1.23.12

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/ubuntu/authd
 
 go 1.23.0
 
-toolchain go1.23.10
+toolchain go1.23.12
 
 require (
 	github.com/charmbracelet/bubbles v0.20.0

--- a/tools/go.mod
+++ b/tools/go.mod
@@ -2,7 +2,7 @@ module github.com/ubuntu/authd/tools
 
 go 1.23.0
 
-toolchain go1.23.10
+toolchain go1.23.12
 
 require (
 	github.com/golang/protobuf v1.5.4


### PR DESCRIPTION
govulncheck reports the following vulnerability in go1.23.10

```
Vulnerability #1: GO-2025-3849
    Incorrect results returned from Rows.Scan in database/sql
  More info: https://pkg.go.dev/vuln/GO-2025-3849
  Standard library
    Found in: database/sql@go1.23.10
    Fixed in: database/sql@go1.23.12
```