### PR TITLE
Fix device login URL being printed twice

### DIFF
--- a/authd-oidc-brokers/internal/broker/broker.go
+++ b/authd-oidc-brokers/internal/broker/broker.go
@@ -486,22 +486,16 @@ func (b *Broker) generateUILayout(session *session, authModeID string) (map[stri
 		session.deviceAuthResponse = response
 		log.Debug(ctx, "Retrieved device code.")
 
-		label := fmt.Sprintf(
-			"Access %q and use the provided login code",
-			response.VerificationURI,
-		)
+		label := "Open the URL and enter the code below."
 		if authModeID == authmodes.DeviceQr {
-			label = fmt.Sprintf(
-				"Scan the QR code or access %q and use the provided login code",
-				response.VerificationURI,
-			)
+			label = "Scan the QR code or open the URL and enter the code below."
 		}
 
 		uiLayout = map[string]string{
 			"type":    "qrcode",
 			"label":   label,
 			"wait":    "true",
-			"button":  "Request new login code",
+			"button":  "Request new code",
 			"content": response.VerificationURI,
 			"code":    response.UserCode,
 		}

--- a/authd-oidc-brokers/internal/broker/testdata/golden/TestSelectAuthenticationMode/Successfully_select_device_auth
+++ b/authd-oidc-brokers/internal/broker/testdata/golden/TestSelectAuthenticationMode/Successfully_select_device_auth
@@ -1,6 +1,6 @@
-button: Request new login code
+button: Request new code
 code: user_code
 content: https://verification_uri.com
-label: Access "https://verification_uri.com" and use the provided login code
+label: Open the URL and enter the code below.
 type: qrcode
 wait: "true"

--- a/authd-oidc-brokers/internal/broker/testdata/golden/TestSelectAuthenticationMode/Successfully_select_device_auth_qr
+++ b/authd-oidc-brokers/internal/broker/testdata/golden/TestSelectAuthenticationMode/Successfully_select_device_auth_qr
@@ -1,6 +1,6 @@
-button: Request new login code
+button: Request new code
 code: user_code
 content: https://verification_uri.com
-label: Scan the QR code or access "https://verification_uri.com" and use the provided login code
+label: Scan the QR code or open the URL and enter the code below.
 type: qrcode
 wait: "true"

--- a/e2e-tests/resources/authd-google/broker.resource
+++ b/e2e-tests/resources/authd-google/broker.resource
@@ -54,7 +54,7 @@ Select Provider
 
 Regenerate QR Code
     # As long as we are in the login process, we can regenerate the QR code
-    Match Text    Request new login code    120
+    Match Text    Request new code    120
     Hid.Keys Combo    Return
     Match Text    google.com/device    15
 

--- a/e2e-tests/resources/authd-msentraid/broker.resource
+++ b/e2e-tests/resources/authd-msentraid/broker.resource
@@ -58,7 +58,7 @@ Select Provider
 
 Regenerate QR Code
     # As long as we are in the login process, we can regenerate the QR code
-    Match Text    Request new login code    120
+    Match Text    Request new code    120
     Hid.Keys Combo    Return
     Match Text    microsoft.com/devicelogin    15
 


### PR DESCRIPTION
Closes #682

Current output for SSH login attempt after the fix
```
== Device Authentication ==
Access the link below and use the provided login code
https://www.google.com/device
        FNC-YVC-MMQX
```
