### PR TITLE
Skip long tests when running `go test -short`

### DIFF
--- a/internal/daemon/daemon_test.go
+++ b/internal/daemon/daemon_test.go
@@ -203,6 +203,10 @@ func TestServe(t *testing.T) {
 func TestQuit(t *testing.T) {
 	t.Parallel()
 
+	if testing.Short() {
+		t.Skip("skipping test in short mode.")
+	}
+
 	testCases := map[string]struct {
 		force bool
 

--- a/internal/users/locking/locking_bwrap_test.go
+++ b/internal/users/locking/locking_bwrap_test.go
@@ -23,6 +23,10 @@ var lockerBinaryPath string
 func TestLockAndWriteUnlock(t *testing.T) {
 	t.Parallel()
 
+	if testing.Short() {
+		t.Skip("skipping test in short mode.")
+	}
+
 	if !testutils.RunningInBubblewrap() {
 		testutils.RunTestInBubbleWrap(t)
 		return
@@ -106,6 +110,10 @@ testgroup:x:1001:testuser`
 
 func TestLockAndLockAgainGroupFileOverridden(t *testing.T) {
 	t.Parallel()
+
+	if testing.Short() {
+		t.Skip("skipping test in short mode.")
+	}
 
 	if !testutils.RunningInBubblewrap() {
 		testutils.RunTestInBubbleWrap(t)
@@ -209,6 +217,10 @@ func TestLockAndLockAgainGroupFile(t *testing.T) {
 func TestLockingLockedDatabase(t *testing.T) {
 	t.Parallel()
 
+	if testing.Short() {
+		t.Skip("skipping test in short mode.")
+	}
+
 	if !testutils.RunningInBubblewrap() {
 		testutils.SkipIfCannotRunBubbleWrap(t)
 		testInBubbleWrapWithLockerBinary(t)
@@ -287,6 +299,10 @@ func TestLockingLockedDatabase(t *testing.T) {
 func TestLockingLockedDatabaseFailsAfterTimeout(t *testing.T) {
 	t.Parallel()
 
+	if testing.Short() {
+		t.Skip("skipping test in short mode.")
+	}
+
 	if !testutils.RunningInBubblewrap() {
 		testInBubbleWrapWithLockerBinary(t)
 		return
@@ -341,6 +357,10 @@ func TestLockingLockedDatabaseFailsAfterTimeout(t *testing.T) {
 
 func TestLockingLockedDatabaseWorksAfterUnlock(t *testing.T) {
 	t.Parallel()
+
+	if testing.Short() {
+		t.Skip("skipping test in short mode.")
+	}
 
 	if !testutils.RunningInBubblewrap() {
 		testInBubbleWrapWithLockerBinary(t)

--- a/pam/integration-tests/cli_test.go
+++ b/pam/integration-tests/cli_test.go
@@ -24,6 +24,10 @@ const cliTapeBaseCommand = "./pam_authd %s socket=${%s}"
 func TestCLIAuthenticate(t *testing.T) {
 	t.Parallel()
 
+	if testing.Short() {
+		t.Skip("skipping test in short mode.")
+	}
+
 	clientPath := t.TempDir()
 	cliEnv := preparePamRunnerTest(t, clientPath)
 	tapeCommand := fmt.Sprintf(cliTapeBaseCommand, pam_test.RunnerActionLogin,
@@ -298,6 +302,10 @@ func TestCLIAuthenticate(t *testing.T) {
 func TestCLIChangeAuthTok(t *testing.T) {
 	t.Parallel()
 
+	if testing.Short() {
+		t.Skip("skipping test in short mode.")
+	}
+
 	clientPath := t.TempDir()
 	cliEnv := preparePamRunnerTest(t, clientPath)
 
@@ -413,6 +421,10 @@ func TestCLIChangeAuthTok(t *testing.T) {
 
 func TestPamCLIRunStandalone(t *testing.T) {
 	t.Parallel()
+
+	if testing.Short() {
+		t.Skip("skipping test in short mode.")
+	}
 
 	clientPath := t.TempDir()
 	pamCleanup, err := buildPAMRunner(clientPath)

--- a/pam/integration-tests/gdm_test.go
+++ b/pam/integration-tests/gdm_test.go
@@ -128,6 +128,10 @@ var testPhoneAckUILayout = authd.UILayout{
 
 func TestGdmModule(t *testing.T) {
 	t.Parallel()
+
+	if testing.Short() {
+		t.Skip("skipping test in short mode.")
+	}
 	t.Cleanup(pam_test.MaybeDoLeakCheck)
 
 	if !pam.CheckPamHasStartConfdir() {
@@ -1047,6 +1051,10 @@ func TestGdmModule(t *testing.T) {
 }
 
 func TestGdmModuleAuthenticateWithoutGdmExtension(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping test in short mode.")
+	}
+
 	// This cannot be parallel!
 	t.Cleanup(pam_test.MaybeDoLeakCheck)
 
@@ -1081,6 +1089,10 @@ func TestGdmModuleAuthenticateWithoutGdmExtension(t *testing.T) {
 }
 
 func TestGdmModuleAcctMgmtWithoutGdmExtension(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping test in short mode.")
+	}
+
 	// This cannot be parallel!
 	t.Cleanup(pam_test.MaybeDoLeakCheck)
 

--- a/pam/integration-tests/native_test.go
+++ b/pam/integration-tests/native_test.go
@@ -21,6 +21,10 @@ const nativeTapeBaseCommand = "./pam_authd %s socket=${%s} force_native_client=t
 func TestNativeAuthenticate(t *testing.T) {
 	t.Parallel()
 
+	if testing.Short() {
+		t.Skip("skipping test in short mode.")
+	}
+
 	clientPath := t.TempDir()
 	cliEnv := preparePamRunnerTest(t, clientPath)
 	tapeCommand := fmt.Sprintf(nativeTapeBaseCommand, pam_test.RunnerActionLogin,
@@ -478,6 +482,10 @@ func TestNativeAuthenticate(t *testing.T) {
 
 func TestNativeChangeAuthTok(t *testing.T) {
 	t.Parallel()
+
+	if testing.Short() {
+		t.Skip("skipping test in short mode.")
+	}
 
 	clientPath := t.TempDir()
 	cliEnv := preparePamRunnerTest(t, clientPath)

--- a/pam/integration-tests/ssh_test.go
+++ b/pam/integration-tests/ssh_test.go
@@ -57,6 +57,10 @@ var (
 func TestSSHAuthenticate(t *testing.T) {
 	t.Parallel()
 
+	if testing.Short() {
+		t.Skip("skipping test in short mode.")
+	}
+
 	runSharedDaemonTests := testutils.IsRace() || os.Getenv("AUTHD_TESTS_SSHD_SHARED") != ""
 
 	// We only test the single-sshd instance when in race mode.

--- a/pam/internal/adapter/gdmmodel_test.go
+++ b/pam/internal/adapter/gdmmodel_test.go
@@ -33,6 +33,10 @@ const gdmTestIgnoredMessage string = "<ignored>"
 func TestGdmModel(t *testing.T) {
 	t.Parallel()
 
+	if testing.Short() {
+		t.Skip("skipping test in short mode.")
+	}
+
 	// This is not technically an error, as it means that during the tests
 	// we've stopped the program with a Quit request.
 	// However we do return a PAM error in such case because that's what we're


### PR DESCRIPTION
This skips all tests that currently take longer than 3 seconds on my system when the `-test.short` flag is set.

Running tests with `go test -short ./...` now finishes in 10 seconds, which is much more convenient compared to the 2.5 minutes it takes to run all tests via `go test ./...`.

> [!IMPORTANT]
> This is based on https://github.com/ubuntu/authd/pull/1129, please review and merge that first.