### PR TITLE
ci: Skip jobs on forks which would fail anyway

### DIFF
--- a/.github/workflows/debian-build.yaml
+++ b/.github/workflows/debian-build.yaml
@@ -192,7 +192,13 @@ jobs:
           run-lrc: true
 
       - name: Prepare deb and sources for upload
-        if: steps.restore-cache.outputs.cache-hit != 'true'
+        # Skip if:
+        # * we have a cache hit and thus didn't build the package ourselves, or
+        # * the PR is from a fork, as we don't have the permission to upload to
+        #   the OCI registry.
+        if: >
+          steps.restore-cache.outputs.cache-hit != 'true' &&
+          github.event.pull_request.head.repo.full_name == github.repository
         run: |
           set -euo pipefail
           set -x
@@ -220,6 +226,9 @@ jobs:
           echo "PKG_TARBALL=${PKG_TARBALL}" >> ${GITHUB_ENV}
 
       - name: Upload deb and sources as OCI artifacts
+        # Skip if the PR is from a fork, as we don't have the permission to
+        # upload to the OCI registry.
+        if: github.event.pull_request.head.repo.full_name == github.repository
         run: |
           set -euo pipefail
           set -x

--- a/.github/workflows/e2e-tests.yaml
+++ b/.github/workflows/e2e-tests.yaml
@@ -59,6 +59,10 @@ concurrency:
 jobs:
   compute-hash:
     name: Compute hash of build-relevant files
+    # Skip this job (and the provision-and-run job which depends on it) if the
+    # PR is from a fork, as we don't have the permission to upload the Debian
+    # package to the OCI registry in the provision-and-run workflow.
+    if: github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     outputs:
       files-hash: ${{ steps.hash.outputs.hash }}


### PR DESCRIPTION
The GitHub token in CI jobs run for PRs from forks don't have the 'packages: write' permission which we need to upload the Debian package to OCI artifacts. Just skip the jobs which would fail because of that when on a PR from a fork.

UDENG-9780