### PR TITLE
Bump Go toolchain version to 1.25.2

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/ubuntu/authd
 
 go 1.23.0
 
-toolchain go1.25.0
+toolchain go1.25.3
 
 require (
 	github.com/charmbracelet/bubbles v0.20.0

--- a/tools/go.mod
+++ b/tools/go.mod
@@ -2,7 +2,7 @@ module github.com/ubuntu/authd/tools
 
 go 1.24.0
 
-toolchain go1.25.0
+toolchain go1.25.3
 
 require (
 	github.com/golang/protobuf v1.5.4


### PR DESCRIPTION
govulncheck reports the following vulnerabilities in go1.25

```
Vulnerability #1: GO-2025-4013
    Panic when validating certificates with DSA public keys in crypto/x509
  More info: https://pkg.go.dev/vuln/GO-2025-4013
  Standard library
    Found in: crypto/x509@go1.25
    Fixed in: crypto/x509@go1.25.2
    Example traces found:
Error:       #1: cmd/authd/daemon/daemon_test.go:248:18: daemon_test.TestAppCanSigHupWithoutExecute calls io.Copy, which eventually calls x509.Certificate.Verify

Vulnerability #2: GO-2025-4011
    Parsing DER payload can cause memory exhaustion in encoding/asn1
  More info: https://pkg.go.dev/vuln/GO-2025-4011
  Standard library
    Found in: encoding/asn1@go1.25
    Fixed in: encoding/asn1@go1.25.2
    Example traces found:
Error:       #1: pam/internal/adapter/model.go:313:41: adapter.uiModel.Update calls x509.ParsePKIXPublicKey, which calls asn1.Unmarshal

Vulnerability #3: GO-2025-4010
    Insufficient validation of bracketed IPv6 hostnames in net/url
  More info: https://pkg.go.dev/vuln/GO-2025-4010
  Standard library
    Found in: net/url@go1.25
    Fixed in: net/url@go1.25.2
    Example traces found:
Error:       #1: internal/testutils/daemon.go:241:29: testutils.StartDaemonWithCancel calls grpc.NewClient, which eventually calls url.Parse
Error:       #2: pam/integration-tests/ssh_test.go:698:30: integration.startSSHd calls httptest.NewServer, which eventually calls url.ParseRequestURI

Vulnerability #4: GO-2025-4009
    Quadratic complexity when parsing some invalid inputs in encoding/pem
  More info: https://pkg.go.dev/vuln/GO-2025-4009
  Standard library
    Found in: encoding/pem@go1.25
    Fixed in: encoding/pem@go1.25.2
    Example traces found:
Error:       #1: pam/internal/adapter/utils.go:121:22: adapter.IsTerminalTTY calls sync.Once.Do, which eventually calls pem.Decode

Vulnerability #5: GO-2025-4008
    ALPN negotiation error contains attacker controlled information in
    crypto/tls
  More info: https://pkg.go.dev/vuln/GO-2025-4008
  Standard library
    Found in: crypto/tls@go1.25
    Fixed in: crypto/tls@go1.25.2
    Example traces found:
Error:       #1: pam/integration-tests/ssh_test.go:698:30: integration.startSSHd calls httptest.NewServer, which eventually calls tls.Conn.HandshakeContext
Error:       #2: cmd/authd/daemon/daemon_test.go:248:18: daemon_test.TestAppCanSigHupWithoutExecute calls io.Copy, which eventually calls tls.Conn.Read
Error:       #3: internal/services/pam/pam_test.go:877:14: pam_test.TestMain calls fmt.Fprintf, which calls tls.Conn.Write

Vulnerability #6: GO-2025-4007
    Quadratic complexity when checking name constraints in crypto/x509
  More info: https://pkg.go.dev/vuln/GO-2025-4007
  Standard library
    Found in: crypto/x509@go1.25
    Fixed in: crypto/x509@go1.25.3
    Example traces found:
Error:       #1: pam/internal/adapter/utils.go:121:22: adapter.IsTerminalTTY calls sync.Once.Do, which eventually calls x509.CertPool.AppendCertsFromPEM
Error:       #2: cmd/authd/daemon/daemon_test.go:248:18: daemon_test.TestAppCanSigHupWithoutExecute calls io.Copy, which eventually calls x509.Certificate.Verify
Error:       #3: examplebroker/broker.go:351:43: examplebroker.Broker.NewSession calls x509.MarshalPKIXPublicKey
Error:       #4: pam/internal/adapter/utils.go:121:22: adapter.IsTerminalTTY calls sync.Once.Do, which eventually calls x509.ParseCertificate
Error:       #5: pam/internal/adapter/model.go:313:41: adapter.uiModel.Update calls x509.ParsePKIXPublicKey
```