### PR TITLE
GitHub issue template: Fix link to troubleshooting doc

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -26,7 +26,7 @@ body:
 
         **Troubleshooting**
 
-        Please read our [Troubleshooting wiki page](https://github.com/ubuntu/authd/wiki/06--Troubleshooting)
+        Please read our [Troubleshooting wiki page](https://documentation.ubuntu.com/authd/stable-docs/reference/troubleshooting/#common-issues-and-limitations)
         and see if you can find a solution to your problem there.
   - type: checkboxes
     attributes:


### PR DESCRIPTION
The link was still pointing to the GitHub wiki which we're not using anymore.

Closes #1183