### PR TITLE
Fix bubblewrap tests on Questing

### DIFF
--- a/internal/testutils/bubblewrap.go
+++ b/internal/testutils/bubblewrap.go
@@ -99,7 +99,7 @@ func runInBubbleWrap(t *testing.T, withSudo bool, testDataPath string, env []str
 		"--ro-bind", "/etc/subgid", "/etc/subgid",
 		"--ro-bind", "/etc/sudo.conf", "/etc/sudo.conf",
 		"--ro-bind", "/etc/sudoers", "/etc/sudoers",
-		"--ro-bind", "/etc/timezone", "/etc/timezone",
+		"--ro-bind-try", "/etc/timezone", "/etc/timezone",
 		"--ro-bind", "/etc/pam.d", "/etc/pam.d",
 		"--ro-bind", "/etc/security", "/etc/security",
 	)


### PR DESCRIPTION
They failed with

    bwrap: Can't find source path /etc/timezone: No such file or directory

To reproduce, run this on main:

```
go test -v ./internal/users/locking/... -run TestUsersLockingInBubbleWrap
=== RUN   TestUsersLockingInBubbleWrap
=== PAUSE TestUsersLockingInBubbleWrap
=== CONT  TestUsersLockingInBubbleWrap
    bubblewrap.go:35: Running command: /usr/bin/bwrap --ro-bind / / --dev /dev --bind /tmp /tmp --bind /tmp/TestUsersLockingInBubbleWrap3505189964/001 /tmp/TestUsersLockingInBubbleWrap3505189964/001 --bind /tmp/TestUsersLockingInBubbleWrap3505189964/001/etc /etc --ro-bind /etc/environment /etc/environment --ro-bind /etc/localtime /etc/localtime --ro-bind /etc/login.defs /etc/login.defs --ro-bind /etc/nsswitch.conf /etc/nsswitch.conf --ro-bind /etc/passwd /etc/passwd --ro-bind /etc/shadow /etc/shadow --ro-bind /etc/subgid /etc/subgid --ro-bind /etc/sudo.conf /etc/sudo.conf --ro-bind /etc/sudoers /etc/sudoers --ro-bind /etc/timezone /etc/timezone --ro-bind /etc/pam.d /etc/pam.d --ro-bind /etc/security /etc/security --unshare-user --uid 0 /bin/true
bwrap: Can't find source path /etc/timezone: No such file or directory
    bubblewrap.go:35: Can't use unprivileged user namespaces: exit status 1
    bubblewrap.go:43: Can't use sudo non-interactively: exit status 1
        invalid option provided
        usage: sudo -h | -K | -k | -V
        usage: sudo [-BknS] [-p prompt] [-D directory] [-g group] [-u user] [-i | -s] [command [arg ...]]
        usage: sudo -v [-BknS] [-p prompt] [-g group] [-u user]
        usage: sudo -l [-BknS] [-p prompt] [-U user] [-g group] [-u user] [command [arg ...]]
        usage: sudo -e [-BknS] [-p prompt] [-D directory] [-g group] [-u user] file ...
    locking_test.go:24: Skipping test: requires root privileges or unprivileged user namespaces
--- SKIP: TestUsersLockingInBubbleWrap (0.00s)
PASS
ok  	github.com/ubuntu/authd/internal/users/locking	0.007s
```