### PR TITLE
e2e-tests: Replace some keyboard input with ssh commands

### DIFF
--- a/e2e-tests/resources/SSH.py
+++ b/e2e-tests/resources/SSH.py
@@ -44,3 +44,28 @@ class SSH:
             logger.debug(f"stderr: {stderr}")
 
         return stdout
+
+    @keyword
+    async def execute_as_user(self, user:str, command: str, timeout: int|None = 30) -> str:
+        """
+        Run a command via SSH as a specific user and return its output.
+        """
+        command = (f"sudo -u {user} "
+                   f"XDG_RUNTIME_DIR=/run/user/$(id -u {user}) "
+                   f"DBUS_SESSION_BUS_ADDRESS=unix:path=/run/user/$(id -u {user})/bus "
+                   f"{command}")
+        return await self.execute(command, timeout)
+
+    @keyword
+    async def execute_as_current_user(self, command: str, timeout: int|None = 30) -> str:
+        # Get the user that is currently logged in by checking which user the
+        # gnome-shell process runs as
+        stdout = await self.execute("ps -C gnome-shell -o user=")
+        users = stdout.strip().split("\n")
+        if len(users) == 0:
+            raise RuntimeError("No user is currently logged in")
+        elif len(users) > 1:
+            raise RuntimeError(f"Multiple users are logged in: {users}")
+        user = users[0].strip()
+        logger.info(f"Running command as user '{user}'")
+        return await self.execute_as_user(user, command, timeout)

--- a/e2e-tests/resources/browser_login/msentraid.py
+++ b/e2e-tests/resources/browser_login/msentraid.py
@@ -33,7 +33,7 @@ def login(browser, username: str, password: str, device_code: str, totp_secret: 
     browser.send_key_taps(
         ascii_string_to_key_events(device_code) + [Gdk.KEY_Return])
 
-    browser.wait_for_pattern("Sign in", timeout_ms=20000)
+    browser.wait_for_pattern("Sign in", timeout_ms=30000)
     browser.wait_for_stable_page()
     browser.capture_snapshot(screenshot_dir, "device-login-enter-username")
     browser.send_key_taps(

--- a/e2e-tests/resources/utils.resource
+++ b/e2e-tests/resources/utils.resource
@@ -151,6 +151,10 @@ Left Button Click
     Hid.Move Pointer To Proportional    1    1
 
 
+# Run Command uses the Alt+F2 shortcut to open the "Run a Command" dialog and
+# execute the given command.
+# Consider using SSH.Execute As Current User instead, which is more reliable and
+# faster because it doesn't use simulated keyboard input.
 Run Command
     [Arguments]    ${command}
     Hid.Keys Combo    Alt_L    F2

--- a/e2e-tests/resources/utils.resource
+++ b/e2e-tests/resources/utils.resource
@@ -42,7 +42,7 @@ Try Select User
 
 
 Log Out
-    Run Command    gnome-session-quit --logout --no-prompt
+    SSH.Execute    loginctl terminate-seat seat0
 
 
 Wait Until Desktop Ready

--- a/e2e-tests/resources/utils.resource
+++ b/e2e-tests/resources/utils.resource
@@ -77,7 +77,11 @@ Try Desktop Ready
 
 
 Open Terminal
-    Run Command    x-terminal-emulator
+    IF    '%{RELEASE}' == 'noble'
+        Launch App    org.gnome.Terminal.desktop
+    ELSE
+        Launch App    org.gnome.Ptyxis.desktop
+    END
     Hid.Move Pointer To Proportional    1    1
     Match Text    @ubuntu:~$    120
     Hid.Keys Combo    F11
@@ -162,9 +166,9 @@ Submit Run Command Dialog
     Should Be Empty    ${matches}
 
 
-Start Application
-    [Arguments]    ${application}
-    Run Command    ${application}
+Launch App
+    [Arguments]    ${app-id}
+    SSH.Execute As Current User    gtk-launch ${app-id}
 
 
 Cancel Operation

--- a/e2e-tests/vm/ssh.sh
+++ b/e2e-tests/vm/ssh.sh
@@ -35,13 +35,13 @@ while [[ $# -gt 0 ]]; do
 done
 
 
-if [ -z "${RELEASE:-}" ]; then
+if [ -z "${VM_NAME:-}" ] && [ -z "${RELEASE:-}" ]; then
     echo >&2 "Error: Missing required argument <release>"
     usage >&2
     exit 1
 fi
 
-VM_NAME="e2e-runner-${RELEASE}"
+VM_NAME=${VM_NAME:-"e2e-runner-${RELEASE}"}
 
 CID=$(virsh dumpxml "${VM_NAME}" | \
       xmllint --xpath 'string(//vsock/cid/@address)' -)


### PR DESCRIPTION
YARF's simulated keyboard input is unreliable (see #1456, #1457, #1413). We should try to avoid it when possible. This replaces some usages with ssh commands.

Closes #1457