### PR TITLE
broker: Set broker.conf.d permissions to 755

### DIFF
--- a/authd-oidc-brokers/cmd/authd-oidc/daemon/daemon.go
+++ b/authd-oidc-brokers/cmd/authd-oidc/daemon/daemon.go
@@ -136,7 +136,7 @@ func (a *App) serve(config daemonConfig) error {
 	}
 
 	brokerConfigDir := broker.GetDropInDir(config.Paths.BrokerConf)
-	if err := ensureDirWithPerms(brokerConfigDir, 0700, os.Geteuid()); err != nil {
+	if err := ensureDirWithPerms(brokerConfigDir, 0755, os.Geteuid()); err != nil {
 		return fmt.Errorf("error initializing broker configuration directory %q: %v", brokerConfigDir, err)
 	}
 

--- a/authd-oidc-brokers/cmd/authd-oidc/daemon/daemon.go
+++ b/authd-oidc-brokers/cmd/authd-oidc/daemon/daemon.go
@@ -128,15 +128,12 @@ func (a *App) serve(config daemonConfig) error {
 	}
 	defer closeFunc()
 
-	// When the data directory is SNAP_DATA, it has permission 0755, else we want to create it with 0700.
-	if err := ensureDirWithPerms(config.Paths.DataDir, 0700, os.Geteuid()); err != nil {
-		if err := ensureDirWithPerms(config.Paths.DataDir, 0755, os.Geteuid()); err != nil {
-			return fmt.Errorf("error initializing data directory %q: %v", config.Paths.DataDir, err)
-		}
+	if err := ensureDirWithOwner(config.Paths.DataDir, 0700, os.Geteuid()); err != nil {
+		return fmt.Errorf("error initializing data directory %q: %v", config.Paths.DataDir, err)
 	}
 
 	brokerConfigDir := broker.GetDropInDir(config.Paths.BrokerConf)
-	if err := ensureDirWithPerms(brokerConfigDir, 0755, os.Geteuid()); err != nil {
+	if err := ensureDirWithOwner(brokerConfigDir, 0755, os.Geteuid()); err != nil {
 		return fmt.Errorf("error initializing broker configuration directory %q: %v", brokerConfigDir, err)
 	}
 

--- a/authd-oidc-brokers/cmd/authd-oidc/daemon/daemon.go
+++ b/authd-oidc-brokers/cmd/authd-oidc/daemon/daemon.go
@@ -140,6 +140,32 @@ func (a *App) serve(config daemonConfig) error {
 		return fmt.Errorf("error initializing broker configuration directory %q: %v", brokerConfigDir, err)
 	}
 
+	// Ensure that the broker configuration files have secure permissions
+	if err := checkFilePerms(config.Paths.BrokerConf, 0600); err != nil && !os.IsNotExist(err) {
+		// The error returned by checkFilePerms already contains the file path,
+		// so we don't need to wrap it with more context here.
+		return err
+	}
+
+	// Iterate over the drop-in directory and check permissions of each
+	// configuration file. We ignore subdirectories because we don't load
+	// them, so they don't represent a security risk.
+	entries, err := os.ReadDir(brokerConfigDir)
+	if err != nil {
+		return fmt.Errorf("error reading broker configuration directory %q: %v", brokerConfigDir, err)
+	}
+	for _, entry := range entries {
+		path := filepath.Join(brokerConfigDir, entry.Name())
+
+		if entry.IsDir() {
+			continue
+		}
+
+		if err := checkFilePerms(path, 0600); err != nil && !os.IsNotExist(err) {
+			return err
+		}
+	}
+
 	b, err := broker.New(broker.Config{
 		ConfigFile: config.Paths.BrokerConf,
 		DataDir:    config.Paths.DataDir,

--- a/authd-oidc-brokers/cmd/authd-oidc/daemon/daemon_test.go
+++ b/authd-oidc-brokers/cmd/authd-oidc/daemon/daemon_test.go
@@ -148,6 +148,49 @@ func TestAppRunFailsOnComponentsCreationAndQuit(t *testing.T) {
 	}
 }
 
+func TestAppRunFailsOnInsecureBrokerConfigPerms(t *testing.T) {
+	tests := map[string]struct {
+		mainConfPerm   os.FileMode
+		dropInFileName string
+		dropInFilePerm os.FileMode
+	}{
+		"Error_on_wrong_permission_on_broker_conf":         {mainConfPerm: 0644},
+		"Error_on_wrong_permission_on_drop_in_config_file": {dropInFileName: "extra.yaml", dropInFilePerm: 0644},
+	}
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			tmpDir := t.TempDir()
+			brokerConf := filepath.Join(tmpDir, "broker.yaml")
+			config := daemon.DaemonConfig{
+				Paths: daemon.SystemPaths{
+					BrokerConf: brokerConf,
+				},
+			}
+
+			a := daemon.NewForTests(t, &config, issuerURL)
+
+			if tc.mainConfPerm != 0 {
+				err := os.Chmod(brokerConf, tc.mainConfPerm)
+				require.NoError(t, err, "Setup: could not change permission on broker config file for tests")
+			}
+
+			if tc.dropInFileName != "" {
+				dropInDir := brokerConf + ".d"
+				err := os.MkdirAll(dropInDir, 0700)
+				require.NoError(t, err, "Setup: could not create drop-in directory for tests")
+				//nolint:gosec // The drop-in directory is expected to have 0755 permissions
+				err = os.Chmod(dropInDir, 0755)
+				require.NoError(t, err, "Setup: could not set permissions on drop-in directory for tests")
+				err = os.WriteFile(filepath.Join(dropInDir, tc.dropInFileName), []byte("content"), tc.dropInFilePerm)
+				require.NoError(t, err, "Setup: could not create drop-in config file for tests")
+			}
+
+			err := a.Run()
+			require.Error(t, err, "Run should return an error")
+		})
+	}
+}
+
 func TestAppCanSigHupWhenExecute(t *testing.T) {
 	r, w, err := os.Pipe()
 	require.NoError(t, err, "Setup: pipe shouldn't fail")

--- a/authd-oidc-brokers/cmd/authd-oidc/daemon/daemon_test.go
+++ b/authd-oidc-brokers/cmd/authd-oidc/daemon/daemon_test.go
@@ -106,7 +106,6 @@ func TestAppRunFailsOnComponentsCreationAndQuit(t *testing.T) {
 	const (
 		// DataDir errors
 		dirIsFile = iota
-		wrongPermission
 		noParentDir
 	)
 
@@ -116,7 +115,6 @@ func TestAppRunFailsOnComponentsCreationAndQuit(t *testing.T) {
 	}{
 		"Error_on_existing_data_dir_being_a_file":    {dataDirBehavior: dirIsFile},
 		"Error_on_data_dir_missing_parent_directory": {dataDirBehavior: noParentDir},
-		"Error_on_wrong_permission_on_data_dir":      {dataDirBehavior: wrongPermission},
 	}
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
@@ -127,9 +125,6 @@ func TestAppRunFailsOnComponentsCreationAndQuit(t *testing.T) {
 			case dirIsFile:
 				err := os.WriteFile(dataDir, []byte("file"), 0600)
 				require.NoError(t, err, "Setup: could not create cache file for tests")
-			case wrongPermission:
-				err := os.Mkdir(dataDir, 0600)
-				require.NoError(t, err, "Setup: could not create cache directory for tests")
 			case noParentDir:
 				dataDir = filepath.Join(dataDir, "doesnotexist", "data")
 			}

--- a/authd-oidc-brokers/cmd/authd-oidc/daemon/fs.go
+++ b/authd-oidc-brokers/cmd/authd-oidc/daemon/fs.go
@@ -2,21 +2,19 @@ package daemon
 
 import (
 	"fmt"
-	"io/fs"
 	"os"
 	"syscall"
 )
 
-// ensureDirWithPerms creates a directory at path if it doesn't exist yet with perm as permissions.
-// If the path exists, it will check if it’s a directory with those perms.
-func ensureDirWithPerms(path string, perm os.FileMode, owner int) error {
+// ensureDirWithOwner creates a directory at path with the given perm if it doesn't exist yet.
+// If the path exists, it will check that it is a directory owned by owner, but will not fail if
+// the permissions differ from perm, as incorrect directory permissions are not a security risk as
+// long as the files inside have secure permissions.
+func ensureDirWithOwner(path string, perm os.FileMode, owner int) error {
 	dir, err := os.Stat(path)
 	if err == nil {
 		if !dir.IsDir() {
 			return &os.PathError{Op: "mkdir", Path: path, Err: syscall.ENOTDIR}
-		}
-		if dir.Mode() != (perm | fs.ModeDir) {
-			return fmt.Errorf("permissions should be %v but are %v", perm|fs.ModeDir, dir.Mode())
 		}
 		stat, ok := dir.Sys().(*syscall.Stat_t)
 		if !ok {

--- a/authd-oidc-brokers/cmd/authd-oidc/daemon/fs.go
+++ b/authd-oidc-brokers/cmd/authd-oidc/daemon/fs.go
@@ -30,3 +30,19 @@ func ensureDirWithPerms(path string, perm os.FileMode, owner int) error {
 	}
 	return os.Mkdir(path, perm)
 }
+
+func checkFilePerms(path string, perm os.FileMode) error {
+	dir, err := os.Stat(path)
+	if err != nil {
+		return err
+	}
+
+	if !dir.Mode().IsRegular() {
+		return fmt.Errorf("path %v is not a regular file", path)
+	}
+
+	if dir.Mode() != perm {
+		return fmt.Errorf("file %v has insecure permissions: %v (should be %v)", path, dir.Mode(), perm)
+	}
+	return nil
+}

--- a/snap/hooks/post-refresh
+++ b/snap/hooks/post-refresh
@@ -11,6 +11,12 @@ fi
 
 PREVIOUS_VERSION=$(snapctl get previous-version)
 
+# Important: If you add new migrations, make sure to tag the commit which
+# first introduces the change, so that pre-release versions which already
+# contain the change (and which were automatically uploaded to the edge channel)
+# will not be migrated.
+INITIAL_WORLD_READABLE_BROKER_CONF_DIR="0.5.0-pre1"
+
 log() {
   logger -t "${SNAP_NAME}" "post-refresh: $*"
 }
@@ -27,8 +33,35 @@ valid_semver() {
   [ "${output}" = "valid" ]
 }
 
+should_transition_to_world_readable_broker_conf_dir() {
+  version_less_than "${PREVIOUS_VERSION}" "${INITIAL_WORLD_READABLE_BROKER_CONF_DIR}"
+}
+
+transition_to_world_readable_broker_conf_dir() {
+  log "Transitioning to world-readable broker.conf.d directory"
+  dir="${SNAP_DATA}/broker.conf.d"
+
+  # shellcheck disable=SC2174 # it's fine that --mode only applies to the deepest directory, because the SNAP_DATA
+  # directory is created by snapd with the correct permissions.
+  mkdir -p --mode=0755 "${dir}"
+
+  # Ensure that the files in the broker config directory are *not* world-readable,
+  # because they can contain sensitive information (like the client_secret).
+  find "${dir}" -type f -exec chmod 0600 {} \;
+
+  # Change the permissions of the broker config directory itself to be world-readable,
+  # so that its files can be listed by non-root users, allowing tab-completion
+  # to work correctly.
+  chmod 0755 "${dir}"
+}
+
 if [ -z "${PREVIOUS_VERSION}" ]; then
   log "previous-version: <not set>"
+elif ! valid_semver "${PREVIOUS_VERSION}"; then
+  log "previous-version: ${PREVIOUS_VERSION} (invalid semver)"
 else
   log "previous-version: $PREVIOUS_VERSION"
+  if should_transition_to_world_readable_broker_conf_dir; then
+    transition_to_world_readable_broker_conf_dir
+  fi
 fi


### PR DESCRIPTION
This is a config directory, so admins are expected to read and modify the files in that directory.  However, the permissions `700` don't allow non-root users to list the directory contents, so tab-completion doesn't list any files. That has caused confusion on multiple occasions.

The config files can contain secrets (e.g. the `client_secret` setting), so it's important that the files are not world-readable, but that's ensured as long as the permissions of the *files* are `600`.

UDENG-9634