### PR TITLE
Use consistent capitalization of "authd"

### DIFF
--- a/debian/authd.service.in
+++ b/debian/authd.service.in
@@ -1,5 +1,5 @@
 [Unit]
-Description=Authd daemon service
+Description=authd daemon service
 After=authd.socket
 Requires=authd.socket
 PartOf=authd.socket

--- a/debian/authd.socket
+++ b/debian/authd.socket
@@ -1,5 +1,5 @@
 [Unit]
-Description=Socket activation for Authd daemon
+Description=Socket activation for authd daemon
 # Ensure there's no ordering cycle since authd needs to start after dbus
 DefaultDependencies=No
 Wants=dbus.service

--- a/debian/control
+++ b/debian/control
@@ -32,10 +32,10 @@ Vcs-Browser: https://github.com/ubuntu/authd
 Vcs-Git: https://github.com/ubuntu/authd.git
 Rules-Requires-Root: no
 Description: Authentication daemon for cloud-based identity provider
- Authd is a versatile authentication service designed to seamlessly integrate
+ authd is a versatile authentication service designed to seamlessly integrate
  with cloud identity providers like OpenID Connect and Entra ID. It offers a
  secure interface for system authentication, supporting cloud-based identity
- management. Authd features a modular structure, facilitating straightforward
+ management. authd features a modular structure, facilitating straightforward
  integration with different cloud services maintaining strong security and
  effective user authentication.
 

--- a/debian/pam-configs/authd.in
+++ b/debian/pam-configs/authd.in
@@ -1,4 +1,4 @@
-Name: Authd authentication
+Name: authd authentication
 Default: yes
 Priority: 1050
 

--- a/pam/integration-tests/helpers_test.go
+++ b/pam/integration-tests/helpers_test.go
@@ -128,7 +128,7 @@ func sharedAuthd(t *testing.T, args ...testutils.DaemonOption) (socketPath strin
 
 	sa.refCount++
 	if testing.Verbose() {
-		t.Logf("Authd shared instances increased: %v", sa.refCount)
+		t.Logf("authd shared instances increased: %v", sa.refCount)
 	}
 	if sa.refCount != 1 {
 		return sa.socketPath, sa.groupsOutputPath


### PR DESCRIPTION
We have been consistently using "authd" in all lowercase in the documentation since 6c4355f372bb17ad221b01ee878d88e560f48a8e.

Let's use it consistently everywhere.