### PR TITLE
docs: Use guilabel semantic markup

### DIFF
--- a/docs/howto/configure-authd.md
+++ b/docs/howto/configure-authd.md
@@ -112,7 +112,7 @@ To register a new application, in Entra, select the menu {menuselection}`Entra I
 
 ![Menu showing selection of App registrations under Applications.](../assets/app-registration.png)
 
-Then {guilabel}`New registration`
+Then {guilabel}`New registration`:
 
 ![User interface showing selection of New registration in App registrations.](../assets/new-registration.png)
 


### PR DESCRIPTION
Use guilabel semantic markup for UI elements on the configure-authd page.

Also includes some minor fixes to the docs.

UDENG-8882