### PR TITLE
l10n: Add Swedish translation

### DIFF
--- a/authd-oidc-brokers/po/sv.po
+++ b/authd-oidc-brokers/po/sv.po
@@ -1,0 +1,59 @@
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: authd\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-04-01 15:21\n"
+"PO-Revision-Date: 2026-04-01 15:21\n"
+"Last-Translator: Daniel Nylander <po@danielnylander.se>\n"
+"Language-Team: Swedish <tp-sv@listor.tp-sv.se>\n"
+"Language: sv\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#: ./authd-oidc-brokers/cmd/authd-oidc/daemon/version.go
+msgid "%s\\t%s"
+msgstr ""
+
+#: ./authd-oidc-brokers/cmd/authd-oidc/daemon/daemon.go
+msgid "issue INFO (-v), DEBUG (-vv) or DEBUG with caller (-vvv) output"
+msgstr "visa INFO (-v), DEBUG (-vv) eller DEBUG med anropare (-vvv) utdata"
+
+#: ./cmd/authd/daemon/config.go
+msgid "use a specific configuration file"
+msgstr "använd en specifik konfigurationsfil"
+
+#: ./internal/brokers/manager.go
+msgid "can't create brokers detection object"
+msgstr "kan inte skapa mäklardetekteringsobjekt"
+
+#: ./internal/daemon/daemon.go
+msgid "unexpected number of systemd socket activation (%d != 1)"
+msgstr "oväntat antal systemd socket-aktiveringar (%d != 1)"
+
+#: ./internal/daemon/daemon.go
+msgid "couldn't send ready notification to systemd: %v"
+msgstr "kunde inte skicka redo-notifikation till systemd: %v"
+
+#: ./internal/daemon/daemon.go
+msgid "can't create daemon"
+msgstr "kan inte skapa daemon"
+
+#: ./internal/daemon/daemon.go
+msgid "error while serving"
+msgstr "fel vid servering"
+
+msgid "Returns version of daemon and exits"
+msgstr "Returnerar version av demonen och avslutar"
+
+msgid "Authentication daemon"
+msgstr "Autentiseringsdemonen"
+
+msgid "Authentication daemon bridging the system with external brokers."
+msgstr ""
+"Autentiseringsdemon som kopplar systemet till externa "
+"autentiseringsförmedlare."
+
+msgid "check configuration and exit"
+msgstr "kontrollera konfiguration och avsluta"

--- a/po/sv.po
+++ b/po/sv.po
@@ -1,0 +1,59 @@
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: authd\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-04-01 15:21\n"
+"PO-Revision-Date: 2026-04-01 15:21\n"
+"Last-Translator: Daniel Nylander <po@danielnylander.se>\n"
+"Language-Team: Swedish <tp-sv@listor.tp-sv.se>\n"
+"Language: sv\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#: ./authd-oidc-brokers/cmd/authd-oidc/daemon/version.go
+msgid "%s\\t%s"
+msgstr ""
+
+#: ./authd-oidc-brokers/cmd/authd-oidc/daemon/daemon.go
+msgid "issue INFO (-v), DEBUG (-vv) or DEBUG with caller (-vvv) output"
+msgstr "visa INFO (-v), DEBUG (-vv) eller DEBUG med anropare (-vvv) utdata"
+
+#: ./cmd/authd/daemon/config.go
+msgid "use a specific configuration file"
+msgstr "använd en specifik konfigurationsfil"
+
+#: ./internal/brokers/manager.go
+msgid "can't create brokers detection object"
+msgstr "kan inte skapa mäklardetekteringsobjekt"
+
+#: ./internal/daemon/daemon.go
+msgid "unexpected number of systemd socket activation (%d != 1)"
+msgstr "oväntat antal systemd socket-aktiveringar (%d != 1)"
+
+#: ./internal/daemon/daemon.go
+msgid "couldn't send ready notification to systemd: %v"
+msgstr "kunde inte skicka redo-notifikation till systemd: %v"
+
+#: ./internal/daemon/daemon.go
+msgid "can't create daemon"
+msgstr "kan inte skapa daemon"
+
+#: ./internal/daemon/daemon.go
+msgid "error while serving"
+msgstr "fel vid servering"
+
+msgid "Returns version of daemon and exits"
+msgstr "Returnerar version av demonen och avslutar"
+
+msgid "Authentication daemon"
+msgstr "Autentiseringsdemonen"
+
+msgid "Authentication daemon bridging the system with external brokers."
+msgstr ""
+"Autentiseringsdemon som kopplar systemet till externa "
+"autentiseringsförmedlare."
+
+msgid "check configuration and exit"
+msgstr "kontrollera konfiguration och avsluta"


### PR DESCRIPTION
Add Swedish (sv) translation for authd and authd-oidc-brokers.

All user-facing strings translated, including:
- CLI help text and descriptions
- Error messages
- Daemon identification strings

Translation follows Swedish language conventions for technical software.