### PR TITLE
ci: Avoid rate limiting in gp/code-sanity action

### DIFF
--- a/.github/workflows/qa.yaml
+++ b/.github/workflows/qa.yaml
@@ -40,6 +40,7 @@ env:
 jobs:
   go-sanity:
     name: "Go: Code sanity"
+    permissions: {}
     runs-on: ubuntu-24.04 # ubuntu-latest-runner
     steps:
       - uses: canonical/desktop-engineering/gh-actions/common/dpkg-install-speedup@main
@@ -82,6 +83,7 @@ jobs:
 
   rust-sanity:
     name: "Rust: Code sanity"
+    permissions: {}
     runs-on: ubuntu-24.04 # ubuntu-latest-runner
     steps:
       - uses: canonical/desktop-engineering/gh-actions/common/dpkg-install-speedup@main


### PR DESCRIPTION
We've [seen it fail](https://github.com/ubuntu/authd/actions/runs/17731772145/job/50385683487?pr=1075#step:5:615) with:

    Failed to get latest protobuf release from GitHub:
    {"message":"API rate limit exceeded for 172.214.44.50. (But here's the good news: Authenticated requests get a higher rate limit. Check out the documentation for more details.)","documentation_url":"https://docs.github.com/rest/overview/resources-in-the-rest-api#rate-limiting"}
    Rate limit remaining: 0
    Warning: GitHub API rate limit may have been hit. Consider providing GITHUB_TOKEN via the token input.