### PR TITLE
Release 0.6.1

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,4 @@
-authd (0.6.1) UNRELEASED; urgency=medium
+authd (0.6.1) resolute; urgency=medium
 
   * Update Go dependencies:
     - github.com/mattn/go-sqlite3 v1.14.38
@@ -11,7 +11,7 @@ authd (0.6.1) UNRELEASED; urgency=medium
     - google.golang.org/genproto/googleapis/rpc
       v0.0.0-20260120221211-b8f7ae30c516
 
- -- Adrian Dombeck <adrian.dombeck@canonical.com>  Fri, 03 Apr 2026 12:43:33 +0200
+ -- Adrian Dombeck <adrian.dombeck@canonical.com>  Fri, 03 Apr 2026 19:36:26 +0200
 
 authd (0.6.0) resolute; urgency=medium
 


### PR DESCRIPTION
```
* Update Go dependencies:
  - github.com/mattn/go-sqlite3 v1.14.38
  - golang.org/x/sys v0.42.0
  - golang.org/x/term v0.41.0
  - google.golang.org/grpc v1.80.0
  Indirect dependencies:
  - golang.org/x/net v0.49.0
  - golang.org/x/text v0.33.0
  - google.golang.org/genproto/googleapis/rpc v0.0.0-20260120221211-b8f7ae30c516
```