### PR TITLE
pam: Support Ctrl-D in text entries

### DIFF
--- a/pam/integration-tests/cli_test.go
+++ b/pam/integration-tests/cli_test.go
@@ -217,6 +217,9 @@ func TestCLIAuthenticate(t *testing.T) {
 		"Exit_authd_if_user_sigints": {
 			tape: "sigint",
 		},
+		"Exit_authd_if_user_presses_ctrl_d": {
+			tape: "ctrl_d",
+		},
 		"Exit_if_authd_is_stopped": {
 			tape:            "authd_stopped",
 			stopDaemonAfter: sleepDuration(defaultSleepValues[authdSleepLong] * 5),
@@ -372,6 +375,9 @@ func TestCLIChangeAuthTok(t *testing.T) {
 		},
 		"Exit_authd_if_user_sigints": {
 			tape: "passwd_sigint",
+		},
+		"Exit_authd_if_user_presses_ctrl_d": {
+			tape: "passwd_ctrl_d",
 		},
 	}
 	for name, tc := range tests {

--- a/pam/integration-tests/testdata/golden/TestCLIAuthenticate/Exit_authd_if_user_presses_ctrl_d
+++ b/pam/integration-tests/testdata/golden/TestCLIAuthenticate/Exit_authd_if_user_presses_ctrl_d
@@ -1,0 +1,36 @@
+> ./pam_authd login socket=${AUTHD_TEST_TAPE_SOCKET}
+Username: user name
+────────────────────────────────────────────────────────────────────────────────
+> ./pam_authd login socket=${AUTHD_TEST_TAPE_SOCKET}
+Username: user-integration-ctrl-d@example.com
+────────────────────────────────────────────────────────────────────────────────
+> ./pam_authd login socket=${AUTHD_TEST_TAPE_SOCKET}
+  Select your provider
+
+> 1. local
+  2. ExampleBroker
+
+  Press escape key to go back to user selection
+────────────────────────────────────────────────────────────────────────────────
+> ./pam_authd login socket=${AUTHD_TEST_TAPE_SOCKET}
+Gimme your password:
+>
+
+  Press escape key to go back to select the authentication method
+────────────────────────────────────────────────────────────────────────────────
+> ./pam_authd login socket=${AUTHD_TEST_TAPE_SOCKET}
+Gimme your password:
+>
+
+PAM Error Message: Authentication aborted by user
+PAM Authenticate()
+  User: "user-integration-ctrl-d@example.com"
+  Result: error: PAM exit code: 26
+    Critical error - immediate abort
+PAM Info Message: acct=incomplete
+PAM AcctMgmt()
+  User: "user-integration-ctrl-d@example.com"
+  Result: error: PAM exit code: 25
+    The return value should be ignored by PAM dispatch
+>
+────────────────────────────────────────────────────────────────────────────────

--- a/pam/integration-tests/testdata/golden/TestCLIAuthenticate/Exit_authd_if_user_sigints
+++ b/pam/integration-tests/testdata/golden/TestCLIAuthenticate/Exit_authd_if_user_sigints
@@ -22,7 +22,7 @@ Gimme your password:
 Gimme your password:
 >
 
-PAM Error Message: cancel requested
+PAM Error Message: Authentication aborted by user
 PAM Authenticate()
   User: "user-integration-sigint@example.com"
   Result: error: PAM exit code: 26

--- a/pam/integration-tests/testdata/golden/TestCLIChangeAuthTok/Exit_authd_if_user_presses_ctrl_d
+++ b/pam/integration-tests/testdata/golden/TestCLIChangeAuthTok/Exit_authd_if_user_presses_ctrl_d
@@ -1,0 +1,36 @@
+> ./pam_authd passwd socket=${AUTHD_TEST_TAPE_SOCKET}
+Username: user name
+────────────────────────────────────────────────────────────────────────────────
+> ./pam_authd passwd socket=${AUTHD_TEST_TAPE_SOCKET}
+Username: user-integration-cli-passwd-exit-authd-if-user-presses-ctrl-d@example.com
+────────────────────────────────────────────────────────────────────────────────
+> ./pam_authd passwd socket=${AUTHD_TEST_TAPE_SOCKET}
+  Select your provider
+
+> 1. local
+  2. ExampleBroker
+
+  Press escape key to go back to user selection
+────────────────────────────────────────────────────────────────────────────────
+> ./pam_authd passwd socket=${AUTHD_TEST_TAPE_SOCKET}
+Gimme your password:
+>
+
+  Press escape key to go back to select the authentication method
+────────────────────────────────────────────────────────────────────────────────
+> ./pam_authd passwd socket=${AUTHD_TEST_TAPE_SOCKET}
+Gimme your password:
+>
+
+PAM Error Message: Authentication aborted by user
+PAM ChangeAuthTok()
+  User: "user-integration-cli-passwd-exit-authd-if-user-presses-ctrl-d@example.com"
+  Result: error: PAM exit code: 26
+    Critical error - immediate abort
+PAM Info Message: acct=incomplete
+PAM AcctMgmt()
+  User: "user-integration-cli-passwd-exit-authd-if-user-presses-ctrl-d@example.com"
+  Result: error: PAM exit code: 25
+    The return value should be ignored by PAM dispatch
+>
+────────────────────────────────────────────────────────────────────────────────

--- a/pam/integration-tests/testdata/golden/TestCLIChangeAuthTok/Exit_authd_if_user_sigints
+++ b/pam/integration-tests/testdata/golden/TestCLIChangeAuthTok/Exit_authd_if_user_sigints
@@ -22,7 +22,7 @@ Gimme your password:
 Gimme your password:
 >
 
-PAM Error Message: cancel requested
+PAM Error Message: Authentication aborted by user
 PAM ChangeAuthTok()
   User: "user-integration-cli-passwd-exit-authd-if-user-sigints@example.com"
   Result: error: PAM exit code: 26

--- a/pam/integration-tests/testdata/tapes/cli/ctrl_d.tape
+++ b/pam/integration-tests/testdata/tapes/cli/ctrl_d.tape
@@ -1,0 +1,25 @@
+Hide
+TypeInPrompt+Shell "${AUTHD_TEST_TAPE_COMMAND}"
+Enter
+Wait /Username: user name\n/
+Show
+
+Hide
+TypeUsername "user-integration-ctrl-d@example.com"
+Show
+
+Hide
+Enter
+Wait+Screen /Select your provider/
+Wait+Screen /2. ExampleBroker/
+Show
+
+Hide
+Type "2"
+Wait+CLIPrompt /Gimme your password/ /Press escape key to go back to select the authentication method/
+Show
+
+Hide
+Ctrl+D
+${AUTHD_TEST_TAPE_COMMAND_AUTH_FINAL_WAIT}
+Show

--- a/pam/integration-tests/testdata/tapes/cli/passwd_ctrl_d.tape
+++ b/pam/integration-tests/testdata/tapes/cli/passwd_ctrl_d.tape
@@ -1,0 +1,25 @@
+Hide
+TypeInPrompt+Shell "${AUTHD_TEST_TAPE_COMMAND}"
+Enter
+Wait /Username: user name\n/
+Show
+
+Hide
+TypeUsername "${AUTHD_TEST_TAPE_USERNAME}"
+Show
+
+Hide
+Enter
+Wait+Screen /Select your provider/
+Wait+Screen /2. ExampleBroker/
+Show
+
+Hide
+Type "2"
+Wait+CLIPrompt /Gimme your password/ /Press escape key to go back to select the authentication method/
+Show
+
+Hide
+Ctrl+D
+${AUTHD_TEST_TAPE_COMMAND_PASSWD_FINAL_WAIT}
+Show

--- a/pam/internal/adapter/formmodel.go
+++ b/pam/internal/adapter/formmodel.go
@@ -11,6 +11,7 @@ import (
 	"github.com/canonical/authd/log"
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
+	"github.com/msteinert/pam/v2"
 )
 
 // formModel is the form layout type to allow authentication and return a password.
@@ -80,13 +81,20 @@ func (m formModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	// Key presses
 	case tea.KeyMsg:
 		switch msg.String() {
-		case "enter":
+		case "enter", "ctrl+d":
 			if m.focusIndex >= len(m.focusableModels) {
 				return m, nil
 			}
 			entry := m.focusableModels[m.focusIndex]
 			switch entry := entry.(type) {
 			case *textinputModel:
+				if msg.String() == "ctrl+d" && len(entry.Value()) == 0 {
+					return m, sendEvent(pamError{
+						status: pam.ErrAbort,
+						msg:    "cancel requested",
+					})
+				}
+
 				return m, sendEvent(isAuthenticatedRequested{
 					item: &authd.IARequest_AuthenticationData_Secret{
 						Secret: entry.Value(),

--- a/pam/internal/adapter/formmodel.go
+++ b/pam/internal/adapter/formmodel.go
@@ -91,7 +91,7 @@ func (m formModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				if msg.String() == "ctrl+d" && len(entry.Value()) == 0 {
 					return m, sendEvent(pamError{
 						status: pam.ErrAbort,
-						msg:    "cancel requested",
+						msg:    "Authentication aborted by user",
 					})
 				}
 

--- a/pam/internal/adapter/model.go
+++ b/pam/internal/adapter/model.go
@@ -248,7 +248,7 @@ func (m uiModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		case "ctrl+c":
 			return m, sendEvent(pamError{
 				status: pam.ErrAbort,
-				msg:    "cancel requested",
+				msg:    "Authentication aborted by user",
 			})
 		case "esc":
 			if !m.canGoBack() {


### PR DESCRIPTION
Currently, Ctrl-D has no effect when authd-pam is used.

Usually, when typing Ctrl-D in a terminal, the input buffer to the reading process is flushed, and, if the buffer is empty, EOF is sent. With sudo the expected behavior is that it doesn't ask for a password again if an empty password was submitted via Ctrl-D.

This commit implements that behavior.

Closes #1432
UDENG-9763