### PR TITLE
docs: fix broken references and improve contributor/developer guides

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,7 +34,7 @@ debuild --prepend-path=${HOME}/.cargo/bin
 
 # Individual components (development)
 go build ./cmd/authd                    # authd daemon only
-go generate ./pam/ && go build -tags pam_binary_exec -o ./pam/authd-pam ./pam  # PAM test client
+go generate ./pam/ && go build -o ./pam/authd-pam ./pam  # PAM helper client
 cargo build                              # NSS (debug mode)
 ```
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,7 +24,7 @@ These are mostly guidelines, not rules. Use your best judgment and feel free to 
       - [Building the PAM module only](#building-the-pam-module-only)
       - [Building the NSS module only](#building-the-nss-module-only)
     - [Building the broker](#building-the-broker)
-    - [About the test suite](#about-the-testsuite)
+    - [About the test suite](#about-the-test-suite)
       - [Tests with dependencies](#tests-with-dependencies)
     - [Code style](#code-style)
   - [Contributing to the documentation](#contributing-to-the-documentation)
@@ -39,11 +39,11 @@ These are mostly guidelines, not rules. Use your best judgment and feel free to 
 
 We take our community seriously, holding ourselves and other contributors to high standards of communication. By contributing to this project you agree to uphold the Ubuntu community [Code of Conduct](https://ubuntu.com/community/ethos/code-of-conduct).
 
-## Getting Started
+## Getting started
 
 Contributions are made to this project via Issues and Pull Requests (PRs). These are some general guidelines that cover both:
 
-* To report security vulnerabilities, use the advisories page of the repository and not a public bug report. Please use [launchpad private bugs](https://bugs.launchpad.net/ubuntu/+source/authd/+filebug), which is monitored by our security team. On an Ubuntu machine, it’s best to use `ubuntu-bug authd` to collect relevant information. <!-- FIXME: snap? -->
+* To report security vulnerabilities, use the advisories page of the repository and not a public bug report. Please use [launchpad private bugs](https://bugs.launchpad.net/ubuntu/+source/authd/+filebug), which is monitored by our security team. On an Ubuntu machine, it's best to use `ubuntu-bug authd` to collect relevant information.
 * General issues or feature requests should be reported to the [GitHub Project](https://github.com/canonical/authd/issues)
 * If you've never contributed before, see [this post on ubuntu.com](https://ubuntu.com/community/contribute) for resources and tips on how to get started.
 * Existing Issues and PRs should be searched for on the [project's repository](https://github.com/canonical/authd) before creating your own.
@@ -55,7 +55,7 @@ Issues can be used to report problems with the software, request a new feature o
 
 If you find an Issue that addresses the problem you're having, please add your own reproduction information to the existing issue rather than creating a new one. Adding a [reaction](https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) can also help by indicating to our maintainers that a particular problem is affecting more than just the reporter.
 
-### Pull Requests
+### Pull requests
 
 PRs to our project are always welcome and can be a quick way to get your fix or improvement slated for the next release. In general, PRs should:
 
@@ -226,7 +226,7 @@ The test suite must pass before merging the PR to our main branch. Any new featu
 
 #### Tests with dependencies
 
-Some tests, such as the [PAM CLI tests](https://github.com/canonical/authd/blob/5ba54c0a573f34e99782fe624b090ab229798fc3/pam/integration-tests/integration_test.go#L21), use external tools such as [VHS](https://github.com/charmbracelet/vhs)
+Some tests, such as the [PAM CLI tests](https://github.com/canonical/authd/blob/main/pam/integration-tests/cli_test.go), use external tools such as [VHS](https://github.com/charmbracelet/vhs)
 to record and run the tape files needed for the tests. Those tools are not included in the project dependencies and must be installed manually.
 
 Information about these tools and their usage will be linked below:
@@ -324,9 +324,6 @@ It is a requirement that you sign the [Contributor License Agreement](https://ub
 You only need to sign this once and if you have previously signed the agreement when contributing to other Canonical projects you will not need to sign it again.
 
 An automated test is executed on PRs to check if this agreement has been accepted.
-
-<!-- TODO: add license. -->
-<!-- This project is covered by [THIS LICENSE](LICENSE). -->
 
 ## Getting help
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -155,10 +155,12 @@ Then build the PAM module:
 
 ```shell
 go generate ./pam/
-go build -tags pam_binary_exec -o ./pam/authd-pam ./pam
+go build -o ./pam/authd-pam ./pam
 ```
 
-This last command will produce two libraries (`./pam/pam_authd.so` and `./pam/go-exec/pam_authd_exec.so`) and an executable (`./pam/authd-pam`).
+The `go generate` step produces two PAM modules (`./pam/pam_authd.so` and `./pam/go-exec/pam_authd_exec.so`).
+
+The `go build` step produces the PAM helper executable (`./pam/authd-pam`).
 
 These modules must be copied to `/usr/lib/$(gcc -dumpmachine)/security/` while the executable must be copied to `/usr/libexec/authd-pam`.
 

--- a/e2e-tests/testing.md
+++ b/e2e-tests/testing.md
@@ -43,7 +43,7 @@ The tests have mainly two sets of dependencies: one required to configure and ru
     python3-tk
     python3-gi
     python3-cairo
-    xvfb    
+    xvfb
     ```
 
     Those are all part of the archive and can be installed on Ubuntu with:
@@ -56,15 +56,16 @@ The tests have mainly two sets of dependencies: one required to configure and ru
 
 The tests need a VM to run. This can be easily setup by using the domain definition and cloud-init configuration provided in the repository.
 
-1. Download the latest Ubuntu Desktop image (and resize it):
+1. Download the Ubuntu cloud image for the target release (and resize it):
 
     ```bash
-    wget https://cloud-images.ubuntu.com/questing/current/questing-server-cloudimg-amd64.img
+    RELEASE=resolute  # Replace with your target release (e.g. noble, questing, resolute)
+    wget https://cloud-images.ubuntu.com/${RELEASE}/current/${RELEASE}-server-cloudimg-amd64.img
 
-    qemu-img resize questing-server-cloudimg-amd64.img 10G
+    qemu-img resize ${RELEASE}-server-cloudimg-amd64.img 10G
     ```
 
-2. Create the cloud-init iso using the provided configuration in `e2e-tests/vm/cloud-init-template.yaml`:
+2. Create the cloud-init iso using the release-specific configuration from `e2e-tests/vm/cloud-init-template-${RELEASE}.yaml`:
    1. Update the file with the ssh key that will be used to access the VM.
    2. Create a directory and copy the YAML file there. The file must be named `user-data`.
    3. Create the `seed.iso` file using `cloud-localds`.
@@ -74,7 +75,7 @@ The tests need a VM to run. This can be easily setup by using the domain definit
         mkdir -p /tmp/seed/
 
         SSH_PUBLIC_KEY=$(cat "${SSH_PUBLIC_KEY_FILE}") \
-            envsubst < e2e-tests/vm/cloud-init-template.yaml > /tmp/seed/user-data
+            envsubst < e2e-tests/vm/cloud-init-template-${RELEASE}.yaml > /tmp/seed/user-data
 
         cloud-localds /tmp/seed.iso /tmp/seed/user-data
         ```
@@ -148,10 +149,10 @@ Now that the VM is ready, we need to install authd and the brokers we want to te
 
 ##### Install authd
 
-1. Revert to the "fresh install" snapshot:
+1. Revert to the `initial-setup` snapshot:
 
     ```bash
-    virsh snapshot-revert e2e-runner fresh-install
+    virsh snapshot-revert e2e-runner initial-setup
     ```
 
 2. Install authd:

--- a/pam/README.md
+++ b/pam/README.md
@@ -47,15 +47,15 @@ TTY availability, which is useful for testing.
 
 ## Directory Structure
 
-| Path | Description |
-|------|-------------|
-| `pam.go` | Core PAM module logic |
-| `pam_module.go` | Auto-generated C-exported `pam_sm_*` entry points |
-| `main-exec.go` | Entry point for the exec-mode child binary |
-| `go-exec/` | C wrapper that implements `pam_authd_exec.so` |
-| `internal/adapter/` | Authentication UI adapters (native CLI and GDM) |
-| `tools/pam-runner/` | Developer tool for manual end-to-end PAM testing |
-| `integration-tests/` | Automated integration tests using `vhs` tapes |
+| Path                 | Description                                       |
+| -------------------- | ------------------------------------------------- |
+| `pam.go`             | Core PAM module logic                             |
+| `pam_module.go`      | Auto-generated C-exported `pam_sm_*` entry points |
+| `main-exec.go`       | Entry point for the exec-mode child binary        |
+| `go-exec/`           | C wrapper that implements `pam_authd_exec.so`     |
+| `internal/adapter/`  | Authentication UI adapters (native CLI and GDM)   |
+| `tools/pam-runner/`  | Developer tool for manual end-to-end PAM testing  |
+| `integration-tests/` | Automated integration tests using `vhs` tapes     |
 
 ## Building
 
@@ -151,7 +151,7 @@ Enable debug logging by passing `debug=true` together with `logfile=` pointing t
 
 ```
 auth sufficient /path/to/pam_authd_exec.so /path/to/pam_authd \
-    debug=true logfile=/dev/stderr
+    --exec-debug --exec-log=/dev/stderr debug=true logfile=/dev/stderr
 ```
 
 Alternatively, leave `logfile` unset and tail the systemd journal in real time:
@@ -161,4 +161,4 @@ journalctl -ef _COMM=exec-child
 ```
 
 > **Note:** To test against an installed version of authd rather than a local
-> build, point `socket=` at the installed socket path (e.g. `/run/authd.sock`).
+> build, point `socket=` at the installed socket path (e.g. `/tmp/authd.sock`).


### PR DESCRIPTION
This PR fixes multiple outdated flags/references, and introduces some improvements to the following documentation files:
- `CONTRIBUTING.md`
- `testing.md`
- `AGENTS.md`


UDENG-9427