### PR TITLE
Fix provision-ubuntu.sh

### DIFF
--- a/e2e-tests/vm/provision-ubuntu.sh
+++ b/e2e-tests/vm/provision-ubuntu.sh
@@ -4,6 +4,7 @@ set -euo pipefail
 
 SCRIPT_DIR="$(dirname "$(readlink -f "$0")")"
 LIB_DIR="${SCRIPT_DIR}/lib"
+SSH="${SCRIPT_DIR}/ssh.sh"
 LIBVIRT_XML_TEMPLATE="${SCRIPT_DIR}/e2e-runner-template.xml"
 CACHE_DIR="${XDG_CACHE_HOME:-$HOME/.cache}/authd-e2e-tests"
 DATA_DIR="${XDG_DATA_HOME:-$HOME/.local/share}/authd-e2e-tests"


### PR DESCRIPTION
Commit 351cf6b19686ebed6ab50d67b30bb5b9d6e622a8 removed the SSH environment variable but it was actually used by the `boot_system` function which we import from `libprovision.sh`.