### PR TITLE
ci/e2e-tests: Fix build of broker snap on main

### DIFF
--- a/.github/workflows/build-broker-snap.yaml
+++ b/.github/workflows/build-broker-snap.yaml
@@ -64,7 +64,9 @@ jobs:
           # Tags and main branch are needed by the snap/scripts/version script
           # which is used during the build of the broker snap.
           git fetch --tags --unshallow
-          git fetch origin main:main
+          if [ "$(git branch --show-current)" != "main" ]; then
+            git fetch origin main:main
+          fi
 
           ./snap/scripts/prepare-variant --broker "${{ inputs.broker }}"
 


### PR DESCRIPTION
It failed with:

    + git fetch origin main:main
    fatal: refusing to fetch into branch 'refs/heads/main' checked out at '/home/runner/work/authd/authd'

We don't need to explicitly fetch the main branch if it's the current branch.

UDENG-9621