### PR TITLE
docs: update stable and edge URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,9 +14,9 @@
 [goreport-image]: https://goreportcard.com/badge/github.com/ubuntu/authd
 [goreport-url]: https://goreportcard.com/report/github.com/ubuntu/authd
 
-[docs-image]: https://readthedocs.com/projects/canonical-authd/badge/?version=latest
-[docs-url-stable]: https://canonical-authd.readthedocs-hosted.com/en/stable/
-[docs-url-latest]: https://canonical-authd.readthedocs-hosted.com/en/latest/
+[docs-image]: https://readthedocs.com/projects/canonical-authd/badge/?version=edge
+[docs-url-stable]: https://documentation.ubuntu.com/authd/stable/
+[docs-url-edge]: https://documentation.ubuntu.com/authd/edge/
 
 [![Code quality][actions-image]][actions-url]
 [![License][license-image]](COPYING)
@@ -38,7 +38,7 @@ supported and several other identity providers are under active development.
 To find out more about using authd, refer to the
 [official authd documentation][docs-url-stable].
 If you are on an edge release then you can also read the
-[latest development version of the documentation][docs-url-latest],
+[edge version of the documentation][docs-url-edge],
 which may include features not yet available in the stable release.
 
 The documentation includes how-to guides on installing and configuring authd,

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -37,6 +37,6 @@ The [Ubuntu Security disclosure and embargo policy](https://ubuntu.com/security/
 - [Canonical's Security Site](https://ubuntu.com/security)
 - [Ubuntu Security disclosure and embargo policy](https://ubuntu.com/security/disclosure-policy)
 - [Ubuntu Security Notices](https://ubuntu.com/security/notices)
-- [authd Documentation](https://canonical-authd.readthedocs-hosted.com/en/latest/)
+- [authd Documentation](https://documentation.ubuntu.com/authd/stable/)
 
 If you have any questions regarding security vulnerabilities, please reach out to the maintainers via the aforementioned channels.

--- a/docs/howto/changing-versions.md
+++ b/docs/howto/changing-versions.md
@@ -91,5 +91,5 @@ sudo snap refresh authd-msentraid
 
 ```{note}
 If using an edge release, you can read the
-[latest development version of the documentation](https://canonical-authd.readthedocs-hosted.com/en/latest/)
+[edge version of the documentation](https://documentation.ubuntu.com/authd/edge/)
 ```

--- a/docs/index.md
+++ b/docs/index.md
@@ -72,7 +72,7 @@ providers.
 
 ::::::
 
-Documentation for the [stable](https://canonical-authd.readthedocs-hosted.com/en/stable/) release of authd and the [latest](https://canonical-authd.readthedocs-hosted.com/en/latest/) development version are
+Documentation for the [stable](https://documentation.ubuntu.com/authd/stable/) release of authd and the [edge](https://documentation.ubuntu.com/authd/edge/) version are
 both available.
 
 ---------


### PR DESCRIPTION
The `latest` version of docs for authd are now named `edge`, to better align with the available versions of the software.
This change was managed through the ReadTheDocs interface and is now live.

In addition, for some time, the URL for our docs has been documentation.ubuntu.com/authd and not canonical-authd.readthedocs.hosted.

This PR:

* Replace readthedocs.hosted URLs with documentation.ubuntu
* Updates references to "latest" docs to "edge" docs

UDENG-8051