### PR TITLE
e2e-tests: Create artifacts in $XDG_DATA_HOME/authd-e2e-tests

### DIFF
--- a/authd-oidc-brokers/e2e-tests/.gitignore
+++ b/authd-oidc-brokers/e2e-tests/.gitignore
@@ -1,4 +1,3 @@
-/vm/.artifacts/
 /vm/config.sh
 /.yarf
 

--- a/authd-oidc-brokers/e2e-tests/vm/provision-authd.sh
+++ b/authd-oidc-brokers/e2e-tests/vm/provision-authd.sh
@@ -5,6 +5,7 @@ set -euo pipefail
 SCRIPT_DIR="$(dirname "$(readlink -f "$0")")"
 LIB_DIR="${SCRIPT_DIR}/lib"
 SSH="${SCRIPT_DIR}/ssh.sh"
+DATA_DIR="${XDG_DATA_HOME:-$HOME/.local/share}/authd-e2e-tests"
 
 usage(){
     cat << EOF
@@ -62,7 +63,7 @@ assert_env_vars RELEASE VM_NAME_BASE BROKERS
 
 IFS=',' read -r -a BROKER_ARRAY <<< "${BROKERS}"
 
-ARTIFACTS_DIR="${SCRIPT_DIR}/.artifacts/${RELEASE}"
+ARTIFACTS_DIR="${DATA_DIR}/${RELEASE}"
 
 if [ -z "${VM_NAME:-}" ]; then
     VM_NAME="${VM_NAME_BASE}-${RELEASE}"

--- a/authd-oidc-brokers/e2e-tests/vm/provision-ubuntu.sh
+++ b/authd-oidc-brokers/e2e-tests/vm/provision-ubuntu.sh
@@ -7,6 +7,7 @@ LIB_DIR="${SCRIPT_DIR}/lib"
 SSH="${SCRIPT_DIR}/ssh.sh"
 LIBVIRT_XML_TEMPLATE="${SCRIPT_DIR}/e2e-runner-template.xml"
 CACHE_DIR="${XDG_CACHE_HOME:-$HOME/.cache}/authd-e2e-tests"
+DATA_DIR="${XDG_DATA_HOME:-$HOME/.local/share}/authd-e2e-tests"
 
 usage(){
     cat << EOF
@@ -89,7 +90,7 @@ sudo -v
 # Installing all the packages can take some time, so we set the timeout to 15 minutes
 CLOUT_INIT_TIMEOUT=900
 
-ARTIFACTS_DIR="${SCRIPT_DIR}/.artifacts/${RELEASE}"
+ARTIFACTS_DIR="${DATA_DIR}/${RELEASE}"
 CLOUD_INIT_TEMPLATE="${SCRIPT_DIR}/cloud-init-template-${RELEASE}.yaml"
 
 if [ -z "${VM_NAME:-}" ]; then


### PR DESCRIPTION
Storing the disk image inside the project directory causes issues when trying to build a snap from the project directory: The "version" part of the snap uses the entire project directory as its source, because it needs to be able to access the git history. That means all files in the project directory are copied to the snap builder, including the huge disk image and other libvirt artifacts. Not only is that inefficient, it also causes a build error because the memory snapshot files are owned by root, so the current user is not be allowed to access it.

Let's avoid that and store the libvirt artifacts in $XDG_DATA_HOME/authd-e2e-tests instead.

UDENG-8886