### PR TITLE
brokers: Avoid path traversal via username

### DIFF
--- a/authd-oidc-brokers/internal/broker/broker.go
+++ b/authd-oidc-brokers/internal/broker/broker.go
@@ -174,7 +174,14 @@ func (b *Broker) NewSession(username, lang, mode string) (sessionID, encryptionK
 	_, issuer, _ := strings.Cut(b.cfg.issuerURL, "://")
 	issuer = strings.ReplaceAll(issuer, "/", "_")
 	issuer = strings.ReplaceAll(issuer, ":", "_")
-	s.userDataDir = filepath.Join(b.cfg.DataDir, issuer, username)
+
+	issuerDataDir := filepath.Join(b.cfg.DataDir, issuer)
+	s.userDataDir = filepath.Join(issuerDataDir, username)
+	// Check that the username does not contain path traversal characters by verifying that the resulting path is within
+	// the issuer data directory and the basename matches the username.
+	if !strings.HasPrefix(s.userDataDir, issuerDataDir) || filepath.Base(s.userDataDir) != username {
+		return "", "", fmt.Errorf("invalid username %q: path traversal detected", username)
+	}
 	// The token is stored in $DATA_DIR/$ISSUER/$USERNAME/token.json.
 	s.tokenPath = filepath.Join(s.userDataDir, "token.json")
 	// The password is stored in $DATA_DIR/$ISSUER/$USERNAME/password.

--- a/authd-oidc-brokers/internal/broker/broker.go
+++ b/authd-oidc-brokers/internal/broker/broker.go
@@ -176,6 +176,12 @@ func (b *Broker) NewSession(username, lang, mode string) (sessionID, encryptionK
 	issuer = strings.ReplaceAll(issuer, ":", "_")
 
 	issuerDataDir := filepath.Join(b.cfg.DataDir, issuer)
+	// Check that the issuer does not contain path traversal characters by verifying that the resulting path is within
+	// the data directory and the basename matches the issuer.
+	if !strings.HasPrefix(issuerDataDir, b.cfg.DataDir) || filepath.Base(issuerDataDir) != issuer {
+		return "", "", fmt.Errorf("invalid issuer URL %q: path traversal detected", b.cfg.issuerURL)
+	}
+
 	s.userDataDir = filepath.Join(issuerDataDir, username)
 	// Check that the username does not contain path traversal characters by verifying that the resulting path is within
 	// the issuer data directory and the basename matches the username.

--- a/authd-oidc-brokers/internal/broker/broker.go
+++ b/authd-oidc-brokers/internal/broker/broker.go
@@ -175,7 +175,11 @@ func (b *Broker) NewSession(username, lang, mode string) (sessionID, encryptionK
 		return "", "", fmt.Errorf("failed to marshal broker public key: %v", err)
 	}
 
-	_, issuer, _ := strings.Cut(b.cfg.issuerURL, "://")
+	_, issuer, found := strings.Cut(b.cfg.issuerURL, "://")
+	if !found {
+		// If the issuer URL does not contain a scheme, use the whole issuer URL as the issuer.
+		issuer = b.cfg.issuerURL
+	}
 	issuer = strings.ReplaceAll(issuer, "/", "_")
 	issuer = strings.ReplaceAll(issuer, ":", "_")
 

--- a/authd-oidc-brokers/internal/broker/broker.go
+++ b/authd-oidc-brokers/internal/broker/broker.go
@@ -157,6 +157,10 @@ func New(cfg Config, args ...Option) (b *Broker, err error) {
 
 // NewSession creates a new session for the user.
 func (b *Broker) NewSession(username, lang, mode string) (sessionID, encryptionKey string, err error) {
+	if username == "" {
+		return "", "", errors.New("username is required")
+	}
+
 	sessionID = uuid.New().String()
 	s := session{
 		username: username,

--- a/authd-oidc-brokers/internal/broker/broker_test.go
+++ b/authd-oidc-brokers/internal/broker/broker_test.go
@@ -84,6 +84,7 @@ func TestNewSession(t *testing.T) {
 
 	tests := map[string]struct {
 		username                     string
+		issuerURL                    string
 		customHandlers               map[string]testutils.EndpointHandler
 		forceAccessCheckWithProvider bool
 
@@ -119,6 +120,10 @@ func TestNewSession(t *testing.T) {
 			username: "test/../other-user",
 			wantErr:  true,
 		},
+		"Error_when_issuer_contains_path_traversal": {
+			issuerURL: "https://..",
+			wantErr:   true,
+		},
 	}
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
@@ -127,6 +132,7 @@ func TestNewSession(t *testing.T) {
 			b := newBrokerForTests(t, &brokerForTestConfig{
 				customHandlers:               tc.customHandlers,
 				forceAccessCheckWithProvider: tc.forceAccessCheckWithProvider,
+				issuerURL:                    tc.issuerURL,
 			})
 
 			username := tc.username

--- a/authd-oidc-brokers/internal/broker/broker_test.go
+++ b/authd-oidc-brokers/internal/broker/broker_test.go
@@ -83,6 +83,7 @@ func TestNewSession(t *testing.T) {
 	t.Parallel()
 
 	tests := map[string]struct {
+		username                     string
 		customHandlers               map[string]testutils.EndpointHandler
 		forceAccessCheckWithProvider bool
 
@@ -110,6 +111,14 @@ func TestNewSession(t *testing.T) {
 			forceAccessCheckWithProvider: true,
 			wantErr:                      true,
 		},
+		"Error_when_username_contains_path_traversal": {
+			username: "../test",
+			wantErr:  true,
+		},
+		"Error_when_username_contains_path_traversal_but_does_not_leave_the_parent_directory": {
+			username: "test/../other-user",
+			wantErr:  true,
+		},
 	}
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
@@ -120,7 +129,13 @@ func TestNewSession(t *testing.T) {
 				forceAccessCheckWithProvider: tc.forceAccessCheckWithProvider,
 			})
 
-			id, _, err := b.NewSession("test-user", "lang", sessionmode.Login)
+			username := tc.username
+			if username == "" {
+				username = "test-user"
+			}
+
+			id, _, err := b.NewSession(username, "lang", sessionmode.Login)
+			t.Logf("NewSession returned id: %q, err: %v", id, err)
 			if tc.wantErr {
 				require.Error(t, err, "NewSession should have returned an error")
 				return

--- a/authd-oidc-brokers/internal/broker/broker_test.go
+++ b/authd-oidc-brokers/internal/broker/broker_test.go
@@ -84,6 +84,7 @@ func TestNewSession(t *testing.T) {
 
 	tests := map[string]struct {
 		username                     string
+		emptyUsername                bool
 		issuerURL                    string
 		customHandlers               map[string]testutils.EndpointHandler
 		forceAccessCheckWithProvider bool
@@ -104,6 +105,10 @@ func TestNewSession(t *testing.T) {
 			},
 			wantOffline: true,
 		},
+		"Creates_new_session_with_schemeless_issuer_URL": {
+			issuerURL:   "example.com",
+			wantOffline: true,
+		},
 
 		"Error_when_provider_authentication_is_forced_and_provider_is_not_available": {
 			customHandlers: map[string]testutils.EndpointHandler{
@@ -111,6 +116,10 @@ func TestNewSession(t *testing.T) {
 			},
 			forceAccessCheckWithProvider: true,
 			wantErr:                      true,
+		},
+		"Error_when_username_is_empty": {
+			emptyUsername: true,
+			wantErr:       true,
 		},
 		"Error_when_username_contains_path_traversal": {
 			username: "../test",
@@ -136,7 +145,9 @@ func TestNewSession(t *testing.T) {
 			})
 
 			username := tc.username
-			if username == "" {
+			if tc.emptyUsername {
+				username = ""
+			} else if username == "" {
 				username = "test-user"
 			}
 


### PR DESCRIPTION
The broker used the unsanitized username in the path to the user data directory. Avoid this by verifying that the resulting path is within the issuer data directory and the basename matches the username.

UDENG-9777