### PR TITLE
provider: Only use verified email as username

### DIFF
--- a/authd-oidc-brokers/internal/providers/genericprovider/genericprovider.go
+++ b/authd-oidc-brokers/internal/providers/genericprovider/genericprovider.go
@@ -48,6 +48,10 @@ func (p GenericProvider) GetUserInfo(idToken info.Claimer) (info.User, error) {
 		return info.User{}, err
 	}
 
+	if userClaims.Email == "" {
+		return info.User{}, fmt.Errorf("authentication failure: email claim is missing in the ID token")
+	}
+
 	if !userClaims.EmailVerified {
 		return info.User{}, &providerErrors.ForDisplayError{Message: "Authentication failure: email not verified"}
 	}

--- a/authd-oidc-brokers/internal/providers/genericprovider/genericprovider.go
+++ b/authd-oidc-brokers/internal/providers/genericprovider/genericprovider.go
@@ -48,6 +48,10 @@ func (p GenericProvider) GetUserInfo(idToken info.Claimer) (info.User, error) {
 		return info.User{}, err
 	}
 
+	if !userClaims.EmailVerified {
+		return info.User{}, &providerErrors.ForDisplayError{Message: "Authentication failure: email not verified"}
+	}
+
 	return info.NewUser(
 		userClaims.Email,
 		userClaims.Home,
@@ -83,11 +87,12 @@ func (p GenericProvider) SupportedOIDCAuthModes() []string {
 }
 
 type claims struct {
-	Email string `json:"email"`
-	Sub   string `json:"sub"`
-	Home  string `json:"home"`
-	Shell string `json:"shell"`
-	Gecos string `json:"gecos"`
+	Email         string `json:"email"`
+	Sub           string `json:"sub"`
+	Home          string `json:"home"`
+	Shell         string `json:"shell"`
+	Gecos         string `json:"gecos"`
+	EmailVerified bool   `json:"email_verified"`
 }
 
 // userClaims returns the user claims parsed from the ID token.

--- a/authd-oidc-brokers/internal/providers/genericprovider/genericprovider.go
+++ b/authd-oidc-brokers/internal/providers/genericprovider/genericprovider.go
@@ -48,6 +48,10 @@ func (p GenericProvider) GetUserInfo(idToken info.Claimer) (info.User, error) {
 		return info.User{}, err
 	}
 
+	if userClaims.Sub == "" {
+		return info.User{}, fmt.Errorf("authentication failure: sub claim is missing in the ID token")
+	}
+
 	if userClaims.Email == "" {
 		return info.User{}, fmt.Errorf("authentication failure: email claim is missing in the ID token")
 	}

--- a/authd-oidc-brokers/internal/providers/genericprovider/genericprovider_test.go
+++ b/authd-oidc-brokers/internal/providers/genericprovider/genericprovider_test.go
@@ -1,0 +1,114 @@
+package genericprovider_test
+
+import (
+	"encoding/json"
+	"fmt"
+	"testing"
+
+	providerErrors "github.com/canonical/authd/authd-oidc-brokers/internal/providers/errors"
+	"github.com/canonical/authd/authd-oidc-brokers/internal/providers/genericprovider"
+	"github.com/canonical/authd/authd-oidc-brokers/internal/providers/info"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetUserInfo(t *testing.T) {
+	t.Parallel()
+
+	tests := map[string]struct {
+		claims      map[string]interface{}
+		wantUser    info.User
+		wantErr     bool
+		wantErrType error
+	}{
+		"Successfully_get_user_info_with_all_fields": {
+			claims: map[string]interface{}{
+				"sub":            "sub123",
+				"email":          "user@example.com",
+				"email_verified": true,
+				"home":           "/home/user",
+				"shell":          "/bin/bash",
+				"gecos":          "Test User",
+			},
+			wantUser: info.NewUser("user@example.com", "/home/user", "sub123", "/bin/bash", "Test User", nil),
+		},
+		"Successfully_get_user_info_with_minimal_fields": {
+			claims: map[string]interface{}{
+				"sub":            "sub123",
+				"email":          "user@example.com",
+				"email_verified": true,
+			},
+			wantUser: info.NewUser("user@example.com", "", "sub123", "", "", nil),
+		},
+
+		"Error_when_sub_is_missing": {
+			claims: map[string]interface{}{
+				"email":          "user@example.com",
+				"email_verified": false,
+			},
+			wantErr: true,
+		},
+		"Error_when_email_is_missing": {
+			claims: map[string]interface{}{
+				"sub": "sub123",
+			},
+			wantErr: true,
+		},
+		"Error_when_email_verified_is_missing": {
+			claims: map[string]interface{}{
+				"sub":   "sub123",
+				"email": "user@example.com",
+			},
+			wantErr:     true,
+			wantErrType: &providerErrors.ForDisplayError{},
+		},
+		"Error_when_email_is_not_verified": {
+			claims: map[string]interface{}{
+				"email":          "user@example.com",
+				"sub":            "sub123",
+				"email_verified": false,
+			},
+			wantErr:     true,
+			wantErrType: &providerErrors.ForDisplayError{},
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			p := genericprovider.New()
+			mockToken := &mockIDToken{claims: tc.claims}
+
+			user, err := p.GetUserInfo(mockToken)
+			t.Logf("GetUserInfo error: %v", err)
+
+			if tc.wantErr {
+				require.Error(t, err)
+				return
+			}
+			if tc.wantErrType != nil {
+				require.ErrorIs(t, err, tc.wantErrType)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, tc.wantUser, user)
+		})
+	}
+}
+
+type mockIDToken struct {
+	claims map[string]interface{}
+}
+
+func (m *mockIDToken) Claims(v interface{}) error {
+	data, err := json.Marshal(m.claims)
+	if err != nil {
+		return fmt.Errorf("failed to marshal claims: %v", err)
+	}
+
+	if err := json.Unmarshal(data, v); err != nil {
+		return fmt.Errorf("failed to unmarshal claims: %v", err)
+	}
+
+	return nil
+}


### PR DESCRIPTION
Keycloak allows users to change their email address themselves without verifying it first. The ID token includes an `email_verified` claim which we now check and return an error if it's false, to avoid that users can log in with arbitrary usernames.

This method of the genericprovider is also used by the Google provider which also includes the `email_verified` claim in the ID token.

The `email_verified` claim is in fact defined as a standard claim in the OIDC spec (which doesn't mean that all IdPs have to set it).

UDENG-8970