### PR TITLE
docs: pin myst-parser extension version

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -2,7 +2,7 @@
 canonical-sphinx>=0.5.1
 
 # Extensions previously auto-loaded by canonical-sphinx
-myst-parser
+myst-parser~=4.0
 sphinx-autobuild
 sphinx-design
 sphinx-notfound-page


### PR DESCRIPTION
A new version of myst-parser (v5.0) was released and is causing issues during docs builds.

Pinning to v4.0 should fix the problem.