### PR TITLE
Add DisplayName() to Provider interface

### DIFF
--- a/authd-oidc-brokers/internal/broker/broker.go
+++ b/authd-oidc-brokers/internal/broker/broker.go
@@ -748,13 +748,13 @@ func (b *Broker) passwordAuth(ctx context.Context, session *session, secret stri
 	}
 
 	if authInfo.UserIsDisabled && session.isOffline {
-		log.Errorf(context.Background(), "Login denied: user %q is disabled in Microsoft Entra ID and session is offline", session.username)
-		return AuthDenied, errorMessage{Message: "This user is disabled in Microsoft Entra ID. Please contact your administrator or try again with a working network connection."}
+		log.Errorf(context.Background(), "Login denied: user %q is disabled in %s and session is offline", session.username, b.provider.DisplayName())
+		return AuthDenied, errorMessage{Message: fmt.Sprintf("Your user account is disabled in %s. Please contact your administrator or try again with a working network connection.", b.provider.DisplayName())}
 	}
 
 	if authInfo.DeviceIsDisabled && session.isOffline {
-		log.Errorf(context.Background(), "Login denied: device %q is disabled in Microsoft Entra ID and session is offline", session.username)
-		return AuthDenied, errorMessage{Message: "This device is disabled in Microsoft Entra ID. Please contact your administrator or try again with a working network connection."}
+		log.Errorf(context.Background(), "Login denied: device %q is disabled in %s and session is offline", session.username, b.provider.DisplayName())
+		return AuthDenied, errorMessage{Message: fmt.Sprintf("This device is disabled in %s. Please contact your administrator or try again with a working network connection.", b.provider.DisplayName())}
 	}
 
 	// Refresh the token if we're online even if the token has not expired
@@ -778,7 +778,7 @@ func (b *Broker) passwordAuth(ctx context.Context, session *session, secret stri
 			}
 			if b.provider.IsUserDisabledError(retrieveErr) {
 				log.Error(context.Background(), retrieveErr.Error())
-				log.Errorf(context.Background(), "Login failed: User %q is disabled in Microsoft Entra ID, please contact your administrator.", session.username)
+				log.Errorf(context.Background(), "Login denied: User %q is disabled in %s, please contact your administrator.", session.username, b.provider.DisplayName())
 
 				// Store the information that the user is disabled, so that we can deny login on subsequent offline attempts.
 				oldAuthInfo.UserIsDisabled = true
@@ -787,7 +787,7 @@ func (b *Broker) passwordAuth(ctx context.Context, session *session, secret stri
 					return AuthDenied, unexpectedErrMsg("failed to store token")
 				}
 
-				return AuthDenied, errorMessage{Message: "This user is disabled in Microsoft Entra ID, please contact your administrator."}
+				return AuthDenied, errorMessage{Message: fmt.Sprintf("Your user account is disabled in %s, please contact your administrator.", b.provider.DisplayName())}
 			}
 		}
 		if err != nil {
@@ -831,7 +831,7 @@ func (b *Broker) passwordAuth(ctx context.Context, session *session, secret stri
 			return AuthDenied, unexpectedErrMsg("failed to store token")
 		}
 
-		return AuthDenied, errorMessage{Message: "This device is disabled in Microsoft Entra ID, please contact your administrator."}
+		return AuthDenied, errorMessage{Message: fmt.Sprintf("This device is disabled in %s, please contact your administrator.", b.provider.DisplayName())}
 	}
 	if errors.Is(err, himmelblau.ErrInvalidRedirectURI) {
 		// Deny login if the redirect URI is invalid, so that users and administrators are aware of the issue.

--- a/authd-oidc-brokers/internal/broker/testdata/golden/TestIsAuthenticated/Error_when_device_is_disabled_and_session_is_offline/first_call
+++ b/authd-oidc-brokers/internal/broker/testdata/golden/TestIsAuthenticated/Error_when_device_is_disabled_and_session_is_offline/first_call
@@ -1,3 +1,3 @@
 access: denied
-data: '{"message":"This device is disabled in Microsoft Entra ID. Please contact your administrator or try again with a working network connection."}'
+data: '{"message":"This device is disabled in the identity provider. Please contact your administrator or try again with a working network connection."}'
 err: <nil>

--- a/authd-oidc-brokers/internal/broker/testdata/golden/TestIsAuthenticated/Error_when_user_is_disabled_and_session_is_offline/first_call
+++ b/authd-oidc-brokers/internal/broker/testdata/golden/TestIsAuthenticated/Error_when_user_is_disabled_and_session_is_offline/first_call
@@ -1,3 +1,3 @@
 access: denied
-data: '{"message":"This user is disabled in Microsoft Entra ID. Please contact your administrator or try again with a working network connection."}'
+data: '{"message":"Your user account is disabled in the identity provider. Please contact your administrator or try again with a working network connection."}'
 err: <nil>

--- a/authd-oidc-brokers/internal/providers/genericprovider/genericprovider.go
+++ b/authd-oidc-brokers/internal/providers/genericprovider/genericprovider.go
@@ -21,6 +21,11 @@ func New() GenericProvider {
 	return GenericProvider{}
 }
 
+// DisplayName returns the display name of the provider.
+func (p GenericProvider) DisplayName() string {
+	return "the identity provider"
+}
+
 // AdditionalScopes returns the generic scopes required by the provider.
 func (p GenericProvider) AdditionalScopes() []string {
 	return []string{}

--- a/authd-oidc-brokers/internal/providers/google/google.go
+++ b/authd-oidc-brokers/internal/providers/google/google.go
@@ -17,6 +17,11 @@ func New() Provider {
 	}
 }
 
+// DisplayName returns the display name of the provider.
+func (Provider) DisplayName() string {
+	return "Google IAM"
+}
+
 // AdditionalScopes returns the generic scopes required by the provider.
 // Note that we do not return oidc.ScopeOfflineAccess, as for TV/limited input devices, the API call will fail as not
 // supported by this application type. However, the refresh token will be acquired and is functional to refresh without

--- a/authd-oidc-brokers/internal/providers/msentraid/msentraid.go
+++ b/authd-oidc-brokers/internal/providers/msentraid/msentraid.go
@@ -61,6 +61,11 @@ func (p *Provider) AdditionalScopes() []string {
 	return []string{oidc.ScopeOfflineAccess, "GroupMember.Read.All", "User.Read"}
 }
 
+// DisplayName returns the display name of the provider.
+func (p *Provider) DisplayName() string {
+	return "Microsoft Entra ID"
+}
+
 // AuthOptions returns the generic auth options required by the EntraID provider.
 func (p *Provider) AuthOptions() []oauth2.AuthCodeOption {
 	return []oauth2.AuthCodeOption{}

--- a/authd-oidc-brokers/internal/providers/providers.go
+++ b/authd-oidc-brokers/internal/providers/providers.go
@@ -13,6 +13,7 @@ import (
 type Provider interface {
 	AdditionalScopes() []string
 	AuthOptions() []oauth2.AuthCodeOption
+	DisplayName() string
 	GetExtraFields(token *oauth2.Token) map[string]interface{}
 	GetMetadata(provider *oidc.Provider) (map[string]interface{}, error)
 


### PR DESCRIPTION
... and use it in disabled-account error messages.

- Add DisplayName() method to the Provider interface
- GenericProvider returns "the identity provider"
- Google provider returns "Google IAM"
- MsEntraID provider returns "Microsoft Entra ID"
- Use provider.DisplayName() in all user/device disabled error messages so users know the account is disabled in the IdP, not locally

Agent-Logs-Url: https://github.com/canonical/authd/sessions/3bc1f769-fb1a-43f2-914b-619d549e6934