### PR TITLE
Tests to ensure local user login with authd/broker disabled

### DIFF
--- a/e2e-tests/tests/authd_disabled.robot
+++ b/e2e-tests/tests/authd_disabled.robot
@@ -19,11 +19,11 @@ ${username}    %{E2E_USER}
 Test that disabling authd prevents remote logins
     [Documentation]    This test verifies that when authd is disabled, remote users cannot log in, while local users can still access the system.
 
-    # Log in with local user
-    Log In
-
     # Disable authd
     Disable Authd Socket And Service
+
+    # Check that local user can still log in
+    Log In
 
     # Ensure local sudo user can still log in
     Open Terminal

--- a/e2e-tests/tests/broker_disabled.robot
+++ b/e2e-tests/tests/broker_disabled.robot
@@ -19,11 +19,11 @@ ${username}    %{E2E_USER}
 Test that disabling broker prevents remote logins
     [Documentation]    This test verifies that when the broker is disabled, remote users cannot log in, while local users can still access the system.
 
-    # Log in with local user
-    Log In
-
     # Disable broker
     Disable Broker And Purge Config
+
+    # Check that local user can still log in
+    Log In
 
     # Ensure local sudo user can still log in
     Open Terminal


### PR DESCRIPTION
We had these tests before, but we only used them to check if the local user still had access to sudo. Now that we disable authd and the brokers through SSH commands, we can reorder the commands a bit to also make sure the local user can authenticate through GDM.


UDENG-9557