### PR TITLE
ci: Fix cleanup of e2e-test VM image

### DIFF
--- a/.github/workflows/oci-artifacts-cleanup.yaml
+++ b/.github/workflows/oci-artifacts-cleanup.yaml
@@ -4,6 +4,9 @@ on:
     # run every day at 5am UTC
     - cron: '0 5 * * *'
   workflow_dispatch:
+  pull_request:
+    paths:
+      - ".github/workflows/oci-artifacts-cleanup.yaml"
 
 jobs:
   cleanup-broker-snap:


### PR DESCRIPTION
GitHub's `delete-package-versions` action always fails to delete the e2e-test images:

        Run actions/delete-package-versions@v5
          with:
            package-name: authd/e2e-runner
            package-type: container
            min-versions-to-keep: 10
            num-old-versions-to-delete: 1
            ignore-versions: ^$
            delete-only-pre-release-versions: false
            delete-only-untagged-versions: false
            token: ***
        Total versions deleted till now: 81
        Error: delete version API failed. Package not found.

It works for the other packages. The only difference I see is that the e2e-runner package is "internal" and the other packages are public.

This is fixed when using a PAT with the `delete:packages` scope.

UDENG-9590