### PR TITLE
Add extra_scopes setting in broker.conf

### DIFF
--- a/authd-oidc-brokers/conf/broker.conf
+++ b/authd-oidc-brokers/conf/broker.conf
@@ -6,6 +6,11 @@ client_id = <CLIENT_ID>
 ## client secret to authenticate with the provider.
 #client_secret = <CLIENT_SECRET>
 
+## Comma-separated list of extra OIDC scopes to request in addition to
+## the default scopes.
+## Example: extra_scopes = offline_access
+#extra_scopes =
+
 ## Force remote authentication with the identity provider during login,
 ## even if a local method (e.g. local password) is used.
 ## This works by forcing a token refresh during login, which fails if the

--- a/authd-oidc-brokers/internal/broker/broker.go
+++ b/authd-oidc-brokers/internal/broker/broker.go
@@ -194,6 +194,8 @@ func (b *Broker) NewSession(username, lang, mode string) (sessionID, encryptionK
 	if b.provider.SupportsDeviceRegistration() && b.cfg.registerDevice {
 		scopes = consts.MicrosoftBrokerAppScopes
 	}
+	// Append extra scopes from config
+	scopes = append(scopes, b.cfg.extraScopes...)
 
 	if s.oidcServer != nil {
 		s.oauth2Config = oauth2.Config{

--- a/authd-oidc-brokers/internal/broker/config.go
+++ b/authd-oidc-brokers/internal/broker/config.go
@@ -27,6 +27,8 @@ const (
 	clientIDKey = "client_id"
 	// clientSecret is the optional client secret for this client.
 	clientSecret = "client_secret"
+	// extraScopesKey is the key in the config file for extra OIDC scopes.
+	extraScopesKey = "extra_scopes"
 
 	// entraIDSection is the section name in the config file for Microsoft Entra ID specific configuration.
 	entraIDSection = "msentraid"
@@ -90,6 +92,7 @@ type userConfig struct {
 	allowedSSHSuffixes    []string
 	extraGroups           []string
 	ownerExtraGroups      []string
+	extraScopes           []string
 
 	provider provider
 }
@@ -223,6 +226,7 @@ func parseConfig(cfgContent []byte, dropInContent []any, p provider) (userConfig
 		cfg.issuerURL = oidc.Key(issuerKey).String()
 		cfg.clientID = oidc.Key(clientIDKey).String()
 		cfg.clientSecret = oidc.Key(clientSecret).String()
+		cfg.extraScopes = oidc.Key(extraScopesKey).Strings(",")
 
 		if oidc.HasKey(forceProviderAuthenticationKey) {
 			cfg.forceProviderAuthentication, err = oidc.Key(forceProviderAuthenticationKey).Bool()

--- a/authd-oidc-brokers/internal/broker/config_test.go
+++ b/authd-oidc-brokers/internal/broker/config_test.go
@@ -27,6 +27,7 @@ client_id = client_id
 issuer = https://issuer.url.com
 client_id = client_id
 force_provider_authentication = true
+extra_scopes = groups,offline_access, some_other_scope
 
 [users]
 home_base_dir = /home

--- a/authd-oidc-brokers/internal/broker/testdata/golden/TestParseConfig/Do_not_fail_if_values_contain_a_single_template_delimiter/config.txt
+++ b/authd-oidc-brokers/internal/broker/testdata/golden/TestParseConfig/Do_not_fail_if_values_contain_a_single_template_delimiter/config.txt
@@ -12,3 +12,4 @@ homeBaseDir=
 allowedSSHSuffixes=[]
 extraGroups=[]
 ownerExtraGroups=[]
+extraScopes=[]

--- a/authd-oidc-brokers/internal/broker/testdata/golden/TestParseConfig/Successfully_parse_config_file/config.txt
+++ b/authd-oidc-brokers/internal/broker/testdata/golden/TestParseConfig/Successfully_parse_config_file/config.txt
@@ -12,3 +12,4 @@ homeBaseDir=
 allowedSSHSuffixes=[]
 extraGroups=[]
 ownerExtraGroups=[]
+extraScopes=[]

--- a/authd-oidc-brokers/internal/broker/testdata/golden/TestParseConfig/Successfully_parse_config_file_with_optional_values/config.txt
+++ b/authd-oidc-brokers/internal/broker/testdata/golden/TestParseConfig/Successfully_parse_config_file_with_optional_values/config.txt
@@ -12,3 +12,4 @@ homeBaseDir=/home
 allowedSSHSuffixes=[]
 extraGroups=[]
 ownerExtraGroups=[]
+extraScopes=[groups offline_access some_other_scope]

--- a/authd-oidc-brokers/internal/broker/testdata/golden/TestParseConfig/Successfully_parse_config_with_drop_in_files/config.txt
+++ b/authd-oidc-brokers/internal/broker/testdata/golden/TestParseConfig/Successfully_parse_config_with_drop_in_files/config.txt
@@ -12,3 +12,4 @@ homeBaseDir=/home
 allowedSSHSuffixes=[]
 extraGroups=[]
 ownerExtraGroups=[]
+extraScopes=[groups offline_access some_other_scope]


### PR DESCRIPTION
This adds the `extra_scopes` setting in the broker.conf which allows a user to add extra scopes required by a provider for the broker to function properly.

For example, the Okta provider requires an `offline_access` scope to be present in the request to return the refresh_token in response (see discussion in #1116). Hence, a user should have a way to add such scopes for the broker though broker.conf.

I have tested this locally and it works good. Have also updated the tests to make sure the parsing of the conf works as expected.