### PR TITLE
autopkgtests: Skip flaky tests

### DIFF
--- a/debian/tests/run-tests.sh
+++ b/debian/tests/run-tests.sh
@@ -4,6 +4,11 @@ set -exuo pipefail
 
 # Skip tests which depend on vhs which is not available in the build environment.
 export AUTHD_SKIP_EXTERNAL_DEPENDENT_TESTS=1
+
+# Skip flaky tests because we don't want autopkgtests to fail, which would cause
+# trouble for maintainers of packages which authd depends on.
+export AUTHD_SKIP_FLAKY_TESTS=1
+
 export GOPROXY=off
 export GOTOOLCHAIN=local
 

--- a/debian/tests/run-tests.sh
+++ b/debian/tests/run-tests.sh
@@ -2,6 +2,7 @@
 
 set -exuo pipefail
 
+# Skip tests which depend on vhs which is not available in the build environment.
 export AUTHD_SKIP_EXTERNAL_DEPENDENT_TESTS=1
 export GOPROXY=off
 export GOTOOLCHAIN=local

--- a/internal/users/manager_test.go
+++ b/internal/users/manager_test.go
@@ -147,6 +147,11 @@ type groupCase struct {
 }
 
 func TestUpdateUser(t *testing.T) {
+	// This test is flaky, see https://github.com/canonical/authd/issues/1120
+	if os.Getenv("AUTHD_SKIP_FLAKY_TESTS") != "" {
+		t.Skip("skipping flaky test")
+	}
+
 	userCases := map[string]userCase{
 		"user1":                             {UserInfo: types.UserInfo{Name: "user1@example.com"}, UID: 1111},
 		"nameless":                          {UID: 1111},
@@ -282,6 +287,11 @@ func TestUpdateUser(t *testing.T) {
 func TestRegisterUserPreauth(t *testing.T) {
 	t.Parallel()
 
+	// This test is flaky, see https://github.com/canonical/authd/issues/1120
+	if os.Getenv("AUTHD_SKIP_FLAKY_TESTS") != "" {
+		t.Skip("skipping flaky test")
+	}
+
 	userCases := map[string]userCase{
 		"user1":                   {UserInfo: types.UserInfo{Name: "user1@example.com"}, UID: 1111},
 		"nameless":                {UID: 1111},
@@ -363,6 +373,11 @@ func TestRegisterUserPreauth(t *testing.T) {
 
 func TestConcurrentUserUpdate(t *testing.T) {
 	t.Parallel()
+
+	// This test is flaky, see https://github.com/canonical/authd/issues/1120
+	if os.Getenv("AUTHD_SKIP_FLAKY_TESTS") != "" {
+		t.Skip("skipping flaky test")
+	}
 
 	const nIterations = 100
 	const preAuthIterations = 3
@@ -875,6 +890,11 @@ func TestUnlockUser(t *testing.T) {
 func TestUserByIDAndName(t *testing.T) {
 	t.Parallel()
 
+	// This test is flaky, see https://github.com/canonical/authd/issues/1120
+	if os.Getenv("AUTHD_SKIP_FLAKY_TESTS") != "" {
+		t.Skip("skipping flaky test")
+	}
+
 	tests := map[string]struct {
 		uid        uint32
 		username   string
@@ -970,6 +990,11 @@ func TestAllUsers(t *testing.T) {
 
 func TestGroupByIDAndName(t *testing.T) {
 	t.Parallel()
+
+	// This test is flaky, see https://github.com/canonical/authd/issues/1120
+	if os.Getenv("AUTHD_SKIP_FLAKY_TESTS") != "" {
+		t.Skip("skipping flaky test")
+	}
 
 	tests := map[string]struct {
 		gid         uint32
@@ -1265,6 +1290,11 @@ func TestRegisterUserPreAuthAfterUnlock(t *testing.T) {
 func TestUpdateUserWhenLocked(t *testing.T) {
 	// This cannot be parallel
 
+	// This test is flaky, see https://github.com/canonical/authd/issues/1120
+	if os.Getenv("AUTHD_SKIP_FLAKY_TESTS") != "" {
+		t.Skip("skipping flaky test")
+	}
+
 	userslocking.Z_ForTests_OverrideLockingAsLockedExternally(t, context.Background())
 	userslocking.Z_ForTests_SetMaxWaitTime(t, testutils.MultipliedSleepDuration(750*time.Millisecond))
 
@@ -1281,6 +1311,11 @@ func TestUpdateUserWhenLocked(t *testing.T) {
 
 func TestUpdateUserAfterUnlock(t *testing.T) {
 	// This cannot be parallel
+
+	// This test is flaky, see https://github.com/canonical/authd/issues/1120
+	if os.Getenv("AUTHD_SKIP_FLAKY_TESTS") != "" {
+		t.Skip("skipping flaky test")
+	}
 
 	waitTime := testutils.MultipliedSleepDuration(750 * time.Millisecond)
 	lockCtx, lockCancel := context.WithTimeout(context.Background(), waitTime/2)

--- a/pam/integration-tests/cli_test.go
+++ b/pam/integration-tests/cli_test.go
@@ -28,6 +28,12 @@ func TestCLIAuthenticate(t *testing.T) {
 		t.Skip("skipping test in short mode.")
 	}
 
+	// Due to external dependencies such as `vhs`, we can't run the tests in some environments (like LP builders), as we
+	// can't install the dependencies there. So we need to be able to skip these tests on-demand.
+	if os.Getenv("AUTHD_SKIP_EXTERNAL_DEPENDENT_TESTS") != "" {
+		t.Skip("Skipping tests with external dependencies as requested")
+	}
+
 	// This test is flaky, see https://github.com/canonical/authd/issues/1329
 	if os.Getenv("AUTHD_SKIP_FLAKY_TESTS") != "" {
 		t.Skip("skipping flaky test")
@@ -309,6 +315,12 @@ func TestCLIChangeAuthTok(t *testing.T) {
 
 	if testing.Short() {
 		t.Skip("skipping test in short mode.")
+	}
+
+	// Due to external dependencies such as `vhs`, we can't run the tests in some environments (like LP builders), as we
+	// can't install the dependencies there. So we need to be able to skip these tests on-demand.
+	if os.Getenv("AUTHD_SKIP_EXTERNAL_DEPENDENT_TESTS") != "" {
+		t.Skip("Skipping tests with external dependencies as requested")
 	}
 
 	clientPath := t.TempDir()

--- a/pam/integration-tests/cli_test.go
+++ b/pam/integration-tests/cli_test.go
@@ -28,6 +28,11 @@ func TestCLIAuthenticate(t *testing.T) {
 		t.Skip("skipping test in short mode.")
 	}
 
+	// This test is flaky, see https://github.com/canonical/authd/issues/1329
+	if os.Getenv("AUTHD_SKIP_FLAKY_TESTS") != "" {
+		t.Skip("skipping flaky test")
+	}
+
 	clientPath := t.TempDir()
 	cliEnv := preparePamRunnerTest(t, clientPath)
 	tapeCommand := fmt.Sprintf(cliTapeBaseCommand, pam_test.RunnerActionLogin,

--- a/pam/integration-tests/exec_test.go
+++ b/pam/integration-tests/exec_test.go
@@ -25,6 +25,12 @@ const execServiceName = "exec-module"
 
 func TestExecModule(t *testing.T) {
 	t.Parallel()
+
+	// This test is flaky, see https://github.com/canonical/authd/issues/966
+	if os.Getenv("AUTHD_SKIP_FLAKY_TESTS") != "" {
+		t.Skip("skipping flaky test")
+	}
+
 	t.Cleanup(pam_test.MaybeDoLeakCheck)
 
 	if !pam.CheckPamHasStartConfdir() {

--- a/pam/integration-tests/gdm_test.go
+++ b/pam/integration-tests/gdm_test.go
@@ -132,6 +132,12 @@ func TestGdmModule(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping test in short mode.")
 	}
+
+	// This test is flaky, see https://github.com/canonical/authd/issues/966
+	if os.Getenv("AUTHD_SKIP_FLAKY_TESTS") != "" {
+		t.Skip("skipping flaky test")
+	}
+
 	t.Cleanup(pam_test.MaybeDoLeakCheck)
 
 	if !pam.CheckPamHasStartConfdir() {

--- a/pam/integration-tests/helpers_test.go
+++ b/pam/integration-tests/helpers_test.go
@@ -149,12 +149,6 @@ func sharedAuthd(t *testing.T, args ...testutils.DaemonOption) (socketPath strin
 func preparePamRunnerTest(t *testing.T, clientPath string) []string {
 	t.Helper()
 
-	// Due to external dependencies such as `vhs`, we can't run the tests in some environments (like LP builders), as we
-	// can't install the dependencies there. So we need to be able to skip these tests on-demand.
-	if os.Getenv("AUTHD_SKIP_EXTERNAL_DEPENDENT_TESTS") != "" {
-		t.Skip("Skipping tests with external dependencies as requested")
-	}
-
 	pamCleanup, err := buildPAMRunner(clientPath)
 	require.NoError(t, err, "Setup: Failed to build PAM executable")
 	t.Cleanup(pamCleanup)

--- a/pam/integration-tests/native_test.go
+++ b/pam/integration-tests/native_test.go
@@ -25,6 +25,12 @@ func TestNativeAuthenticate(t *testing.T) {
 		t.Skip("skipping test in short mode.")
 	}
 
+	// Due to external dependencies such as `vhs`, we can't run the tests in some environments (like LP builders), as we
+	// can't install the dependencies there. So we need to be able to skip these tests on-demand.
+	if os.Getenv("AUTHD_SKIP_EXTERNAL_DEPENDENT_TESTS") != "" {
+		t.Skip("Skipping tests with external dependencies as requested")
+	}
+
 	clientPath := t.TempDir()
 	cliEnv := preparePamRunnerTest(t, clientPath)
 	tapeCommand := fmt.Sprintf(nativeTapeBaseCommand, pam_test.RunnerActionLogin,
@@ -477,6 +483,12 @@ func TestNativeChangeAuthTok(t *testing.T) {
 
 	if testing.Short() {
 		t.Skip("skipping test in short mode.")
+	}
+
+	// Due to external dependencies such as `vhs`, we can't run the tests in some environments (like LP builders), as we
+	// can't install the dependencies there. So we need to be able to skip these tests on-demand.
+	if os.Getenv("AUTHD_SKIP_EXTERNAL_DEPENDENT_TESTS") != "" {
+		t.Skip("Skipping tests with external dependencies as requested")
 	}
 
 	// This test is flaky, see https://github.com/canonical/authd/issues/1330

--- a/pam/integration-tests/native_test.go
+++ b/pam/integration-tests/native_test.go
@@ -479,6 +479,11 @@ func TestNativeChangeAuthTok(t *testing.T) {
 		t.Skip("skipping test in short mode.")
 	}
 
+	// This test is flaky, see https://github.com/canonical/authd/issues/1330
+	if os.Getenv("AUTHD_SKIP_FLAKY_TESTS") != "" {
+		t.Skip("skipping flaky test")
+	}
+
 	clientPath := t.TempDir()
 	cliEnv := preparePamRunnerTest(t, clientPath)
 

--- a/pam/integration-tests/ssh_test.go
+++ b/pam/integration-tests/ssh_test.go
@@ -86,6 +86,11 @@ func testSSHAuthenticate(t *testing.T, sharedSSHD bool) {
 		t.Skip("Skipping tests with external dependencies as requested")
 	}
 
+	// These tests are flaky, see https://github.com/canonical/authd/issues/1328
+	if os.Getenv("AUTHD_SKIP_FLAKY_TESTS") != "" {
+		t.Skip("skipping flaky test")
+	}
+
 	if uv := getUbuntuVersion(t); uv == 0 || uv < 2404 {
 		require.Empty(t, os.Getenv("GITHUB_REPOSITORY"),
 			"Golden files need to be updated to run tests on Ubuntu %v", uv)

--- a/pam/internal/adapter/gdmmodel_test.go
+++ b/pam/internal/adapter/gdmmodel_test.go
@@ -7,6 +7,7 @@ import (
 	"encoding/base64"
 	"errors"
 	"fmt"
+	"os"
 	"slices"
 	"strings"
 	"sync"
@@ -35,6 +36,11 @@ func TestGdmModel(t *testing.T) {
 
 	if testing.Short() {
 		t.Skip("skipping test in short mode.")
+	}
+
+	// // These tests are flaky, see https://github.com/canonical/authd/issues/1092
+	if os.Getenv("AUTHD_SKIP_FLAKY_TESTS") != "" {
+		t.Skip("skipping flaky test")
 	}
 
 	// This is not technically an error, as it means that during the tests


### PR DESCRIPTION
> [!important]
> This is based on https://github.com/canonical/authd/pull/1326

Some tests are very flaky when run on launchpad builders. This is not only causing issues for us when we try to publish a new release but can also cause issues for maintainers of packages which authd depends on, because authd's autopkgtests are also run when a new version of one of its dependencies is released.

Let's skip known flaky tests in autopkgtests.

UDENG-9439