### PR TITLE
Fix version of broker snaps for stable releases

### DIFF
--- a/snap/scripts/version
+++ b/snap/scripts/version
@@ -20,6 +20,17 @@ set -eu
 get_version() {
     current_branch=$(git branch --show-current)
 
+    # If the current commit is tagged with a "$broker-*" tag, where $broker is
+    # the name of the current branch, use that tag as the version after stripping the prefix.
+    tags=$(git tag --points-at HEAD)
+    for tag in ${tags}; do
+        if echo "${tag}" | grep -qE "^${current_branch}-"; then
+            version="${tag#${current_branch}-}"
+            echo "${version}"
+            return
+        fi
+    done
+
     # Get the highest version tag which is prefixed with "broker-"
     tag=$(git -c "versionsort.suffix=-pre" tag --sort=-v:refname --merged="${current_branch}" | grep -E '^broker-' | head -n 1)
     version="${tag}"


### PR DESCRIPTION
We only considered tags which start with "broker-", but the packaging branches (msentraid, google, oidc) add a "Copy msentraid variant files" commit on top, which means that broker releases still had a version like 0.4.0+a254a2c.81db5c3 instead of just 0.4.0.

The fix is to tag these commits with "msentraid-0.4.0" etc. and to use those tags for the version (after stripping the prefix).

UDENG-9604