### PR TITLE
tests: Use t.Output()

### DIFF
--- a/internal/testutils/bubblewrap.go
+++ b/internal/testutils/bubblewrap.go
@@ -147,8 +147,8 @@ func runInBubbleWrap(t *testing.T, withSudo bool, testDataPath string, env []str
 	}
 
 	cmd.Args = append(cmd.Args, args...)
-	cmd.Stderr = os.Stderr
-	cmd.Stdout = os.Stdout
+	cmd.Stderr = t.Output()
+	cmd.Stdout = t.Output()
 
 	t.Log("Running command:", cmd.String())
 	return cmd.Run()

--- a/internal/testutils/rust.go
+++ b/internal/testutils/rust.go
@@ -105,8 +105,8 @@ func BuildRustNSSLib(t *testing.T, disableCoverage bool, features ...string) (li
 	}
 	cmd.Env = append(os.Environ(), rustCovEnv...)
 	cmd.Dir = projectRoot
-	cmd.Stdout = os.Stdout
-	cmd.Stderr = os.Stderr
+	cmd.Stdout = t.Output()
+	cmd.Stderr = t.Output()
 
 	if isNightly && IsAsan() {
 		cmd.Env = append(cmd.Env, "RUSTFLAGS=-Zsanitizer=address")

--- a/nss/integration-tests/helper_test.go
+++ b/nss/integration-tests/helper_test.go
@@ -35,8 +35,8 @@ func getentOutputForLib(t *testing.T, libPath, socketPath string, rustCovEnv []s
 	}
 
 	var out bytes.Buffer
-	cmd.Stdout = io.MultiWriter(os.Stdout, &out)
-	cmd.Stderr = os.Stderr
+	cmd.Stdout = io.MultiWriter(t.Output(), &out)
+	cmd.Stderr = t.Output()
 
 	// We are only interested in the output and the exit code of the command, so we can ignore the error.
 	_ = cmd.Run()


### PR DESCRIPTION
Output written directly to stdout/stderr is sometimes assigned to the wrong test, even when using `go test -json`. Using `t.Output` instead avoids the problem.


> [!IMPORTANT]
> This is based on https://github.com/ubuntu/authd/pull/1129, please review and merge that first.