### PR TITLE
pam/main-exec: Don't set timeout for D-Bus connection

### DIFF
--- a/pam/integration-tests/cmd/exec-client/modulewrapper.go
+++ b/pam/integration-tests/cmd/exec-client/modulewrapper.go
@@ -22,7 +22,7 @@ type moduleWrapper struct {
 }
 
 func newModuleWrapper(serverAddress string) (pam.ModuleTransaction, func(), error) {
-	mTx, closeFunc, err := dbusmodule.NewTransaction(context.TODO(), serverAddress)
+	mTx, closeFunc, err := dbusmodule.NewTransaction(serverAddress)
 	return &moduleWrapper{mTx}, closeFunc, err
 }
 

--- a/pam/internal/dbusmodule/transaction.go
+++ b/pam/internal/dbusmodule/transaction.go
@@ -41,14 +41,14 @@ const variantNothing = "<@mv nothing>"
 // NewTransaction creates a new [dbusmodule.Transaction] with the provided connection.
 // A [pam.ModuleTransaction] implementation is returned together with a cleanup function that
 // should be called to release the connection.
-func NewTransaction(ctx context.Context, address string, o ...TransactionOptions) (tx pam.ModuleTransaction, cleanup func(), err error) {
+func NewTransaction(address string, o ...TransactionOptions) (tx pam.ModuleTransaction, cleanup func(), err error) {
 	opts := options{}
 	for _, f := range o {
 		f(&opts)
 	}
 
 	log.Debugf(context.TODO(), "Connecting to %s", address)
-	conn, err := dbus.Dial(address, dbus.WithContext(ctx))
+	conn, err := dbus.Dial(address)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/pam/internal/dbusmodule/transaction_test.go
+++ b/pam/internal/dbusmodule/transaction_test.go
@@ -1,7 +1,6 @@
 package dbusmodule_test
 
 import (
-	"context"
 	"errors"
 	"fmt"
 	"sync"
@@ -21,7 +20,7 @@ const objectPath = "/com/ubuntu/authd/pam"
 func TestTransactionConnectionError(t *testing.T) {
 	t.Parallel()
 
-	tx, cleanup, err := dbusmodule.NewTransaction(context.TODO(), "invalid-address")
+	tx, cleanup, err := dbusmodule.NewTransaction("invalid-address")
 	require.Nil(t, tx, "Transaction must be unset")
 	require.Nil(t, cleanup, "Cleanup func must be unset")
 	require.NotNil(t, err, "Error must be set")
@@ -633,7 +632,7 @@ func prepareTransaction(t *testing.T, expectedReturns []methodReturn) (pam.Modul
 	t.Helper()
 
 	address, obj := prepareTestServer(t, expectedReturns)
-	tx, cleanup, err := dbusmodule.NewTransaction(context.TODO(), address,
+	tx, cleanup, err := dbusmodule.NewTransaction(address,
 		dbusmodule.WithSharedConnection(true))
 	require.NoError(t, err, "Setup: Can't connect to %s", address)
 	t.Cleanup(cleanup)

--- a/pam/main-exec.go
+++ b/pam/main-exec.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"os"
 	"runtime"
-	"time"
 
 	"github.com/canonical/authd/log"
 	"github.com/canonical/authd/pam/internal/dbusmodule"
@@ -17,7 +16,6 @@ import (
 var (
 	pamFlags      = flag.Int64("flags", 0, "pam flags")
 	serverAddress = flag.String("server-address", "", "the dbus connection to use to communicate with module")
-	timeout       = flag.Int64("timeout", 120, "timeout for the server connection (in seconds)")
 )
 
 func init() {
@@ -46,9 +44,7 @@ func mainFunc() error {
 		return fmt.Errorf("%w: no connection provided", pam.ErrSystem)
 	}
 
-	ctx, cancel := context.WithTimeout(context.TODO(), time.Duration(*timeout)*time.Second)
-	defer cancel()
-	mTx, closeFunc, err := dbusmodule.NewTransaction(ctx, *serverAddress)
+	mTx, closeFunc, err := dbusmodule.NewTransaction(context.Background(), *serverAddress)
 	if err != nil {
 		return fmt.Errorf("%w: can't connect to server: %w", pam.ErrSystem, err)
 	}

--- a/pam/main-exec.go
+++ b/pam/main-exec.go
@@ -44,7 +44,7 @@ func mainFunc() error {
 		return fmt.Errorf("%w: no connection provided", pam.ErrSystem)
 	}
 
-	mTx, closeFunc, err := dbusmodule.NewTransaction(context.Background(), *serverAddress)
+	mTx, closeFunc, err := dbusmodule.NewTransaction(*serverAddress)
 	if err != nil {
 		return fmt.Errorf("%w: can't connect to server: %w", pam.ErrSystem, err)
 	}


### PR DESCRIPTION
We've seen cases in e2e-tests where device auth took longer than 2 minutes to complete. When it finally succeeds, the login fails because the subsequent SetData(authenticationBrokerIDKey, ...) call fails:

```
failed to call com.ubuntu.authd.pam.SetData: dbus: connection closed by user LOGIN: exiting with error System error: dbus: connection closed by user
```

We don't to enforce a timeout for the login procedure here. If there should be a timeout, it should be the caller who enforces it - similar to the behavior of `login`which is configured via LOGIN_TIMEOUT in /etc/login.defs.

Closes #1431
UDENG-9792