### PR TITLE
snap: Fix unquoted variable in version script

### DIFF
--- a/snap/scripts/version
+++ b/snap/scripts/version
@@ -25,7 +25,7 @@ get_version() {
     tags=$(git tag --points-at HEAD)
     for tag in ${tags}; do
         if echo "${tag}" | grep -qE "^${current_branch}-"; then
-            version="${tag#${current_branch}-}"
+            version="${tag#"${current_branch}"-}"
             echo "${version}"
             return
         fi


### PR DESCRIPTION
This caused our shellcheck CI job to fail.