### PR TITLE
docs: Remove unnecessary `apt update` after `add-apt-repository`

### DIFF
--- a/docs/howto/changing-versions.md
+++ b/docs/howto/changing-versions.md
@@ -25,7 +25,6 @@ counterpart.
 
 ```shell
 sudo add-apt-repository ppa:ubuntu-enterprise-desktop/authd-edge
-sudo apt update
 sudo apt install authd gnome-shell
 ```
 

--- a/docs/howto/install-authd.md
+++ b/docs/howto/install-authd.md
@@ -22,11 +22,10 @@ authd is delivered as a Debian package for Ubuntu Desktop and Ubuntu Server.
 
 You can install authd from the [stable PPA](https://launchpad.net/~ubuntu-enterprise-desktop/+archive/ubuntu/authd).
 
-To add this PPA to your system's software sources, run the following commands:
+To add this PPA to your system's software sources, run the following command:
 
 ```shell
 sudo add-apt-repository ppa:ubuntu-enterprise-desktop/authd
-sudo apt update
 ```
 
 ```{note}


### PR DESCRIPTION
`add-apt-repository` updates the package information automatically.