### PR TITLE
docs: remove outdated symlink for linter

### DIFF
--- a/.wokeignore
+++ b/.wokeignore
@@ -1,1 +1,0 @@
-docs/.wokeignore


### PR DESCRIPTION
Woke was a linter used for docs accessibility checking in older versions of the documentation tooling, during which time
the `.wokeignore` file needed to be symlinked to the docs dir from the root of the repo.

The woke linter has since been replaced by vale for accessibility checks. We can safely remove this file and remove unneeded clutter from the repo's root.