### PR TITLE
Use go-oidc constants for standard OIDC scopes in MicrosoftBrokerAppScopes

### DIFF
--- a/authd-oidc-brokers/internal/consts/oidc.go
+++ b/authd-oidc-brokers/internal/consts/oidc.go
@@ -19,7 +19,7 @@ const (
 var (
 	// MicrosoftBrokerAppScopes contains the OIDC scopes that we require for the Microsoft Authentication Broker app.
 	// The ".default" scope for the Azure Portal app is needed to acquire a token for device registration.
-	MicrosoftBrokerAppScopes = []string{"openid", "profile", "offline_access", azurePortalScope}
+	MicrosoftBrokerAppScopes = []string{oidc.ScopeOpenID, "profile", oidc.ScopeOfflineAccess, azurePortalScope}
 
 	// DefaultScopes contains the OIDC scopes that we require for all providers.
 	// Provider implementations can append additional scopes.


### PR DESCRIPTION
Replace hardcoded "openid" and "offline_access" strings with oidc.ScopeOpenID and oidc.ScopeOfflineAccess constants from the coreos/go-oidc library.

Using library-provided constants ensures consistency with the OIDC specification, reduces the risk of typos, and improves code maintainability.