### PR TITLE
ci: Use apt-get instead of apt

### DIFF
--- a/.github/workflows/auto-updates.yaml
+++ b/.github/workflows/auto-updates.yaml
@@ -40,16 +40,16 @@ jobs:
         run: |
           set -euo pipefail
 
-          apt update -y
-          apt install -y dh-cargo git
+          apt-get update -y
+          apt-get install -y dh-cargo git
 
           if [ "${{ matrix.ubuntu-version }}" = "noble" ]; then
             # Special behavior on noble as dh-cargo is not new enough there
-            apt install -y libssl-dev pkg-config
+            apt-get install -y libssl-dev pkg-config
             cargo install --locked --root=/usr \
               cargo-vendor-filterer@${{ env.CARGO_VENDOR_FILTERER_NOBLE_VERSION }}
           else
-            apt install -y cargo-vendor-filterer
+            apt-get install -y cargo-vendor-filterer
           fi
 
       - name: Checkout the code

--- a/.github/workflows/build-deb.yaml
+++ b/.github/workflows/build-deb.yaml
@@ -164,8 +164,8 @@ jobs:
       run: |
         set -euo pipefail
 
-        sudo apt update -y
-        sudo apt install -y --no-install-suggests --no-install-recommends \
+        sudo apt-get update -y
+        sudo apt-get install -y --no-install-suggests --no-install-recommends \
           dpkg-dev devscripts
 
     - name: Checkout code

--- a/.github/workflows/qa.yaml
+++ b/.github/workflows/qa.yaml
@@ -50,8 +50,8 @@ jobs:
           # Install dependencies
           set -eu
 
-          sudo apt update
-          sudo apt install -y ${{ env.go_build_dependencies }}
+          sudo apt-get update
+          sudo apt-get install -y ${{ env.go_build_dependencies }}
       - name: Go code sanity check
         uses: canonical/desktop-engineering/gh-actions/go/code-sanity@v1
         with:
@@ -92,11 +92,11 @@ jobs:
           # Install dependencies
           set -eu
 
-          sudo apt update
+          sudo apt-get update
           # In Rust the grpc stubs are generated at build time
           # so we always need to install the protobuf compilers
           # when building the NSS crate.
-          sudo apt install -y protobuf-compiler
+          sudo apt-get install -y protobuf-compiler
       - name: Rust code sanity check
         uses: canonical/desktop-engineering/gh-actions/rust/code-sanity@main
         with:
@@ -116,8 +116,8 @@ jobs:
           # Install dependencies
           set -eu
 
-          sudo apt update
-          sudo apt install -y ${{ env.c_build_dependencies }}
+          sudo apt-get update
+          sudo apt-get install -y ${{ env.c_build_dependencies }}
       - name: Prepare report dir
         run: |
           set -eu
@@ -162,10 +162,10 @@ jobs:
           # Install dependencies
           set -eu
 
-          sudo apt update
+          sudo apt-get update
 
           # The integration tests build the NSS crate, so we need the cargo build dependencies in order to run them.
-          sudo apt install -y ${{ env.go_build_dependencies }} ${{ env.go_test_dependencies}}
+          sudo apt-get install -y ${{ env.go_build_dependencies }} ${{ env.go_test_dependencies}}
 
           # Load the apparmor profile for bubblewrap.
           sudo ln -s /usr/share/apparmor/extra-profiles/bwrap-userns-restrict /etc/apparmor.d/
@@ -181,14 +181,14 @@ jobs:
           deb http://ddebs.ubuntu.com $(lsb_release -cs)-proposed main restricted universe multiverse" | \
           sudo tee -a /etc/apt/sources.list.d/ddebs.list
           # Sometimes ddebs archive is stuck, so in case of failure we need to go manual
-          sudo apt update -y || true
-          if ! sudo apt install -y libpam-modules-dbgsym libpam0*-dbgsym libglib2.0-0*-dbgsym; then
-            sudo apt install -y ubuntu-dev-tools
+          sudo apt-get update -y || true
+          if ! sudo apt-get install -y libpam-modules-dbgsym libpam0*-dbgsym libglib2.0-0*-dbgsym; then
+            sudo apt-get install -y ubuntu-dev-tools
             for pkg in pam glib2.0; do
               pull-lp-debs "${pkg}" $(lsb_release -cs)
               pull-lp-ddebs "${pkg}" $(lsb_release -cs)
             done
-            sudo apt install -y ./libpam0*.*deb ./libpam-modules*.*deb ./libglib2.0-0*-dbgsym*.ddeb
+            sudo apt-get install -y ./libpam0*.*deb ./libpam-modules*.*deb ./libglib2.0-0*-dbgsym*.ddeb
             sudo apt remove -y ubuntu-dev-tools
             sudo apt autoremove -y
           fi
@@ -236,7 +236,7 @@ jobs:
           set -eu
 
           # Dependendencies for C coverage collection
-          sudo apt install -y gcovr
+          sudo apt-get install -y gcovr
 
           # Dependendencies for Go coverage collection
           go install github.com/AlekSi/gocov-xml@latest
@@ -320,7 +320,7 @@ jobs:
           set -x
 
           # For llvm-symbolizer
-          sudo apt install -y llvm
+          sudo apt-get install -y llvm
 
           go test -C ./pam/internal -json -asan -gcflags=all="${GO_GC_FLAGS}" -failfast -timeout ${GO_TESTS_TIMEOUT} ./... | \
             gotestfmt --logfile "${AUTHD_TESTS_ARTIFACTS_PATH}/gotestfmt.pam-internal-asan.log" || exit_code=$?


### PR DESCRIPTION
To avoid this warning being printed:

    WARNING: apt does not have a stable CLI interface. Use with caution in scripts.