### PR TITLE
debian/changelog: List Go and Rust dependencies updated in 0.6.0

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -28,20 +28,21 @@ authd (0.6.0) resolute; urgency=medium
     - google.golang.org/grpc v1.79.1
     - google.golang.org/protobuf v1.36.11
     - gopkg.in/ini.v1 v1.67.1
-    - github.com/cpuguy83/go-md2man/v2 v2.0.6 // indirect
-    - github.com/fsnotify/fsnotify v1.9.0 // indirect
-    - github.com/go-viper/mapstructure/v2 v2.4.0 // indirect
-    - github.com/pelletier/go-toml/v2 v2.2.4 // indirect
-    - github.com/russross/blackfriday/v2 v2.1.0 // indirect
-    - github.com/sagikazarmark/locafero v0.11.0 // indirect
-    - github.com/sourcegraph/conc v0.3.1-0.20240121214520-5f936abd7ae8 // indirect
-    - github.com/spf13/afero v1.15.0 // indirect
-    - github.com/spf13/cast v1.10.0 // indirect
-    - go.yaml.in/yaml/v3 v3.0.4 // indirect
-    - golang.org/x/net v0.48.0 // indirect
-    - golang.org/x/sync v0.19.0 // indirect
-    - golang.org/x/text v0.32.0 // indirect
-    - google.golang.org/genproto/googleapis/rpc v0.0.0-20251202230838-ff82c1b0f217 // indirect
+    Indirect dependencies:
+    - github.com/cpuguy83/go-md2man/v2 v2.0.6
+    - github.com/fsnotify/fsnotify v1.9.0
+    - github.com/go-viper/mapstructure/v2 v2.4.0
+    - github.com/pelletier/go-toml/v2 v2.2.4
+    - github.com/russross/blackfriday/v2 v2.1.0
+    - github.com/sagikazarmark/locafero v0.11.0
+    - github.com/sourcegraph/conc v0.3.1-0.20240121214520-5f936abd7ae8
+    - github.com/spf13/afero v1.15.0
+    - github.com/spf13/cast v1.10.0
+    - go.yaml.in/yaml/v3 v3.0.4
+    - golang.org/x/net v0.48.0
+    - golang.org/x/sync v0.19.0
+    - golang.org/x/text v0.32.0
+    - google.golang.org/genproto/googleapis/rpc v0.0.0-20251202230838-ff82c1b0f217
   * Update Rust dependencies:
     - cc ^1.2.34
     - ctor ^0.5.0


### PR DESCRIPTION
We forgot to add these when preparing the changelog entry.