### PR TITLE
pam/integration-tests: Avoid downloading chromium on each test run

### DIFF
--- a/pam/integration-tests/vhs-helpers_test.go
+++ b/pam/integration-tests/vhs-helpers_test.go
@@ -248,6 +248,10 @@ func (td tapeData) RunVhs(t *testing.T, testType vhsTestType, outDir string, cli
 	// If vhs is installed with "go install", we need to add GOPATH to PATH.
 	cmd.Env = append(cmd.Env, prependBinToPath(t))
 
+	// vhs uses rod, which downloads chromium to $HOME/.cache/rod,
+	// so $HOME needs to be set to avoid that it downloads it every time.
+	cmd.Env = append(cmd.Env, fmt.Sprintf("HOME=%s", os.Getenv("HOME")))
+
 	u, err := user.Current()
 	require.NoError(t, err, "Setup: getting current user")
 	if u.Name == "root" || os.Getenv("SCHROOT_CHROOT_NAME") != "" {


### PR DESCRIPTION
The `$HOME` environment variable wasn't set in the environment which the vhs command runs in, resulting in chromium being downloaded to `.cache/rod` in the current working directory, which is a temporary directory. In effect, chromium was being downloaded each time a test using vhs was executed, which made the test take ~1m longer.