### PR TITLE
GitHub issue template: Redact authd config files

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -107,7 +107,7 @@ body:
         \`\`\`
 
         #### authd broker configuration
-        $(sudo sh -c 'if ! find /etc/authd/brokers.d -name \*.conf | grep -q .; then echo ":warning: No config files in /etc/authd/brokers.d/"; else for f in /etc/authd/brokers.d/*.conf; do echo "#### $f"; echo "\`\`\`";  cat $f; echo "\`\`\`"; done; fi')
+        $(sudo sh -c 'if ! find /etc/authd/brokers.d -name \*.conf | grep -q .; then echo ":warning: No config files in /etc/authd/brokers.d/"; else for f in /etc/authd/brokers.d/*.conf; do echo "#### $f"; echo "\`\`\`";  cat $f; echo "\`\`\`"; done; fi' | sed -E 's/client_secret = .*/client_secret = <redacted>/g')
 
         #### authd-msentraid configuration
         \`\`\`


### PR DESCRIPTION
There shouldn't be any secrets in those, but the corporate laptop setup script incorrectly copied the broker config file into `/etc/authd/brokers.d`, so lets avoid accidental leakage of secrets by also redacting the content of those files.

Closes #1184
UDENG-8784