### PR TITLE
ci: Run coverage tests without -failfast

### DIFF
--- a/.github/workflows/qa.yaml
+++ b/.github/workflows/qa.yaml
@@ -185,7 +185,7 @@ jobs:
           # we need to override it using the test.gocoverdir flag instead.
           #TODO: Update when https://go-review.googlesource.com/c/go/+/456595 is merged.
           go test -json -timeout ${GO_TESTS_TIMEOUT} -cover -covermode=set ./... -coverpkg=./... \
-            -shuffle=on -failfast -args -test.gocoverdir="${RAW_COVERAGE_DIR}" | \
+            -shuffle=on -args -test.gocoverdir="${RAW_COVERAGE_DIR}" | \
             gotestfmt --logfile "${AUTHD_TESTS_ARTIFACTS_PATH}/gotestfmt.cover.log"
 
       # Upload the test output for the go-tests-coverage-retry job which retries
@@ -257,7 +257,7 @@ jobs:
           for i in $(seq 1 3); do
             echo "Retrying failed tests (attempt ${i})"
             gotest-rerun-failed -json -timeout ${GO_TESTS_TIMEOUT} -cover -covermode=set -- -coverpkg=./... \
-              -shuffle=on -failfast -args -test.gocoverdir="${RAW_COVERAGE_DIR}" \
+              -shuffle=on -args -test.gocoverdir="${RAW_COVERAGE_DIR}" \
               < "${test_output}" \
               | gotestfmt --logfile "${AUTHD_TESTS_ARTIFACTS_PATH}/gotestfmt.cover.retry-$i.log" \
               && exit_code=0 || exit_code=$?


### PR DESCRIPTION
The `-failfast` flag has the effect that no new tests are started after the first test failure. Since we only retry the failed tests, the the skipped tests are not re-run by the retry job.

Let's run the coverage tests without` -failfast` to ensure that, if the retry job succeeds, all tests were actually run and succeeded.