### PR TITLE
authd-oidc-brokers/go.mod: Don't replace github.com/canonical/authd

### DIFF
--- a/authd-oidc-brokers/go.mod
+++ b/authd-oidc-brokers/go.mod
@@ -69,5 +69,3 @@ require (
 	golang.org/x/sys v0.43.0 // indirect
 	golang.org/x/text v0.36.0 // indirect
 )
-
-replace github.com/canonical/authd => ../

--- a/authd-oidc-brokers/go.sum
+++ b/authd-oidc-brokers/go.sum
@@ -2,6 +2,8 @@ github.com/Azure/azure-sdk-for-go/sdk/azcore v1.21.0 h1:fou+2+WFTib47nS+nz/ozhEB
 github.com/Azure/azure-sdk-for-go/sdk/azcore v1.21.0/go.mod h1:t76Ruy8AHvUAC8GfMWJMa0ElSbuIcO03NLpynfbgsPA=
 github.com/Azure/azure-sdk-for-go/sdk/internal v1.11.2 h1:9iefClla7iYpfYWdzPCRDozdmndjTm8DXdpCzPajMgA=
 github.com/Azure/azure-sdk-for-go/sdk/internal v1.11.2/go.mod h1:XtLgD3ZD34DAaVIIAyG3objl5DynM3CQ/vMcbBNJZGI=
+github.com/canonical/authd v0.6.1 h1:kzSi7k2CRY8AB73gg9uB5EgZ6NWpy8KQK4vSoiBwikI=
+github.com/canonical/authd v0.6.1/go.mod h1:1qc5kb7RPsMkS4USZWiQU8p9801mWY5DvN7E8xo3TEo=
 github.com/coreos/go-oidc/v3 v3.18.0 h1:V9orjXynvu5wiC9SemFTWnG4F45v403aIcjWo0d41+A=
 github.com/coreos/go-oidc/v3 v3.18.0/go.mod h1:DYCf24+ncYi+XkIH97GY1+dqoRlbaSI26KVTCI9SrY4=
 github.com/coreos/go-systemd v0.0.0-20191104093116-d3cd4ed1dbcf h1:iW4rZ826su+pqaw19uhpSCzhj44qo35pNgKFGqzDKkU=


### PR DESCRIPTION
Copilot added this in fc86ba761331e898b6dc5d625b457f3983d6f00c and we missed it during the review. It breaks the snap build on Launchpad:

```
:: + go mod download all
:: go: github.com/canonical/authd@v0.6.1 (replaced by ../): reading ../go.mod: open /build/authd-oidc/parts/broker/go.mod: no such file or directory
```