### PR TITLE
ci: Block merging PRs with fixup commits

### DIFF
--- a/.github/workflows/git.yml
+++ b/.github/workflows/git.yml
@@ -9,7 +9,16 @@ jobs:
     steps:
     - uses: actions/checkout@v5
     - name: Block Fixup Commit Merge
-      uses: 13rac1/block-fixup-merge-action@v2.0.0
+      run: |
+        PR_REF="${GITHUB_REF%/merge}/head"
+        BASE_REF="${GITHUB_BASE_REF}"
+        git fetch --no-tags --prune --progress --no-recurse-submodules --depth=1 origin "${BASE_REF}:__ci_base"
+        git fetch --no-tags --prune --progress --no-recurse-submodules --shallow-exclude="${BASE_REF}" origin "${PR_REF}:__ci_pr"
+        COMMIT_LIST=$(/usr/bin/git log --pretty=format:%s __ci_base..__ci_pr)
+        echo "Fixup commits:"
+        if echo "${COMMIT_LIST}" | grep -iE '^(fixup|squash|wip)'; then
+          exit 1
+        fi
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
The GitHub Action we were using only searched for `fixup!` commits (as created by `git commit --fixup`) but not for commits which start with just `fixup`, which I am used to create manually.

It happened recently that I accidentally merged a PR with such fixup commits. This change should avoid that in the future by also blocking PRs with such commits.