### PR TITLE
ci: Skip build-deb workflow if only authd-oidc-brokers changed

### DIFF
--- a/.github/workflows/build-deb.yaml
+++ b/.github/workflows/build-deb.yaml
@@ -8,6 +8,7 @@ on:
       - .github/workflows/automatic-doc-checks.yml
       - .readthedocs.yaml
       - docs/**
+      - authd-oidc-brokers/**
     tags:
       - "*"
   pull_request:
@@ -15,6 +16,7 @@ on:
       - .github/workflows/automatic-doc-checks.yml
       - .readthedocs.yaml
       - docs/**
+      - authd-oidc-brokers/**
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
We don't have to build a new Debian package if the only changes are in the authd-oidc-brokers directory.