### PR TITLE
Bump Go version to 1.25

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/ubuntu/authd
 
-go 1.24.0
+go 1.25.0
 
 toolchain go1.25.3
 


### PR DESCRIPTION
We want to use `t.Output` in our tests which is only available in Go 1.25.