### PR TITLE
TestGdmModel: Increase default timeout

### DIFF
--- a/pam/internal/adapter/gdmmodel_test.go
+++ b/pam/internal/adapter/gdmmodel_test.go
@@ -1306,7 +1306,6 @@ func TestGdmModel(t *testing.T) {
 			wantExitStatus: PamSuccess{BrokerID: firstBrokerInfo.Id},
 		},
 		"Authenticated_with_qrcode_after_auth_selection_stage_from_client_after_client_side_broker_and_auth_mode_selection": {
-			timeout: 20 * time.Second,
 			supportedLayouts: []*authd.UILayout{
 				pam_test.FormUILayout(pam_test.WithWait(true)),
 				pam_test.QrCodeUILayout(),
@@ -1465,7 +1464,6 @@ func TestGdmModel(t *testing.T) {
 			wantExitStatus: PamSuccess{BrokerID: firstBrokerInfo.Id},
 		},
 		"Authenticated_with_qrcode_regenerated_after_wait_started_at_auth_selection_stage_from_client_after_client_side_broker_and_auth_mode_selection": {
-			timeout: 20 * time.Second,
 			supportedLayouts: []*authd.UILayout{
 				pam_test.FormUILayout(pam_test.WithWait(true)),
 				pam_test.QrCodeUILayout(),
@@ -2557,7 +2555,7 @@ func TestGdmModel(t *testing.T) {
 
 				t.Log("Waiting for expected events")
 				if tc.timeout == 0 {
-					tc.timeout = 10 * time.Second
+					tc.timeout = 20 * time.Second
 				}
 				waitChan := make(chan struct{})
 				go func() {


### PR DESCRIPTION
This test is notoriously flaky in CI. Instead of increasing the timeout of even more subtests, as we already did in
cf9361274b080b507d3c3e6c776e63b38b0e9db5 and cb65a78682bf77c13062dd9d47858f79caaebf97, let's just increase the default timeout of all subtests and see if that improves things.