### PR TITLE
ci: Fix Update packaging branch

### DIFF
--- a/.github/workflows/debian-build-test-and-sync.yaml
+++ b/.github/workflows/debian-build-test-and-sync.yaml
@@ -82,9 +82,6 @@ jobs:
 
     steps:
       - uses: actions/checkout@v6
-        with:
-          fetch-depth: 100
-          path: repo
 
       - uses: ./.github/actions/setup-oras
 


### PR DESCRIPTION
The checkout action checked out the repo into directory 'repo', even though that is unused since 2afc2037eca0e8d29693cf1662d8919670e2a280.