### PR TITLE
e2e-tests: Record an actual video of the test VM

### DIFF
--- a/.github/workflows/e2e-tests-run.yaml
+++ b/.github/workflows/e2e-tests-run.yaml
@@ -260,6 +260,7 @@ jobs:
         uses: actions/github-script@v7
         if: always() && steps.deploy-pages.outcome == 'success'
         with:
+          retries: 3
           script: |
             await github.rest.repos.createCommitStatus({
               owner: context.repo.owner,

--- a/.github/workflows/e2e-tests-run.yaml
+++ b/.github/workflows/e2e-tests-run.yaml
@@ -241,7 +241,7 @@ jobs:
         id: upload-results
         uses: actions/upload-artifact@v6
         with:
-          name: e2e-${{ inputs.broker }}-output-${{ inputs.ubuntu-version }}-${{ github.run_id }}-${{ github.run_attempt }}
+          name: e2e-tests-${{ inputs.ubuntu-version }}-${{ inputs.broker }}-${{ github.run_id }}-${{ github.run_attempt }}
           path: ${{ env.OUTPUT_DIR }}
 
       - name: Prepare upload to Pages

--- a/.github/workflows/e2e-tests-run.yaml
+++ b/.github/workflows/e2e-tests-run.yaml
@@ -210,12 +210,13 @@ jobs:
 
           # Run the tests
           ${{ env.E2E_TESTS_DIR }}/run-tests.sh \
-              --user "${E2E_USER}" \
-              --password "${E2E_PASSWORD}" \
-              --totp-secret "${TOTP_SECRET}" \
-              --release "${{ inputs.ubuntu-version }}" \
-              --broker "${{ inputs.broker }}" \
-              --output-dir "${{ env.OUTPUT_DIR }}"
+            --user "${E2E_USER}" \
+            --password "${E2E_PASSWORD}" \
+            --totp-secret "${TOTP_SECRET}" \
+            --release "${{ inputs.ubuntu-version }}" \
+            --broker "${{ inputs.broker }}" \
+            --output-dir "${{ env.OUTPUT_DIR }}" \
+            || exit_code=$?
 
           # Redact secrets from the test output
           for file in "${{ env.OUTPUT_DIR }}"/{log,report}.html; do
@@ -223,9 +224,21 @@ jobs:
             sed -i "s/${TOTP_SECRET}/<redacted-totp-secret>/g" "$file"
           done
 
+          if [ -n "${exit_code:-}" ]; then
+            state="failure"
+          else
+            state="success"
+          fi
+
+          echo "log=${{ env.OUTPUT_DIR }}/log.html" >> "$GITHUB_OUTPUT"
+          echo "report=${{ env.OUTPUT_DIR }}/report.html" >> "$GITHUB_OUTPUT"
+          echo "state=${state}" >> "$GITHUB_OUTPUT"
+          echo "exit-code=${exit_code:-0}" >> "$GITHUB_OUTPUT"
+          echo "Exit code: ${exit_code:-0}"
+
       - name: Upload test results as artifact
-        id: upload-results
         if: always()
+        id: upload-results
         uses: actions/upload-artifact@v6
         with:
           name: e2e-${{ inputs.broker }}-output-${{ inputs.ubuntu-version }}-${{ github.run_id }}-${{ github.run_attempt }}
@@ -233,12 +246,14 @@ jobs:
 
       - name: Prepare upload to Pages
         id: prepare-pages
-        if: always()
+        # Only run if either the log or the report file exists
+        if: always() && (steps.run-tests.outputs.log != '' || steps.run-tests.outputs.report != '')
         run: |
           set -euo pipefail
           TARGET_DIR="pr/${{ github.event.pull_request.number }}/${{ github.run_id }}/${{ github.run_attempt }}/e2e-tests/${{ inputs.ubuntu-version }}/${{ inputs.broker }}"
           mkdir -p "pages/${TARGET_DIR}"
-          cp "${{ env.OUTPUT_DIR }}"/*.html "pages/${TARGET_DIR}/"
+          cp "${{ steps.run-tests.outputs.log }}" "pages/${TARGET_DIR}/log.html"
+          cp "${{ steps.run-tests.outputs.report }}" "pages/${TARGET_DIR}/report.html"
           echo "target-dir=${TARGET_DIR}" >> "$GITHUB_OUTPUT"
 
           OWNER="${{ github.repository_owner }}"
@@ -273,3 +288,17 @@ jobs:
               context: 'e2e-tests (${{ inputs.ubuntu-version }}) (${{ inputs.broker }})',
             });
             console.log(JSON.stringify(response, null, 2));
+
+      - name: Check the test result
+        uses: actions/github-script@v7
+        if: always()
+        with:
+          script: |
+            const state = '${{ steps.run-tests.outputs.state }}';
+            const logUrl = '${{ steps.prepare-pages.outputs.log-url }}';
+
+            if (state === 'failure') {
+              core.setFailed(`e2e-tests failed with exit code ${{ steps.run-tests.outputs.exit-code }}. See the logs at ${logUrl}`);
+            } else {
+              console.log(`::notice::e2e-tests passed, see the logs at ${logUrl}`);
+            }

--- a/.github/workflows/e2e-tests-run.yaml
+++ b/.github/workflows/e2e-tests-run.yaml
@@ -257,17 +257,19 @@ jobs:
           force: false
 
       - name: Create commit status with link to the logs
+        id: create-commit-status
         uses: actions/github-script@v7
         if: always() && steps.deploy-pages.outcome == 'success'
         with:
           retries: 3
           script: |
-            await github.rest.repos.createCommitStatus({
+            const response = await github.rest.repos.createCommitStatus({
               owner: context.repo.owner,
               repo: context.repo.repo,
               sha: context.sha,
-              state: '${{ steps.run-tests.outcome }}',
+              state: '${{ steps.run-tests.outputs.state }}',
               target_url: '${{ steps.prepare-pages.outputs.log-url }}',
               description: 'View logs',
               context: 'e2e-tests (${{ inputs.ubuntu-version }}) (${{ inputs.broker }})',
             });
+            console.log(JSON.stringify(response, null, 2));

--- a/.github/workflows/e2e-tests-run.yaml
+++ b/.github/workflows/e2e-tests-run.yaml
@@ -256,7 +256,7 @@ jobs:
           # Rebase instead of force-push, so concurrent PRs don't overwrite each other
           force: false
 
-      - name: Post link to logs as a PR check
+      - name: Create commit status with link to the logs
         uses: actions/github-script@v7
         if: always() && steps.deploy-pages.outcome == 'success'
         with:

--- a/e2e-tests/install-deps.sh
+++ b/e2e-tests/install-deps.sh
@@ -18,4 +18,6 @@ sudo apt-get update && sudo apt-get -y install \
     python3-tk \
     socat \
     systemd-journal-remote \
+    unclutter \
+    xtightvncviewer \
     xvfb

--- a/e2e-tests/resources/authd-google/browser_login.py
+++ b/e2e-tests/resources/authd-google/browser_login.py
@@ -66,7 +66,7 @@ def main():
         finally:
             if browser.get_mapped():
                 browser.capture_snapshot(screenshot_dir, "failure")
-            browser.stop_recording(os.path.join(args.output_dir, "webview_recording.webm"))
+            browser.stop_recording(os.path.join(args.output_dir, "Webview_Recording.webm"))
             browser.destroy()
 
 

--- a/e2e-tests/resources/authd-msentraid/browser_login.py
+++ b/e2e-tests/resources/authd-msentraid/browser_login.py
@@ -66,7 +66,7 @@ def main():
         finally:
             if browser.get_mapped():
                 browser.capture_snapshot(screenshot_dir, "failure")
-            browser.stop_recording(os.path.join(args.output_dir, "webview_recording.webm"))
+            browser.stop_recording(os.path.join(args.output_dir, "Webview_Recording.webm"))
             browser.destroy()
 
 

--- a/e2e-tests/resources/authd/VNCRecorder.py
+++ b/e2e-tests/resources/authd/VNCRecorder.py
@@ -68,7 +68,7 @@ class VNCRecorder:
     def start_recording(self, host='localhost', port=5901, resolution='1280x800'):
         """Start recording the VNC session to a video file."""
         output_dir = str(BuiltIn().get_variable_value('${OUTPUT DIR}', '.'))
-        output_path = os.path.join(output_dir, 'recording.webm')
+        output_path = os.path.join(output_dir, 'VM_Recording.webm')
 
         display_num = find_unused_display()
         display = f':{display_num}'

--- a/e2e-tests/resources/authd/VNCRecorder.py
+++ b/e2e-tests/resources/authd/VNCRecorder.py
@@ -1,0 +1,142 @@
+import ctypes
+import subprocess
+import signal
+import os
+import time
+
+from robot.api.deco import library, keyword
+from robot.api import logger
+from robot.libraries.BuiltIn import BuiltIn
+
+PR_SET_PDEATHSIG = 1
+SIGTERM = 15
+
+# Ensure child processes are terminated when the parent process dies
+def set_death_signal():
+    libc = ctypes.CDLL('libc.so.6')
+    libc.prctl(PR_SET_PDEATHSIG, SIGTERM)
+
+def find_unused_display() -> int:
+    used = set()
+    for name in os.listdir('/tmp/.X11-unix'):
+        if name.startswith('X'):
+            try:
+                used.add(int(name[1:]))
+            except ValueError:
+                continue
+    for num in range(99, 200):
+        if num not in used:
+            return num
+    raise RuntimeError("No unused display found")
+
+def wait_for_xvfb(display_num: int, timeout: float = 10.0):
+    socket_path = f'/tmp/.X11-unix/X{display_num}'
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if os.path.exists(socket_path):
+            return
+        time.sleep(0.1)
+    raise RuntimeError(f"Xvfb display :{display_num} did not become ready in time")
+
+def stop_process(proc: subprocess.Popen, stop_signal: int = signal.SIGTERM):
+    """Terminate a process, killing it if it doesn't stop in time, and log its stderr."""
+    if not proc:
+        return
+    name = proc.args[0]
+    try:
+        proc.send_signal(stop_signal)
+        _, stderr = proc.communicate(timeout=5)
+    except subprocess.TimeoutExpired:
+        logger.warn(f"{name} did not terminate, killing it.")
+        proc.kill()
+        _, stderr = proc.communicate(timeout=5)
+    msg = f"{name} exited with exit code {proc.returncode}."
+    if stderr:
+        msg += f" stderr:\n{stderr}"
+    logger.info(msg)
+
+@library
+class VNCRecorder:
+
+    def __init__(self):
+        self._xvfb_proc = None
+        self._unclutter_proc = None
+        self._viewer_proc = None
+        self._ffmpeg_proc = None
+
+    @keyword
+    def start_recording(self, host='localhost', port=5901, resolution='1280x800'):
+        """Start recording the VNC session to a video file."""
+        output_dir = str(BuiltIn().get_variable_value('${OUTPUT DIR}', '.'))
+        output_path = os.path.join(output_dir, 'recording.webm')
+
+        display_num = find_unused_display()
+        display = f':{display_num}'
+
+        # Start a virtual X server for the VNC session
+        cmd = ['Xvfb', display, '-screen', '0', f'{resolution}x24']
+        logger.info(f"Starting Xvfb with command: {' '.join(cmd)}")
+        self._xvfb_proc = subprocess.Popen(
+            cmd,
+            text=True,
+            stderr=subprocess.PIPE,
+            preexec_fn=set_death_signal,
+        )
+        wait_for_xvfb(display_num)
+
+        # Run unclutter to hide the mouse cursor so it doesn't show up in the recording
+        cmd = ['unclutter', '-display', display, '-root', '-idle', '0.1']
+        logger.info(f"Starting unclutter with command: {' '.join(cmd)}")
+        self._unclutter_proc = subprocess.Popen(
+            cmd,
+            text=True,
+            stderr=subprocess.PIPE,
+            preexec_fn=set_death_signal,
+        )
+
+        # Start a VNC viewer on the virtual X server
+        env = os.environ.copy()
+        env['DISPLAY'] = display
+        cmd = ['xtightvncviewer', '-shared', '-viewonly', '-fullscreen',
+               f'{host}:{port}']
+        logger.info(f"Starting xtightvncviewer with command: {' '.join(cmd)}")
+        self._viewer_proc = subprocess.Popen(
+            cmd,
+            env=env,
+            text=True,
+            stderr=subprocess.PIPE,
+            preexec_fn=set_death_signal,
+        )
+
+        # Give the viewer a moment to start and connect to the VNC server
+        # before starting ffmpeg to avoid recording a black screen
+        time.sleep(0.1)
+
+        # Record the VNC session to a video file
+        cmd = ['ffmpeg',
+               '-loglevel', 'warning',
+               '-y',
+               '-f', 'x11grab',
+               '-r', '25',
+               '-s', resolution,
+               '-i', f'{display}.0',
+               '-codec:v', 'libvpx-vp9',
+               '-preset', 'fast',
+               '-crf', '23',
+               output_path]
+        logger.info(f"Starting ffmpeg with command: {' '.join(cmd)}")
+        self._ffmpeg_proc = subprocess.Popen(
+            cmd,
+            text=True,
+            stdin=subprocess.DEVNULL,
+            stderr=subprocess.PIPE,
+            preexec_fn=set_death_signal,
+        )
+
+    @keyword
+    def stop_recording(self):
+        """Stop recording and clean up."""
+        stop_process(self._ffmpeg_proc, signal.SIGINT)
+        stop_process(self._viewer_proc)
+        stop_process(self._unclutter_proc)
+        stop_process(self._xvfb_proc)

--- a/e2e-tests/resources/authd/VideoLogger.py
+++ b/e2e-tests/resources/authd/VideoLogger.py
@@ -15,9 +15,9 @@ class VideoLogger:
         pattern = os.path.join(output_dir, '*.webm')
         videos = glob.glob(pattern)
         for path in videos:
-            description = os.path.basename(path).removesuffix('.webm').replace('_', ' ')
+            title = os.path.basename(path).removesuffix('.webm').replace('_', ' ')
             with open(path, 'rb') as f:
                 data = f.read()
             b64 = base64.b64encode(data).decode('utf-8')
             html = f'<video controls style="max-width: 50%" src="data:video/webm;base64,{b64}" />'
-            logger.error(f'{description}\n{html}', html=True, console=False)
+            BuiltIn().set_test_message(f'*HTML*<h3>{title}</h3>{html}', append=True, separator='\n')

--- a/e2e-tests/resources/authd/utils.resource
+++ b/e2e-tests/resources/authd/utils.resource
@@ -5,6 +5,7 @@ Resource            ../kvm.resource
 Library             ./Journal.py    AS    Journal
 Library             ./StringUtils.py    AS    StringUtils
 Library             ./VideoLogger.py    AS    VideoLogger
+Library             ./VNCRecorder.py   AS    VNCRecorder
 Library             ./Snapshot.py    AS    Snapshot
 Library             ./SSH.py    AS    SSH
 Library             Process

--- a/e2e-tests/run-tests.sh
+++ b/e2e-tests/run-tests.sh
@@ -178,12 +178,14 @@ env \
     VNC_PORT="$VNC_PORT" \
     SYSTEMD_SUPPORTS_VSOCK="${SYSTEMD_SUPPORTS_VSOCK:-}" \
     robot \
+        --consolecolors on \
         --loglevel DEBUG \
         --pythonpath "${YARF_DIR}/yarf/rf_libraries/libraries/vnc" \
         --outputdir "${OUTPUT_DIR}" \
         "${ROBOT_ARGS[@]}" \
         "$@" \
         tests \
+        | grep -v "<video controls style" \
         || test_result=$?
 
 exit "${test_result:-0}"

--- a/e2e-tests/run-tests.sh
+++ b/e2e-tests/run-tests.sh
@@ -169,6 +169,9 @@ for test_file in $TESTS_TO_RUN; do
     ln -s "${test_file}" tests
 done
 
+# Make YARF not log videos, we log them ourselves in the test case error message.
+YARF_LOG_VIDEO=0
+
 env \
     E2E_USER="$E2E_USER" \
     E2E_PASSWORD="$E2E_PASSWORD" \
@@ -177,6 +180,7 @@ env \
     RELEASE="$RELEASE" \
     VNC_PORT="$VNC_PORT" \
     SYSTEMD_SUPPORTS_VSOCK="${SYSTEMD_SUPPORTS_VSOCK:-}" \
+    YARF_LOG_VIDEO="${YARF_LOG_VIDEO}" \
     robot \
         --consolecolors on \
         --loglevel DEBUG \

--- a/e2e-tests/tests/authd_disabled.robot
+++ b/e2e-tests/tests/authd_disabled.robot
@@ -14,8 +14,10 @@ Test Teardown   Test Teardown
 Test Setup
     Restore Snapshot    %{BROKER}-installed
     Journal.Start Receiving Journal
+    VNCRecorder.Start Recording
 
 Test Teardown
+    VNCRecorder.Stop Recording
     Journal.Stop Receiving Journal
     Journal.Log Journal
     Log Videos On Error

--- a/e2e-tests/tests/broker_disabled.robot
+++ b/e2e-tests/tests/broker_disabled.robot
@@ -14,8 +14,10 @@ Test Teardown   Test Teardown
 Test Setup
     Restore Snapshot    %{BROKER}-installed
     Journal.Start Receiving Journal
+    VNCRecorder.Start Recording
 
 Test Teardown
+    VNCRecorder.Stop Recording
     Journal.Stop Receiving Journal
     Journal.Log Journal
     Log Videos On Error

--- a/e2e-tests/tests/config_issuer_invalid.robot
+++ b/e2e-tests/tests/config_issuer_invalid.robot
@@ -14,8 +14,10 @@ Test Teardown   Test Teardown
 Test Setup
     Restore Snapshot    %{BROKER}-installed
     Journal.Start Receiving Journal
+    VNCRecorder.Start Recording
 
 Test Teardown
+    VNCRecorder.Stop Recording
     Journal.Stop Receiving Journal
     Journal.Log Journal
     Log Videos On Error

--- a/e2e-tests/tests/config_owner_auto_update.robot
+++ b/e2e-tests/tests/config_owner_auto_update.robot
@@ -14,8 +14,10 @@ Test Teardown   Test Teardown
 Test Setup
     Restore Snapshot    %{BROKER}-installed
     Journal.Start Receiving Journal
+    VNCRecorder.Start Recording
 
 Test Teardown
+    VNCRecorder.Stop Recording
     Journal.Stop Receiving Journal
     Journal.Log Journal
     Log Videos On Error

--- a/e2e-tests/tests/deny_login_if_user_not_allowed.robot
+++ b/e2e-tests/tests/deny_login_if_user_not_allowed.robot
@@ -14,8 +14,10 @@ Test Teardown   Test Teardown
 Test Setup
     Restore Snapshot    %{BROKER}-installed
     Journal.Start Receiving Journal
+    VNCRecorder.Start Recording
 
 Test Teardown
+    VNCRecorder.Stop Recording
     Journal.Stop Receiving Journal
     Journal.Log Journal
     Log Videos On Error

--- a/e2e-tests/tests/deny_login_if_username_does_not_match.robot
+++ b/e2e-tests/tests/deny_login_if_username_does_not_match.robot
@@ -14,8 +14,10 @@ Test Teardown   Test Teardown
 Test Setup
     Restore Snapshot    %{BROKER}-installed
     Journal.Start Receiving Journal
+    VNCRecorder.Start Recording
 
 Test Teardown
+    VNCRecorder.Stop Recording
     Journal.Stop Receiving Journal
     Journal.Log Journal
     Log Videos On Error

--- a/e2e-tests/tests/login.robot
+++ b/e2e-tests/tests/login.robot
@@ -13,8 +13,10 @@ Test Teardown   Test Teardown
 Test Setup
     Restore Snapshot    %{BROKER}-installed
     Journal.Start Receiving Journal
+    VNCRecorder.Start Recording
 
 Test Teardown
+    VNCRecorder.Stop Recording
     Journal.Stop Receiving Journal
     Journal.Log Journal
     Log Videos On Error

--- a/e2e-tests/tests/login_gdm.robot
+++ b/e2e-tests/tests/login_gdm.robot
@@ -14,8 +14,10 @@ Test Teardown   Test Teardown
 Test Setup
     Restore Snapshot    %{BROKER}-installed
     Journal.Start Receiving Journal
+    VNCRecorder.Start Recording
 
 Test Teardown
+    VNCRecorder.Stop Recording
     Journal.Stop Receiving Journal
     Journal.Log Journal
     Log Videos On Error

--- a/e2e-tests/tests/migration_authd.robot
+++ b/e2e-tests/tests/migration_authd.robot
@@ -12,10 +12,12 @@ Test Teardown   Test Teardown
 
 *** Keywords ***
 Test Setup
-    Journal.Start Receiving Journal
     Restore Snapshot    %{BROKER}-stable-installed
+    Journal.Start Receiving Journal
+    VNCRecorder.Start Recording
 
 Test Teardown
+    VNCRecorder.Stop Recording
     Journal.Stop Receiving Journal
     Journal.Log Journal
     Log Videos On Error

--- a/e2e-tests/tests/migration_authd_broker.robot
+++ b/e2e-tests/tests/migration_authd_broker.robot
@@ -12,10 +12,12 @@ Test Teardown   Test Teardown
 
 *** Keywords ***
 Test Setup
-    Journal.Start Receiving Journal
     Restore Snapshot    %{BROKER}-stable-installed
+    Journal.Start Receiving Journal
+    VNCRecorder.Start Recording
 
 Test Teardown
+    VNCRecorder.Stop Recording
     Journal.Stop Receiving Journal
     Journal.Log Journal
     Log Videos On Error

--- a/e2e-tests/tests/migration_broker.robot
+++ b/e2e-tests/tests/migration_broker.robot
@@ -12,10 +12,12 @@ Test Teardown   Test Teardown
 
 *** Keywords ***
 Test Setup
-    Journal.Start Receiving Journal
     Restore Snapshot    %{BROKER}-stable-installed
+    Journal.Start Receiving Journal
+    VNCRecorder.Start Recording
 
 Test Teardown
+    VNCRecorder.Stop Recording
     Journal.Stop Receiving Journal
     Journal.Log Journal
     Log Videos On Error

--- a/e2e-tests/tests/mixed_case_username.robot
+++ b/e2e-tests/tests/mixed_case_username.robot
@@ -14,8 +14,10 @@ Test Teardown   Test Teardown
 Test Setup
     Restore Snapshot    %{BROKER}-installed
     Journal.Start Receiving Journal
+    VNCRecorder.Start Recording
 
 Test Teardown
+    VNCRecorder.Stop Recording
     Journal.Stop Receiving Journal
     Journal.Log Journal
     Log Videos On Error

--- a/e2e-tests/tests/password_change.robot
+++ b/e2e-tests/tests/password_change.robot
@@ -14,8 +14,10 @@ Test Teardown   Test Teardown
 Test Setup
     Restore Snapshot    %{BROKER}-installed
     Journal.Start Receiving Journal
+    VNCRecorder.Start Recording
 
 Test Teardown
+    VNCRecorder.Stop Recording
     Journal.Stop Receiving Journal
     Journal.Log Journal
     Log Videos On Error

--- a/e2e-tests/tests/regenerate_qrcode.robot
+++ b/e2e-tests/tests/regenerate_qrcode.robot
@@ -14,8 +14,10 @@ Test Teardown   Test Teardown
 Test Setup
     Restore Snapshot    %{BROKER}-installed
     Journal.Start Receiving Journal
+    VNCRecorder.Start Recording
 
 Test Teardown
+    VNCRecorder.Stop Recording
     Journal.Stop Receiving Journal
     Journal.Log Journal
     Log Videos On Error

--- a/e2e-tests/tests/ssh_deny_login_if_prefix_not_allowed.robot
+++ b/e2e-tests/tests/ssh_deny_login_if_prefix_not_allowed.robot
@@ -14,9 +14,11 @@ Test Teardown   Test Teardown
 Test Setup
     Restore Snapshot    %{BROKER}-installed
     Journal.Start Receiving Journal
+    VNCRecorder.Start Recording
     Change Broker Configuration    ssh_allowed_suffixes_first_auth    %{E2E_USER}
 
 Test Teardown
+    VNCRecorder.Stop Recording
     Journal.Stop Receiving Journal
     Journal.Log Journal
     Log Videos On Error

--- a/e2e-tests/tests/ssh_login.robot
+++ b/e2e-tests/tests/ssh_login.robot
@@ -14,9 +14,11 @@ Test Teardown   Test Teardown
 Test Setup
     Restore Snapshot    %{BROKER}-installed
     Journal.Start Receiving Journal
+    VNCRecorder.Start Recording
     Change Broker Configuration    ssh_allowed_suffixes_first_auth    %{E2E_USER}
 
 Test Teardown
+    VNCRecorder.Stop Recording
     Journal.Stop Receiving Journal
     Journal.Log Journal
     Log Videos On Error

--- a/e2e-tests/vm/e2e-runner-template.xml
+++ b/e2e-tests/vm/e2e-runner-template.xml
@@ -45,7 +45,7 @@
             <clipboard copypaste='yes'/>
             <mouse mode='client'/>
         </graphics>
-        <graphics type="vnc" autoport="yes">
+        <graphics type="vnc" autoport="yes" sharePolicy="force-shared">
             <listen type="address" />
             <clipboard copypaste='yes'/>
             <mouse mode='client'/>


### PR DESCRIPTION
YARF combines the screenshots it takes for image matching into a video. That misses everything that happens in between those screenshots. Let's record an actual video of the VNC output instead.

Also log videos in the error message of the failing test case instead of the separate "Execution Errors" section.

UDENG-9379