### PR TITLE
Document how to add changes to the stable-docs branch

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -80,6 +80,11 @@ In general, we follow the ["fork-and-pull" Git workflow](https://github.com/susa
 
 Once merged into the main branch, `po` files and any documentation change will be automatically updated. Updates to these files are therefore not necessary in the pull request itself, which helps minimize diff review.
 
+The authd documentation is published in **edge-docs** and **stable-docs** versions. Only the edge version is updated when documentation changes are merged into the main branch.
+If a documentation change should be applied to the stable documentation *before* the next release, create a separate PR
+against the `stable-docs` branch after your main PR has been merged, with the changes to the documentation cherry-picked
+from your main PR.
+
 ## Contributing to the code
 
 ### Required dependencies


### PR DESCRIPTION
We now have a `stable-docs` branch which allows us to apply changes to the "stable" version of the documentation before publishing the next release.

This change documents the process to update that branch.