### PR TITLE
ci: Fix update packaging branch

### DIFF
--- a/.github/workflows/debian-build-test-and-sync.yaml
+++ b/.github/workflows/debian-build-test-and-sync.yaml
@@ -128,7 +128,7 @@ jobs:
           fi
 
       - name: Extract the debian sources
-        run: dpkg-source -x ${{ env.pkg_dsc }} sources
+        run: dpkg-source -x ${{ needs.build-deb.outputs.pkg-dsc }} sources
 
       - name: Commit packaging sources
         run: |


### PR DESCRIPTION
The outputs of the build-deb job are not set as environment variables anymore since c39f0202b38432fb93c15ac8edd15000965c4cef.