### PR TITLE
Update stable docs

### DIFF
--- a/docs/.custom_wordlist.txt
+++ b/docs/.custom_wordlist.txt
@@ -4,6 +4,7 @@ auth
 authd
 authd's
 biometric
+cleartext
 Center
 DBus
 entra
@@ -20,6 +21,7 @@ grpc
 hostname
 https
 IDMAP
+IdP
 io
 KDC
 Kerberos
@@ -42,10 +44,12 @@ PR
 protoc
 PRs
 repo
+sandboxing
 smartcard
 sshd
 styleguide
 sudo
+systemd
 TPM
 ubuntu
 UEFI

--- a/docs/.sphinx/_static/version-warning.css
+++ b/docs/.sphinx/_static/version-warning.css
@@ -1,0 +1,17 @@
+/* Use subtle bg with strongly contrasting fg */
+.version-warning {
+    padding: 5px;
+    width: 100%;
+    text-align: center;
+    font-size: var(--font-size--small);
+    background-color: #EAE9E7;
+    color: #111;
+}
+
+/* Fix one fg color as only one bg color */
+.version-warning a {
+    color: #06C;
+}
+.version-warning a:visited {
+    color: #872EE0;
+}

--- a/docs/.sphinx/_templates/page.html
+++ b/docs/.sphinx/_templates/page.html
@@ -1,0 +1,52 @@
+
+{% extends "furo/page.html" %}
+
+{% block footer %}
+   {% include "footer.html" %}
+{% endblock footer %}
+
+{% block body -%}
+   {% include "header.html" %}
+   <!-- NOTE: need to inject version warning if not using standard stable/latest on RTD -->
+   {% include "version-warning.html" %}
+   {{ super() }}
+{%- endblock body %}
+
+{% if meta and ((meta.discourse and discourse_prefix) or meta.relatedlinks) %}
+   {% set furo_hide_toc_orig = furo_hide_toc %}
+   {% set furo_hide_toc=false %}
+{% endif %}
+
+{% block right_sidebar %}
+<div class="toc-sticky toc-scroll">
+   {% if not furo_hide_toc_orig %}
+    <div class="toc-title-container">
+      <span class="toc-title">
+       {{ _("Contents") }}
+      </span>
+    </div>
+    <div class="toc-tree-container">
+      <div class="toc-tree">
+        {{ toc }}
+      </div>
+    </div>
+   {% endif %}
+    {% if meta and ((meta.discourse and discourse_prefix) or meta.relatedlinks) %}
+    <div class="relatedlinks-title-container">
+      <span class="relatedlinks-title">
+       Related links
+      </span>
+    </div>
+    <div class="relatedlinks-container">
+      <div class="relatedlinks">
+        {% if meta.discourse and discourse_prefix %}
+          {{ discourse_links(meta.discourse) }}
+        {% endif %}
+        {% if meta.relatedlinks %}
+          {{ related_links(meta.relatedlinks) }}
+        {% endif %}
+      </div>
+    </div>
+    {% endif %}
+  </div>
+{% endblock right_sidebar %}

--- a/docs/.sphinx/_templates/version-warning.html
+++ b/docs/.sphinx/_templates/version-warning.html
@@ -1,0 +1,20 @@
+{# define the current page and strip the index from the URL #}
+{% set clean_pagename = pagename | replace('/index', '') | replace('index', '') %}
+
+<header id="header" class="p-navigation">
+
+  <div class="p-navigation__nav">
+
+        {% if version == "edge-docs" %}
+        <div class="version-warning">
+          <p class="version-warning-content">
+          This is the <strong>edge</strong> version. Some features may not be available in the stable release.
+          Read the <a href="{{ ogp_site_url }}/{{ clean_pagename }}"><strong>stable</strong></a> version of the documentation.
+          </p>
+        </div>
+        {% else %}
+        {# Show no warning for non-edge versions — no HTML output #}
+        {% endif %}
+
+  </div>
+</header>

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -229,7 +229,11 @@ linkcheck_ignore = [
 
 # A regex list of URLs where anchors are ignored by 'make linkcheck'
 
-linkcheck_anchors_ignore_for_url = [r"https://github\.com/.*"]
+linkcheck_anchors_ignore_for_url = [
+    r"https://github\.com/.*",
+    # Using anchors on manpages.ubuntu.com leads to false positives
+    r"https://manpages\.ubuntu\.com/.*",
+]
 
 # give linkcheck multiple tries on failure
 # linkcheck_timeout = 30

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -71,7 +71,7 @@ copyright = "%s CC-BY-SA, %s" % (datetime.date.today().year, author)
 # NOTE: The Open Graph Protocol (OGP) enhances page display in a social graph
 #       and is used by social media platforms; see https://ogp.me/
 
-ogp_site_url = "https://documentation.ubuntu/authd/en/stable"
+ogp_site_url = "https://documentation.ubuntu.com/authd/stable-docs"
 
 
 # Preview name of the documentation website
@@ -98,7 +98,12 @@ ogp_image = "https://assets.ubuntu.com/v1/253da317-image-document-ubuntudocs.svg
 # Dictionary of values to pass into the Sphinx context for all pages:
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#confval-html_context
 
+version = os.getenv("READTHEDOCS_VERSION", "")
+
 html_context = {
+    # Used for rendering version information and links in authd documentation
+    "version": version,
+    "ogp_site_url": ogp_site_url,
     # Product page URL; can be different from product docs URL
     #
     # TODO: Change to your product website URL,
@@ -280,7 +285,7 @@ extensions = [
 
 # Adds custom CSS files, located under 'html_static_path'
 
-html_css_files = ["cookie-banner.css"]
+html_css_files = ["cookie-banner.css", "version-warning.css"]
 
 # Adds custom JavaScript files, located under 'html_static_path'
 

--- a/docs/explanation/index.md
+++ b/docs/explanation/index.md
@@ -14,3 +14,14 @@ multiple cloud providers through different identity brokers.
 
 authd architecture <authd-architecture>
 ```
+
+## Security
+
+Learn about key design decisions, security practices, and configuration options
+that affect the security of authd.
+
+```{toctree}
+:titlesonly:
+
+authd security overview <security>
+```

--- a/docs/explanation/index.md
+++ b/docs/explanation/index.md
@@ -2,7 +2,11 @@
 
 # Explanation
 
-Read about the modular design of authd and how it interfaces with
+These guides explain how authd works.
+
+## Architecture
+
+authd has a modular design and can interface with
 multiple cloud providers through different identity brokers.
 
 ```{toctree}

--- a/docs/explanation/security.md
+++ b/docs/explanation/security.md
@@ -1,0 +1,204 @@
+# Security overview for authd
+
+authd lets Ubuntu systems verify user identities through trusted cloud identity
+providers and integrate those identities into local logins securely.
+
+This overview outlines the key design decisions, security practices, and
+configuration options that affect the security of authd, and provides guidance
+for administrators on deploying authd securely.
+
+## Deploying authd securely as an administrator
+
+The first section of this overview provides guidance for administrators on
+deploying authd securely, and the second section explains design decisions that
+were made to enhance the security of authd.
+
+### Package updates
+
+Keeping authd up to date is essential to ensure that security fixes are applied
+as soon as they are available.
+
+A full authd installation consists of both the authd Debian package and at least
+one broker snap. Snaps are updated automatically. Further information is
+provided in the [snap documentation on managing updates](https://snapcraft.io/docs/managing-updates)).
+
+Update Debian packages regularly, either manually or by enabling
+[automatic updates](https://documentation.ubuntu.com/server/how-to/software/automatic-updates/).
+
+### Security of the identity provider
+
+As described in the [authd architecture](authd-architecture.md) explanation,
+users authenticate with an identity provider, such as Microsoft Entra ID or
+Google IAM. The security of any system using authd therefore depends on the
+security of the configured identity provider.
+
+Ensure that only authorized administrators have access to the identity provider.
+Administrators can add or remove users or change user credentials, which allows
+them to grant, revoke, or modify access to systems using authd.
+
+### Allowed users
+
+In addition to access control at the identity provider's side, allowed users can
+be restricted locally. See the [Configure allowed users](ref::config-allowed-users)
+section for details.
+
+Ensure that only users who should have system access are configured as allowed
+users.
+
+### Local password
+
+To improve usability, authd allows users to create a local password after
+successfully authenticating with the identity provider. This password can then
+be used for subsequent logins without repeating the full identity provider
+authentication flow.
+
+#### Password strength
+
+Strong passwords are critical to prevent unauthorized access.
+
+authd uses libpwquality to enforce password complexity requirements. See the
+[Configure password quality](ref::config-pwquality) section for details.
+
+#### Force provider authentication
+
+If the identity provider is reachable during login, authd verifies that the user
+is still allowed to authenticate with the identity provider. If the user’s
+account has been disabled or removed, login is denied.
+
+By default, if the identity provider cannot be reached (for example, due to
+network issues), users can still log in with their local password. This is to
+prevent accidental lockouts, but it also allows users whose access has been
+revoked at the identity provider to log in while offline.
+
+To enforce verification with the identity provider even when offline, enable the
+[force_provider_authentication](ref::config-force-provider-auth) setting.
+
+### Login via SSH
+
+#### SSH public key authentication
+
+If SSH public key authentication is enabled, users whose access has been revoked
+at the identity provider can still log in using their SSH keys. This is because
+SSH key authentication does not involve authd.
+
+To prevent users with revoked access from logging in with SSH, disable public
+key authentication for users managed by authd, by adding the following to by
+adding the following to `/etc/ssh/sshd_config.d/authd.conf` or directly to
+`/etc/ssh/sshd_config`:
+
+```text
+Match User *@example.com
+    PubkeyAuthentication no
+```
+
+```{note}
+Replace `@example.com` with the domain of your identity provider.
+```
+
+#### SSH password authentication
+
+As described in the [SSH configuration](ref::ssh-configuration) section, PAM
+integration must be enabled in sshd:
+
+```text
+UsePAM yes
+KbdInteractiveAuthentication yes
+```
+
+This setup allows users managed by authd to log in through PAM.
+It also enables PAM-based login for local Unix accounts, even when
+`PasswordAuthentication no` is set.
+
+Administrators who want to deviate from the default SSH configuration and
+disallow password authentication for non-authd users can do so safely by using a
+match block that re-enables keyboard-interactive authentication only for authd
+users:
+
+```text
+KbdInteractiveAuthentication no
+PasswordAuthentication no
+
+Match User *@example.com
+    KbdInteractiveAuthentication yes
+```
+
+```{note}
+Replace `@example.com` with the domain of your identity provider.
+```
+
+### UID and GID conflicts
+
+When a new user logs in for the first time, or when a user is added to a new
+group in the identity provider (for providers that support group management, see
+[Group management](https://documentation.ubuntu.com/authd/stable-docs/reference/group-management/)),
+authd automatically assigns a unique user ID (UID) and group ID (GID).
+
+Before assigning a UID or GID, authd checks that there are no collisions with
+existing users or groups on the system. However, if a user or group is later
+removed, or if the entire authd database (`/var/lib/authd/authd.sqlite3`) is
+deleted, previously assigned IDs can be reused for new users or groups.
+
+This reuse can allow unintended access to files or directories owned by the old
+user, as the new user would inherit their numeric UID or GID.
+
+To avoid this risk:
+
+* Do not remove the authd database.
+* Remove all files and directories owned by any users that you delete,
+  especially if they contain sensitive data.
+
+```{important}
+A tool for removing authd users along with their home directories will be
+provided in the future.
+```
+
+## How authd is designed for security
+
+This section describes how authd is built to protect stored data and limit
+system exposure.
+
+### Stored secrets
+
+authd stores user secrets under
+`/var/snap/authd-<broker>/current/<issuer>/<user>/`.
+
+That directory is created with mode `0700`, ensuring that only root can access
+it.
+
+The secrets that authd stores are described below.
+
+#### Local password
+
+A salted Argon2id hash of the local password is stored for verification. Hashing
+parameters:
+* Memory: 64 KB
+* Iterations: 1
+* Parallelism: 1
+
+#### Tokens and user information
+
+Tokens and user data retrieved during authentication — including the OAuth 2.0
+refresh token and OpenID Connect `UserInfo` response — are cached to support
+login with the local password. These values are currently stored in cleartext.
+
+We recommend enabling [full disk encryption](https://documentation.ubuntu.com/security/docs/security-features/storage/encryption-full-disk/)
+to protect these secrets in case of device theft or loss.
+
+### Sandboxing
+
+authd uses sandboxing to limit system exposure:
+
+* The authd brokers run as [strictly confined](https://snapcraft.io/docs/snap-confinement)
+  snaps. Their only granted interface is network, required to communicate with
+  the identity provider.
+* The authd service uses
+  [systemd sandboxing options](https://manpages.ubuntu.com/manpages/noble/en/man5/systemd.exec.5.html#sandboxing)
+  to restrict access to system resources.
+
+Because authd acts as an authentication service, a vulnerability in authd could
+still be exploited to gain full root privileges.
+
+## Reporting a vulnerability
+
+See the [authd security policy](https://github.com/ubuntu/authd?tab=security-ov-file#security-ov-file)
+for details on how to report security vulnerabilities in authd.

--- a/docs/explanation/security.md
+++ b/docs/explanation/security.md
@@ -20,7 +20,7 @@ as soon as they are available.
 
 A full authd installation consists of both the authd Debian package and at least
 one broker snap. Snaps are updated automatically. Further information is
-provided in the [snap documentation on managing updates](https://snapcraft.io/docs/managing-updates)).
+provided in the [snap documentation on managing updates](https://snapcraft.io/docs/managing-updates).
 
 Update Debian packages regularly, either manually or by enabling
 [automatic updates](https://documentation.ubuntu.com/server/how-to/software/automatic-updates/).

--- a/docs/howto/configure-authd.md
+++ b/docs/howto/configure-authd.md
@@ -161,6 +161,7 @@ client_id = <CLIENT_ID>
 ::::
 :::::
 
+(ref::config-force-provider-auth)=
 ## Force remote authentication with the identity provider
 
 By default, remote authentication with the identity provider only happens
@@ -321,6 +322,7 @@ The authd service is configured in `/etc/authd/authd.yaml`.
 
 This provides configuration options for logging verbosity and UID/GID ranges.
 
+(ref::config-pwquality)=
 ## Configure password quality
 
 You can change authd's local password policy to ensure that users always set

--- a/docs/howto/index.md
+++ b/docs/howto/index.md
@@ -2,10 +2,13 @@
 
 # How-to guides
 
+These guides walk you through key operations you can perform with authd.
+
 ## Installation and configuration
 
-Install authd and identity brokers then configure them for your cloud identity
-provider.
+Installation of the authd daemon and an identity broker is required to support
+authentication of Ubuntu devices, with various options available for
+configuring authentication behavior and user management:
 
 ```{toctree}
 :titlesonly:
@@ -16,8 +19,8 @@ Configuring authd <configure-authd>
 
 ## Login and authentication
 
-Read about how users can authenticate when
-logging into Ubuntu Desktop or Server.
+Users can log in and authenticate on Ubuntu Desktop or Ubuntu Server, with
+authd supporting both GDM and SSH:
 
 ```{toctree}
 :titlesonly:
@@ -28,7 +31,8 @@ Logging in with SSH <login-ssh>
 
 ## Network file systems
 
-Learn how to use authd with different network file systems.
+If using a network file system to access shared directories from
+authd-enabled machines, you can use ID mapping:
 
 ```{toctree}
 :titlesonly:
@@ -39,7 +43,8 @@ Using authd with Samba <use-with-samba>
 
 ## Debugging and troubleshooting
 
-Actions you can take if something goes wrong.
+When troubleshooting authd, you may need to work with logs or enter recovery
+mode:
 
 ```{toctree}
 :titlesonly:
@@ -50,8 +55,8 @@ Entering recovery mode on failed login <enter-recovery-mode>
 
 ## Updating and upgrading
 
-authd and its brokers can currently be switched between
-stable and edge releases.
+Use the stable version of authd for production use, or switch to the edge
+version to try new features:
 
 ```{toctree}
 :titlesonly:
@@ -61,7 +66,8 @@ Changing authd versions <changing-versions>
 
 ## Contributing to authd
 
-Contribute to the development of authd and its brokers.
+Contribute to the development of authd and its brokers, in addition to the
+authd documentation:
 
 ```{toctree}
 :titlesonly:

--- a/docs/howto/login-ssh.md
+++ b/docs/howto/login-ssh.md
@@ -4,6 +4,7 @@
 
 To enable SSH access with `authd` you must configure `sshd` and the broker.
 
+(ref::ssh-configuration)=
 ### SSH configuration
 
 To configure SSH, create a file `/etc/ssh/sshd_config.d/authd.conf` with the following content:

--- a/docs/reference/index.md
+++ b/docs/reference/index.md
@@ -2,20 +2,22 @@
 
 # Reference
 
+These guides provide technical information about authd.
+
 ## Providers
 
-Find the cloud providers and brokers currently supported by authd.
+Multiple cloud providers and brokers are supported by authd:
 
 ```{toctree}
 :titlesonly:
 
-Cloud providers <cloud-providers>
+Cloud providers that authd supports <cloud-providers>
 ```
 
 ## Troubleshooting
 
-Read tips on troubleshooting the authd authentication service and its identity
-brokers.
+The documentation includes several pages that are helpful when troubleshooting
+authd:
 
 ```{toctree}
 :titlesonly:
@@ -25,7 +27,8 @@ Troubleshooting <troubleshooting>
 
 ## Groups
 
-Learn more about managing groups with authd and MS Entra ID.
+Managing groups of users that need the same access and permissions to resources
+is supported by the MS Entra ID broker for authd:
 
 ```{toctree}
 :titlesonly:


### PR DESCRIPTION
Update the stable docs with some changes from main:
* [improve context statements on landing pages](https://github.com/ubuntu/authd/commit/0e06b54cc81b3537acf2081e30917efcf3bbd572) - also relevant for stable docs
* [add custom version banner](https://github.com/ubuntu/authd/commit/0b5d0cbd8ded24603d9a572d6948fb600df3710f) - not really relevant for stable docs, but there is no disadvantage in merging it (as far as I can tell) and it reduces the delta to main which helps avoid merge conflicts
* [Add security overview doc](https://github.com/ubuntu/authd/commit/cf590104b7dd2fdc4fe0fc3aa3f15c1b151be878) - also relevant for stable docs