### PR TITLE
docs: updated link to pam/README.md in contributing guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -163,7 +163,7 @@ This last command will produce two libraries (`./pam/pam_authd.so` and `./pam/go
 These modules must be copied to `/usr/lib/$(gcc -dumpmachine)/security/` while the executable must be copied to `/usr/libexec/authd-pam`.
 
 For further information about the PAM module architecture and testing see the
-[PAM Hacking](https://github.com/canonical/authd/blob/main/pam/Hacking.md) page.
+[README for the authd PAM module](https://github.com/canonical/authd/blob/main/pam/README.md).
 
 #### Building the NSS module only
 


### PR DESCRIPTION
A failing link in the docs for
`https://github.com/canonical/authd/blob/main/pam/Hacking.md` was introduced in https://github.com/canonical/authd/pull/1468, when the name of the file was changed to README.md. As text from CONTRIBUTING.md is transcluded into the docs, it trips up the linkchecker.