### PR TITLE
docs: add note on versions to install guide

### DIFF
--- a/docs/howto/install-authd.md
+++ b/docs/howto/install-authd.md
@@ -13,6 +13,14 @@ This project consists of two components:
 
 authd is delivered as a Debian package for Ubuntu Desktop and Ubuntu Server.
 
+```{admonition} (Optional) Switching from stable to edge
+:class: important
+This guide describes how to install the stable version of authd and its brokers, which is recommended for production use. 
+
+If you want to try the **edge** version, read our guide on [changing authd
+versions](ref::changing-versions).
+```
+
 ## System requirements
 
 * Ubuntu: Desktop or Server editions


### PR DESCRIPTION
The installation guide currently only covers installing stable versions of the daemon and broker.
But users may be interested in the edge version, or may be on the edge docs and expect to see guidance on edge versions.

For now, the most immediate solution to this problem is to provide a prominent link to the documentation on [changing versions](https://documentation.ubuntu.com/authd/stable-docs/howto/changing-versions/).

The purpose of the edge docs is not strictly to promote the edge version or to only offer guidance on the edge version. It primarily allows us to document the latest features available on edge. For now, there is no harm in defaulting to stable for the install guide, even in the edge docs, as long as we clearly link to the relevant documentation. If anything, it reinforces the recommendation for use of stable in production.

Readers of the stable docs may also benefit from knowing about switching versions (for testing features, debugging, etc.), so the link helps both groups.

Alternative solutions, such as conditional rendering of docs in stable | edge, may be investigated in future, but could introduce complexity.

Closes https://github.com/canonical/authd/issues/1341

UDENG-9457