### PR TITLE
Fix cargo always treating nss crate as dirty

### DIFF
--- a/internal/testutils/args.go
+++ b/internal/testutils/args.go
@@ -16,7 +16,23 @@ var (
 	isRaceOnce          sync.Once
 	sleepMultiplier     float64
 	sleepMultiplierOnce sync.Once
+	testVerbosity       int
+	testVerbosityOnce   sync.Once
 )
+
+// TestVerbosity returns the verbosity level that should be used in tests.
+func TestVerbosity() int {
+	testVerbosityOnce.Do(func() {
+		if v := os.Getenv("AUTHD_TEST_VERBOSITY"); v != "" {
+			var err error
+			testVerbosity, err = strconv.Atoi(v)
+			if err != nil {
+				panic(err)
+			}
+		}
+	})
+	return testVerbosity
+}
 
 func haveBuildFlag(flag string) bool {
 	b, ok := debug.ReadBuildInfo()

--- a/internal/testutils/rust.go
+++ b/internal/testutils/rust.go
@@ -95,14 +95,16 @@ func BuildRustNSSLib(t *testing.T, disableCoverage bool, features ...string) (li
 		"--features", strings.Join(features, ","), "--target-dir", target)
 	cmd.Env = append(os.Environ(), rustCovEnv...)
 	cmd.Dir = projectRoot
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
 
 	if isNightly && IsAsan() {
 		cmd.Env = append(cmd.Env, "RUSTFLAGS=-Zsanitizer=address")
 	}
 
 	t.Log("Building NSS library...", cmd.Args)
-	out, err := cmd.CombinedOutput()
-	require.NoError(t, err, "Setup: could not build Rust NSS library: %s", out)
+	err = cmd.Run()
+	require.NoError(t, err, "Setup: could not build Rust NSS library")
 
 	// When building the crate with dh-cargo, this env is set to indicate which architecture the code
 	// is being compiled to. When it's set, the compiled is stored under target/$(DEB_HOST_RUST_TYPE)/debug,

--- a/internal/testutils/rust.go
+++ b/internal/testutils/rust.go
@@ -91,8 +91,7 @@ func BuildRustNSSLib(t *testing.T, disableCoverage bool, features ...string) (li
 
 	// Builds the nss library.
 	// #nosec:G204 - we control the command arguments in tests
-	cmd := exec.Command(cargo, "build", "--verbose",
-		"--features", strings.Join(features, ","), "--target-dir", target)
+	cmd := exec.Command(cargo, "build", "--features", strings.Join(features, ","), "--target-dir", target)
 	cmd.Env = append(os.Environ(), rustCovEnv...)
 	cmd.Dir = projectRoot
 	cmd.Stdout = os.Stdout

--- a/internal/testutils/rust.go
+++ b/internal/testutils/rust.go
@@ -100,6 +100,9 @@ func BuildRustNSSLib(t *testing.T, disableCoverage bool, features ...string) (li
 	// Builds the nss library.
 	// #nosec:G204 - we control the command arguments in tests
 	cmd := exec.Command(cargo, "build", "--features", strings.Join(features, ","), "--target-dir", target)
+	if TestVerbosity() > 0 {
+		cmd.Args = append(cmd.Args, "--verbose")
+	}
 	cmd.Env = append(os.Environ(), rustCovEnv...)
 	cmd.Dir = projectRoot
 	cmd.Stdout = os.Stdout

--- a/internal/testutils/rust.go
+++ b/internal/testutils/rust.go
@@ -74,13 +74,8 @@ func BuildRustNSSLib(t *testing.T, disableCoverage bool, features ...string) (li
 	cargo, isNightly, err := getCargoPath()
 	require.NoError(t, err, "Setup: looking for cargo")
 
-	// Note that for developing purposes and avoiding keeping building the rust program dependencies,
-	// TEST_RUST_TARGET environment variable can be set to an absolute path to keep iterative
-	// build artifacts.
-	target := os.Getenv("TEST_RUST_TARGET")
-	if target == "" {
-		target = t.TempDir()
-	}
+	// Store the build artifacts in a common temp directory, so that they can be reused between tests.
+	target := filepath.Join(os.TempDir(), "authd-tests-rust-build-artifacts")
 
 	rustDir := filepath.Join(projectRoot, "nss")
 	if !disableCoverage {

--- a/nss/build.rs
+++ b/nss/build.rs
@@ -2,7 +2,10 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     tonic_build::configure()
         .build_server(false)
         .protoc_arg("--experimental_allow_proto3_optional")
-        .compile_protos(&["../internal/proto/authd/authd.proto"], &["../"])?;
+        .compile_protos(
+            &["../internal/proto/authd/authd.proto"],
+            &["../internal/proto"],
+        )?;
 
     #[cfg(feature = "integration_tests")]
     cc::Build::new()


### PR DESCRIPTION
I couldn't figure out exactly why, but `cargo build` always treated the nss crate as dirty and re-compiled it even when nothing changed in between two runs:

```
cargo build --verbose
[...]
Dirty nss v0.1.0 (/home/user/projects/authd/nss): the file `nss/..` has changed (1756139002.017575102s, 2s after last build at 1756139000.627582074s)
Compiling nss v0.1.0 (/home/user/projects/authd/nss)
```

Using `"../internal/proto"` instead of `"../"` as the includes directory in the `compile_protos` call fixes that.

UDENG-7825