### PR TITLE
broker: use /userinfo as fallback for claims not available in id token

### DIFF
--- a/authd-oidc-brokers/go.mod
+++ b/authd-oidc-brokers/go.mod
@@ -16,6 +16,7 @@ require (
 	github.com/k0kubun/pp v3.0.1+incompatible
 	github.com/microsoftgraph/msgraph-sdk-go v1.97.0
 	github.com/microsoftgraph/msgraph-sdk-go-core v1.4.0
+	github.com/mitchellh/mapstructure v1.5.0
 	github.com/spf13/cobra v1.10.2
 	github.com/spf13/viper v1.21.0
 	github.com/stretchr/testify v1.11.1

--- a/authd-oidc-brokers/go.sum
+++ b/authd-oidc-brokers/go.sum
@@ -72,6 +72,8 @@ github.com/microsoftgraph/msgraph-sdk-go v1.97.0 h1:CWS3muHuVlX8nerNWtllzPpO4dWT
 github.com/microsoftgraph/msgraph-sdk-go v1.97.0/go.mod h1:3vZD5qsulctIsk1wb1Cf6tzi01k++3qaNqF+yGZwkVw=
 github.com/microsoftgraph/msgraph-sdk-go-core v1.4.0 h1:0SrIoFl7TQnMRrsi5TFaeNe0q8KO5lRzRp4GSCCL2So=
 github.com/microsoftgraph/msgraph-sdk-go-core v1.4.0/go.mod h1:A1iXs+vjsRjzANxF6UeKv2ACExG7fqTwHHbwh1FL+EE=
+github.com/mitchellh/mapstructure v1.5.0 h1:jeMsZIYE/09sWLaz43PL7Gy6RuMjD2eJVyuac5Z2hdY=
+github.com/mitchellh/mapstructure v1.5.0/go.mod h1:bFUtVrKA4DC2yAKiSyO/QUcy7e+RRV2QTWOzhPopBRo=
 github.com/otiai10/copy v1.14.1 h1:5/7E6qsUMBaH5AnQ0sSLzzTg1oTECmcCmT6lvF45Na8=
 github.com/otiai10/copy v1.14.1/go.mod h1:oQwrEDDOci3IM8dJF0d8+jnbfPDllW6vUjNc3DoZm9I=
 github.com/otiai10/mint v1.6.3 h1:87qsV/aw1F5as1eH1zS/yqHY85ANKVMgkDrf9rcxbQs=

--- a/authd-oidc-brokers/internal/broker/broker.go
+++ b/authd-oidc-brokers/internal/broker/broker.go
@@ -716,7 +716,7 @@ func (b *Broker) deviceAuth(ctx context.Context, session *session) (string, isAu
 		return AuthDenied, unexpectedErrMsg("could not get provider metadata")
 	}
 
-	authInfo.UserInfo, err = b.userInfoFromIDToken(ctx, session, rawIDToken)
+	authInfo.UserInfo, err = b.getUserInfo(ctx, session, t, rawIDToken)
 	if err != nil {
 		log.Errorf(context.Background(), "could not get user info: %s", err)
 		return AuthDenied, errorMessageForDisplay(err, "Could not get user info")
@@ -1154,7 +1154,7 @@ func (b *Broker) refreshToken(ctx context.Context, session *session, oldToken *t
 	t.ProviderMetadata = oldToken.ProviderMetadata
 	t.DeviceRegistrationData = oldToken.DeviceRegistrationData
 
-	t.UserInfo, err = b.userInfoFromIDToken(ctx, session, rawIDToken)
+	t.UserInfo, err = b.getUserInfo(ctx, session, oauthToken, rawIDToken)
 	if err != nil {
 		return nil, err
 	}
@@ -1164,16 +1164,37 @@ func (b *Broker) refreshToken(ctx context.Context, session *session, oldToken *t
 	return t, nil
 }
 
-// userInfoFromIDToken verifies and parses the raw ID token and returns the user info from it.
+// getUserInfo verifies and parses the raw ID token and returns the user info from it.
+// If any provider specific mandatory claims are not present in the ID token, the missing claims are
+// fetched from the `/userinfo` endpoint and merged before extracting user info.
 // Note that verifying the ID token requires a working network connection to the provider's JWKs endpoint,
 // so make sure to only call this function if the session is online.
-func (b *Broker) userInfoFromIDToken(ctx context.Context, session *session, rawIDToken string) (info.User, error) {
+func (b *Broker) getUserInfo(ctx context.Context, session *session, token *oauth2.Token, rawIDToken string) (info.User, error) {
 	idToken, err := session.oidcServer.Verifier(&b.oidcCfg).Verify(ctx, rawIDToken)
 	if err != nil {
 		return info.User{}, fmt.Errorf("could not verify token: %w", err)
 	}
 
 	userInfo, err := b.provider.GetUserInfo(idToken)
+	var missingClaimErr *providerErrors.MissingClaimError
+	if errors.As(err, &missingClaimErr) {
+		// The ID token is missing a required claim. Try fetching the claims from the UserInfo endpoint.
+		log.Infof(context.Background(), "ID token is missing claim %q. Fetching claims from UserInfo endpoint.", missingClaimErr.Claim)
+		var userInfoClaims info.Claimer
+		userInfoClaims, err = session.oidcServer.UserInfo(ctx, oauth2.StaticTokenSource(token))
+		if err != nil {
+			return info.User{}, fmt.Errorf("could not get user info from UserInfo endpoint: %w", err)
+		}
+
+		// Merge ID token claims with UserInfo claims.
+		// UserInfo claims override ID token claims for the same key.
+		var claims info.Claimer
+		claims, err = info.NewMergedClaimer(idToken, userInfoClaims)
+		if err != nil {
+			return info.User{}, fmt.Errorf("could not merge ID token and UserInfo endpoint claims: %w", err)
+		}
+		userInfo, err = b.provider.GetUserInfo(claims)
+	}
 	if err != nil {
 		return info.User{}, err
 	}

--- a/authd-oidc-brokers/internal/broker/broker_test.go
+++ b/authd-oidc-brokers/internal/broker/broker_test.go
@@ -590,8 +590,9 @@ func TestIsAuthenticated(t *testing.T) {
 		useOldNameForSecretField bool
 		groupsReturnedByProvider []info.Group
 
-		customHandlers map[string]testutils.EndpointHandler
-		address        string
+		customHandlers      map[string]testutils.EndpointHandler
+		address             string
+		tokenHandlerOptions *testutils.TokenHandlerOptions
 
 		wantSecondCall bool
 		secondMode     string
@@ -607,6 +608,20 @@ func TestIsAuthenticated(t *testing.T) {
 	}{
 		"Successfully_authenticate_user_with_device_auth_and_newpassword": {firstSecret: "-", wantSecondCall: true},
 		"Successfully_authenticate_user_with_password":                    {firstMode: authmodes.Password, token: &tokenOptions{}},
+		"Successfully_authenticate_with_device_auth_when_provider_uses_thin_id_token": {
+			firstSecret:    "-",
+			wantSecondCall: true,
+			tokenHandlerOptions: &testutils.TokenHandlerOptions{
+				// Remove "must-have-claim" from the ID token.
+				DeleteClaims: []string{"must-have-claim"},
+			},
+			customHandlers: map[string]testutils.EndpointHandler{
+				// Provide "must-have-claim" via the userinfo endpoint.
+				"/userinfo": testutils.UserInfoHandler(map[string]interface{}{
+					"must-have-claim": "present",
+				}),
+			},
+		},
 
 		"Authenticating_with_qrcode_reacquires_token":          {firstSecret: "-", wantSecondCall: true, token: &tokenOptions{}},
 		"Authenticating_with_password_refreshes_expired_token": {firstMode: authmodes.Password, token: &tokenOptions{expired: true}},
@@ -834,6 +849,26 @@ func TestIsAuthenticated(t *testing.T) {
 			sessionOffline: true,
 		},
 		"Error_when_mode_is_invalid": {firstMode: "invalid"},
+		"Error_when_thin_id_token_and_userinfo_endpoint_is_unavailable": {
+			firstSecret:    "-",
+			wantSecondCall: true,
+			tokenHandlerOptions: &testutils.TokenHandlerOptions{
+				DeleteClaims: []string{"must-have-claim"},
+			},
+			customHandlers: map[string]testutils.EndpointHandler{
+				"/userinfo": testutils.UnavailableHandler(),
+			},
+		},
+		"Error_when_thin_id_token_and_userinfo_does_not_have_must_have_claim": {
+			firstSecret:    "-",
+			wantSecondCall: true,
+			tokenHandlerOptions: &testutils.TokenHandlerOptions{
+				DeleteClaims: []string{"must-have-claim"},
+			},
+			customHandlers: map[string]testutils.EndpointHandler{
+				"/userinfo": testutils.UserInfoHandler(map[string]interface{}{}),
+			},
+		},
 	}
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
@@ -866,6 +901,7 @@ func TestIsAuthenticated(t *testing.T) {
 				ownerExtraGroups:             tc.ownerExtraGroups,
 				supportsDeviceRegistration:   tc.providerSupportsDeviceRegistration,
 				registerDevice:               tc.registerDevice,
+				tokenHandlerOptions:          tc.tokenHandlerOptions,
 			}
 			if tc.customHandlers == nil {
 				// Use the default provider URL if no custom handlers are provided.

--- a/authd-oidc-brokers/internal/broker/testdata/golden/TestIsAuthenticated/Error_when_thin_id_token_and_userinfo_does_not_have_must_have_claim/first_call
+++ b/authd-oidc-brokers/internal/broker/testdata/golden/TestIsAuthenticated/Error_when_thin_id_token_and_userinfo_does_not_have_must_have_claim/first_call
@@ -1,0 +1,3 @@
+access: denied
+data: '{"message":"Could not get user info"}'
+err: <nil>

--- a/authd-oidc-brokers/internal/broker/testdata/golden/TestIsAuthenticated/Error_when_thin_id_token_and_userinfo_does_not_have_must_have_claim/second_call
+++ b/authd-oidc-brokers/internal/broker/testdata/golden/TestIsAuthenticated/Error_when_thin_id_token_and_userinfo_does_not_have_must_have_claim/second_call
@@ -1,0 +1,3 @@
+access: denied
+data: '{"message":"An unexpected error occurred: auth info is not set. Please report this error on https://github.com/canonical/authd/issues"}'
+err: <nil>

--- a/authd-oidc-brokers/internal/broker/testdata/golden/TestIsAuthenticated/Error_when_thin_id_token_and_userinfo_endpoint_is_unavailable/first_call
+++ b/authd-oidc-brokers/internal/broker/testdata/golden/TestIsAuthenticated/Error_when_thin_id_token_and_userinfo_endpoint_is_unavailable/first_call
@@ -1,0 +1,3 @@
+access: denied
+data: '{"message":"Could not get user info"}'
+err: <nil>

--- a/authd-oidc-brokers/internal/broker/testdata/golden/TestIsAuthenticated/Error_when_thin_id_token_and_userinfo_endpoint_is_unavailable/second_call
+++ b/authd-oidc-brokers/internal/broker/testdata/golden/TestIsAuthenticated/Error_when_thin_id_token_and_userinfo_endpoint_is_unavailable/second_call
@@ -1,0 +1,3 @@
+access: denied
+data: '{"message":"An unexpected error occurred: auth info is not set. Please report this error on https://github.com/canonical/authd/issues"}'
+err: <nil>

--- a/authd-oidc-brokers/internal/broker/testdata/golden/TestIsAuthenticated/Successfully_authenticate_with_device_auth_when_provider_uses_thin_id_token/data/provider_url/test-user@email.com/password
+++ b/authd-oidc-brokers/internal/broker/testdata/golden/TestIsAuthenticated/Successfully_authenticate_with_device_auth_when_provider_uses_thin_id_token/data/provider_url/test-user@email.com/password
@@ -1,0 +1,1 @@
+Definitely a hashed password

--- a/authd-oidc-brokers/internal/broker/testdata/golden/TestIsAuthenticated/Successfully_authenticate_with_device_auth_when_provider_uses_thin_id_token/data/provider_url/test-user@email.com/token.json
+++ b/authd-oidc-brokers/internal/broker/testdata/golden/TestIsAuthenticated/Successfully_authenticate_with_device_auth_when_provider_uses_thin_id_token/data/provider_url/test-user@email.com/token.json
@@ -1,0 +1,1 @@
+Definitely a token

--- a/authd-oidc-brokers/internal/broker/testdata/golden/TestIsAuthenticated/Successfully_authenticate_with_device_auth_when_provider_uses_thin_id_token/first_call
+++ b/authd-oidc-brokers/internal/broker/testdata/golden/TestIsAuthenticated/Successfully_authenticate_with_device_auth_when_provider_uses_thin_id_token/first_call
@@ -1,0 +1,3 @@
+access: next
+data: '{}'
+err: <nil>

--- a/authd-oidc-brokers/internal/broker/testdata/golden/TestIsAuthenticated/Successfully_authenticate_with_device_auth_when_provider_uses_thin_id_token/second_call
+++ b/authd-oidc-brokers/internal/broker/testdata/golden/TestIsAuthenticated/Successfully_authenticate_with_device_auth_when_provider_uses_thin_id_token/second_call
@@ -1,0 +1,3 @@
+access: granted
+data: '{"userinfo":{"name":"test-user@email.com","uuid":"test-user-id","dir":"/home/test-user@email.com","shell":"/usr/bin/bash","gecos":"test-user","groups":[{"name":"remote-test-group","ugid":"12345"},{"name":"local-test-group","ugid":""}]}}'
+err: <nil>

--- a/authd-oidc-brokers/internal/providers/errors/errors.go
+++ b/authd-oidc-brokers/internal/providers/errors/errors.go
@@ -18,3 +18,17 @@ func (e *ForDisplayError) Error() string {
 func (e *ForDisplayError) Unwrap() error {
 	return e.Err
 }
+
+// MissingClaimError is an error type for missing claims in the ID token or the claims returned by the UserInfo endpoint.
+type MissingClaimError struct {
+	Claim string
+}
+
+func (e *MissingClaimError) Error() string {
+	return e.Claim + " claim is missing"
+}
+
+// NewMissingClaimError creates a new MissingClaimError for the specified claim.
+func NewMissingClaimError(claim string) error {
+	return &MissingClaimError{Claim: claim}
+}

--- a/authd-oidc-brokers/internal/providers/genericprovider/genericprovider.go
+++ b/authd-oidc-brokers/internal/providers/genericprovider/genericprovider.go
@@ -3,6 +3,7 @@ package genericprovider
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"slices"
 	"strings"
@@ -47,31 +48,49 @@ func (p GenericProvider) GetMetadata(provider *oidc.Provider) (map[string]interf
 	return nil, nil
 }
 
-// GetUserInfo is a no-op when no specific provider is in use.
-func (p GenericProvider) GetUserInfo(idToken info.Claimer) (info.User, error) {
-	userClaims, err := p.userClaims(idToken)
-	if err != nil {
-		return info.User{}, err
+// GetUserInfo returns user information from the claims of the provided Claimer.
+func (p GenericProvider) GetUserInfo(claimer info.Claimer) (info.User, error) {
+	var claimsMap map[string]interface{}
+	if err := claimer.Claims(&claimsMap); err != nil {
+		return info.User{}, fmt.Errorf("failed to get ID token claims: %v", err)
 	}
 
-	if userClaims.Sub == "" {
-		return info.User{}, fmt.Errorf("authentication failure: sub claim is missing in the ID token")
+	// Check required claims
+	sub, ok := claimsMap["sub"].(string)
+	if !ok || sub == "" {
+		return info.User{}, providerErrors.NewMissingClaimError("sub")
 	}
 
-	if userClaims.Email == "" {
-		return info.User{}, fmt.Errorf("authentication failure: email claim is missing in the ID token")
+	email, ok := claimsMap["email"].(string)
+	if !ok || email == "" {
+		return info.User{}, providerErrors.NewMissingClaimError("email")
 	}
 
-	if !userClaims.EmailVerified {
-		return info.User{}, &providerErrors.ForDisplayError{Message: "Authentication failure: email not verified"}
+	rawEmailVerified, present := claimsMap["email_verified"]
+	if !present {
+		return info.User{}, &providerErrors.ForDisplayError{
+			Message: "Authentication failure: email not verified",
+			Err:     providerErrors.NewMissingClaimError("email_verified"),
+		}
 	}
+	if verified, ok := rawEmailVerified.(bool); !ok || !verified {
+		return info.User{}, &providerErrors.ForDisplayError{
+			Message: "Authentication failure: email not verified",
+			Err:     errors.New("email_verified claim value is false or malformed"),
+		}
+	}
+
+	// Optional claims: home, shell, name
+	home, _ := claimsMap["home"].(string)
+	shell, _ := claimsMap["shell"].(string)
+	gecos, _ := claimsMap["name"].(string)
 
 	return info.NewUser(
-		userClaims.Email,
-		userClaims.Home,
-		userClaims.Sub,
-		userClaims.Shell,
-		userClaims.Gecos,
+		email,
+		home,
+		sub,
+		shell,
+		gecos,
 		nil,
 	), nil
 }
@@ -98,24 +117,6 @@ func (p GenericProvider) VerifyUsername(requestedUsername, username string) erro
 // SupportedOIDCAuthModes returns the OIDC authentication modes supported by the provider.
 func (p GenericProvider) SupportedOIDCAuthModes() []string {
 	return []string{authmodes.Device, authmodes.DeviceQr}
-}
-
-type claims struct {
-	Email         string `json:"email"`
-	Sub           string `json:"sub"`
-	Home          string `json:"home"`
-	Shell         string `json:"shell"`
-	Gecos         string `json:"name"`
-	EmailVerified bool   `json:"email_verified"`
-}
-
-// userClaims returns the user claims parsed from the ID token.
-func (p GenericProvider) userClaims(idToken info.Claimer) (claims, error) {
-	var userClaims claims
-	if err := idToken.Claims(&userClaims); err != nil {
-		return claims{}, fmt.Errorf("failed to get ID token claims: %v", err)
-	}
-	return userClaims, nil
 }
 
 // IsTokenExpiredError returns true if the reason for the error is that the refresh token is expired.

--- a/authd-oidc-brokers/internal/providers/genericprovider/genericprovider_test.go
+++ b/authd-oidc-brokers/internal/providers/genericprovider/genericprovider_test.go
@@ -60,7 +60,7 @@ func TestGetUserInfo(t *testing.T) {
 				"email": "user@example.com",
 			},
 			wantErr:     true,
-			wantErrType: &providerErrors.ForDisplayError{},
+			wantErrType: &providerErrors.MissingClaimError{Claim: "email_verified"},
 		},
 		"Error_when_email_is_not_verified": {
 			claims: map[string]interface{}{
@@ -85,10 +85,9 @@ func TestGetUserInfo(t *testing.T) {
 
 			if tc.wantErr {
 				require.Error(t, err)
-				return
-			}
-			if tc.wantErrType != nil {
-				require.ErrorIs(t, err, tc.wantErrType)
+				if tc.wantErrType != nil {
+					require.ErrorAs(t, err, &tc.wantErrType)
+				}
 				return
 			}
 			require.NoError(t, err)

--- a/authd-oidc-brokers/internal/providers/info/info.go
+++ b/authd-oidc-brokers/internal/providers/info/info.go
@@ -1,6 +1,10 @@
 // Package info defines types used by the broker.
 package info
 
+import (
+	"github.com/mitchellh/mapstructure"
+)
+
 // Group represents the group information that is fetched by the broker.
 type Group struct {
 	Name string `json:"name"`
@@ -46,4 +50,41 @@ func NewUser(name, home, uuid, shell, gecos string, groups []Group) User {
 // Claimer is an interface that defines a method to extract the claims from the ID token.
 type Claimer interface {
 	Claims(any) error
+}
+
+// MergedClaimer is a Claimer that holds a merged map of claims from multiple sources.
+// Claims from later Claimers override claims from earlier ones.
+type MergedClaimer struct {
+	merged map[string]interface{}
+}
+
+// NewMergedClaimer creates a MergedClaimer by merging claims from multiple Claimers.
+// Claims from later Claimers override claims from earlier ones for the same key.
+func NewMergedClaimer(claimers ...Claimer) (*MergedClaimer, error) {
+	merged := make(map[string]interface{})
+	for _, c := range claimers {
+		var m map[string]interface{}
+		if err := c.Claims(&m); err != nil {
+			return nil, err
+		}
+		for k, v := range m {
+			merged[k] = v
+		}
+	}
+	return &MergedClaimer{merged: merged}, nil
+}
+
+// Claims deserializes the merged claims into the provided value.
+func (mc *MergedClaimer) Claims(v any) error {
+	decoder, err := mapstructure.NewDecoder(&mapstructure.DecoderConfig{
+		TagName:          "json",
+		Result:           v,
+		ZeroFields:       true,
+		ErrorUnused:      false,
+		WeaklyTypedInput: false,
+	})
+	if err != nil {
+		return err
+	}
+	return decoder.Decode(mc.merged)
 }

--- a/authd-oidc-brokers/internal/providers/info/info_test.go
+++ b/authd-oidc-brokers/internal/providers/info/info_test.go
@@ -1,6 +1,7 @@
 package info_test
 
 import (
+	"errors"
 	"testing"
 
 	"github.com/canonical/authd/authd-oidc-brokers/internal/providers/info"
@@ -77,6 +78,125 @@ func TestNewUser(t *testing.T) {
 			require.Equal(t, wantShell, got.Shell, "Shell does not match the expected value")
 			require.Equal(t, wantGecos, got.Gecos, "Gecos does not match the expected value")
 			require.Equal(t, tc.groups, got.Groups, "Groups do not match the expected value")
+		})
+	}
+}
+
+// mockClaimer implements info.Claimer for testing.
+type mockClaimer struct {
+	data map[string]interface{}
+	err  error
+}
+
+func (m *mockClaimer) Claims(v any) error {
+	if m.err != nil {
+		return m.err
+	}
+	p, ok := v.(*map[string]interface{})
+	if !ok {
+		return errors.New("mockClaimer: expected *map[string]interface{}")
+	}
+	*p = m.data
+	return nil
+}
+
+func TestNewMergedClaimer(t *testing.T) {
+	t.Parallel()
+
+	tests := map[string]struct {
+		claimers    []info.Claimer
+		wantErr     bool
+		wantMissing string
+		wantMerged  map[string]interface{}
+	}{
+		"Single_claimer": {
+			claimers: []info.Claimer{
+				&mockClaimer{data: map[string]interface{}{"foo": "bar"}},
+			},
+			wantMerged: map[string]interface{}{"foo": "bar"},
+		},
+		"Later_claimer_overrides_earlier_for_same_key": {
+			claimers: []info.Claimer{
+				&mockClaimer{data: map[string]interface{}{"key": "first", "only_first": "v1"}},
+				&mockClaimer{data: map[string]interface{}{"key": "second", "only_second": "v2"}},
+			},
+			wantMerged: map[string]interface{}{"key": "second", "only_first": "v1", "only_second": "v2"},
+		},
+		"No_claimers_produces_empty_merged_map": {
+			claimers:   []info.Claimer{},
+			wantMerged: map[string]interface{}{},
+		},
+		"Error_from_any_claimer_propagates": {
+			claimers: []info.Claimer{
+				&mockClaimer{data: map[string]interface{}{"foo": "bar"}},
+				&mockClaimer{err: errors.New("claimer failure")},
+			},
+			wantErr: true,
+		},
+	}
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			mc, err := info.NewMergedClaimer(tc.claimers...)
+			if tc.wantErr {
+				require.Error(t, err)
+				require.Nil(t, mc)
+				return
+			}
+			require.NoError(t, err)
+			require.NotNil(t, mc)
+
+			// Verify merged content by decoding into a plain map.
+			var got map[string]interface{}
+			err = mc.Claims(&got)
+			require.NoError(t, err)
+			require.Equal(t, tc.wantMerged, got)
+		})
+	}
+}
+
+func TestMergedClaimerClaims(t *testing.T) {
+	t.Parallel()
+
+	type dest struct {
+		Name  string `json:"name"`
+		Value int    `json:"value"`
+	}
+
+	tests := map[string]struct {
+		data    map[string]interface{}
+		want    dest
+		wantErr bool
+	}{
+		"Decodes_known_fields_into_struct": {
+			data: map[string]interface{}{"name": "alice", "value": 42},
+			want: dest{Name: "alice", Value: 42},
+		},
+		"Unknown_fields_are_ignored": {
+			data: map[string]interface{}{"name": "bob", "value": 7, "extra": "ignored"},
+			want: dest{Name: "bob", Value: 7},
+		},
+		"Missing_fields_are_zeroed": {
+			data: map[string]interface{}{"name": "carol"},
+			want: dest{Name: "carol", Value: 0},
+		},
+	}
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			mc, err := info.NewMergedClaimer(&mockClaimer{data: tc.data})
+			require.NoError(t, err)
+
+			var got dest
+			err = mc.Claims(&got)
+			if tc.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, tc.want, got)
 		})
 	}
 }

--- a/authd-oidc-brokers/internal/providers/msentraid/msentraid.go
+++ b/authd-oidc-brokers/internal/providers/msentraid/msentraid.go
@@ -118,11 +118,11 @@ func (p *Provider) GetMetadata(provider *oidc.Provider) (map[string]interface{},
 	}, nil
 }
 
-// GetUserInfo returns the user info from the ID token.
-func (p *Provider) GetUserInfo(idToken info.Claimer) (info.User, error) {
+// GetUserInfo returns the user info from the provided Claimer.
+func (p *Provider) GetUserInfo(claimer info.Claimer) (info.User, error) {
 	var err error
 
-	userClaims, err := p.userClaims(idToken)
+	userClaims, err := p.userClaims(claimer)
 	if err != nil {
 		return info.User{}, err
 	}

--- a/authd-oidc-brokers/internal/providers/providers.go
+++ b/authd-oidc-brokers/internal/providers/providers.go
@@ -17,7 +17,7 @@ type Provider interface {
 	GetExtraFields(token *oauth2.Token) map[string]interface{}
 	GetMetadata(provider *oidc.Provider) (map[string]interface{}, error)
 
-	GetUserInfo(idToken info.Claimer) (info.User, error)
+	GetUserInfo(claimer info.Claimer) (info.User, error)
 
 	GetGroups(
 		ctx context.Context,

--- a/authd-oidc-brokers/internal/testutils/provider.go
+++ b/authd-oidc-brokers/internal/testutils/provider.go
@@ -6,6 +6,7 @@ import (
 	"crypto/rsa"
 	"crypto/x509"
 	"crypto/x509/pkix"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"math/big"
@@ -18,6 +19,7 @@ import (
 	"time"
 
 	"github.com/canonical/authd/authd-oidc-brokers/internal/consts"
+	providerErrors "github.com/canonical/authd/authd-oidc-brokers/internal/providers/errors"
 	"github.com/canonical/authd/authd-oidc-brokers/internal/providers/genericprovider"
 	"github.com/canonical/authd/authd-oidc-brokers/internal/providers/info"
 	"github.com/canonical/authd/log"
@@ -113,6 +115,7 @@ func StartMockProviderServer(address string, tokenHandlerOpts *TokenHandlerOptio
 			"/device_auth":                      DefaultDeviceAuthHandler(),
 			"/token":                            TokenHandler(server.URL, tokenHandlerOpts),
 			"/keys":                             DefaultJWKHandler(),
+			"/userinfo":                         UserInfoHandler(map[string]interface{}{"must-have-claim": "present"}),
 		},
 	}
 	for _, arg := range args {
@@ -140,12 +143,30 @@ func DefaultOpenIDHandler(serverURL string) EndpointHandler {
 			"device_authorization_endpoint": "%[1]s/device_auth",
 			"token_endpoint": "%[1]s/token",
 			"jwks_uri": "%[1]s/keys",
+			"userinfo_endpoint": "%[1]s/userinfo",
 			"id_token_signing_alg_values_supported": ["RS256"]
 		}`, serverURL)
 
 		w.Header().Add("Content-Type", "application/json")
 		_, err := w.Write([]byte(wellKnown))
 		if err != nil {
+			w.WriteHeader(http.StatusInternalServerError)
+		}
+	}
+}
+
+// UserInfoHandler returns a handler that returns a userinfo response with the provided claims.
+// It is meant to be registered at the /userinfo endpoint when testing thin-ID-token flows.
+func UserInfoHandler(claims map[string]interface{}) EndpointHandler {
+	return func(w http.ResponseWriter, _ *http.Request) {
+		data, err := json.Marshal(claims)
+		if err != nil {
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+
+		w.Header().Add("Content-Type", "application/json")
+		if _, err := w.Write(data); err != nil {
 			w.WriteHeader(http.StatusInternalServerError)
 		}
 	}
@@ -195,6 +216,9 @@ type TokenHandlerOptions struct {
 	// will be added to the token, and then that element will be removed from
 	// the list.
 	IDTokenClaims []map[string]interface{}
+	// DeleteClaims lists claim keys to remove from the ID token before signing.
+	// This is useful to simulate thin ID tokens that are missing certain claims.
+	DeleteClaims []string
 }
 
 var idTokenClaimsMutex sync.Mutex
@@ -247,6 +271,7 @@ func TokenHandler(serverURL string, opts *TokenHandlerOptions) EndpointHandler {
 			"preferred_username": "test-user-preferred-username@email.com",
 			"email":              "test-user@email.com",
 			"email_verified":     true,
+			"must-have-claim":    "present",
 		}
 
 		idTokenClaimsMutex.Lock()
@@ -258,6 +283,11 @@ func TokenHandler(serverURL string, opts *TokenHandlerOptions) EndpointHandler {
 			opts.IDTokenClaims = opts.IDTokenClaims[1:]
 		}
 		idTokenClaimsMutex.Unlock()
+
+		// Delete any claims that should be absent (simulates thin ID tokens).
+		for _, key := range opts.DeleteClaims {
+			delete(claims, key)
+		}
 
 		idToken := jwt.NewWithClaims(jwt.SigningMethodRS256, claims)
 
@@ -402,11 +432,15 @@ func (p *MockProvider) GetMetadata(provider *oidc.Provider) (map[string]interfac
 	return nil, nil
 }
 
-// GetUserInfo returns the user info parsed from the ID token.
+// GetUserInfo returns the user info parsed from the provided Claimer.
 func (p *MockProvider) GetUserInfo(idToken info.Claimer) (info.User, error) {
 	userClaims, err := p.userClaims(idToken)
 	if err != nil {
 		return info.User{}, err
+	}
+
+	if userClaims.MustHave == "" {
+		return info.User{}, providerErrors.NewMissingClaimError("must-have-claim")
 	}
 
 	p.numCallsLock.Lock()
@@ -473,11 +507,12 @@ func (p *MockProvider) SupportsDeviceRegistration() bool {
 }
 
 type claims struct {
-	Email string `json:"email"`
-	Sub   string `json:"sub"`
-	Home  string `json:"home"`
-	Shell string `json:"shell"`
-	Gecos string `json:"name"`
+	Email    string `json:"email"`
+	Sub      string `json:"sub"`
+	Home     string `json:"home"`
+	Shell    string `json:"shell"`
+	Gecos    string `json:"name"`
+	MustHave string `json:"must-have-claim"`
 }
 
 // userClaims returns the user claims parsed from the ID token.


### PR DESCRIPTION
Fixes #1440.

This uses the information retrieved from /userinfo endpoint as a fallback for claims not available in id token.

This only affects the generic oidc broker, for msentraid, we simple drop the information retrieved from /userinfo.

I have verified both oidc and msentraid brokers with these changes, they both work fine.