### PR TITLE
Bump Go toolchain version to 1.25.8

### DIFF
--- a/authd-oidc-brokers/go.mod
+++ b/authd-oidc-brokers/go.mod
@@ -2,7 +2,7 @@ module github.com/canonical/authd/authd-oidc-brokers
 
 go 1.25.0
 
-toolchain go1.25.7
+toolchain go1.25.8
 
 require (
 	github.com/Azure/azure-sdk-for-go/sdk/azcore v1.21.0

--- a/authd-oidc-brokers/tools/go.mod
+++ b/authd-oidc-brokers/tools/go.mod
@@ -2,7 +2,7 @@ module github.com/canonical/authd/authd-oidc-brokers/tools
 
 go 1.25.0
 
-toolchain go1.25.7
+toolchain go1.25.8
 
 require (
 	github.com/golangci/golangci-lint/v2 v2.8.0

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/canonical/authd
 
 go 1.25.0
 
-toolchain go1.25.7
+toolchain go1.25.8
 
 require (
 	github.com/charmbracelet/bubbles v0.20.0

--- a/tools/go.mod
+++ b/tools/go.mod
@@ -2,7 +2,7 @@ module github.com/canonical/authd/tools
 
 go 1.24.0
 
-toolchain go1.25.7
+toolchain go1.25.8
 
 require (
 	github.com/golang/protobuf v1.5.4


### PR DESCRIPTION
govulncheck reports the following vulnerabilities in go1.25.7:

```
Vulnerability #1: GO-2026-4603
    URLs in meta content attribute actions are not escaped in html/template
  More info: https://pkg.go.dev/vuln/GO-2026-4603
  Standard library
    Found in: html/template@go1.25.7
    Fixed in: html/template@go1.25.8
    Example traces found:
Error:       #1: examplebroker/broker.go:1000:14: examplebroker.userInfoFromName calls template.Template.Execute
Error:       #2: pam/integration-tests/ssh_test.go:720:30: integration.startSSHD calls httptest.NewServer, which eventually calls template.Template.ExecuteTemplate

Vulnerability #2: GO-2026-4602
    FileInfo can escape from a Root in os
  More info: https://pkg.go.dev/vuln/GO-2026-4602
  Standard library
    Found in: os@go1.25.7
    Fixed in: os@go1.25.8
    Example traces found:
Error:       #1: internal/users/proc/proc.go:42:33: proc.CheckUserBusy calls os.File.Readdir
Error:       #2: internal/brokers/manager.go:65:29: brokers.NewManager calls os.ReadDir

Vulnerability #3: GO-2026-4601
    Incorrect parsing of IPv6 host literals in net/url
  More info: https://pkg.go.dev/vuln/GO-2026-4601
  Standard library
    Found in: net/url@go1.25.7
    Fixed in: net/url@go1.25.8
    Example traces found:
Error:       #1: internal/testutils/daemon.go:249:29: testutils.StartAuthdWithCancel calls grpc.NewClient, which eventually calls url.Parse
Error:       #2: pam/integration-tests/ssh_test.go:720:30: integration.startSSHD calls httptest.NewServer, which eventually calls url.ParseRequestURI
```