### PR TITLE
Improve comment of BrokerExists() function

### DIFF
--- a/internal/brokers/manager.go
+++ b/internal/brokers/manager.go
@@ -206,9 +206,7 @@ func (m *Manager) EndSession(sessionID string) error {
 	return nil
 }
 
-// BrokerExists returns true if the brokerID is known by the manager. It can
-// happen that a broker which was stored in the database is not available anymore
-// because the user removed the configuration file.
+// BrokerExists returns true if the brokerID is known by the manager.
 func (m *Manager) BrokerExists(brokerID string) bool {
 	_, exists := m.brokers[brokerID]
 	return exists

--- a/internal/services/pam/pam.go
+++ b/internal/services/pam/pam.go
@@ -100,6 +100,8 @@ func (s Service) GetPreviousBroker(ctx context.Context, req *authd.GPBRequest) (
 		return &authd.GPBResponse{}, nil
 	}
 
+	// Check if the broker still exists. Its config file might have been removed from the config directory after the
+	// user logged in the last time, in which case we let the user select a new broker.
 	if !s.brokerManager.BrokerExists(brokerID) {
 		log.Warningf(ctx, "GetPreviousBroker: Broker %q set for user %q does not exist, letting the user select a new one", brokerID, req.GetUsername())
 		return &authd.GPBResponse{}, nil


### PR DESCRIPTION
It took me a quite long time to make sense of that comment. Let's rephrase it and move it to the place where we have the necessary context (the broker ID being fetched from the database) to make sense of it.