### PR TITLE
Draft: Try to replace the broken gocov dependency

### DIFF
--- a/.github/workflows/qa.yaml
+++ b/.github/workflows/qa.yaml
@@ -245,7 +245,7 @@ jobs:
 
           # Dependencies for Go coverage collection
           dotnet tool install -g dotnet-reportgenerator-globaltool
-          go install github.com/boumenot/gocover-cobertura@latest
+          go install github.com/boumenot/gocover-cobertura@71dbd18f1eb1fa30866e6a4114cdabaa422db2fe
 
       - name: Run tests (with coverage collection)
         if: matrix.test == 'coverage'


### PR DESCRIPTION
The "Go: Tests (coverage)" job started to fail consistently with
    
        go: downloading github.com/axw/gocov v1.1.0
        go: downloading github.com/axw/gocov v1.2.1
        go: downloading golang.org/x/tools v0.13.0
        go: downloading golang.org/x/mod v0.21.0
        go: downloading golang.org/x/sys v0.12.0
        # golang.org/x/tools/internal/tokeninternal
        Error: ../../../go/pkg/mod/golang.org/x/tools@v0.13.0/internal/tokeninternal/tokeninternal.go:78:9: invalid array length -delta * delta (constant -256 of type int64)
        Error: Process completed with exit code 1.
    
Using gocover-cobertura instead of gocov fixes the issue.
