### PR TITLE
ci: Complete the drop of Plucky

### DIFF
--- a/.github/workflows/debian-build.yaml
+++ b/.github/workflows/debian-build.yaml
@@ -97,7 +97,7 @@ jobs:
           docker-image: ubuntu:${{ inputs.ubuntu-version }}
           # Add the Go backports PPA if we're testing a Ubuntu release which
           # doesn't have the required Go version in main.
-          extra-apt-repositories: ${{ (inputs.ubuntu-version == 'noble' || inputs.ubuntu-version == 'plucky' || inputs.ubuntu-version == 'questing') && 'ppa:ubuntu-enterprise-desktop/golang' || '' }}
+          extra-apt-repositories: ${{ (inputs.ubuntu-version == 'noble' || inputs.ubuntu-version == 'questing') && 'ppa:ubuntu-enterprise-desktop/golang' || '' }}
           # Extra build dependencies:
           # - systemd-dev: Required to read compile time variables from systemd via pkg-config.
           extra-source-build-deps: |
@@ -112,12 +112,10 @@ jobs:
               command -v cargo-vendor-filterer
             fi
 
-            if [ "${{ inputs.ubuntu-version }}" == noble ] || \
-               [ "${{ inputs.ubuntu-version }}" == plucky ]; then
-              # Avoid lintian warnings on Noble and Plucky by disabling the
+            if [ "${{ inputs.ubuntu-version }}" == noble ]; then
+              # Avoid lintian warnings on Noble by disabling the
               # silent-on-rules-requiring-root tag. That tag doesn't exist in
-              # newer versions of lintian so we must only disable it on Noble
-              # and Plucky.
+              # newer versions of lintian so we must only disable it on Noble.
               echo "authd source: silent-on-rules-requiring-root [debian/control]" >> debian/source/lintian-overrides
             fi
           allow-sudo: true


### PR DESCRIPTION
We already stopped building Debian packages for Plucky in c39f0202b38432fb93c15ac8edd15000965c4cef but there are some leftovers which were not cleaned up yet.

UDENG-9332