### PR TITLE
ci: Configure dependabot for authd-oidc-brokers

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -20,7 +20,7 @@ updates:
     commit-message:
       prefix: "deps(ci)"
 
-  # Codebase
+  # authd codebase
   ## Go dependencies
   - package-ecosystem: "gomod"
     directory: "/" # Location of package manifests
@@ -59,5 +59,42 @@ updates:
       minor-updates:
         #applies-to: version-updates
         update-types: ["minor", "patch"]
+    commit-message:
+      prefix: "deps(rust)"
+
+  ## git submodules
+  - package-ecosystem: "gitsubmodule"
+    directory: "/" # Directory containing .gitmodules
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: "deps(submodule)"
+
+  # authd-oidc-brokers codebase
+  ## Go dependencies
+  - package-ecosystem: "gomod"
+    directory: "/authd-oidc-brokers" # Location of package manifests
+    schedule:
+      interval: "weekly"
+    groups:
+      minor-updates:
+        update-types: [ "minor", "patch" ]
+    commit-message:
+      prefix: "deps(go)"
+
+  - package-ecosystem: "gomod"
+    directory: "/authd-oidc-brokers/tools"
+    schedule:
+      interval: "weekly"
+    groups:
+      minor-updates:
+        update-types: [ "minor", "patch" ]
+    commit-message:
+      prefix: "deps(go-tools)"
+  ## rust-toolchain.toml
+  - package-ecosystem: "cargo"
+    directory: "/authd-oidc-brokers"
+    schedule:
+      interval: "weekly"
     commit-message:
       prefix: "deps(rust)"


### PR DESCRIPTION
We didn't merge the dependabot config in https://github.com/canonical/authd/pull/1203