### PR TITLE
docs: improve group management content

### DIFF
--- a/docs/howto/configure-authd.md
+++ b/docs/howto/configure-authd.md
@@ -421,6 +421,8 @@ Changing the base directory only affects users logging in for the first time.
 
 Some brokers support adding users to groups that are configured in the identity
 provider.
+Group membership can be used to manage user privileges, including **sudo** and
+**docker** rights.
 
 > See the [group management reference](reference::group-management) for more details.
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -55,6 +55,7 @@ full transition to the cloud.
 
 * **Setup**: [Installing authd](/howto/install-authd/) • [Configuring authd](/howto/configure-authd/) • [Changing authd versions](/howto/changing-versions/)
 * **User login**: [Logging in with GDM](/howto/login-gdm/) • [Logging in with SSH](/howto/login-ssh/)
+* **Groups and privileges (sudo, docker)**: [Configure user groups](ref::config-user-groups) • [Group management reference](/reference/group-management)
 * **Deployment**: [Deploying with Landscape](/reference/landscape-deploy/) • [Deploying with cloud-init](/reference/cloud-init-deploy/)
 * **Network file systems**: [Using with NFS](/howto/use-with-nfs/) • [Using with Samba](/howto/use-with-samba/)
 * **authd design**: [Architecture](/explanation/authd-architecture/) • [Security overview](/explanation/security/)

--- a/docs/reference/group-management.md
+++ b/docs/reference/group-management.md
@@ -1,20 +1,22 @@
 ---
 myst:
   html_meta:
-    "description lang=en": "Management of groups using authd with Microsoft Entra ID."
+    "description lang=en": "Management of groups, and privileges like sudo and docker, using authd."
 ---
 
 (reference::group-management)=
-# Group management
+# Group and privilege management
 
 Groups are used to manage users that all need the same access and permissions to resources.
-Groups from the remote provider can be mapped into local Linux groups for the user.
+For example, you can manage **sudo** and **docker** rights of users based on group membership.
 
-In addition, you can configure extra groups
-[in the broker configuration file](ref::config-user-groups).
+Groups from the identity provider can be mapped into local Linux groups for the user.
+You can also configure extra groups in the broker configuration file,
+as described in the [configuration guide](ref::config-user-groups).
 
-```{note}
-  Groups are currently supported for the `msentraid` broker.
+```{admonition} Broker support for group management
+:class: important
+Groups are currently supported for the `msentraid` broker.
 ```
 
 ## Microsoft Entra ID
@@ -23,11 +25,11 @@ Microsoft Entra ID supports creating groups and adding users to them.
 
 > See [Manage Microsoft Entra groups and group membership](https://learn.microsoft.com/en-us/entra/fundamentals/how-to-manage-groups)
 
-For example the user `authd test`, is a member of the Entra ID groups `Azure_OIDC_Test` and `linux-sudo`:
+For example, the user `authd test` is a member of the Entra ID groups `Azure_OIDC_Test` and `linux-sudo`:
 
 ![Azure portal interface showing the Azure groups.](../assets/entraid-groups.png)
 
-This translates to the following unix groups on the local machine:
+This translates to the following Linux groups on the local machine:
 
 ```shell
 ~$ groups
@@ -36,5 +38,5 @@ aadtest-testauthd@uaadtest.onmicrosoft.com sudo azure_oidc_test
 
 There are three types of groups:
 1. **Primary group**: Created automatically based on the user name
-1. **Local group**: Group local to the machine prefixed with `linux-`. For instance if the user is a member of the Azure group `linux-sudo`, they will be a member of the `sudo` group locally.
+1. **Local group**: Group local to the machine prefixed with `linux-`. For example, if the user is a member of the Azure group `linux-sudo`, they will be a member of the `sudo` group locally.
 1. **Remote group**: All the other Azure groups the user is a member of.

--- a/docs/reference/index.md
+++ b/docs/reference/index.md
@@ -40,7 +40,7 @@ is supported by the Microsoft Entra ID broker for authd:
 ```{toctree}
 :titlesonly:
 
-Group management <group-management>
+Group and privilege management <group-management>
 ```
 ## Deployment
 


### PR DESCRIPTION
Users with a particular interest in common privilege management scenarios, such as those related to sudo and docker, may have difficulty finding the relevant information by internal or external search.

Here, the following changes are proposed to better surface this aspect of group management:

* Retitle main reference page to "Group and privilege management"
* Include entry for Group and privilege management on the homepage docs map
* Update reference page content and metadescription to include explicit mention of common use-cases (sudo, docker)
* Update section in config guide related to groups to mention common use-cases

In addition, several minor copy improvements were made to the reference page for consistency and clarity.

UDENG-9497