### PR TITLE
ci: Fix auto-updates workflow

### DIFF
--- a/.github/workflows/auto-updates.yaml
+++ b/.github/workflows/auto-updates.yaml
@@ -1,4 +1,4 @@
-name: Update translations and Rust packaging related files in main
+name: Update Rust packaging related files in main
 on:
   push:
     branches:

--- a/.github/workflows/auto-updates.yaml
+++ b/.github/workflows/auto-updates.yaml
@@ -71,14 +71,16 @@ jobs:
         run: |
           set -euo pipefail
 
+          echo "Running dh-cargo-vendored-sources"
           VENDORED_SOURCES=$(/usr/share/cargo/bin/dh-cargo-vendored-sources 2>&1) \
             || cmd_status=$?
+          echo "${VENDORED_SOURCES}"
+
           OUTPUT=$(echo "$VENDORED_SOURCES" | grep ^XS-Vendored-Sources-Rust: || true)
           if [ -z "${OUTPUT}" ]; then
             if [ "${cmd_status:-0}" -ne 0 ]; then
               # dh-cargo-vendored-sources failed because of other reason, so let's fail with it!
-              echo "dh-cargo-vendored-sources failed:"
-              echo "${VENDORED_SOURCES}"
+              echo "dh-cargo-vendored-sources failed unexpectedly (exit code ${cmd_status})"
               exit "${cmd_status}"
             fi
 

--- a/.github/workflows/auto-updates.yaml
+++ b/.github/workflows/auto-updates.yaml
@@ -3,7 +3,8 @@ on:
   push:
     branches:
       - main
-    paths-ignore:
+    paths:
+      - 'Cargo.lock'
       - 'debian/control'
 concurrency: auto-update
 


### PR DESCRIPTION
* Fix the name of the workflow
* Log output of `dh-cargo-vendored-sources`
* Fix include/exclude paths

See commit messages for details.