### PR TITLE
authctl: Avoid regenerating man page if only date changed

### DIFF
--- a/cmd/authctl/internal/docgen/main.go
+++ b/cmd/authctl/internal/docgen/main.go
@@ -16,6 +16,10 @@ func logf(format string, v ...any) {
 	fmt.Fprintf(os.Stderr, format+"\n", v...)
 }
 
+func log(v ...any) {
+	logf("%v", v...)
+}
+
 func fatalf(format string, v ...any) {
 	logf(format, v...)
 	os.Exit(1)
@@ -38,10 +42,9 @@ func main() {
 	rootCmd := root.RootCmd
 	rootCmd.DisableAutoGenTag = true // stable, reproducible files (no timestamp footer)
 
-	logf("generating %s documentation in %s", *format, *out)
-
 	switch *format {
 	case "markdown":
+		logf("Generating markdown documentation in %s", *out)
 		if err := os.MkdirAll(*out, 0o750); err != nil {
 			fatal(err)
 		}
@@ -63,6 +66,7 @@ func main() {
 			}
 		}
 	case "rest":
+		logf("Generating reStructuredText documentation in %s", *out)
 		if err := os.MkdirAll(*out, 0o750); err != nil {
 			fatal(err)
 		}
@@ -70,6 +74,7 @@ func main() {
 			fatal(err)
 		}
 	case "man":
+		logf("Generating man page in %s", *out)
 		if err := genManPage(rootCmd, *out); err != nil {
 			fatal(err)
 		}

--- a/cmd/authctl/internal/docgen/manpage.go
+++ b/cmd/authctl/internal/docgen/manpage.go
@@ -30,7 +30,7 @@ func genManPage(cmd *cobra.Command, path string) error {
 	fmt.Fprintf(buf, ".\\\" Do not edit manually\n")
 	fmt.Fprintf(buf, ".nh\n")
 	fmt.Fprintf(buf, ".TH \"%s\" \"%s\" \"%s\" \"%s\"\n",
-		header.Title, header.Section, header.Date.Format("Jan 2006"), header.Source)
+		header.Title, header.Section, header.Date.Format("2006-01-02"), header.Source)
 
 	// NAME
 	fmt.Fprintf(buf, ".SH NAME\n")

--- a/cmd/authctl/internal/docgen/manpage.go
+++ b/cmd/authctl/internal/docgen/manpage.go
@@ -75,6 +75,10 @@ func genManPage(cmd *cobra.Command, path string) error {
 	fmt.Fprintf(buf, "\\%%https://documentation.ubuntu.com/authd\n")
 	fmt.Fprintf(buf, ".RE\n")
 
+	if !shouldWriteManPage(path, buf.Bytes()) {
+		return nil
+	}
+
 	return os.WriteFile(path, buf.Bytes(), 0600)
 }
 
@@ -244,4 +248,37 @@ func manPrintFlags(buf *bytes.Buffer, flags *pflag.FlagSet) {
 
 		fmt.Fprintf(buf, ".RE\n")
 	})
+}
+
+// stripDate returns the given man page data with the date removed.
+func stripDate(data []byte) []byte {
+	lines := strings.Split(string(data), "\n")
+	var out []string
+	for _, line := range lines {
+		if strings.HasPrefix(line, ".TH ") {
+			parts := strings.Fields(line)
+			if len(parts) >= 5 {
+				parts[3] = "" // Remove date
+				line = strings.Join(parts, " ")
+			}
+		}
+		out = append(out, line)
+	}
+	return []byte(strings.Join(out, "\n"))
+}
+
+func shouldWriteManPage(path string, content []byte) bool {
+	existing, err := os.ReadFile(path)
+	if err != nil {
+		// The man page doesn't exist yet, so we should write it
+		return true
+	}
+
+	if bytes.Equal(stripDate(existing), stripDate(content)) {
+		// The man page is unchanged (except for the date), so don't write it
+		log("Man page is up-to-date")
+		return false
+	}
+
+	return true
 }

--- a/man/authctl.1
+++ b/man/authctl.1
@@ -1,7 +1,7 @@
 .\" Generated from authctl man page generator
 .\" Do not edit manually
 .nh
-.TH "AUTHCTL" "1" "Feb 2026" "authd"
+.TH "AUTHCTL" "1" "2026-03-03" "authd"
 .SH NAME
 authctl \- Manage authd users and groups
 .SH SYNOPSIS


### PR DESCRIPTION
Avoid regenerating the man page if only the date has changed. This has caused our CI to fail because we check that all generated files are up-to-date.

