### PR TITLE
docs: cross-ref relevant SSH content

### DIFF
--- a/docs/howto/login-ssh.md
+++ b/docs/howto/login-ssh.md
@@ -28,6 +28,12 @@ Then restart the SSH server:
 sudo systemctl restart ssh
 ```
 
+```{admonition} Managing SSH securely for authd deployments
+:class: tip
+More detail on securely managing SSH authentication is provided in the [SSH
+section of the security overview](/explanation/security.md#login-via-ssh).
+```
+
 ### Broker configuration
 
 To configure the broker edit the file `/var/snap/authd-<broker_name>/current/broker.conf` and set the key `ssh_allowed_suffixes` with the list of domains that you want to allow.


### PR DESCRIPTION
Content on SSH in the security overview is relevant to the reader of the SSH how-to guide.

This adds brief note and a link in the how-to guide.

UDENG-8258