### PR TITLE
Fix misaligned pointer conversion

### DIFF
--- a/internal/users/localentries/getgrent_c.go
+++ b/internal/users/localentries/getgrent_c.go
@@ -86,11 +86,15 @@ func strvToSlice(strv **C.char) []string {
 		return nil
 	}
 	n := C.strv_len(strv)
+	if n == 0 {
+		return nil
+	}
+
+	cStrings := unsafe.Slice(strv, int(n))
 
 	out := make([]string, int(n))
 	for i := 0; i < int(n); i++ {
-		p := *(**C.char)(unsafe.Add(unsafe.Pointer(strv), uintptr(i)*unsafe.Sizeof(*strv)))
-		out[i] = C.GoString(p)
+		out[i] = C.GoString(cStrings[i])
 	}
 	return out
 }


### PR DESCRIPTION
I've seen tests fail with:

    fatal error: checkptr: misaligned pointer conversion

    goroutine 70 gp=0xc0005a4700 m=5 mp=0xc00007f808 [running]:
    runtime.throw({0x103c1e7?, 0xc00059ba01?})
    	/home/adrian.dombeck@gmail.com/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.25.3.linux-amd64/src/runtime/panic.go:1094 +0x48 fp=0xc00059ba48 sp=0xc00059ba18 pc=0x488608
    runtime.checkptrAlignment(0xc00013901a?, 0x1?, 0x0?)
    	/home/adrian.dombeck@gmail.com/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.25.3.linux-amd64/src/runtime/checkptr.go:20 +0x6c fp=0xc00059ba68 sp=0xc00059ba48 pc=0x41a8ac
    github.com/ubuntu/authd/internal/users/localentries.strvToSlice(0xc00013901a)
    	/home/adrian.dombeck@gmail.com/projects/authd/internal/users/localentries/getgrent_c.go:92 +0xd5 fp=0xc00059bad8 sp=0xc00059ba68 pc=0x97a795

Using `unsafe.Slice` seems to fix the issue.