### PR TITLE
docs: access check config docs rework

### DIFF
--- a/docs/explanation/security.md
+++ b/docs/explanation/security.md
@@ -66,6 +66,7 @@ Strong passwords are critical to prevent unauthorized access.
 authd uses libpwquality to enforce password complexity requirements. See the
 [Configure password quality](ref::config-pwquality) section for details.
 
+(ref::force-auth-security)=
 #### Force provider authentication
 
 If the identity provider is reachable during login, authd verifies that the user

--- a/docs/howto/configure-authd.md
+++ b/docs/howto/configure-authd.md
@@ -267,6 +267,9 @@ user does not have the necessary permissions in the identity provider.
 In some cases, forcing the access check may prevent login, such as when there are network issues.
 ```
 
+Additional information on the forced access check is provided in the [security
+overview](ref::force-auth-security).
+
 (ref::config-extra-scopes)=
 
 ## Configure extra scopes

--- a/docs/howto/configure-authd.md
+++ b/docs/howto/configure-authd.md
@@ -259,6 +259,9 @@ unreachable, enable it as follows:
 force_access_check_with_provider = true
 ```
 
+This check works by forcing a token refresh during login, which fails if the
+user does not have the necessary permissions in the identity provider.
+
 ```{warning}
 In some cases, this may prevent login, such as when there are network issues.
 ```

--- a/docs/howto/configure-authd.md
+++ b/docs/howto/configure-authd.md
@@ -244,14 +244,15 @@ client_secret = <CLIENT_SECRET>
 :::::
 
 (ref::config-force-provider-auth)=
-## Force remote authentication with the identity provider
+## Force remote access check with the identity provider
 
 By default, remote authentication with the identity provider only happens if
 there is a working internet connection and the provider is reachable during
 login.
 
-If you want to force remote authentication, even when the provider is
-unreachable, enable it as follows:
+To ensure that user access permissions are always checked with the identity
+provider during login, even when the provider is unreachable, enable the check
+as follows:
 
 ```ini
 [oidc]
@@ -263,7 +264,7 @@ This check works by forcing a token refresh during login, which fails if the
 user does not have the necessary permissions in the identity provider.
 
 ```{warning}
-In some cases, this may prevent login, such as when there are network issues.
+In some cases, forcing the access check may prevent login, such as when there are network issues.
 ```
 
 (ref::config-extra-scopes)=


### PR DESCRIPTION
Updates section in configuration guide to reflect recent naming and description changes for config option `force_access_check_with_provider`.

* Use terms from the config option, like "check", "access" and "force",
to map more clearly between the wording of the config option and the
text in this section
* Explicitly mention what is being checked from a user perspective, i.e., whether
they have permission to access the system according to the IdP
* Add a brief explanation of how the check works
* Link to section on this check in the Security Overview

Closes https://github.com/canonical/authd/issues/1340

UDENG-9749

