### PR TITLE
Allow login for user with group named same as a system group

### DIFF
--- a/internal/users/manager.go
+++ b/internal/users/manager.go
@@ -281,9 +281,10 @@ func (m *Manager) UpdateUser(u types.UserInfo) (err error) {
 			if err != nil {
 				return err
 			}
+			// If a system group with that name already exists, we log a warning and skip the creation of this group.
 			if !unique {
-				log.Warningf(context.Background(), "Group %q already exists", g.Name)
-				return fmt.Errorf("another system group exists with %q name", g.Name)
+				log.Warningf(context.Background(), "Group '%[1]s' already exists on the system, skipping creation. To have the user added to this local group, add them to the IdP group 'linux-%[1]s'.", g.Name)
+				continue
 			}
 
 			gid, cleanupGID, err := m.idGenerator.GenerateGID(lockedEntries, m)

--- a/internal/users/manager_test.go
+++ b/internal/users/manager_test.go
@@ -195,13 +195,13 @@ func TestUpdateUser(t *testing.T) {
 		"GID_does_not_change_if_group_with_same_UGID_exists":                {groupsCase: "different-name-same-ugid", dbFile: "one_user_and_group"},
 		"GID_does_not_change_if_group_with_same_name_and_empty_UGID_exists": {groupsCase: "authd-group", dbFile: "group-with-empty-UGID"},
 		"Removing_last_user_from_a_group_keeps_the_group_record":            {groupsCase: "no-groups", dbFile: "one_user_and_group"},
+		"Allow_login_with_existing_group_on_system":                         {groupsCase: "group-exists-on-system"},
 
 		"Error_if_user_has_no_username":                           {userCase: "nameless", wantErr: true, noOutput: true},
 		"Error_if_group_has_no_name":                              {groupsCase: "nameless-group", wantErr: true, noOutput: true},
 		"Error_if_group_has_conflicting_gid":                      {groupsCase: "different-name-same-gid", dbFile: "one_user_and_group", wantErr: true, noOutput: true},
 		"Error_if_group_with_same_name_but_different_UGID_exists": {groupsCase: "authd-group", dbFile: "one_user_and_group", wantErr: true, noOutput: true},
 		"Error_if_user_exists_on_system":                          {userCase: "user-exists-on-system", wantErr: true, noOutput: true},
-		"Error_if_group_exists_on_system":                         {groupsCase: "group-exists-on-system", wantErr: true, noOutput: true},
 	}
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
@@ -389,10 +389,10 @@ func TestConcurrentUserUpdate(t *testing.T) {
 	idGenerator := &users.IDGenerator{
 		UIDMin: 0,
 		//nolint: gosec // we're in tests, overflow is very unlikely to happen.
-		UIDMax: uint32(len(systemPasswd)) + nIterations*preAuthIterations,
+		UIDMax: uint32(len(systemPasswd)) + nIterations*preAuthIterations + uint32(len(systemGroups)),
 		GIDMin: 0,
 		//nolint: gosec // we're in tests, overflow is very unlikely to happen.
-		GIDMax: uint32(len(systemGroups)) + nIterations*perUserGroups,
+		GIDMax: uint32(len(systemGroups)) + nIterations*perUserGroups + uint32(len(systemGroups)),
 	}
 	m := newManagerForTests(t, dbDir, users.WithIDGenerator(idGenerator))
 
@@ -482,8 +482,9 @@ func TestConcurrentUserUpdate(t *testing.T) {
 		})
 	}
 
+	// Test that adding users with the same name as system users fails
 	for _, u := range systemPasswd {
-		t.Run(fmt.Sprintf("Error_updating_user_%s", u.Name), func(t *testing.T) {
+		t.Run(fmt.Sprintf("Error_updating_user_with_name_conflict_%s", u.Name), func(t *testing.T) {
 			t.Parallel()
 
 			err := m.UpdateUser(types.UserInfo{
@@ -495,11 +496,12 @@ func TestConcurrentUserUpdate(t *testing.T) {
 		})
 	}
 
+	// Test that adding users with groups with the same name as local groups does not fail (we print a warning instead).
 	for idx, g := range systemGroups {
-		t.Run(fmt.Sprintf("Error_updating_user_with_non_local_group_%s", g.Name), func(t *testing.T) {
+		t.Run(fmt.Sprintf("Allow_updating_user_with_group_name_conflict_%s", g.Name), func(t *testing.T) {
 			t.Parallel()
 
-			userName := fmt.Sprintf("%s-with-invalid-groups%d", registeredUserPrefix, idx)
+			userName := fmt.Sprintf("%s-with-group-name-conflict%d", registeredUserPrefix, idx)
 			err := m.UpdateUser(types.UserInfo{
 				Name:  userName,
 				Dir:   "/home-prefixes/" + g.Name,
@@ -507,9 +509,12 @@ func TestConcurrentUserUpdate(t *testing.T) {
 				Groups: []types.GroupInfo{{
 					Name: g.Name,
 					UGID: fmt.Sprintf("authd-test-ugid-for-%s", g.Name),
+				}, {
+					Name: fmt.Sprintf("authd-test-local-group%d", idx),
 				}},
 			})
-			require.Error(t, err, "Updating user %q must fail but it does not", g.Name)
+			// UpdateUser call should pass although the user would not be added to the system group
+			require.NoError(t, err, "Updating user %q with group name conflict %q should not fail but it did", userName, g.Name)
 		})
 	}
 
@@ -520,15 +525,17 @@ func TestConcurrentUserUpdate(t *testing.T) {
 		// since this is actually a test.
 		wg.Wait()
 
-		// This includes the extra user that was already in the DB.
+		// This includes the extra user that was already in the DB and the
+		// users registered via non-local groups loop.
 		users, err := m.AllUsers()
 		require.NoError(t, err, "AllUsers should not fail but it did")
-		require.Len(t, users, nIterations+1, "Number of registered users mismatch")
+		require.Len(t, users, nIterations+1+len(systemGroups), "Number of registered users mismatch")
 
-		// This includes the extra group that was already in the DB.
+		// This includes the extra group that was already in the DB and the
+		// private groups for users registered via the non-local groups loop.
 		groups, err := m.AllGroups()
 		require.NoError(t, err, "AllGroups should not fail but it did")
-		require.Len(t, groups, nIterations*3+1, "Number of registered groups mismatch")
+		require.Len(t, groups, nIterations*3+1+len(systemGroups), "Number of registered groups mismatch")
 
 		lockedEntries, entriesUnlock, err := localentries.WithUserDBLock()
 		require.NoError(t, err, "Failed to lock the local entries")

--- a/internal/users/testdata/golden/TestUpdateUser/Allow_login_with_existing_group_on_system
+++ b/internal/users/testdata/golden/TestUpdateUser/Allow_login_with_existing_group_on_system
@@ -1,0 +1,15 @@
+users:
+    - name: user1
+      uid: 1111
+      gid: 1111
+      gecos: gecos for user1
+      dir: /home/user1
+      shell: /bin/bash
+groups:
+    - name: user1
+      gid: 1111
+      ugid: user1
+users_to_groups:
+    - uid: 1111
+      gid: 1111
+schema_version: 2


### PR DESCRIPTION
Closes #957

Currently, if an Entra group (e.g., a group named `sudo`) already existed on the system but was not managed by authd, UpdateUser returned an error and login failed. This PR changes the behavior to log a warning and skip creating the group instead of failing, allowing the user to log in successfully without managing the conflicting system group.

Tests are updated to verify that UpdateUser succeeds in this scenario, the user is not added to the conflicting local group. 

I have verified this with Entra and it works as described above.
```
~$ id
uid=10001(test@<redacted>.onmicrosoft.com) gid=10001(test@<redacted>.onmicrosoft.com) groups=10001(test@<redacted>.onmicrosoft.com),10002(my-group)
```
I was successfully able to login without being added to the sudo group. The logs also showed the warning as expected.