### PR TITLE
brokers: Bump Go version to 1.25

### DIFF
--- a/authd-oidc-brokers/go.mod
+++ b/authd-oidc-brokers/go.mod
@@ -1,8 +1,8 @@
 module github.com/canonical/authd/authd-oidc-brokers
 
-go 1.24.0
+go 1.25.0
 
-toolchain go1.24.12
+toolchain go1.25.7
 
 require (
 	github.com/Azure/azure-sdk-for-go/sdk/azcore v1.21.0

--- a/authd-oidc-brokers/tools/go.mod
+++ b/authd-oidc-brokers/tools/go.mod
@@ -1,8 +1,8 @@
 module github.com/canonical/authd/authd-oidc-brokers/tools
 
-go 1.24.0
+go 1.25.0
 
-toolchain go1.24.12
+toolchain go1.25.7
 
 require (
 	github.com/golangci/golangci-lint/v2 v2.8.0


### PR DESCRIPTION
govulncheck reports the following vulnerabilities in go1.24.12

```
Vulnerability #1: GO-2026-4337
    Unexpected session resumption in crypto/tls
  More info: https://pkg.go.dev/vuln/GO-2026-4337
  Standard library
    Found in: crypto/tls@go1.24.12
    Fixed in: crypto/tls@go1.24.13
    Example traces found:
Error:       #1: internal/testutils/provider.go:104:14: testutils.StartMockProviderServer calls httptest.Server.Start, which eventually calls tls.Conn.HandshakeContext
Error:       #2: cmd/authd-oidc/daemon/daemon_test.go:211:18: daemon_test.TestAppCanSigHupWithoutExecute calls io.Copy, which eventually calls tls.Conn.Read
Error:       #3: cmd/authd-oidc/daemon/daemon_test.go:399:14: daemon_test.TestMain calls fmt.Fprintf, which calls tls.Conn.Write
Error:       #4: internal/broker/broker.go:482:51: broker.Broker.generateUILayout calls oauth2.Config.DeviceAuth, which eventually calls tls.Dialer.DialContext
```

We bump the Go version of the brokers from 1.24 to 1.25 and the Go toolchain version to 1.25.7 instead of 1.24.13 to reduce maintenance effort. It matches the version used by authd, so we can now bump the version used by authd and the version used by the brokers in a single PR.