### PR TITLE
Fix build of authd deb targeting Resolute

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,4 @@ exclude-crate-paths = [
     { name = "*", exclude = "docs" },
     { name = "*", exclude = "examples" },
     { name = "*", exclude = "tests" },
-    { name = "*", exclude = "*.svg" },
-    { name = "*", exclude = "*.png" },
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,4 +14,9 @@ exclude-crate-paths = [
     { name = "*", exclude = "docs" },
     { name = "*", exclude = "examples" },
     { name = "*", exclude = "tests" },
+
+    # For some reason, this file is excluded from the source tarball. Exclude
+    # it here to exclude it from the checksum calculation to avoid build
+    # failures due to checksum mismatches.
+    { name = "*", exclude = "Cargo.toml.orig" },
 ]

--- a/debian/rules
+++ b/debian/rules
@@ -91,6 +91,8 @@ override_dh_auto_configure:
 		env DEB_CARGO_CRATE="$(DEB_SOURCE)_$(DEB_VERSION_UPSTREAM)" \
 		  $(CARGO_PATH) prepare-debian "$(CARGO_VENDOR_DIR)"; \
 	else \
+	    echo "cargo version: $$(cargo --version)"; \
+	    echo "cargo-vendor-filterer version: $$(cargo-vendor-filterer --version)"; \
 		dh_auto_configure --buildsystem=cargo; \
 	fi
 

--- a/debian/source/options
+++ b/debian/source/options
@@ -1,9 +1,13 @@
+tar-ignore = */.editor*
 tar-ignore = */.git*
 tar-ignore = */.go*
-tar-ignore = */.editor*
 tar-ignore = */.mailmap
 tar-ignore = */.vscode
 tar-ignore = *.so
 tar-ignore = *.o
-tar-ignore = authd/docs
 tar-ignore = vendor_rust/*.a
+
+tar-ignore = authd/authd-oidc-brokers
+tar-ignore = authd/docs
+tar-ignore = authd/e2e-tests
+tar-ignore = authd/snap

--- a/debian/source/options
+++ b/debian/source/options
@@ -1,13 +1,17 @@
-tar-ignore = */.editor*
-tar-ignore = */.git*
-tar-ignore = */.go*
-tar-ignore = */.mailmap
-tar-ignore = */.vscode
-tar-ignore = *.so
-tar-ignore = *.o
-tar-ignore = vendor_rust/*.a
-
+tar-ignore = authd/.git*
+tar-ignore = authd/.go*
+tar-ignore = authd/.editor*
+tar-ignore = authd/.vscode
 tar-ignore = authd/authd-oidc-brokers
 tar-ignore = authd/docs
 tar-ignore = authd/e2e-tests
 tar-ignore = authd/snap
+
+tar-ignore = authd/vendor/*/.git*
+tar-ignore = authd/vendor/*/.go*
+tar-ignore = authd/vendor/*/.editor*
+tar-ignore = authd/vendor/*/.mailmap
+
+tar-ignore = *.a
+tar-ignore = *.o
+tar-ignore = *.so

--- a/debian/vendor-rust.sh
+++ b/debian/vendor-rust.sh
@@ -12,6 +12,10 @@ if ! command -v cargo-vendor-filterer 2>/dev/null; then
     exit 3
 fi
 
+# Print the versions of cargo and cargo-vendor-filterer for debugging purposes.
+echo "Using cargo version: $(${CARGO_PATH} --version)"
+echo "Using cargo-vendor-filterer version: $(cargo-vendor-filterer --version)"
+
 # Some crates are shipped with .a files, which get removed by the helpers during the package build as a safety measure.
 # This results in cargo failing to compile, since the files (which are listed in the checksums) are not there anymore.
 # For those crates, we need to replace their checksum with a more general one that only lists the crate checksum, instead of each file.


### PR DESCRIPTION
This includes two separate fixes for build failures both caused by the new Cargo version on Resolute. See commit messages for details.

Closes #1310
UDENG-9388
