### PR TITLE
e2e-tests: fix resource headers for `authctl` set-uid/set-gid tests

### DIFF
--- a/e2e-tests/tests/authctl_group_set_gid.robot
+++ b/e2e-tests/tests/authctl_group_set_gid.robot
@@ -1,7 +1,7 @@
 *** Settings ***
-Resource        ./resources/authd/utils.resource
-Resource        ./resources/authd/authd.resource
-Resource        ./resources/broker/broker.resource
+Resource        resources/utils.resource
+Resource        resources/authd.resource
+Resource        resources/broker.resource
 
 # Test Tags       robot:exit-on-failure
 

--- a/e2e-tests/tests/authctl_group_set_gid.robot
+++ b/e2e-tests/tests/authctl_group_set_gid.robot
@@ -5,12 +5,11 @@ Resource        resources/broker.resource
 
 # Test Tags       robot:exit-on-failure
 
-Test Setup    utils.Test Setup    ${snapshot}
+Test Setup    utils.Test Setup    snapshot=%{BROKER}-installed
 Test Teardown   utils.Test Teardown
 
 
 *** Variables ***
-${snapshot}    %{BROKER}-installed
 ${username}    %{E2E_USER}
 ${local_password}    qwer1234
 ${new_gid}    60500

--- a/e2e-tests/tests/authctl_user_set_uid.robot
+++ b/e2e-tests/tests/authctl_user_set_uid.robot
@@ -5,12 +5,11 @@ Resource        resources/broker.resource
 
 # Test Tags       robot:exit-on-failure
 
-Test Setup    utils.Test Setup    ${snapshot}
+Test Setup    utils.Test Setup    snapshot=%{BROKER}-installed
 Test Teardown   utils.Test Teardown
 
 
 *** Variables ***
-${snapshot}    %{BROKER}-installed
 ${username}    %{E2E_USER}
 ${local_password}    qwer1234
 ${new_uid}    60500

--- a/e2e-tests/tests/authctl_user_set_uid.robot
+++ b/e2e-tests/tests/authctl_user_set_uid.robot
@@ -1,7 +1,7 @@
 *** Settings ***
-Resource        ./resources/authd/utils.resource
-Resource        ./resources/authd/authd.resource
-Resource        ./resources/broker/broker.resource
+Resource        resources/utils.resource
+Resource        resources/authd.resource
+Resource        resources/broker.resource
 
 # Test Tags       robot:exit-on-failure
 


### PR DESCRIPTION
Follow-up to #1385