### PR TITLE
pam: show password prompt directly on TTY if possible

### DIFF
--- a/pam/pam.go
+++ b/pam/pam.go
@@ -294,7 +294,7 @@ func (h *pamModule) handleAuthRequest(mode authd.SessionMode, mTx pam.ModuleTran
 		pamClientType = adapter.InteractiveTerminal
 		tty, cleanup := adapter.GetPamTTY(mTx)
 		defer cleanup()
-		teaOpts = append(teaOpts, tea.WithInput(tty))
+		teaOpts = append(teaOpts, tea.WithOutput(tty), tea.WithInput(tty))
 	} else {
 		pamClientType = adapter.Native
 		modeOpts, err := adapter.TeaHeadlessOptions()


### PR DESCRIPTION
Closes #1230 

This makes PAM to write authentication prompt while executing sudo directly to tty in order to make sure it is visible even if stdout/stderr are redirected. 

Verified locally, it is working as expected.

```
<redacted>@authd-test:~$ sudo ls > /dev/null 2>&1
Enter your local password:                                                                                              
> ***                                                                                                                   
                                                                                                                        
  Press escape key to go back to select the authentication method
```