### PR TITLE
Follow-up to "Rename setting to force_access_check_with_provider"

### DIFF
--- a/authd-oidc-brokers/conf/variants/google/broker.conf
+++ b/authd-oidc-brokers/conf/variants/google/broker.conf
@@ -3,14 +3,14 @@ issuer = https://accounts.google.com
 client_id = <CLIENT_ID>
 client_secret = <CLIENT_SECRET>
 
-## Force remote authentication with the identity provider during login,
-## even if a local method (e.g. local password) is used.
-## This works by forcing a token refresh during login, which fails if the
-## user does not have the necessary permissions in the identity provider.
+## Force verification with the identity provider during login.
 ##
-## If set to false (the default), remote authentication with the identity
-## provider only happens if there is a working internet connection and
-## the provider is reachable during login.
+## When enabled, authd always verifies during login that the user still
+## has permission to access the system according to the identity provider.
+##
+## When disabled (default), authd only performs this verification if there
+## is a working network connection and the identity provider is reachable
+## during login.
 ##
 ## Important: Enabling this option prevents authd users from logging in
 ## if the identity provider is unreachable (e.g. due to network issues).

--- a/authd-oidc-brokers/conf/variants/msentraid/broker.conf
+++ b/authd-oidc-brokers/conf/variants/msentraid/broker.conf
@@ -2,14 +2,14 @@
 issuer = https://login.microsoftonline.com/<ISSUER_ID>/v2.0
 client_id = <CLIENT_ID>
 
-## Force remote authentication with the identity provider during login,
-## even if a local method (e.g. local password) is used.
-## This works by forcing a token refresh during login, which fails if the
-## user does not have the necessary permissions in the identity provider.
+## Force verification with the identity provider during login.
 ##
-## If set to false (the default), remote authentication with the identity
-## provider only happens if there is a working internet connection and
-## the provider is reachable during login.
+## When enabled, authd always verifies during login that the user still
+## has permission to access the system according to the identity provider.
+##
+## When disabled (default), authd only performs this verification if there
+## is a working network connection and the identity provider is reachable
+## during login.
 ##
 ## Important: Enabling this option prevents authd users from logging in
 ## if the identity provider is unreachable (e.g. due to network issues).

--- a/authd-oidc-brokers/internal/broker/config.go
+++ b/authd-oidc-brokers/internal/broker/config.go
@@ -18,7 +18,8 @@ import (
 const (
 	// forceAccessCheckWithProviderKey is the key in the config file for the setting to force verification with the
 	// identity provider during login.
-	forceAccessCheckWithProviderKey = "force_access_check_with_provider"
+	forceAccessCheckWithProviderKey    = "force_access_check_with_provider"
+	forceAccessCheckWithProviderKeyOld = "force_provider_authentication"
 
 	// oidcSection is the section name in the config file for the OIDC specific configuration.
 	oidcSection = "oidc"
@@ -229,10 +230,15 @@ func parseConfig(cfgContent []byte, dropInContent []any, p provider) (userConfig
 		cfg.clientSecret = oidc.Key(clientSecret).String()
 		cfg.extraScopes = oidc.Key(extraScopesKey).Strings(",")
 
-		if oidc.HasKey(forceAccessCheckWithProviderKey) {
-			cfg.forceAccessCheckWithProvider, err = oidc.Key(forceAccessCheckWithProviderKey).Bool()
+		forceAccessCheckKey := forceAccessCheckWithProviderKey
+		// If we don't have the new key, we should try reading the old one instead.
+		if !oidc.HasKey(forceAccessCheckKey) {
+			forceAccessCheckKey = forceAccessCheckWithProviderKeyOld
+		}
+		if oidc.HasKey(forceAccessCheckKey) {
+			cfg.forceAccessCheckWithProvider, err = oidc.Key(forceAccessCheckKey).Bool()
 			if err != nil {
-				return userConfig{}, fmt.Errorf("error parsing '%s': %w", forceAccessCheckWithProviderKey, err)
+				return userConfig{}, fmt.Errorf("error parsing '%s': %w", forceAccessCheckKey, err)
 			}
 		}
 	}


### PR DESCRIPTION
I was sloppy in https://github.com/canonical/authd/pull/1444 and made two mistakes:

1. Commit de17fffbe9c1907d3a58772d60b17b964e21a12b only updated the comment of the `force_access_check_with_provider` setting in `oidc/broker.conf`. We also have to update it in `msentraid/broker.conf` and `google/broker.conf`.
2. We still have to support the old setting name for backwards compatibility.