### PR TITLE
[e2e] Add tests to cover user selection through `su`

### DIFF
--- a/e2e-tests/resources/broker.resource
+++ b/e2e-tests/resources/broker.resource
@@ -106,6 +106,39 @@ Log In With Remote User Through CLI: Local Password
     Match Text    ${username}@ubuntu:~$    120
 
 
+Try Changing Username In sudo su Log In
+    Hid.Type String    sudo su
+    Hid.Keys Combo    Return
+    Try Navigating Back to User Selection
+    Cancel Operation
+
+
+Try Changing Username In su Log In
+    [Arguments]    ${username}
+    Hid.Type String    su ${username}
+    Hid.Keys Combo    Return
+    Try Navigating Back to User Selection
+    Cancel Operation
+
+Try Navigating Back to User Selection
+    # First screen is the autoselected local password mode
+    Match Text    Enter your local password:    120
+    Hid.Keys Combo    Escape
+
+    # The previous screen should be the authentication mode selection
+    Match Text    Select your authentication method    120
+    Hid.Keys Combo    Escape
+
+    # The previous screen should be the broker selection
+    Match Text    Select your provider    120
+    Hid.Keys Combo    Escape
+
+    # The previous screen is the username prompt, but it shouldn't be possible to get there
+    Match Text    Select your provider    120
+    Hid.Keys Combo    Escape
+    Match Text    Select your provider    120
+
+
 # Uses sed to change the broker configuration.
 # It should match both commented and uncommented lines.
 # The full command looks like:

--- a/e2e-tests/resources/utils.resource
+++ b/e2e-tests/resources/utils.resource
@@ -176,8 +176,8 @@ Launch App
 
 
 Cancel Operation
-    Match Text    @ubuntu    15
     Hid.Keys Combo    Control_L    C
+    Match Text    @ubuntu    15
 
 
 Update And Upgrade Packages

--- a/e2e-tests/tests/su_login.robot
+++ b/e2e-tests/tests/su_login.robot
@@ -1,0 +1,40 @@
+*** Settings ***
+Resource        resources/utils.resource
+Resource        resources/authd.resource
+Resource        resources/broker.resource
+
+# Test Tags       robot:exit-on-failure
+
+Test Setup    utils.Test Setup    snapshot=%{BROKER}-installed
+Test Teardown   utils.Test Teardown
+
+
+*** Variables ***
+${username}    %{E2E_USER}
+${local_password}    qwer1234
+
+
+*** Test Cases ***
+Test su login
+    [Documentation]    Test login functionality with su command for remote users.
+
+    # Log in with local user
+    Log In
+
+    # Log in with remote user with device authentication
+    Open Terminal
+    Log In With Remote User Through CLI: QR Code    ${username}    ${local_password}
+    # Check remote user is properly added to the system
+    Check If User Was Added Properly    ${username}
+    Log Out From Terminal Session
+    Close Focused Window
+
+    # Log in with remote user with local password
+    Open Terminal In Sudo Mode
+    Log In With Remote User Through CLI: Local Password    ${username}    ${local_password}
+
+    # Try to change username during su login, it should not be possible
+    Try Changing Username In su Log In    ${username}
+
+    # Try to change username during su login with sudo, it should not be possible
+    Try Changing Username In sudo su Log In


### PR DESCRIPTION
Users authenticating with `su` should not be able to change the username after the authentication process has already started, since the `su` command sets it beforehand. 


UDENG-9550
UDENG-9551