### PR TITLE
Fix build failure on resolute because Go backports PPA not found

### DIFF
--- a/.github/workflows/build-deb.yaml
+++ b/.github/workflows/build-deb.yaml
@@ -60,9 +60,9 @@ jobs:
         uses: canonical/desktop-engineering/gh-actions/common/build-debian@main
         with:
           docker-image: ubuntu:${{ matrix.ubuntu-version }}
-          # Add the Go backports PPA, so that we can build with a newer
-          # version of Go than the one available in the archive.
-          extra-apt-repositories: ppa:ubuntu-enterprise-desktop/golang
+          # Add the Go backports PPA if we're testing a Ubuntu release which
+          # doesn't have the required Go version in main.
+          extra-apt-repositories: ${{ (matrix.ubuntu-version == 'noble' || matrix.ubuntu-version == 'plucky') && 'ppa:ubuntu-enterprise-desktop/golang' || '' }}
           # Extra build dependencies:
           # - systemd-dev: Required to read compile time variables from systemd via pkg-config.
           extra-source-build-deps: |


### PR DESCRIPTION
We don't backport Go in our PPA because resolute already has Go 1.25 in main. However, since we still add the Go backports PPA, the build fails because `apt update` can't find the PPA's package list for resolute.

This change only adds the PPA when testing a Ubuntu releases which doesn't have the required Go version in main.