### PR TITLE
move AADSTS70043 error code to IsTokenExpiredError

### DIFF
--- a/authd-oidc-brokers/internal/providers/msentraid/msentraid.go
+++ b/authd-oidc-brokers/internal/providers/msentraid/msentraid.go
@@ -533,10 +533,10 @@ func (c azureTokenCredential) GetToken(_ context.Context, _ policy.TokenRequestO
 
 // IsTokenExpiredError returns true if the reason for the error is that the refresh token is expired.
 func (p *Provider) IsTokenExpiredError(err *oauth2.RetrieveError) bool {
-	return err.ErrorCode == "invalid_grant" && strings.HasPrefix(err.ErrorDescription, "AADSTS50173:")
+	return err.ErrorCode == "invalid_grant" && (strings.HasPrefix(err.ErrorDescription, "AADSTS50173:") || strings.HasPrefix(err.ErrorDescription, "AADSTS70043:"))
 }
 
 // IsUserDisabledError returns true if the reason for the error is that the user is disabled.
 func (p *Provider) IsUserDisabledError(err *oauth2.RetrieveError) bool {
-	return err.ErrorCode == "invalid_grant" && (strings.HasPrefix(err.ErrorDescription, "AADSTS50057:") || strings.HasPrefix(err.ErrorDescription, "AADSTS70043:"))
+	return err.ErrorCode == "invalid_grant" && strings.HasPrefix(err.ErrorDescription, "AADSTS50057:")
 }


### PR DESCRIPTION
This commit fixes a mix up from this PR: https://github.com/ubuntu/authd-oidc-brokers/pull/821/changes

During the shuffle of opening a new PR, the new error code condition was moved to the wrong error function (IsUserDisabledError instead of IsTokenExpiredError). You can see in the linked PR that it was actually intended to be alongside IsTokenExpiredError / AADSTS50173.

The customer who requested this change noticed the incorrect error message, but otherwise reports that it correctly captured the AADSTS70043 error code.