### PR TITLE
debian/control: Add build dependency on cargo 1.82

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -11,6 +11,7 @@ Build-Depends: debhelper-compat (= 13),
                dh-exec,
                dh-golang,
                dctrl-tools,
+               cargo (>= 1.82) | cargo-1.82,
 # FIXME: We need cargo-vendor-filterer starting from plucky, but noble isn't ready yet
 # so workaround it, making it kind of optional, and requiring it only on versions after
 # noble (controlled via base-files version that matches the one in noble).


### PR DESCRIPTION
Some of our dependencies (deranged v0.5.4) require a newer rustc version (1.81) than the one installed by default on Noble (1.75). Fortunately, the Noble archives also include newer cargo versions, up to 1.82, so let's install that.

UDENG-8123