### PR TITLE
ci: Fix OCI artifact cleanup (second try)

### DIFF
--- a/.github/workflows/oci-artifacts-cleanup.yaml
+++ b/.github/workflows/oci-artifacts-cleanup.yaml
@@ -17,7 +17,7 @@ jobs:
       - name: Delete broker snap OCI artifacts
         uses: actions/delete-package-versions@v5
         with:
-          package-name: ${{ matrix.broker }}-snap
+          package-name: authd/${{ matrix.broker }}-snap
           package-type: container
           min-versions-to-keep: 10
 
@@ -32,14 +32,14 @@ jobs:
       - name: Delete deb OCI artifacts
         uses: actions/delete-package-versions@v5
         with:
-          package-name: authd-deb-${{ matrix.ubuntu-version }}
+          package-name: authd/authd-deb-${{ matrix.ubuntu-version }}
           package-type: container
           min-versions-to-keep: 10
 
       - name: Delete deb sources OCI artifacts
         uses: actions/delete-package-versions@v5
         with:
-          package-name: authd-deb-sources-${{ matrix.ubuntu-version }}
+          package-name: authd/authd-deb-sources-${{ matrix.ubuntu-version }}
           package-type: container
           min-versions-to-keep: 10
 
@@ -51,6 +51,6 @@ jobs:
       - name: Delete e2e-test VM image OCI artifacts
         uses: actions/delete-package-versions@v5
         with:
-          package-name: e2e-runner
+          package-name: authd/e2e-runner
           package-type: container
           min-versions-to-keep: 10


### PR DESCRIPTION
The cleanup jobs still fail. Commit fd44cc3e07c0502e87b86bf45ad2e308657cecda removed the `ghcr.io/${{ github.repository }}` prefix from the package name. When you [search for the packages](https://github.com/orgs/canonical/packages?tab=packages&q=authd) in the Canonical packages, they are listed as `authd-msentraid-snap` etc. However, the name of the repository itself is actually part of the package name, so the package is `authd/authd-msentraid-snap`, as can be seen [here](https://github.com/canonical/authd/pkgs/container/authd%2Fauthd-msentraid-snap).

We don't use `${{ github.repository }}` as the prefix because that also includes the owner, i.e. it expands to `canonical/authd`, but we only need `authd`.