### PR TITLE
brokers: Bump Go toolchain version to 1.24.12

### DIFF
--- a/authd-oidc-brokers/go.mod
+++ b/authd-oidc-brokers/go.mod
@@ -2,7 +2,7 @@ module github.com/canonical/authd/authd-oidc-brokers
 
 go 1.24.0
 
-toolchain go1.24.11
+toolchain go1.24.12
 
 require (
 	github.com/Azure/azure-sdk-for-go/sdk/azcore v1.21.0

--- a/authd-oidc-brokers/tools/go.mod
+++ b/authd-oidc-brokers/tools/go.mod
@@ -2,7 +2,7 @@ module github.com/canonical/authd/authd-oidc-brokers/tools
 
 go 1.24.0
 
-toolchain go1.24.11
+toolchain go1.24.12
 
 require (
 	github.com/golangci/golangci-lint/v2 v2.8.0


### PR DESCRIPTION
govulncheck reports the following vulnerabilities in go1.24.11

```
Vulnerability #1: GO-2026-4341
    Memory exhaustion in query parameter parsing in net/url
  More info: https://pkg.go.dev/vuln/GO-2026-4341
  Standard library
    Found in: net/url@go1.24.11
    Fixed in: net/url@go1.24.12
    Example traces found:
Error:       #1: internal/broker/broker.go:482:51: broker.Broker.generateUILayout calls oauth2.Config.DeviceAuth, which eventually calls url.ParseQuery
Error:       #2: internal/providers/msentraid/msmock_test.go:175:18: msentraid_test.mockMSServer.handleAuthorizeRequest calls url.URL.Query

Vulnerability #2: GO-2026-4340
    Handshake messages may be processed at the incorrect encryption level in
    crypto/tls
  More info: https://pkg.go.dev/vuln/GO-2026-4340
  Standard library
    Found in: crypto/tls@go1.24.11
    Fixed in: crypto/tls@go1.24.12
    Example traces found:
Error:       #1: internal/testutils/provider.go:104:14: testutils.StartMockProviderServer calls httptest.Server.Start, which eventually calls tls.Conn.HandshakeContext
Error:       #2: cmd/authd-oidc/daemon/daemon_test.go:211:18: daemon_test.TestAppCanSigHupWithoutExecute calls io.Copy, which eventually calls tls.Conn.Read
Error:       #3: cmd/authd-oidc/daemon/daemon_test.go:399:14: daemon_test.TestMain calls fmt.Fprintf, which calls tls.Conn.Write
Error:       #4: internal/broker/broker.go:482:51: broker.Broker.generateUILayout calls oauth2.Config.DeviceAuth, which eventually calls tls.Dialer.DialContext
```