### PR TITLE
docs: improve context statements on landing pages

### DIFF
--- a/docs/explanation/index.md
+++ b/docs/explanation/index.md
@@ -2,7 +2,11 @@
 
 # Explanation
 
-Read about the modular design of authd and how it interfaces with
+These guides explain how authd works.
+
+## Architecture
+
+authd has a modular design and can interface with
 multiple cloud providers through different identity brokers.
 
 ```{toctree}

--- a/docs/howto/index.md
+++ b/docs/howto/index.md
@@ -2,10 +2,13 @@
 
 # How-to guides
 
+These guides walk you through key operations you can perform with authd.
+
 ## Installation and configuration
 
-Install authd and identity brokers then configure them for your cloud identity
-provider.
+Installation of the authd daemon and an identity broker is required to support
+authentication of Ubuntu devices, with various options available for
+configuring authentication behavior and user management:
 
 ```{toctree}
 :titlesonly:
@@ -16,8 +19,8 @@ Configuring authd <configure-authd>
 
 ## Login and authentication
 
-Read about how users can authenticate when
-logging into Ubuntu Desktop or Server.
+Users can log in and authenticate on Ubuntu Desktop or Ubuntu Server, with
+authd supporting both GDM and SSH:
 
 ```{toctree}
 :titlesonly:
@@ -28,7 +31,8 @@ Logging in with SSH <login-ssh>
 
 ## Network file systems
 
-Learn how to use authd with different network file systems.
+If using a network file system to access shared directories from
+authd-enabled machines, you can use ID mapping:
 
 ```{toctree}
 :titlesonly:
@@ -39,7 +43,8 @@ Using authd with Samba <use-with-samba>
 
 ## Debugging and troubleshooting
 
-Actions you can take if something goes wrong.
+When troubleshooting authd, you may need to work with logs or enter recovery
+mode:
 
 ```{toctree}
 :titlesonly:
@@ -50,8 +55,8 @@ Entering recovery mode on failed login <enter-recovery-mode>
 
 ## Updating and upgrading
 
-authd and its brokers can currently be switched between
-stable and edge releases.
+Use the stable version of authd for production use, or switch to the edge
+version to try new features:
 
 ```{toctree}
 :titlesonly:
@@ -61,7 +66,8 @@ Changing authd versions <changing-versions>
 
 ## Contributing to authd
 
-Contribute to the development of authd and its brokers.
+Contribute to the development of authd and its brokers, in addition to the
+authd documentation:
 
 ```{toctree}
 :titlesonly:

--- a/docs/reference/index.md
+++ b/docs/reference/index.md
@@ -2,20 +2,22 @@
 
 # Reference
 
+These guides provide technical information about authd.
+
 ## Providers
 
-Find the cloud providers and brokers currently supported by authd.
+Multiple cloud providers and brokers are supported by authd:
 
 ```{toctree}
 :titlesonly:
 
-Cloud providers <cloud-providers>
+Cloud providers that authd supports <cloud-providers>
 ```
 
 ## Troubleshooting
 
-Read tips on troubleshooting the authd authentication service and its identity
-brokers.
+The documentation includes several pages that are helpful when troubleshooting
+authd:
 
 ```{toctree}
 :titlesonly:
@@ -25,7 +27,8 @@ Troubleshooting <troubleshooting>
 
 ## Groups
 
-Learn more about managing groups with authd and MS Entra ID.
+Managing groups of users that need the same access and permissions to resources
+is supported by the MS Entra ID broker for authd:
 
 ```{toctree}
 :titlesonly:


### PR DESCRIPTION
A user does not necessarily understand Diataxis (how-to, reference, explanation) and the landing page should give context for the top-level grouping of pages and the individual sub-sets listed.

* Adds top-level context statement between two headers where it is absent
* Makes statements before links more consistent and descriptive
* Avoids telling users to "find" or "read", and just gives them the relevant information to provide context for the link(s) that follow. It's obvious that the documentation is for reading the information is for finding
* Adds missing header for architecture in reference index
* Provides better link text if it is unclear

Note: the documentation team are expected to engage in a larger review of landing pages specifically next cycle, where further improvements are likely to be made.

UDENG-7787