### PR TITLE
debian/rules: Specify Go packages to build

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -44,10 +44,11 @@ export AUTHD_SKIP_EXTERNAL_DEPENDENT_TESTS=1
 export AUTHD_SKIP_ROOT_TESTS := 1
 
 # Defines the targets to be built as part of dh_auto_build
-export DH_GOLANG_BUILDPKG := $(AUTHD_GO_PACKAGE)/... \
+export DH_GOLANG_BUILDPKG := \
+    $(AUTHD_GO_PACKAGE)/cmd/authctl \
+    $(AUTHD_GO_PACKAGE)/cmd/authd \
+	$(AUTHD_GO_PACKAGE)/pam \
 	$(NULL)
-export DH_GOLANG_EXCLUDES := authd-oidc-brokers/ cmd/authctl/internal/docgen/
-export DH_GOLANG_EXCLUDES_ALL := 1
 
 # We add the required backported version to the $PATH so that if it exists, then
 # we can use it. Otherwise we default to the go installed in original $PATH that

--- a/tools/generate-proto.sh
+++ b/tools/generate-proto.sh
@@ -3,7 +3,7 @@
 set -euo pipefail
 
 if [ -v DEB_HOST_GNU_TYPE ]; then
-    echo "Proto files should not be regenerated during package building"
+    echo "generate-proto.sh: Package build environment detected, skipping proto generation"
     exit 0
 fi
 


### PR DESCRIPTION
Fixes the build of the Debian package to fail with:

    dh_missing: warning: usr/bin/docgen exists in debian/tmp but is not installed to anywhere
    dh_missing: error: missing files, aborting