### PR TITLE
Fix "Build debian packages" workflow 

### DIFF
--- a/.github/workflows/build-deb.yaml
+++ b/.github/workflows/build-deb.yaml
@@ -233,6 +233,31 @@ jobs:
       with:
         fetch-depth: 100
         path: repo
+        persist-credentials: true
+
+    - name: Checkout packaging branch
+      uses: actions/checkout@v6
+      with:
+        path: packaging-branch
+        persist-credentials: true
+        fetch-depth: 0
+
+    - name: Prepare packaging branch
+      run: |
+        set -euo pipefail
+
+        cd packaging-branch
+
+        # Checkout to the packaging branch if it exists, otherwise create a new orphan branch with a clean state to make
+        # sure we don't accidentally include files from the repository that are not part of the package sources.
+        if git ls-remote --exit-code --heads origin "${{ env.PACKAGING_BRANCH }}" >/dev/null 2>&1; then
+          git fetch origin "${{ env.PACKAGING_BRANCH }}"
+          git checkout -B "${{ env.PACKAGING_BRANCH }}" "origin/${{ env.PACKAGING_BRANCH }}"
+        else
+          git checkout --orphan "${{ env.PACKAGING_BRANCH }}"
+          git rm -rf . >/dev/null 2>&1 || true
+          git clean -fdx
+        fi
 
     - name: Extract the debian sources
       run: |
@@ -244,16 +269,11 @@ jobs:
       run: |
         set -exuo pipefail
 
-        # Create or switch to the packaging branch
-        if git -C repo fetch --depth=1 origin "${{ env.PACKAGING_BRANCH }}:${{ env.PACKAGING_BRANCH }}"; then
-          git -C repo checkout "${{ env.PACKAGING_BRANCH }}"
-        else
-          git -C repo checkout -b "${{ env.PACKAGING_BRANCH }}"
-        fi
-
         # Replace the repository content with the package sources
-        mv repo/.git sources/
-        cd sources
+        find packaging-branch -mindepth 1 -maxdepth 1 ! -name .git -exec rm -rf {} +
+        cp --force --recursive sources/. packaging-branch/
+
+        cd packaging-branch
 
         # Drop the ubuntu version, as the PPA recipe will add it anyways
         version=$(dpkg-parsechangelog -SVersion)
@@ -276,7 +296,7 @@ jobs:
       run: |
         set -exuo pipefail
 
-        git -C sources push origin "${{ env.PACKAGING_BRANCH }}:${{ env.PACKAGING_BRANCH }}"
+        git -C packaging-branch push origin "${{ env.PACKAGING_BRANCH }}:${{ env.PACKAGING_BRANCH }}"
 
   run-autopkgtests:
     name: Run autopkgtests


### PR DESCRIPTION
The action was failing when trying to push changes to the release branch, as can be seen [here](https://github.com/canonical/authd/actions/runs/21762796624/job/62792276228). The issue seems like an authentication issue with GitHub, which is fixed in this PR.

Fixed run: https://github.com/canonical/authd/actions/runs/22622136237/job/65549437796


UDENG-8983