### PR TITLE
ci: Fix artifacts not uploaded on failure

### DIFF
--- a/.github/actions/upload-test-artifacts/action.yaml
+++ b/.github/actions/upload-test-artifacts/action.yaml
@@ -4,7 +4,6 @@ runs:
   using: 'composite'
   steps:
     - name: Upload test artifacts
-      if: always()
       uses: actions/upload-artifact@v5
       with:
         name: authd-${{ github.job }}-artifacts-${{ github.run_attempt }}

--- a/.github/workflows/qa.yaml
+++ b/.github/workflows/qa.yaml
@@ -211,6 +211,7 @@ jobs:
           codecov-token: ${{ secrets.CODECOV_TOKEN }}
 
       - uses: ./.github/actions/upload-test-artifacts
+        if: always()
 
   go-tests-coverage-retry:
     name: "Retry Go Tests with Coverage Collection"
@@ -274,6 +275,7 @@ jobs:
           codecov-token: ${{ secrets.CODECOV_TOKEN }}
 
       - uses: ./.github/actions/upload-test-artifacts
+        if: always()
 
   go-tests-race:
     name: "Go Tests with Race Detector"
@@ -301,6 +303,7 @@ jobs:
           fi
 
       - uses: ./.github/actions/upload-test-artifacts
+        if: always()
 
   go-tests-asan:
     name: "Go PAM tests with Address Sanitizer"
@@ -368,3 +371,4 @@ jobs:
           exit ${exit_code}
 
       - uses: ./.github/actions/upload-test-artifacts
+        if: always()


### PR DESCRIPTION
When using a composite action, the `if: always()` needs to be in the workflow file, not in the action file.