### PR TITLE
e2e-tests: Add tests for `allowed_users` broker property

### DIFF
--- a/e2e-tests/resources/broker.resource
+++ b/e2e-tests/resources/broker.resource
@@ -95,6 +95,8 @@ Continue Log In With Remote User Through CLI: Define Local Password
 
 Log In With Remote User Through CLI: Local Password
     [Arguments]    ${username}    ${local_password}
+    Hid.Type String    clear
+    Hid.Keys Combo    Return
     Try machinectl login Prompt
     Hid.Type String    ${username}
     Hid.Keys Combo    Return
@@ -137,6 +139,34 @@ Try Navigating Back to User Selection
     Match Text    Select your provider    120
     Hid.Keys Combo    Escape
     Match Text    Select your provider    120
+
+
+Log In With Remote User Through CLI: Local Password And Expect Failure
+    [Arguments]    ${username}    ${local_password}
+    Hid.Type String    clear
+    Hid.Keys Combo    Return
+    Try machinectl login Prompt
+    Hid.Type String    ${username}
+    Hid.Keys Combo    Return
+    Builtin.Sleep    2
+    Match Text    Enter your local password:    120
+    Hid.Type String    ${local_password}
+    Hid.Keys Combo    Return
+    Check That Remote User Is Not Allowed To Log In
+    # Exit the machinectl session (three ^] within 1 s exits the session).
+    Hid.Keys Combo    Control_L    ]
+    Hid.Keys Combo    Control_L    ]
+    Hid.Keys Combo    Control_L    ]
+    # Wait until the shell prompt is back before the next login attempt.
+    Match Text    @ubuntu:~$    30
+
+
+Remove Registered Owner
+    [Documentation]    Removes the auto-registration drop-in that the broker creates when
+    ...               the first user logs in, so that subsequent OWNER-based tests start
+    ...               from a known-clean state.
+    SSH.Execute    sudo rm -f ${BROKER_CFG_DIR}/20-owner-autoregistration.conf
+    SSH.Execute    sudo snap restart ${BROKER_SNAP_NAME}
 
 
 # Uses sed to change the broker configuration.

--- a/e2e-tests/tests/allowed_users.robot
+++ b/e2e-tests/tests/allowed_users.robot
@@ -1,0 +1,74 @@
+*** Settings ***
+Resource        resources/utils.resource
+Resource        resources/authd.resource
+
+Resource        resources/broker.resource
+
+# Test Tags       robot:exit-on-failure
+
+Test Setup    utils.Test Setup    snapshot=%{BROKER}-installed
+Test Teardown   utils.Test Teardown
+
+
+*** Variables ***
+${username}    %{E2E_USER}
+${local_password}    qwer1234
+${non_allowed_user}    different-user
+
+
+*** Test Cases ***
+Test allowed_users values with cached local password authentication
+    [Documentation]    Verify all allowed_users scenarios with a single device auth.
+    ...
+    ...    The test registers the remote user once via device authentication (QR code),
+    ...    which caches a local password.  All five allowed_users scenarios are then
+    ...    exercised using local-password authentication only, so the browser flow is
+    ...    not repeated for every scenario.
+    ...
+    ...    Scenarios covered (in order):
+    ...      1. allowed_users=OWNER, owner=<username>       → login succeeds
+    ...      2. allowed_users=OWNER, owner=<different-user> → login fails
+    ...      3. allowed_users=<username>                    → login succeeds
+    ...      4. allowed_users=<non-allowed-user>            → login fails
+    ...      5. allowed_users=ALL                           → login succeeds
+
+    Log In
+
+    # Perform device authentication once to register the user and cache their
+    # local password.  All subsequent logins reuse this cached password.
+    Open Terminal
+    Log In With Remote User Through CLI: QR Code    ${username}    ${local_password}
+    Log Out From Terminal Session
+
+    # The initial login auto-registers the user as owner via a drop-in config.
+    # Remove it so that OWNER-based scenarios start from a clean state.
+    Remove Registered Owner
+
+    # Scenario 1: OWNER + owner=<username> → success
+    Change allowed_users In Broker Configuration    OWNER
+    Change Broker Configuration    owner    ${username}
+    Log In With Remote User Through CLI: Local Password    ${username}    ${local_password}
+    Log Out From Terminal Session
+
+    # Scenario 2: OWNER + owner=different-user → failure
+    # Using a non-empty wrong owner so the broker performs a deterministic
+    # username comparison and denies access. An empty owner would trigger
+    # auto-registration (covered by config_owner_auto_update.robot), not denial.
+    Change Broker Configuration    owner    ${non_allowed_user}
+    Log In With Remote User Through CLI: Local Password And Expect Failure    ${username}    ${local_password}
+
+    # Scenario 3: explicit username → success
+    Change allowed_users In Broker Configuration    ${username}
+    Log In With Remote User Through CLI: Local Password    ${username}    ${local_password}
+    Log Out From Terminal Session
+
+    # Scenario 4: non-allowed username → failure
+    Change allowed_users In Broker Configuration    ${non_allowed_user}
+    Log In With Remote User Through CLI: Local Password And Expect Failure    ${username}    ${local_password}
+
+    # Scenario 5: ALL → success
+    Change allowed_users In Broker Configuration    ALL
+    Log In With Remote User Through CLI: Local Password    ${username}    ${local_password}
+    Log Out From Terminal Session
+
+    Close Focused Window


### PR DESCRIPTION
Add tests for the following scenarios:
- `allowed_users` is set to `OWNER` and the `owner` is set to the test user (login successful)
- `allowed_users` is set to `OWNER` and `owner` is explicitly set to an empty value (login denied)
- `allowed_users` is set to `user` and login with that user (login successful)
- `allowed_users` set to a specific user and login with a different user (login denied)
- `allowed_users` is set to to `ALL` (login successful)


UDENG-9543
UDENG-9544
UDENG-9545
UDENG-9546
UDENG-9547
