### PR TITLE
snap/scripts/version: Fix failure when no tag is found

### DIFF
--- a/snap/scripts/version
+++ b/snap/scripts/version
@@ -49,8 +49,8 @@ get_version() {
 
     version="${tag}"
     if [ -z "${version}" ]; then
-        # No tag found, use "notag" as version.
-        version="notag"
+        # No tag found, use "0.0.0"
+        version="0.0.0"
     fi
     version=$(strip_branch_tag_prefix "${version}")
 


### PR DESCRIPTION
We used the version "notag" when no tag was found, but then we use our semver tool to check if the version is a valid semantic version, which "notag" is not, so the script failed.