### PR TITLE
fix: use max of GIDMax and UIDMax when checking generated GID upper bound in TestConcurrentUserUpdate

### DIFF
--- a/internal/users/manager_test.go
+++ b/internal/users/manager_test.go
@@ -609,7 +609,10 @@ func TestConcurrentUserUpdate(t *testing.T) {
 
 			require.GreaterOrEqual(t, g.GID, idGenerator.GIDMin,
 				"Generated GID should be an ID greater or equal to the minimum")
-			require.LessOrEqual(t, g.GID, idGenerator.GIDMax,
+			// The GID of user private groups is set to the same value as the UID, even if GIDMax is smaller,
+			// so we need to check that the generated GID is less or equal to the maximum between GIDMax and UIDMax.
+			gidMax := max(idGenerator.GIDMax, idGenerator.UIDMax)
+			require.LessOrEqual(t, g.GID, gidMax,
 				"Generate GID should be an ID less or equal to the maximum")
 		}
 	})


### PR DESCRIPTION
This PR fixes a failure in `TestConcurrentUserUpdate/Database_checks` on main branch. 
```
23:01:17 DEBUG TestOverride: Local entries unlocked!
--- FAIL: TestConcurrentUserUpdate (0.02s)
    --- FAIL: TestConcurrentUserUpdate/Database_checks (1.49s)
        /home/shiv/work/authd_workspace/authd/internal/users/manager_test.go:612: 
            	Error Trace:	/home/shiv/work/authd_workspace/authd/internal/users/manager_test.go:612
            	Error:      	"385" is not less than or equal to "384"
            	Test:       	TestConcurrentUserUpdate/Database_checks
            	Messages:   	Generate GID should be an ID less or equal to the maximum
FAIL
FAIL	github.com/canonical/authd/internal/users	1.510s
FAIL
```

The root cause was that the ID generator also considers local users private GIDs as already used

https://github.com/canonical/authd/blob/759dcc07f52d4348ba44dbc529ae087d21f51fff/internal/users/idgenerator.go#L272

As a result, the effective pool of available GID slots was smaller than assumed in the test, leading to premature exhaustion and overflow of the expected upper bound.

To address this, we relax the maximum allowed GID in the test to account for system local user GIDs being included in the allocation space.

**Edit: The actual root cause was something else. Described in [this](https://github.com/canonical/authd/pull/1284#issuecomment-3943707333) comment.**