### PR TITLE
Better error message when failing to connect to provider

### DIFF
--- a/pam/internal/adapter/authmodeselection.go
+++ b/pam/internal/adapter/authmodeselection.go
@@ -2,7 +2,6 @@ package adapter
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/canonical/authd/internal/brokers/layouts"
 	"github.com/canonical/authd/internal/brokers/layouts/entries"
@@ -231,7 +230,7 @@ func getAuthenticationModes(client authd.PAMClient, sessionID string, uiLayouts 
 		if err != nil {
 			return pamError{
 				status: pam.ErrSystem,
-				msg:    fmt.Sprintf("could not get authentication modes: %v", err),
+				msg:    err.Error(),
 			}
 		}
 


### PR DESCRIPTION
When trying to log in as a user which doesn't have a local password yet and the broker fails to connect to the provider, we showed this error:

    could not get authentication modes: no authentication modes available for user "user@example.com"

That's not very helpful. This commit strips the "could not get authentication modes:" part.

UDENG-8817