### PR TITLE
Better error message on invalid broker response

### DIFF
--- a/internal/brokers/broker.go
+++ b/internal/brokers/broker.go
@@ -171,7 +171,7 @@ func (b Broker) IsAuthenticated(ctx context.Context, sessionID, authenticationDa
 
 	// Validate access authentication.
 	if !slices.Contains(auth.Replies, access) {
-		return "", "", fmt.Errorf("invalid access authentication key: %v", access)
+		return "", "", fmt.Errorf("invalid broker response: %q", access)
 	}
 
 	if data == "" {

--- a/internal/brokers/testdata/golden/TestIsAuthenticated/Error_when_broker_returns_invalid_access
+++ b/internal/brokers/testdata/golden/TestIsAuthenticated/Error_when_broker_returns_invalid_access
@@ -1,4 +1,4 @@
 FIRST CALL:
 	access: 
 	data: 
-	err: invalid access authentication key: invalid
+	err: invalid broker response: "invalid"

--- a/internal/services/pam/testdata/golden/TestIsAuthenticated/Error_when_broker_returns_invalid_access/IsAuthenticated
+++ b/internal/services/pam/testdata/golden/TestIsAuthenticated/Error_when_broker_returns_invalid_access/IsAuthenticated
@@ -1,4 +1,4 @@
 FIRST CALL:
 	access: 
 	msg: 
-	err: invalid access authentication key: invalid
+	err: invalid broker response: "invalid"


### PR DESCRIPTION
"invalid access authentication key" sounds like a cryptographic key is invalid.