### PR TITLE
ci: Avoid unnecessary artifact downloads

### DIFF
--- a/.github/workflows/build-deb.yaml
+++ b/.github/workflows/build-deb.yaml
@@ -44,7 +44,12 @@ jobs:
         ubuntu-version: ${{ fromJSON(needs.define-versions.outputs.ubuntu-versions) }}
     outputs:
       run-id: ${{ github.run_id }}
+      pkg-name: ${{ steps.outputs.outputs.pkg-name }}
       # FIXME: Use dynamic outputs when possible: https://github.com/actions/runner/pull/2477
+      pkg-version-devel: ${{ steps.outputs.outputs.pkg-version-devel }}
+      pkg-version-questing: ${{ steps.outputs.outputs.pkg-version-questing }}
+      pkg-version-plucky: ${{ steps.outputs.outputs.pkg-version-plucky }}
+      pkg-version-noble: ${{ steps.outputs.outputs.pkg-version-noble }}
       pkg-dsc-devel:  ${{ steps.outputs.outputs.pkg-dsc-devel }}
       pkg-dsc-questing:  ${{ steps.outputs.outputs.pkg-dsc-questing }}
       pkg-dsc-plucky:  ${{ steps.outputs.outputs.pkg-dsc-plucky }}
@@ -84,6 +89,8 @@ jobs:
         id: outputs
         run: |
           (
+            echo "pkg-name=${{ env.PKG_NAME }}"
+            echo "pkg-version-${{ matrix.ubuntu-version }}=${{ env.PKG_VERSION }}"
             echo "pkg-dsc-${{ matrix.ubuntu-version }}=${{ env.PKG_DSC }}"
             echo "pkg-src-changes-${{ matrix.ubuntu-version }}=${{ env.PKG_SOURCE_CHANGES }}"
           ) >> "${GITHUB_OUTPUT}"
@@ -272,6 +279,7 @@ jobs:
       uses: actions/download-artifact@v7
       with:
         run-id: ${{ needs.build-deb-package.outputs.run-id }}
+        pattern: ${{ needs.build-deb-package.outputs.pkg-name }}_${{ env.pkg_version }}-*
         merge-multiple: true
 
     - name: Run autopkgtests


### PR DESCRIPTION
Each run-autopkgtests job downloaded the Debian packages of all the Ubuntu versions which we test. They now only download the version which they actually test.

UDENG-8690