### PR TITLE
debian/postrm: Remove /etc/pam.d/gdm-authd

### DIFF
--- a/debian/authd.gdm-authd.pam
+++ b/debian/authd.gdm-authd.pam
@@ -1,6 +1,6 @@
 #%PAM-1.0
 auth    [success=ok user_unknown=ignore default=bad] pam_succeed_if.so user != root quiet_success
-auth    [success=1 ignore=ignore default=die authinfo_unavail=ignore] pam_authd.so
+auth    [success=1 ignore=ignore default=die authinfo_unavail=ignore module_unknown=ignore] pam_authd.so
 # If authd ignored the request => local broker is selected,
 # then we continue with normal stack
 auth    substack        common-auth


### PR DESCRIPTION
Having /etc/pam.d/gdm-authd around when authd was uninstalled breaks GDM.

Closes #1171
UDENG-8726