### PR TITLE
authctl: Fix int overflow in test on 32-bit architectures

### DIFF
--- a/cmd/authctl/group/set-gid_test.go
+++ b/cmd/authctl/group/set-gid_test.go
@@ -49,7 +49,7 @@ func TestSetGIDCommand(t *testing.T) {
 			expectedExitCode: 1,
 		},
 		"Error_when_gid_is_too_large": {
-			args:             []string{"set-gid", "group1", strconv.Itoa(math.MaxInt32 + 1)},
+			args:             []string{"set-gid", "group1", strconv.FormatInt(int64(math.MaxInt32)+1, 10)},
 			expectedExitCode: int(codes.Unknown),
 		},
 		"Error_when_gid_is_already_taken": {


### PR DESCRIPTION
On 32-bit architectures, math.MaxInt32 + 1 is larger than the int type, so it causes the test to fail with

    cmd/authctl/group/set-gid_test.go:52:65: cannot use math.MaxInt32 + 1 (untyped int constant 2147483648) as int value in argument to strconv.Itoa (overflows)

The fix is to use an int64 instead.

refs: https://bugs.launchpad.net/ubuntu/+source/authd/+bug/2148363

UDENG-9791