### PR TITLE
Create /etc/authd/brokers.d during installation

### DIFF
--- a/debian/dirs
+++ b/debian/dirs
@@ -1,0 +1,1 @@
+etc/authd/brokers.d


### PR DESCRIPTION
So users don't have to create it themselves. It's standard behavior for Debian packages to create their config directories during installation, even when they're empty.