### PR TITLE
debian/authd.service: Don't set mode for /etc/authd

### DIFF
--- a/debian/authd.service.in
+++ b/debian/authd.service.in
@@ -34,7 +34,6 @@ StateDirectoryMode=0700
 
 # This always corresponds to /etc/authd
 ConfigurationDirectory=authd
-ConfigurationDirectoryMode=0700
 
 # Prevent writing to /usr and bootloader paths.
 # We don't use "full" or "strict", because home paths can be anywhere and so we need


### PR DESCRIPTION
When installing the Debian package, the directory is created with mode 0777 - umask (so 0755 by default). Telling systemd that it should be 0700 results in the following warning in the logs:

    authd.service: ConfigurationDirectory 'authd' already exists but the mode is different. (File system: 755 ConfigurationDirectoryMode: 700)

Commit 9ff0d1a3840db0d1dc46a05cfc260c7d23897ba0 intended to fix that by changing the mode to 0700 but only did so when updating from a version < 0.4.0.

The directory doesn't contain any secrets, so it's fine to use the default mode. That has some UX benefits because it allows users to use shell completion for paths below /etc/authd and to read the config file without sudo.