### PR TITLE
Address current rust architecture.mk file

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -2,7 +2,7 @@
 #export DH_VERBOSE = 1
 
 include /usr/share/dpkg/pkg-info.mk
-include /usr/share/rustc/architecture.mk
+include /usr/share/dpkg/architecture.mk
 
 # The package name for authd, used only locally to avoid repetitions
 AUTHD_GO_PACKAGE := $(shell grep-dctrl -s XS-Go-Import-Path -n - ./debian/control)


### PR DESCRIPTION
The file has been moved from the rustc subdirectory to a per version.
The generic rustc subdirectory location does not exist anymore since24.10.
24.04 already has both locations for 1.85.
Move it to point to the location compatible with 24.04+, but we need to have a better agnostic-way in the long term.