### PR TITLE
ci: Fix coverage tests only retried once

### DIFF
--- a/.github/workflows/qa.yaml
+++ b/.github/workflows/qa.yaml
@@ -257,8 +257,8 @@ jobs:
             gotest-rerun-failed -json -timeout ${GO_TESTS_TIMEOUT} -cover -covermode=set -- -coverpkg=./... \
               -shuffle=on -failfast -args -test.gocoverdir="${RAW_COVERAGE_DIR}" \
               < "${test_output}" \
-              | gotestfmt --logfile "${AUTHD_TESTS_ARTIFACTS_PATH}/gotestfmt.cover.retry-$i.log"
-            exit_code=$?
+              | gotestfmt --logfile "${AUTHD_TESTS_ARTIFACTS_PATH}/gotestfmt.cover.retry-$i.log" \
+              && exit_code=0 || exit_code=$?
             if [ "${exit_code}" -eq 0 ]; then
               break
             fi


### PR DESCRIPTION
The CI job exited when the first retry failed because of `set -e`. Using `|| exit_code=$?` fixes that, but we also need `&& exit_code=0` to ensure that after that command, `$exit_code` contains the exit code of that command on not the one from the last iteration.