### PR TITLE
Fix QA action not installing the needed deps

### DIFF
--- a/.github/workflows/qa.yaml
+++ b/.github/workflows/qa.yaml
@@ -160,6 +160,8 @@ jobs:
           sudo apt-get update
 
           # The integration tests build the NSS crate, so we need the cargo build dependencies in order to run them.
+          sudo apt-get install -y protobuf-compiler
+
           sudo apt-get install -y ${{ env.go_build_dependencies }} ${{ env.go_test_dependencies}}
 
           # Load the apparmor profile for bubblewrap.


### PR DESCRIPTION
We need protoc in order to run the tests as Rust always compiles the proto files at build time.