### PR TITLE
Fix spelling of D-Bus in our documents

### DIFF
--- a/docs/explanation/authd-architecture.md
+++ b/docs/explanation/authd-architecture.md
@@ -37,7 +37,7 @@ The broker is a trusted component within the system and serves as the interface 
 
 Internal components of authd, such as PAM and NSS modules, communicate over gRPC. The advantage of gRPC is that it delivers high performance and native streaming, with built-in security for efficient and secure communication in distributed systems.
 
-The communication between authd and the brokers is done over DBus. DBus supports message broadcasting and enables efficient resource sharing. The communication only goes from the authentication daemon to the broker, which responds to requests. The transactions are encrypted, ensuring that communications between the broker and authd are secure.
+The communication between authd and the brokers is done over D-Bus. D-Bus supports message broadcasting and enables efficient resource sharing. The communication only goes from the authentication daemon to the broker, which responds to requests. The transactions are encrypted, ensuring that communications between the broker and authd are secure.
 
 ## Links
 

--- a/pam/Hacking.md
+++ b/pam/Hacking.md
@@ -12,7 +12,7 @@ it.
  2. When used in normal PAM transactions by any other PAM application we
     instead compile the module as an executable application that is launched
     by our [`go-exec`](./go-exec/module.c) PAM module implemented in C
-    and that does some DBus communication over a private bus with the actual
+    and that does some D-Bus communication over a private bus with the actual
     PAM application.
 
 
@@ -40,9 +40,9 @@ hanging when loaded by some applications (such as `sshd`).
 As mentioned in order to make our Go PAM implementation of the PAM module to be
 reliable, we relied on a simpler C module that only acts as a wrapper between
 the actual PAM APIs and a go program that is called and that communicates with
-the actual module using a DBus private connection (where the security of that
+the actual module using a D-Bus private connection (where the security of that
 is both grantee by the fact that it's almost impossible to predict its address,
-but also by native DBus credentials checks and on child PID verification).
+but also by native D-Bus credentials checks and on child PID verification).
 
 In order to build the module and its relative companion PAM program you can do:
 


### PR DESCRIPTION
It's spelled [D-Bus](https://dbus.freedesktop.org/doc/dbus-specification.html#introduction), not DBus.