### PR TITLE
Set AUTHD_AUTH_MODE PAM env when an authentication mode is selected.

### DIFF
--- a/pam/internal/adapter/model.go
+++ b/pam/internal/adapter/model.go
@@ -365,8 +365,6 @@ func (m uiModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				msg:    "reselection of current auth mode without current ID",
 			})
 		}
-		// Export selected auth mode to the PAM environment.
-		m.pamMTx.PutEnv("AUTHD_AUTH_MODE=" + msg.ID)
 		return m, tea.Sequence(
 			m.updateClientModel(msg),
 			getLayout(m.client, m.currentSession.sessionID, msg.ID),
@@ -408,6 +406,8 @@ func (m uiModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 	cmds = append(cmds, m.updateClientModel(msg))
 
+	// Export last selected auth mode to the PAM environment.
+	m.pamMTx.PutEnv("AUTHD_AUTH_LAST_MODE=" + m.authModeSelectionModel.currentAuthModeSelectedID)
 	return m, tea.Batch(cmds...)
 }
 


### PR DESCRIPTION
To start off, big thank you for working on this project !
I found it extremely useful and would love to offer a tiny improvement.


### Context
My org needs to have 2FA on client devices, and that's one feature I couldn't figure out how to do.
Seems like I'm not alone (e.g. #1124 ), so I hope this PR adds value for everyone else with this requirement.

We are using authd with Entra plugin on our client and server machines. Regulations require us to enforce 2FA. 
I know it's technically the case with the "device authentication", but I don't want to make users go through it every time - it's quite slow. 

I can edit `/etc/pam.d/gdm-authd` (to take gdm as an example) and always require a yubikey, but I couldn't figure out a way to _not_ enforce a yubikey when user goes through the device auth mode. 

I want it to work specifically this way to cover the case when the user looses their yubikey -- device authentication should allow them to regain access and set up another yubikey.

### Proposed solution
I spent some time looking at pam, and from what I understood authd does either device flow or password flow internally
There is no way I can see what mode the user used. **(Let me know if I'm wrong !)** 

I then realized I can export a pam env when the user changes the authentication method.
We can read this variable downstream to branch on the authentication method, such as requiring a second factor when the user authenticates with a local password.


### GDM Example 
(please don't roll this out in production, more needs to be done here)
1. Configure a yubikey
2. /etc/pam.d/gdm-authd:
```
#%PAM-1.0
auth    [success=ok user_unknown=ignore default=bad] pam_succeed_if.so user != root quiet_success
auth    [success=ok ignore=ignore default=die authinfo_unavail=ignore] pam_authd.so debug=true

auth    [success=1 default=ignore] pam_exec.so quiet /usr/lib/x86_64-linux-gnu/security/require_u2f_when_local.sh
auth    required        pam_u2f.so cue

auth    requisite       pam_nologin.so
auth    optional        pam_gnome_keyring.so
```
3. /usr/lib/x86_64-linux-gnu/security/require_u2f_when_local.sh
```
#!/bin/sh
[ "$AUTHD_AUTH_MODE" = "newpassword" ] && exit 0
exit 1
```

With the steps above I achieved the desired functionality.
I'm no security expert, but I think this is safe. The proposed solution in the linked issue also suggested passing an env variable
Please let me know if you need supporting photo/video.

Thank you