### PR TITLE
ci: Use my fork of gocov

### DIFF
--- a/.github/workflows/qa.yaml
+++ b/.github/workflows/qa.yaml
@@ -245,7 +245,7 @@ jobs:
 
           # Dependendencies for Go coverage collection
           go install github.com/AlekSi/gocov-xml@latest
-          go install github.com/axw/gocov/gocov@latest
+          go install github.com/adombeck/gocov/gocov@latest
           dotnet tool install -g dotnet-reportgenerator-globaltool
 
       - name: Run tests (with coverage collection)


### PR DESCRIPTION
Some time after bumping the Go toolchain to 1.25, the `Go: Tests (coverage)` job started to fail consistently with:

    go: downloading github.com/axw/gocov v1.1.0
    go: downloading github.com/axw/gocov v1.2.1
    go: downloading golang.org/x/tools v0.13.0
    go: downloading golang.org/x/mod v0.21.0
    go: downloading golang.org/x/sys v0.12.0
    # golang.org/x/tools/internal/tokeninternal
    Error: ../../../go/pkg/mod/golang.org/x/tools@v0.13.0/internal/tokeninternal/tokeninternal.go:78:9: invalid array length -delta * delta (constant -256 of type int64)
    Error: Process completed with exit code 1.

To fix that, the `golang.org/x/tools` package needs to be updated in `github.com/axw/gocov`, but the package is not maintained anymore (it's a public archive).

I tried to replace `gocov` with `gocover-cobertura` in #1134 but I encountered multiple hard to debug issues. I eventually got it to work, but:
* Unlike `gocov`, it fails if any of the packages for which coverage data is available can't be found, for example because of build tags.
* After uploading the Cobertura report produced by it, codecov shows 7125 of 11549 lines covered while on main its 5399 of 6150 lines.

So it would require more work now to investigate the difference in covered lines and it will require more work to maintain the list of packages to ignore because of build tags. Forking `github.com/axw/gocov` and updating its dependencies when issues arise seems like less effort, so that's what I'm going with for now.