### PR TITLE
ci: Automatically cancel in-progress workflow runs on push

### DIFF
--- a/.github/workflows/build-deb.yaml
+++ b/.github/workflows/build-deb.yaml
@@ -16,6 +16,10 @@ on:
       - .readthedocs.yaml
       - docs/**
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 env:
   UBUNTU_VERSIONS: |
     ["noble", "plucky", "devel"]

--- a/.github/workflows/cla-check.yaml
+++ b/.github/workflows/cla-check.yaml
@@ -10,3 +10,7 @@ jobs:
         uses: canonical/has-signed-canonical-cla@v2
         with:
           accept-existing-contributors: true
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true

--- a/.github/workflows/git.yml
+++ b/.github/workflows/git.yml
@@ -10,3 +10,7 @@ jobs:
     - uses: actions/checkout@v5
     - name: Block Fixup Commit Merge
       uses: 13rac1/block-fixup-merge-action@v2.0.0
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true

--- a/.github/workflows/qa.yaml
+++ b/.github/workflows/qa.yaml
@@ -15,6 +15,10 @@ on:
       - '.readthedocs.yaml'
       - 'docs/**'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 env:
   DEBIAN_FRONTEND: noninteractive
   GO_TESTS_TIMEOUT: 20m

--- a/.github/workflows/validate-dependabot.yaml
+++ b/.github/workflows/validate-dependabot.yaml
@@ -17,3 +17,7 @@ jobs:
         with:
           header: validate-dependabot
           message: ${{ steps.validate.outputs.markdown }}
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true


### PR DESCRIPTION
Our CI jobs run for a long time and use a lot of resources.

It happens quite often to me that, after I push something to a PR, I find something to small to fix (e.g. improve the commit message) and push that fix soon after. We can save some resources by automatically cancelling in-progress workflows on new pushes to the same branch (I do that manually sometimes, but that's wasting my time).

The implementation is directly from the example of the concurrency keyword: https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax#example-using-concurrency-and-the-default-behavior

UDENG-8268