### PR TITLE
docs: add custom version banner

### DIFF
--- a/docs/.sphinx/_static/version-warning.css
+++ b/docs/.sphinx/_static/version-warning.css
@@ -1,0 +1,17 @@
+/* Use subtle bg with strongly contrasting fg */
+.version-warning {
+    padding: 5px;
+    width: 100%;
+    text-align: center;
+    font-size: var(--font-size--small);
+    background-color: #EAE9E7;
+    color: #111;
+}
+
+/* Fix one fg color as only one bg color */
+.version-warning a {
+    color: #06C;
+}
+.version-warning a:visited {
+    color: #872EE0;
+}

--- a/docs/.sphinx/_templates/page.html
+++ b/docs/.sphinx/_templates/page.html
@@ -1,0 +1,52 @@
+
+{% extends "furo/page.html" %}
+
+{% block footer %}
+   {% include "footer.html" %}
+{% endblock footer %}
+
+{% block body -%}
+   {% include "header.html" %}
+   <!-- NOTE: need to inject version warning if not using standard stable/latest on RTD -->
+   {% include "version-warning.html" %}
+   {{ super() }}
+{%- endblock body %}
+
+{% if meta and ((meta.discourse and discourse_prefix) or meta.relatedlinks) %}
+   {% set furo_hide_toc_orig = furo_hide_toc %}
+   {% set furo_hide_toc=false %}
+{% endif %}
+
+{% block right_sidebar %}
+<div class="toc-sticky toc-scroll">
+   {% if not furo_hide_toc_orig %}
+    <div class="toc-title-container">
+      <span class="toc-title">
+       {{ _("Contents") }}
+      </span>
+    </div>
+    <div class="toc-tree-container">
+      <div class="toc-tree">
+        {{ toc }}
+      </div>
+    </div>
+   {% endif %}
+    {% if meta and ((meta.discourse and discourse_prefix) or meta.relatedlinks) %}
+    <div class="relatedlinks-title-container">
+      <span class="relatedlinks-title">
+       Related links
+      </span>
+    </div>
+    <div class="relatedlinks-container">
+      <div class="relatedlinks">
+        {% if meta.discourse and discourse_prefix %}
+          {{ discourse_links(meta.discourse) }}
+        {% endif %}
+        {% if meta.relatedlinks %}
+          {{ related_links(meta.relatedlinks) }}
+        {% endif %}
+      </div>
+    </div>
+    {% endif %}
+  </div>
+{% endblock right_sidebar %}

--- a/docs/.sphinx/_templates/version-warning.html
+++ b/docs/.sphinx/_templates/version-warning.html
@@ -1,0 +1,20 @@
+{# define the current page and strip the index from the URL #}
+{% set clean_pagename = pagename | replace('/index', '') | replace('index', '') %}
+
+<header id="header" class="p-navigation">
+
+  <div class="p-navigation__nav">
+
+        {% if version == "edge-docs" %}
+        <div class="version-warning">
+          <p class="version-warning-content">
+          This is the <strong>edge</strong> version. Some features may not be available in the stable release.
+          Read the <a href="{{ ogp_site_url }}/{{ clean_pagename }}"><strong>stable</strong></a> version of the documentation.
+          </p>
+        </div>
+        {% else %}
+        {# Show no warning for non-edge versions — no HTML output #}
+        {% endif %}
+
+  </div>
+</header>

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -71,7 +71,7 @@ copyright = "%s CC-BY-SA, %s" % (datetime.date.today().year, author)
 # NOTE: The Open Graph Protocol (OGP) enhances page display in a social graph
 #       and is used by social media platforms; see https://ogp.me/
 
-ogp_site_url = "https://documentation.ubuntu/authd/en/stable"
+ogp_site_url = "https://documentation.ubuntu.com/authd/stable-docs"
 
 
 # Preview name of the documentation website
@@ -98,7 +98,12 @@ ogp_image = "https://assets.ubuntu.com/v1/253da317-image-document-ubuntudocs.svg
 # Dictionary of values to pass into the Sphinx context for all pages:
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#confval-html_context
 
+version = os.getenv("READTHEDOCS_VERSION", "")
+
 html_context = {
+    # Used for rendering version information and links in authd documentation
+    "version": version,
+    "ogp_site_url": ogp_site_url,
     # Product page URL; can be different from product docs URL
     #
     # TODO: Change to your product website URL,
@@ -280,7 +285,7 @@ extensions = [
 
 # Adds custom CSS files, located under 'html_static_path'
 
-html_css_files = ["cookie-banner.css"]
+html_css_files = ["cookie-banner.css", "version-warning.css"]
 
 # Adds custom JavaScript files, located under 'html_static_path'
 


### PR DESCRIPTION
As we are not using the standard stable/latest versions on Read the Docs, we need to use a custom version banner.

The banner only needs to warn users if they are reading the `edge-docs` version. No banner is required on `stable-docs`, which is how it works with the native RTD notification.

This template applies to all pages, so when a user is on the edge version of a page and they click on the stable link in the banner, it will take them to the stable version of that page.

To make this work:

* Current version is grabbed from RTD during docs build
* Link to stable version of page is concatenated together
* Check for edge version before showing the banner
* Banner uses one background color and foreground colors with accessible contrast, which requires fixing hyperlink colors that normally shift depending on whether background is black or white
* Standard wording used for consistency with other docs sites

> [!NOTE]
> The PR preview of the docs doesn't build an `edge-docs` or `stable-docs` version.
> So you won't see the functionality in the PR preview.

This is a screenshot using the PR version `1100` in place of `edge-docs` (commit reverted after test):

<img width="1666" height="988" alt="image" src="https://github.com/user-attachments/assets/14f5910f-ce96-41d2-b1a4-6e520326aa30" />

Here's a video showing how it should work on a test site:

https://github.com/user-attachments/assets/cf3574fb-fd80-4fbf-b82e-355722c55b7e

It shows:

* Homepage on `edge` showing the banner
* Switching homepage to `stable` using banner link (no banner)
* Switching back to `edge` using RTD's flyout menu
* Changing to a different page on `edge` with the banner still showing
* Changing back to `stable` on the same page using the banner link (no banner)

UDENG-8091