### PR TITLE
docs: Provide a command to enable debug logs in PAM module

### DIFF
--- a/docs/howto/logging.md
+++ b/docs/howto/logging.md
@@ -72,8 +72,9 @@ sudo sed -i '/pam_authd_exec\.so\|pam_authd\.so/ s/$/ debug=true/' /etc/pam.d/*
 
 ### NSS module
 
-Export `AUTHD_NSS_INFO=stderr` environment variable on any program using the
-authd NSS module to get more info on NSS requests to authd.
+To get more info on NSS requests to authd,
+export the `AUTHD_NSS_INFO=stderr` environment variable on any program using the
+authd NSS module.
 
 ### authd service
 


### PR DESCRIPTION
It's quite a lot of effort to do it manually.