### PR TITLE
[e2e] Update list of releases to run the tests on

### DIFF
--- a/.github/workflows/e2e-tests.yaml
+++ b/.github/workflows/e2e-tests.yaml
@@ -81,7 +81,7 @@ jobs:
     needs: compute-hash
     strategy:
       matrix:
-        ubuntu-version: [ 'noble', 'questing', 'devel' ]
+        ubuntu-version: [ 'noble', 'resolute' ]
       fail-fast: false
     uses: ./.github/workflows/e2e-tests-provision-and-run.yaml
     with:


### PR DESCRIPTION
Resolute is now officially released. This means that running the e2e tests on Questing doesn't have as much value and devel will now resolve to 26.10 which doesn't have a valid image yet, so we need to update the list of releases we intend to run the e2e tests on.