### PR TITLE
docs: add missing meta descriptions to docs

### DIFF
--- a/docs/explanation/authd-architecture.md
+++ b/docs/explanation/authd-architecture.md
@@ -1,3 +1,10 @@
+---
+myst:
+  html_meta:
+    "description lang=en":
+      "authd has a modular architecture, consisting of an authentication daemon and an identity broker."
+---
+
 # authd architecture
 
 authd can help organizations ensure secure identity and access management by enabling seamless cloud-based authentication of Ubuntu machines.

--- a/docs/explanation/index.md
+++ b/docs/explanation/index.md
@@ -1,3 +1,10 @@
+---
+myst:
+  html_meta:
+    "description lang=en":
+      "authd explanation guides covering architecture, security, and documentation."
+---
+
 (explanation)=
 
 # Explanation

--- a/docs/explanation/security.md
+++ b/docs/explanation/security.md
@@ -1,3 +1,10 @@
+---
+myst:
+  html_meta:
+    "description lang=en":
+      "Design decisions, security practices, and configurations affecting authd security."
+---
+
 # Security overview for authd
 
 authd lets Ubuntu systems verify user identities through trusted cloud identity

--- a/docs/explanation/structure-of-authd-documentation.md
+++ b/docs/explanation/structure-of-authd-documentation.md
@@ -1,3 +1,10 @@
+---
+myst:
+  html_meta:
+    "description lang=en":
+      "The authd documentation uses the Diátaxis structure."
+---
+
 # Structure of authd documentation
 
 The authd documentation uses the [Diátaxis structure](https://diataxis.fr/).

--- a/docs/howto/contributing.md
+++ b/docs/howto/contributing.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    "description lang=en": "Guidelines on contributing to the authd code and documentation."
+---
+
 % Include content from [../CONTRIBUTING.md](../CONTRIBUTING.md)
 ```{include} ../../CONTRIBUTING.md
     :start-after: <!-- Include start contributing intro -->

--- a/docs/howto/index.md
+++ b/docs/howto/index.md
@@ -1,3 +1,10 @@
+---
+myst:
+  html_meta:
+    "description lang=en":
+      "authd how-to guides covering installation, configuration, user login, network file systems, and contributing."
+---
+
 (howtos)=
 
 # How-to guides

--- a/docs/howto/login-gdm.md
+++ b/docs/howto/login-gdm.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    "description lang=en": "Use authd for cloud-based login to Ubuntu with GDM."
+---
+
 # Log in with GDM
 
 ## Logging in with a remote provider

--- a/docs/howto/login-ssh.md
+++ b/docs/howto/login-ssh.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    "description lang=en": "Use authd for cloud-based login to Ubuntu with SSH."
+---
+
 # Log in with SSH
 
 ## Server configuration

--- a/docs/howto/use-with-nfs.md
+++ b/docs/howto/use-with-nfs.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    "description lang=en": "Use authd with an NFS server."
+---
+
 # Using authd with NFS
 
 The user identifiers (UIDs) and group identifiers (GIDs) assigned by authd are

--- a/docs/howto/use-with-samba.md
+++ b/docs/howto/use-with-samba.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    "description lang=en": "Use authd with a Samba server."
+---
+
 # Using authd with Samba
 
 The user identifiers (UIDs) and group identifiers (GIDs) assigned by authd are

--- a/docs/reference/cloud-providers.md
+++ b/docs/reference/cloud-providers.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    "description lang=en": "Cloud providers supported by authd."
+---
+
 # Cloud providers that authd supports
 
 authd supports cloud providers through its identity brokers.

--- a/docs/reference/group-management.md
+++ b/docs/reference/group-management.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    "description lang=en": "Management of groups using authd with Microsoft Entra ID."
+---
+
 (reference::group-management)=
 # Group management
 

--- a/docs/reference/index.md
+++ b/docs/reference/index.md
@@ -1,3 +1,10 @@
+---
+myst:
+  html_meta:
+    "description lang=en":
+      "authd reference pages covering supported providers, troubleshooting, groups management, and deployment."
+---
+
 (reference)=
 
 # Reference


### PR DESCRIPTION
Meta descriptions affect the description of docs pages shown to users of search engines.

An appropriate and concise description increases the likelihood that users find what they need when searching.

Some authd docs pages have meta descriptions, but not all. This PR adds the missing ones.

UDENG-8556