### PR TITLE
ci: Fix jobs also skipped on push and release events

### DIFF
--- a/.github/workflows/debian-build.yaml
+++ b/.github/workflows/debian-build.yaml
@@ -198,7 +198,11 @@ jobs:
         #   the OCI registry.
         if: >
           steps.restore-cache.outputs.cache-hit != 'true' &&
-          github.event.pull_request.head.repo.full_name == github.repository
+          (
+            (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository) ||
+            github.event_name == 'push' ||
+            github.event_name == 'release'
+          )
         run: |
           set -euo pipefail
           set -x
@@ -228,7 +232,10 @@ jobs:
       - name: Upload deb and sources as OCI artifacts
         # Skip if the PR is from a fork, as we don't have the permission to
         # upload to the OCI registry.
-        if: github.event.pull_request.head.repo.full_name == github.repository
+        if: >
+          (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository) ||
+          github.event_name == 'push' ||
+          github.event_name == 'release'
         run: |
           set -euo pipefail
           set -x

--- a/.github/workflows/e2e-tests.yaml
+++ b/.github/workflows/e2e-tests.yaml
@@ -62,7 +62,10 @@ jobs:
     # Skip this job (and the provision-and-run job which depends on it) if the
     # PR is from a fork, as we don't have the permission to upload the Debian
     # package to the OCI registry in the provision-and-run workflow.
-    if: github.event.pull_request.head.repo.full_name == github.repository
+    if: >
+      (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository) ||
+      github.event_name == 'push' ||
+      github.event_name == 'release'
     runs-on: ubuntu-latest
     outputs:
       files-hash: ${{ steps.hash.outputs.hash }}


### PR DESCRIPTION
An unintended effect of 29bde55317c3ef07e758437029ddffae349dc537 is that the jobs that upload the Debian package to the OCI registry are also skipped on push events to main and release events, which causes the "Update packaging branch" job (triggered by those events) to fail because the package it needs to download was never uploaded.

Fix this by running the upload steps whenever the synchronize-packaging-branches job runs, i.e. on push events to main and release events, in addition to PRs from the same repository.