### PR TITLE
Bump Go toolchain version to 1.25.7

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/canonical/authd
 
 go 1.25.0
 
-toolchain go1.25.6
+toolchain go1.25.7
 
 require (
 	github.com/charmbracelet/bubbles v0.20.0

--- a/tools/go.mod
+++ b/tools/go.mod
@@ -2,7 +2,7 @@ module github.com/canonical/authd/tools
 
 go 1.24.0
 
-toolchain go1.25.6
+toolchain go1.25.7
 
 require (
 	github.com/golang/protobuf v1.5.4


### PR DESCRIPTION
govulncheck reports the following vulnerabilities in go1.25.6

```
Vulnerability #1: GO-2026-4337
    Unexpected session resumption in crypto/tls
  More info: https://pkg.go.dev/vuln/GO-2026-4337
  Standard library
    Found in: crypto/tls@go1.25.6
    Fixed in: crypto/tls@go1.25.7
    Example traces found:
Error:       #1: pam/integration-tests/ssh_test.go:720:30: integration.startSSHD calls httptest.NewServer, which eventually calls tls.Conn.HandshakeContext
Error:       #2: cmd/authd/daemon/daemon_test.go:248:18: daemon_test.TestAppCanSigHupWithoutExecute calls io.Copy, which eventually calls tls.Conn.Read
Error:       #3: internal/services/pam/pam_test.go:895:14: pam_test.TestMain calls fmt.Fprintf, which calls tls.Conn.Write
```