### PR TITLE
Return PAM_MAXTRIES on too many auth failures

### DIFF
--- a/authd-oidc-brokers/internal/broker/broker.go
+++ b/authd-oidc-brokers/internal/broker/broker.go
@@ -618,8 +618,11 @@ func (b *Broker) IsAuthenticated(sessionID, authenticationData string) (string, 
 
 	if access == AuthRetry {
 		session.attemptsPerMode[session.selectedMode]++
-		if session.attemptsPerMode[session.selectedMode] == maxAuthAttempts {
-			access = AuthDenied
+		if session.attemptsPerMode[session.selectedMode] >= maxAuthAttempts {
+			access = AuthDeniedMaxTries
+			if b.apiVersion < 2 {
+				access = AuthDenied
+			}
 			iadResponse = errorMessage{Message: "Maximum number of authentication attempts reached"}
 		}
 	}

--- a/authd-oidc-brokers/internal/broker/broker.go
+++ b/authd-oidc-brokers/internal/broker/broker.go
@@ -38,7 +38,7 @@ const (
 	// LatestAPIVersion is the latest API version supported by the broker. It should be incremented when a non backward
 	// compatible change is made to the API.
 	// Note: Remember to also bump the LatestAPIVersion in internal/brokers/dbusbroker.go.
-	LatestAPIVersion = 2
+	LatestAPIVersion uint = 2
 
 	maxAuthAttempts    = 3
 	maxRequestDuration = 5 * time.Second

--- a/authd-oidc-brokers/internal/broker/broker_test.go
+++ b/authd-oidc-brokers/internal/broker/broker_test.go
@@ -1353,6 +1353,61 @@ func TestCancelIsAuthenticated(t *testing.T) {
 	<-stopped
 }
 
+func TestIsAuthenticatedMaxAttempts(t *testing.T) {
+	t.Parallel()
+
+	correctPassword := "password"
+
+	tests := map[string]struct {
+		apiVersion uint
+		wantAccess string
+	}{
+		"Returns_denied-max-tries_when_api_version_is_2": {
+			apiVersion: 2,
+			wantAccess: broker.AuthDeniedMaxTries,
+		},
+		"Returns_denied-max-tries_when_api_version_is_greater_than_2": {
+			apiVersion: 3,
+			wantAccess: broker.AuthDeniedMaxTries,
+		},
+		"Returns_denied_when_api_version_is_less_than_2": {
+			apiVersion: 1,
+			wantAccess: broker.AuthDenied,
+		},
+	}
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			b := newBrokerForTests(t, &brokerForTestConfig{
+				issuerURL:  defaultIssuerURL,
+				apiVersion: tc.apiVersion,
+			})
+
+			sessionID, key := newSessionForTests(t, b, "", "")
+
+			// Store a valid token and password so that password auth mode is available.
+			generateAndStoreCachedInfo(t, tokenOptions{}, b.TokenPathForSession(sessionID))
+			err := password.HashAndStorePassword(correctPassword, b.PasswordFilepathForSession(sessionID))
+			require.NoError(t, err, "Setup: HashAndStorePassword should not have returned an error")
+
+			wrongSecret := encryptSecret(t, "wrongpassword", key)
+			authData := fmt.Sprintf(`{"%s":"%s"}`, broker.AuthDataSecret, wrongSecret)
+
+			err = b.SetAttemptsPerMode(sessionID, authmodes.Password, broker.MaxAuthAttempts-1)
+			require.NoError(t, err, "Setup: Failed to set auth attempts")
+			updateAuthModes(t, b, sessionID, authmodes.Password)
+
+			access, data, err := b.IsAuthenticated(sessionID, authData)
+			require.NoError(t, err, "IsAuthenticated should not have returned an error")
+
+			require.True(t, json.Valid([]byte(data)), "IsAuthenticated returned data must be valid JSON")
+			require.Equal(t, tc.wantAccess, access, "Final attempt should return %s", tc.wantAccess)
+			golden.CheckOrUpdateYAML(t, isAuthenticatedResponse{Access: access, Data: data, Err: ""})
+		})
+	}
+}
+
 func TestEndSession(t *testing.T) {
 	t.Parallel()
 

--- a/authd-oidc-brokers/internal/broker/consts.go
+++ b/authd-oidc-brokers/internal/broker/consts.go
@@ -6,6 +6,8 @@ const (
 	AuthGranted = "granted"
 	// AuthDenied is the response when the authentication is denied.
 	AuthDenied = "denied"
+	// AuthDeniedMaxTries is the response when the maximum number of tries has been exceeded.
+	AuthDeniedMaxTries = "denied-max-tries"
 	// AuthCancelled is the response when the authentication is cancelled.
 	AuthCancelled = "cancelled"
 	// AuthRetry is the response when the authentication needs to be retried (another chance).
@@ -15,7 +17,7 @@ const (
 )
 
 // AuthReplies is the list of all possible authentication replies.
-var AuthReplies = []string{AuthGranted, AuthDenied, AuthCancelled, AuthRetry, AuthNext}
+var AuthReplies = []string{AuthGranted, AuthDenied, AuthDeniedMaxTries, AuthCancelled, AuthRetry, AuthNext}
 
 const (
 	// AuthDataSecret is the key for the secret in the authentication data.

--- a/authd-oidc-brokers/internal/broker/export_test.go
+++ b/authd-oidc-brokers/internal/broker/export_test.go
@@ -180,5 +180,21 @@ func (b *Broker) IsOffline(sessionID string) (bool, error) {
 	return session.isOffline, nil
 }
 
+func (b *Broker) SetAttemptsPerMode(sessionID, mode string, attempts int) error {
+	s, err := b.getSession(sessionID)
+	if err != nil {
+		return err
+	}
+	if s.attemptsPerMode == nil {
+		s.attemptsPerMode = make(map[string]int)
+	}
+	s.attemptsPerMode[mode] = attempts
+
+	return b.updateSession(sessionID, s)
+}
+
 // MaxRequestDuration exposes the broker's maxRequestDuration for tests.
 const MaxRequestDuration = maxRequestDuration
+
+// MaxAuthAttempts exposes the broker's maxAuthAttempts for tests.
+const MaxAuthAttempts = maxAuthAttempts

--- a/authd-oidc-brokers/internal/broker/helper_test.go
+++ b/authd-oidc-brokers/internal/broker/helper_test.go
@@ -37,6 +37,7 @@ type brokerForTestConfig struct {
 	homeBaseDir                  string
 	allowedSSHSuffixes           []string
 	provider                     providers.Provider
+	apiVersion                   uint
 
 	getGroupsFails             bool
 	supportsDeviceRegistration bool
@@ -123,7 +124,12 @@ func newBrokerForTests(t *testing.T, cfg *brokerForTestConfig) (b *broker.Broker
 		cfg.SetIssuerURL(issuerURL)
 	}
 
-	b, err := broker.New(cfg.Config, broker.LatestAPIVersion, broker.WithCustomProvider(provider))
+	apiVersion := broker.LatestAPIVersion
+	if cfg.apiVersion != 0 {
+		apiVersion = cfg.apiVersion
+	}
+
+	b, err := broker.New(cfg.Config, apiVersion, broker.WithCustomProvider(provider))
 	require.NoError(t, err, "Setup: New should not have returned an error")
 	return b
 }

--- a/authd-oidc-brokers/internal/broker/testdata/golden/TestIsAuthenticatedMaxAttempts/Returns_denied-max-tries_when_api_version_is_2
+++ b/authd-oidc-brokers/internal/broker/testdata/golden/TestIsAuthenticatedMaxAttempts/Returns_denied-max-tries_when_api_version_is_2
@@ -1,0 +1,3 @@
+access: denied-max-tries
+data: '{"message":"Maximum number of authentication attempts reached"}'
+err: ""

--- a/authd-oidc-brokers/internal/broker/testdata/golden/TestIsAuthenticatedMaxAttempts/Returns_denied-max-tries_when_api_version_is_greater_than_2
+++ b/authd-oidc-brokers/internal/broker/testdata/golden/TestIsAuthenticatedMaxAttempts/Returns_denied-max-tries_when_api_version_is_greater_than_2
@@ -1,0 +1,3 @@
+access: denied-max-tries
+data: '{"message":"Maximum number of authentication attempts reached"}'
+err: ""

--- a/authd-oidc-brokers/internal/broker/testdata/golden/TestIsAuthenticatedMaxAttempts/Returns_denied_when_api_version_is_less_than_2
+++ b/authd-oidc-brokers/internal/broker/testdata/golden/TestIsAuthenticatedMaxAttempts/Returns_denied_when_api_version_is_less_than_2
@@ -1,0 +1,3 @@
+access: denied
+data: '{"message":"Maximum number of authentication attempts reached"}'
+err: ""

--- a/examplebroker/broker.go
+++ b/examplebroker/broker.go
@@ -658,7 +658,8 @@ func (b *Broker) IsAuthenticated(ctx context.Context, sessionID, authenticationD
 	} else if access == auth.Retry {
 		sessionInfo.attemptsPerMode[sessionInfo.currentAuthMode]++
 		if sessionInfo.attemptsPerMode[sessionInfo.currentAuthMode] >= maxAttempts {
-			access = auth.Denied
+			access = auth.DeniedMaxTries
+			data = `{"message": "Maximum number of authentication attempts reached"}`
 		}
 	}
 

--- a/examplebroker/dbus.go
+++ b/examplebroker/dbus.go
@@ -15,8 +15,9 @@ import (
 const (
 	dbusObjectPath = "/com/ubuntu/authd/ExampleBroker"
 	busName        = "com.ubuntu.authd.ExampleBroker"
-	// we need to redeclare the interface here to avoid include cycles.
-	dbusInterface = "com.ubuntu.authd.Broker"
+	// we need to redeclare the interface and API version here to avoid include cycles.
+	dbusInterface    = "com.ubuntu.authd.Broker"
+	latestAPIVersion = 2
 )
 
 // Bus is the D-Bus object that will answer calls for the broker.
@@ -35,7 +36,7 @@ func StartBus(cfgPath string) (conn *dbus.Conn, err error) {
 
 	b, _, _ := New("ExampleBroker")
 	obj := Bus{broker: b}
-	err = conn.Export(&obj, dbusObjectPath, dbusInterface)
+	err = conn.Export(&obj, dbusObjectPath, fmt.Sprintf("%s%d", dbusInterface, latestAPIVersion))
 	if err != nil {
 		return nil, err
 	}
@@ -45,7 +46,7 @@ func StartBus(cfgPath string) (conn *dbus.Conn, err error) {
 		Interfaces: []introspect.Interface{
 			introspect.IntrospectData,
 			{
-				Name:    dbusInterface,
+				Name:    fmt.Sprintf("%s%d", dbusInterface, latestAPIVersion),
 				Methods: introspect.Methods(&obj),
 			},
 		},

--- a/internal/brokers/auth/consts.go
+++ b/internal/brokers/auth/consts.go
@@ -6,6 +6,8 @@ const (
 	Granted = "granted"
 	// Denied is the response when the authentication is denied.
 	Denied = "denied"
+	// DeniedMaxTries is the response when the maximum number of tries has been exceeded.
+	DeniedMaxTries = "denied-max-tries"
 	// Cancelled is the response when the authentication is cancelled.
 	Cancelled = "cancelled"
 	// Retry is the response when the authentication needs to be retried (another chance).
@@ -15,7 +17,7 @@ const (
 )
 
 // Replies is the list of all possible authentication replies.
-var Replies = []string{Granted, Denied, Cancelled, Retry, Next}
+var Replies = []string{Granted, Denied, DeniedMaxTries, Cancelled, Retry, Next}
 
 const (
 	// SessionModeLogin is used when the session is for user login.

--- a/internal/testutils/broker.go
+++ b/internal/testutils/broker.go
@@ -18,6 +18,8 @@ import (
 )
 
 const (
+	latestAPIVersion = 2
+
 	dbusInterface = "com.ubuntu.authd.Broker"
 	objectPathFmt = "/com/ubuntu/authd/%s"
 	nameFmt       = "com.ubuntu.authd.%s"
@@ -75,7 +77,7 @@ func StartBusBrokerMock(cfgDir string, brokerName string) (string, func(), error
 		isAuthenticatedCallsMu: sync.RWMutex{},
 	}
 
-	if err = conn.Export(&bus, dbus.ObjectPath(busObjectPath), dbusInterface); err != nil {
+	if err = conn.Export(&bus, dbus.ObjectPath(busObjectPath), fmt.Sprintf("%s%d", dbusInterface, latestAPIVersion)); err != nil {
 		conn.Close()
 		return "", nil, err
 	}
@@ -85,7 +87,7 @@ func StartBusBrokerMock(cfgDir string, brokerName string) (string, func(), error
 		Interfaces: []introspect.Interface{
 			introspect.IntrospectData,
 			{
-				Name:    dbusInterface,
+				Name:    fmt.Sprintf("%s%d", dbusInterface, latestAPIVersion),
 				Methods: introspect.Methods(&bus),
 			},
 		},

--- a/pam/integration-tests/gdm_test.go
+++ b/pam/integration-tests/gdm_test.go
@@ -874,14 +874,14 @@ func TestGdmModule(t *testing.T) {
 					Msg:    "invalid password 'not yet goodpass', should be 'goodpass'",
 				},
 				{
-					Access: auth.Denied,
-					Msg:    "invalid password 'really, it's not a goodpass!', should be 'goodpass'",
+					Access: auth.DeniedMaxTries,
+					Msg:    "Maximum number of authentication attempts reached",
 				},
 			},
 			wantPamErrorMessages: []string{
-				"invalid password 'really, it's not a goodpass!', should be 'goodpass'",
+				"Maximum number of authentication attempts reached",
 			},
-			wantError:       pam.ErrAuth,
+			wantError:       pam.ErrMaxtries,
 			wantAcctMgmtErr: pam_test.ErrIgnore,
 		},
 		"Error_on_authenticating_unknown_user": {

--- a/pam/integration-tests/testdata/golden/TestCLIAuthenticate/Deny_authentication_if_max_attempts_reached
+++ b/pam/integration-tests/testdata/golden/TestCLIAuthenticate/Deny_authentication_if_max_attempts_reached
@@ -81,11 +81,11 @@ invalid password 'wrongpass', should be 'goodpass'
   Press escape key to go back to select the authentication method
 ────────────────────────────────────────────────────────────────────────────────
 > ./pam_authd login socket=${AUTHD_TEST_TAPE_SOCKET}
-PAM Error Message: invalid password 'wrongpass', should be 'goodpass'
+PAM Error Message: Maximum number of authentication attempts reached
 PAM Authenticate()
   User: "user-integration-max-attempts@example.com"
-  Result: error: PAM exit code: 7
-    Authentication failure
+  Result: error: PAM exit code: 11
+    Have exhausted maximum number of retries for service
 PAM Info Message: acct=incomplete
 PAM AcctMgmt()
   User: "user-integration-max-attempts@example.com"

--- a/pam/integration-tests/testdata/golden/TestCLIChangeAuthTok/Prevent_change_password_if_auth_fails
+++ b/pam/integration-tests/testdata/golden/TestCLIChangeAuthTok/Prevent_change_password_if_auth_fails
@@ -81,11 +81,11 @@ invalid password 'wrongpass', should be 'goodpass'
   Press escape key to go back to select the authentication method
 ────────────────────────────────────────────────────────────────────────────────
 > ./pam_authd passwd socket=${AUTHD_TEST_TAPE_SOCKET}
-PAM Error Message: invalid password 'wrongpass', should be 'goodpass'
+PAM Error Message: Maximum number of authentication attempts reached
 PAM ChangeAuthTok()
   User: "user-integration-cli-passwd-prevent-change-password-if-auth-fails@example.com"
-  Result: error: PAM exit code: 7
-    Authentication failure
+  Result: error: PAM exit code: 11
+    Have exhausted maximum number of retries for service
 PAM Info Message: acct=incomplete
 PAM AcctMgmt()
   User: "user-integration-cli-passwd-prevent-change-password-if-auth-fails@example.com"

--- a/pam/integration-tests/testdata/golden/TestNativeAuthenticate/Deny_authentication_if_max_attempts_reached
+++ b/pam/integration-tests/testdata/golden/TestNativeAuthenticate/Deny_authentication_if_max_attempts_reached
@@ -147,11 +147,11 @@ PAM Error Message: invalid password 'wrongpass', should be 'goodpass'
 Enter 'r' to cancel the request and go back to select the authentication method
 Gimme your password:
 >
-PAM Error Message: invalid password 'wrongpass', should be 'goodpass'
+PAM Error Message: Maximum number of authentication attempts reached
 PAM Authenticate()
   User: "user-integration-native-deny-authentication-if-max-attempts-reached@example.com"
-  Result: error: PAM exit code: 7
-    Authentication failure
+  Result: error: PAM exit code: 11
+    Have exhausted maximum number of retries for service
 acct=incomplete
 PAM AcctMgmt()
   User: "user-integration-native-deny-authentication-if-max-attempts-reached@example.com"

--- a/pam/integration-tests/testdata/golden/TestNativeChangeAuthTok/Prevent_change_password_if_auth_fails
+++ b/pam/integration-tests/testdata/golden/TestNativeChangeAuthTok/Prevent_change_password_if_auth_fails
@@ -166,11 +166,11 @@ PAM Error Message: invalid password 'wrongpass', should be 'goodpass'
 Enter 'r' to cancel the request and go back to select the authentication method
 Gimme your password:
 >
-PAM Error Message: invalid password 'wrongpass', should be 'goodpass'
+PAM Error Message: Maximum number of authentication attempts reached
 PAM ChangeAuthTok()
   User: "user-integration-native-passwd-prevent-change-password-if-auth-fails@example.com"
-  Result: error: PAM exit code: 7
-    Authentication failure
+  Result: error: PAM exit code: 11
+    Have exhausted maximum number of retries for service
 acct=incomplete
 PAM AcctMgmt()
   User: "user-integration-native-passwd-prevent-change-password-if-auth-fails@example.com"

--- a/pam/integration-tests/testdata/golden/TestSSHAuthenticate/Deny_authentication_if_max_attempts_reached
+++ b/pam/integration-tests/testdata/golden/TestSSHAuthenticate/Deny_authentication_if_max_attempts_reached
@@ -147,7 +147,7 @@ invalid password 'wrongpass', should be 'goodpass'
 Enter 'r' to cancel the request and go back to select the authentication method
 (user-integration-pre-check-ssh-deny-authentication-if-max-attempts-reached@example.com@localhost) Gimme your password:
 >
-invalid password 'wrongpass', should be 'goodpass'
+Maximum number of authentication attempts reached
 Received disconnect from ${SSH_HOST} port ${SSH_PORT} Too many authentication failures
 Disconnected from ${SSH_HOST} port ${SSH_PORT}
 >

--- a/pam/integration-tests/testdata/golden/TestSSHAuthenticate/Deny_authentication_if_max_attempts_reached_with_shared_sshd
+++ b/pam/integration-tests/testdata/golden/TestSSHAuthenticate/Deny_authentication_if_max_attempts_reached_with_shared_sshd
@@ -147,7 +147,7 @@ invalid password 'wrongpass', should be 'goodpass'
 Enter 'r' to cancel the request and go back to select the authentication method
 (user-integration-pre-check-ssh-deny-authentication-if-max-attempts-reached-with-shared-sshd@example.com@localhost) Gimme your password:
 >
-invalid password 'wrongpass', should be 'goodpass'
+Maximum number of authentication attempts reached
 Received disconnect from ${SSH_HOST} port ${SSH_PORT} Too many authentication failures
 Disconnected from ${SSH_HOST} port ${SSH_PORT}
 >

--- a/pam/integration-tests/testdata/tapes/cli/max_attempts.tape
+++ b/pam/integration-tests/testdata/tapes/cli/max_attempts.tape
@@ -61,6 +61,6 @@ Show
 
 Hide
 Enter
-Wait+Screen /invalid password 'wrongpass', should be[^\n]+/
+Wait+Screen /Maximum number of authentication attempts reached/
 ${AUTHD_TEST_TAPE_COMMAND_AUTH_FINAL_WAIT}
 Show

--- a/pam/integration-tests/testdata/tapes/native/max_attempts.tape
+++ b/pam/integration-tests/testdata/tapes/native/max_attempts.tape
@@ -44,6 +44,6 @@ Show
 Hide
 Type "wrongpass"
 Enter
-Wait+Nth(5)  /invalid password 'wrongpass', should be/
+Wait+Screen  /Maximum number of authentication attempts reached/
 ${AUTHD_TEST_TAPE_COMMAND_AUTH_FINAL_WAIT}
 Show

--- a/pam/integration-tests/testdata/tapes/native/passwd_auth_fail.tape
+++ b/pam/integration-tests/testdata/tapes/native/passwd_auth_fail.tape
@@ -50,6 +50,6 @@ Show
 Hide
 Type "wrongpass"
 Enter
-Wait+Nth(5) /invalid password 'wrongpass', should be/
+Wait+Screen /Maximum number of authentication attempts reached/
 ${AUTHD_TEST_TAPE_COMMAND_PASSWD_FINAL_WAIT}
 Show

--- a/pam/internal/adapter/authentication.go
+++ b/pam/internal/adapter/authentication.go
@@ -373,6 +373,12 @@ func (m authenticationModel) Update(msg tea.Msg) (authModel authenticationModel,
 			}
 			return m, sendEvent(pamError{status: pam.ErrAuth, msg: authMsg})
 
+		case auth.DeniedMaxTries:
+			if authMsg == "" {
+				authMsg = "Maximum number of tries exceeded"
+			}
+			return m, sendEvent(pamError{status: pam.ErrMaxtries, msg: authMsg})
+
 		case auth.Next:
 			if authMsg != "" {
 				m.errorMsg = authMsg

--- a/pam/internal/adapter/authentication.go
+++ b/pam/internal/adapter/authentication.go
@@ -399,6 +399,12 @@ func (m authenticationModel) Update(msg tea.Msg) (authModel authenticationModel,
 		case auth.Cancelled:
 			// nothing to do
 			return m, nil
+
+		default:
+			return m, sendEvent(pamError{
+				status: pam.ErrSystem,
+				msg:    fmt.Sprintf("Unknown authentication access: %q", msg.access),
+			})
 		}
 
 	case errMsgToDisplay:

--- a/pam/internal/adapter/gdmmodel.go
+++ b/pam/internal/adapter/gdmmodel.go
@@ -273,6 +273,7 @@ func (m gdmModel) Update(msg tea.Msg) (gdmModel, tea.Cmd) {
 		switch access {
 		case auth.Granted:
 		case auth.Denied:
+		case auth.DeniedMaxTries:
 		case auth.Cancelled:
 		case auth.Retry:
 		case auth.Next:

--- a/pam/internal/adapter/gdmmodel_test.go
+++ b/pam/internal/adapter/gdmmodel_test.go
@@ -2257,8 +2257,8 @@ func TestGdmModel(t *testing.T) {
 				Msg:    `Access "" is not valid`,
 			}},
 			wantExitStatus: pamError{
-				status: pam.ErrAuth,
-				msg:    `Access "" is not valid`,
+				status: pam.ErrSystem,
+				msg:    `Unknown authentication access: ""`,
 			},
 		},
 		"Error_on_authentication_client_because_of_invalid_auth_data_access_with_message": {
@@ -2302,8 +2302,8 @@ func TestGdmModel(t *testing.T) {
 				Msg:    `Access "no way you get here!" is not valid`,
 			}},
 			wantExitStatus: pamError{
-				status: pam.ErrAuth,
-				msg:    `Access "no way you get here!" is not valid`,
+				status: pam.ErrSystem,
+				msg:    `Unknown authentication access: "no way you get here!"`,
 			},
 		},
 		"Error_on_change_stage_using_an_unknown_stage": {

--- a/pam/internal/adapter/nativemodel.go
+++ b/pam/internal/adapter/nativemodel.go
@@ -333,6 +333,9 @@ func (m nativeModel) Update(msg tea.Msg) (nativeModel, tea.Cmd) {
 		case auth.Denied:
 			// This is handled by the main authentication model
 			return m, nil
+		case auth.DeniedMaxTries:
+			// This is handled by the main authentication model
+			return m, nil
 		case auth.Cancelled:
 			return m, nil
 		default:


### PR DESCRIPTION
We used to return PAM_AUTH_ERR, but this created problems in some adapters, since they would keep retriggering the authentication requests even after MAX_TRIES was reached. Returning PAM_MAXTRIES should stop the requests from coming.


UDENG-9459