### PR TITLE
Add changelog entry for 0.6.2

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,8 +1,8 @@
-authd (0.6.2) UNRELEASED; urgency=medium
+authd (0.6.2) resolute; urgency=medium
 
   * New upload
 
- -- Adrian Dombeck <adrian.dombeck@canonical.com>  Wed, 08 Apr 2026 18:22:45 +0200
+ -- Adrian Dombeck <adrian.dombeck@canonical.com>  Wed, 08 Apr 2026 18:29:02 +0200
 
 authd (0.6.1) resolute; urgency=medium
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+authd (0.6.2) UNRELEASED; urgency=medium
+
+  * New upload
+
+ -- Adrian Dombeck <adrian.dombeck@canonical.com>  Wed, 08 Apr 2026 18:22:45 +0200
+
 authd (0.6.1) resolute; urgency=medium
 
   * Update Go dependencies:


### PR DESCRIPTION
New upload to fix the version of the packages backported to Noble and Questing. We used `0.6.1+ubuntu24.04` / `0.6.1+ubuntu25.10` in the last release. The `+` in there breaks uploads to the edge PPA, they currently fail with:

```
Version older than that in the archive. 0.6.1+git260407+178+1590501b~ubuntu24.04.1 <= 0.6.1+ubuntu24.04
```

To fix that, we're switching back to using `~` instead of `+`, so the new backported packages will have version `0.6.2~ubuntu24.04` / `0.6.2~ubuntu25.10`.

UDENG-9745