### PR TITLE
Fix errors in t.Cleanup not being printed

### DIFF
--- a/cmd/authd/daemon/migration_test.go
+++ b/cmd/authd/daemon/migration_test.go
@@ -5,6 +5,7 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/ubuntu/authd/internal/consts"
 	"github.com/ubuntu/authd/internal/fileutils"
@@ -211,7 +212,7 @@ func TestMaybeMigrateBBoltToSQLite(t *testing.T) {
 			database, err := db.New(dbDir)
 			t.Cleanup(func() {
 				err := database.Close()
-				require.NoError(t, err)
+				assert.NoError(t, err)
 			})
 			require.NoError(t, err)
 

--- a/internal/brokers/broker_test.go
+++ b/internal/brokers/broker_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/ubuntu/authd/internal/brokers"
 	"github.com/ubuntu/authd/internal/brokers/auth"
@@ -363,7 +364,7 @@ func newBrokerForTests(t *testing.T, cfgDir, brokerCfg string) (b brokers.Broker
 
 	conn, err := testutils.GetSystemBusConnection(t)
 	require.NoError(t, err, "Setup: could not connect to system bus")
-	t.Cleanup(func() { require.NoError(t, conn.Close(), "Teardown: Failed to close the connection") })
+	t.Cleanup(func() { assert.NoError(t, conn.Close(), "Teardown: Failed to close the connection") })
 
 	b, err = brokers.NewBroker(context.Background(), cfgPath, conn)
 	require.NoError(t, err, "Setup: could not create broker")

--- a/internal/testutils/path.go
+++ b/internal/testutils/path.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -57,7 +58,7 @@ func MakeReadOnly(t *testing.T, dest string) {
 		}
 
 		err = os.Chmod(dest, mode)
-		require.NoError(t, err)
+		assert.NoError(t, err)
 	})
 }
 

--- a/internal/users/db/db_test.go
+++ b/internal/users/db/db_test.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/ubuntu/authd/internal/consts"
 	"github.com/ubuntu/authd/internal/fileutils"
@@ -929,7 +930,7 @@ func initDB(t *testing.T, dbFile string) *db.Manager {
 	if os.Getenv("SKIP_TEST_CLEANUP") == "" {
 		t.Cleanup(func() {
 			err := os.RemoveAll(dbDir)
-			require.NoError(t, err, "Cleanup: could not remove temporary database directory")
+			assert.NoError(t, err, "Cleanup: could not remove temporary database directory")
 		})
 	}
 

--- a/internal/users/idgenerator_test.go
+++ b/internal/users/idgenerator_test.go
@@ -6,6 +6,7 @@ import (
 	"math"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/ubuntu/authd/internal/users/localentries"
 )
@@ -376,7 +377,7 @@ func TestGenerateIDMocked(t *testing.T) {
 				if tc.noCleanupCheck {
 					return
 				}
-				require.Empty(t, tc.generator.pendingIDs, "Expected generator to be empty after cleanup")
+				assert.Empty(t, tc.generator.pendingIDs, "Expected generator to be empty after cleanup")
 			})
 
 			require.GreaterOrEqual(t, int(id), int(tc.genID.minID), "Id %d is less than minID %d",

--- a/internal/users/localentries/localgroups_test.go
+++ b/internal/users/localentries/localgroups_test.go
@@ -8,6 +8,7 @@ import (
 	"sync"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/ubuntu/authd/internal/fileutils"
 	"github.com/ubuntu/authd/internal/testutils"
@@ -120,7 +121,7 @@ func TestUpdatelocalentries(t *testing.T) {
 			require.NoError(t, err, "Failed to lock the local entries")
 			t.Cleanup(func() {
 				err := entriesUnlock()
-				require.NoError(t, err, "entriesUnlock should not fail to unlock the local entries")
+				assert.NoError(t, err, "entriesUnlock should not fail to unlock the local entries")
 			})
 
 			err = localentries.UpdateGroups(entries, tc.username, tc.newGroups, tc.oldGroups)
@@ -400,7 +401,7 @@ func TestRacingGroupsLockingActions(t *testing.T) {
 			require.NoError(t, err, "Failed to lock the local entries")
 			t.Cleanup(func() {
 				err := entriesUnlock()
-				require.NoError(t, err, "entriesUnlock should not fail to unlock the local entries")
+				assert.NoError(t, err, "entriesUnlock should not fail to unlock the local entries")
 			})
 
 			groups, err := localentries.GetGroupEntries(entries)

--- a/internal/users/localentries/localusers_test.go
+++ b/internal/users/localentries/localusers_test.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/ubuntu/authd/internal/users/localentries"
 	"github.com/ubuntu/authd/internal/users/types"
@@ -152,7 +153,7 @@ func TestParseLocalPasswdFile(t *testing.T) {
 			require.NoError(t, err, "Failed to lock the local entries")
 			t.Cleanup(func() {
 				err := entriesUnlock()
-				require.NoError(t, err, "entriesUnlock should not fail to unlock the local entries")
+				assert.NoError(t, err, "entriesUnlock should not fail to unlock the local entries")
 			})
 
 			got, err := le.GetLocalUserEntries()

--- a/internal/users/localentries/lockedentries_test.go
+++ b/internal/users/localentries/lockedentries_test.go
@@ -8,6 +8,7 @@ import (
 	"sync"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/ubuntu/authd/internal/users/localentries"
 	"github.com/ubuntu/authd/internal/users/types"
@@ -106,7 +107,7 @@ func TestIsUniqueUserName(t *testing.T) {
 
 	t.Cleanup(func() {
 		err := unlock()
-		require.NoError(t, err, "TearDown: Unlock should not fail, but it did")
+		assert.NoError(t, err, "TearDown: Unlock should not fail, but it did")
 	})
 
 	users, err := le.GetUserEntries()
@@ -141,7 +142,7 @@ func TestIsUniqueGroupName(t *testing.T) {
 
 	t.Cleanup(func() {
 		err := unlock()
-		require.NoError(t, err, "TearDown: Unlock should not fail, but it did")
+		assert.NoError(t, err, "TearDown: Unlock should not fail, but it did")
 	})
 
 	groups, err := le.GetGroupEntries()
@@ -176,7 +177,7 @@ func TestIsUniqueUID(t *testing.T) {
 
 	t.Cleanup(func() {
 		err := unlock()
-		require.NoError(t, err, "TearDown: Unlock should not fail, but it did")
+		assert.NoError(t, err, "TearDown: Unlock should not fail, but it did")
 	})
 
 	users, err := le.GetUserEntries()
@@ -220,7 +221,7 @@ func TestIsUniqueGID(t *testing.T) {
 
 	t.Cleanup(func() {
 		err := unlock()
-		require.NoError(t, err, "TearDown: Unlock should not fail, but it did")
+		assert.NoError(t, err, "TearDown: Unlock should not fail, but it did")
 	})
 
 	groups, err := le.GetGroupEntries()

--- a/internal/users/locking/locking_bwrap_test.go
+++ b/internal/users/locking/locking_bwrap_test.go
@@ -12,6 +12,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	userslocking "github.com/ubuntu/authd/internal/users/locking"
 )
@@ -78,7 +79,7 @@ testgroup:x:1001:testuser`
 	require.NoError(t, err, "Locking once it is allowed")
 	t.Cleanup(func() {
 		err := userslocking.WriteUnlock()
-		require.NoError(t, err, "Unlocking should be allowed")
+		assert.NoError(t, err, "Unlocking should be allowed")
 	})
 
 	output, err := runCmd(t, "getent", "group", "root", "testgroup")
@@ -186,9 +187,9 @@ func TestLockingLockedDatabase(t *testing.T) {
 	t.Cleanup(func() {
 		cancel()
 		syscall.Kill(lockerProcess.Pid, syscall.SIGKILL)
-		require.Error(t, <-lockerExited, "Stopping locking process")
-		require.NoError(t, <-writeLockExited, "Final locking")
-		require.NoError(t, userslocking.WriteUnlock(), "Final unlocking")
+		assert.Error(t, <-lockerExited, "Stopping locking process")
+		assert.NoError(t, <-writeLockExited, "Final locking")
+		assert.NoError(t, userslocking.WriteUnlock(), "Final unlocking")
 	})
 
 	go func() {
@@ -249,7 +250,7 @@ func TestLockingLockedDatabaseFailsAfterTimeout(t *testing.T) {
 	t.Cleanup(func() {
 		cancel()
 		syscall.Kill(lockerProcess.Pid, syscall.SIGKILL)
-		require.Error(t, <-lockerExited, "Stopping locking process")
+		assert.Error(t, <-lockerExited, "Stopping locking process")
 	})
 
 	go func() {

--- a/internal/users/locking/testutils.go
+++ b/internal/users/locking/testutils.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/ubuntu/authd/internal/testsdetection"
 	"github.com/ubuntu/authd/log"
@@ -212,7 +213,7 @@ func Z_ForTests_SetMaxWaitTime(t *testing.T, maxWaitTime time.Duration) {
 	maxWait = maxWaitTime
 
 	t.Cleanup(func() {
-		require.True(t, overrideMaxWait.CompareAndSwap(int64(maxWaitTime), int64(defaultMaxWait)),
+		assert.True(t, overrideMaxWait.CompareAndSwap(int64(maxWaitTime), int64(defaultMaxWait)),
 			"Waiting time has been changed: %v", overrideMaxWait.Load())
 		maxWait = defaultMaxWait
 	})

--- a/pam/integration-tests/exec_test.go
+++ b/pam/integration-tests/exec_test.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/godbus/dbus/v5"
 	"github.com/msteinert/pam/v2"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/ubuntu/authd/internal/testutils"
 	"github.com/ubuntu/authd/pam/internal/pam_test"
@@ -936,7 +937,7 @@ func preparePamTransactionForServiceFile(t *testing.T, serviceFile string, user 
 	saveArtifactsForDebugOnCleanup(t, []string{serviceFile})
 	require.NoError(t, err, "PAM: Error to initialize module")
 	require.NotNil(t, tx, "PAM: Transaction is not set")
-	t.Cleanup(func() { require.NoError(t, tx.End(), "PAM: can't end transaction") })
+	t.Cleanup(func() { assert.NoError(t, tx.End(), "PAM: can't end transaction") })
 
 	return tx
 }

--- a/pam/integration-tests/gdm_test.go
+++ b/pam/integration-tests/gdm_test.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/msteinert/pam/v2"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/ubuntu/authd/examplebroker"
 	"github.com/ubuntu/authd/internal/brokers"
@@ -952,7 +953,7 @@ func TestGdmModule(t *testing.T) {
 			gh := newGdmTestModuleHandler(t, serviceFile, pamUser)
 			t.Cleanup(func() {
 				if !timedOut {
-					require.NoError(t, gh.tx.End(), "PAM: can't end transaction")
+					assert.NoError(t, gh.tx.End(), "PAM: can't end transaction")
 				}
 			})
 			gh.eventPollResponses = tc.eventPollResponses
@@ -1063,7 +1064,7 @@ func TestGdmModuleAuthenticateWithoutGdmExtension(t *testing.T) {
 	saveArtifactsForDebugOnCleanup(t, []string{serviceFile})
 	pamUser := vhsTestUserName(t, "gdm")
 	gh := newGdmTestModuleHandler(t, serviceFile, pamUser)
-	t.Cleanup(func() { require.NoError(t, gh.tx.End(), "PAM: can't end transaction") })
+	t.Cleanup(func() { assert.NoError(t, gh.tx.End(), "PAM: can't end transaction") })
 
 	// We disable gdm extension support, as if it was the case when the module is loaded
 	// outside GDM.
@@ -1097,7 +1098,7 @@ func TestGdmModuleAcctMgmtWithoutGdmExtension(t *testing.T) {
 	saveArtifactsForDebugOnCleanup(t, []string{serviceFile})
 	pamUser := vhsTestUserName(t, "gdm")
 	gh := newGdmTestModuleHandler(t, serviceFile, pamUser)
-	t.Cleanup(func() { require.NoError(t, gh.tx.End(), "PAM: can't end transaction") })
+	t.Cleanup(func() { assert.NoError(t, gh.tx.End(), "PAM: can't end transaction") })
 
 	gh.supportedLayouts = []*authd.UILayout{pam_test.FormUILayout(pam_test.WithWait(true))}
 	gh.protoVersion = gdm.ProtoVersion

--- a/pam/integration-tests/helpers_test.go
+++ b/pam/integration-tests/helpers_test.go
@@ -15,6 +15,7 @@ import (
 	"testing"
 	"time"
 
+	assert "github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/ubuntu/authd/internal/consts"
 	"github.com/ubuntu/authd/internal/fileutils"
@@ -122,7 +123,10 @@ func sharedAuthd(t *testing.T, args ...testutils.DaemonOption) (socketPath strin
 		if sa.refCount != 0 {
 			return
 		}
-		require.NotNil(t, sa.cleanup)
+		assert.NotNil(t, sa.cleanup)
+		if sa.cleanup == nil {
+			return
+		}
 		cleanup := sa.cleanup
 		sa.socketPath = ""
 		sa.groupsOutputPath = ""
@@ -219,7 +223,7 @@ func prepareFileLogging(t *testing.T, fileName string) string {
 		if errors.Is(err, fs.ErrNotExist) {
 			return
 		}
-		require.NoError(t, err, "Teardown: Impossible to read PAM client logs")
+		assert.NoError(t, err, "Teardown: Impossible to read PAM client logs")
 		t.Log(string(out))
 	})
 

--- a/pam/integration-tests/modulehelpers_test.go
+++ b/pam/integration-tests/modulehelpers_test.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/ubuntu/authd/internal/testutils"
 	"github.com/ubuntu/authd/pam/internal/pam_test"
@@ -100,8 +101,11 @@ func buildCModule(t *testing.T, sources []string, pkgConfigDeps []string, cFlags
 				notesFilename)
 			gcov.Dir = gcovDir
 			out, err := gcov.CombinedOutput()
-			require.NoError(t, err,
+			assert.NoError(t, err,
 				"Teardown: Can't get coverage report on C library: %s", out)
+			if err != nil {
+				return
+			}
 			if string(out) != "" {
 				t.Log(string(out))
 			}
@@ -110,11 +114,14 @@ func buildCModule(t *testing.T, sources []string, pkgConfigDeps []string, cFlags
 			// an html output locally using geninfo + genhtml.
 			err = os.Rename(filepath.Join(libDir, dataFilename),
 				filepath.Join(gcovDir, dataFilename))
-			require.NoError(t, err,
+			assert.NoError(t, err,
 				"Teardown: Can't move coverage report data for c Library: %v", err)
+			if err != nil {
+				return
+			}
 			err = os.Rename(filepath.Join(libDir, notesFilename),
 				filepath.Join(gcovDir, notesFilename))
-			require.NoError(t, err,
+			assert.NoError(t, err,
 				"Teardown: Can't move coverage report notes for c Library: %v", err)
 		})
 	}

--- a/pam/integration-tests/ssh_test.go
+++ b/pam/integration-tests/ssh_test.go
@@ -21,6 +21,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/ubuntu/authd/examplebroker"
 	"github.com/ubuntu/authd/internal/grpcutils"
@@ -719,8 +720,11 @@ func startSSHd(t *testing.T, hostKey, forcedCommand string, env []string, daemon
 			return
 		}
 		sshdLog := filepath.Join(t.TempDir(), "sshd.log")
-		require.NoError(t, os.WriteFile(sshdLog, sshdStderr.Bytes(), 0600),
-			"TearDown: Saving sshd log")
+		err := os.WriteFile(sshdLog, sshdStderr.Bytes(), 0600)
+		assert.NoError(t, err, "TearDown: Saving sshd log")
+		if err != nil {
+			return
+		}
 		saveArtifactsForDebug(t, []string{sshdLog})
 	})
 
@@ -771,20 +775,32 @@ func startSSHd(t *testing.T, hostKey, forcedCommand string, env []string, daemon
 			return
 		}
 		contents, err := os.ReadFile(sshdLogFile)
-		require.NoError(t, err, "TearDown: Reading SSHd log failed")
+		assert.NoError(t, err, "TearDown: Reading SSHd log failed")
 		t.Logf(" ##### LOG FILE #####\n %s \n ##### END #####", contents)
 	})
 
 	t.Cleanup(func() {
 		pidFileContent, err := os.ReadFile(sshdPidFile)
-		require.NoError(t, err, "TearDown: Reading SSHd pid file failed")
+		assert.NoError(t, err, "TearDown: Reading SSHd pid file failed")
+		if err != nil {
+			return
+		}
 		p := strings.TrimSpace(string(pidFileContent))
 		pid, err := strconv.Atoi(p)
-		require.NoError(t, err, "TearDown: Parsing SSHd pid file content: %q", p)
+		assert.NoError(t, err, "TearDown: Parsing SSHd pid file content: %q", p)
+		if err != nil {
+			return
+		}
 		process, err := os.FindProcess(pid)
-		require.NoError(t, err, "TearDown: Finding SSHd process")
+		assert.NoError(t, err, "TearDown: Finding SSHd process")
+		if err != nil {
+			return
+		}
 		err = process.Kill()
-		require.NoError(t, err, "TearDown: Killing SSHd process")
+		assert.NoError(t, err, "TearDown: Killing SSHd process")
+		if err != nil {
+			return
+		}
 		t.Logf("SSHd pid %d killed", pid)
 	})
 

--- a/pam/integration-tests/vhs-helpers_test.go
+++ b/pam/integration-tests/vhs-helpers_test.go
@@ -17,6 +17,7 @@ import (
 	"unicode/utf8"
 
 	"github.com/msteinert/pam/v2"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/ubuntu/authd/examplebroker"
 	"github.com/ubuntu/authd/internal/proto/authd"
@@ -437,8 +438,11 @@ func (td tapeData) ExpectedOutput(t *testing.T, outputDir string) string {
 		}
 		baseName, _ := strings.CutSuffix(td.Output(), ".txt")
 		tempOutput := filepath.Join(t.TempDir(), fmt.Sprintf("%s_sanitized.txt", baseName))
-		require.NoError(t, os.WriteFile(tempOutput, []byte(got), 0600),
-			"TearDown: Saving sanitized output file %q", tempOutput)
+		err := os.WriteFile(tempOutput, []byte(got), 0600)
+		assert.NoError(t, err, "TearDown: Saving sanitized output file %q", tempOutput)
+		if err != nil {
+			return
+		}
 		saveArtifactsForDebug(t, []string{tempOutput})
 	})
 


### PR DESCRIPTION
It's a [known issue](https://github.com/golang/go/issues/29207) that using `t.FailNow()` in deferred functions can result in the error not being printed.

`t.FailNow` is also called by the `require` package, so using that in deferred functions, including `t.Cleanup` functions, can result in the error not being printed.

I can consistently reproduce that issue when the test is run in parallel and also has subtests which are run in parallel. Minimal reproducer:

    package main

    import (
    	"testing"
    	"github.com/stretchr/testify/require"
    )

    func Test(t *testing.T) {
    	t.Parallel()
    	t.Cleanup(func() { require.Fail(t, "This error is never printed") })
    	t.Run("subtest", func(t *testing.T) { t.Parallel() })
    }

Using non-fatal errors instead fixes the issue.