### PR TITLE
broker: deduplicate extra/owner extra groups to prevent UNIQUE-constraint failure on offline retry

### DIFF
--- a/authd-oidc-brokers/internal/broker/broker.go
+++ b/authd-oidc-brokers/internal/broker/broker.go
@@ -934,17 +934,25 @@ func (b *Broker) finishAuth(session *session, authInfo *token.AuthCachedInfo) (s
 		return AuthDenied, errorMessage{Message: "Authentication failure: user not allowed in broker configuration"}
 	}
 
-	// Add extra groups to the user info.
-	for _, name := range b.cfg.extraGroups {
-		log.Debugf(context.Background(), "Adding extra group %q", name)
-		authInfo.UserInfo.Groups = append(authInfo.UserInfo.Groups, info.Group{Name: name})
+	// Append extra groups from config, avoiding duplicates.
+	existingGroups := make(map[string]struct{}, len(authInfo.UserInfo.Groups)+len(b.cfg.extraGroups)+len(b.cfg.ownerExtraGroups))
+	for _, g := range authInfo.UserInfo.Groups {
+		existingGroups[g.Name] = struct{}{}
 	}
-
-	if b.isOwner(authInfo.UserInfo.Name) {
-		// Add the owner extra groups to the user info.
-		for _, name := range b.cfg.ownerExtraGroups {
-			log.Debugf(context.Background(), "Adding owner extra group %q", name)
+	for _, name := range b.cfg.extraGroups {
+		if _, exists := existingGroups[name]; !exists {
+			log.Debugf(context.Background(), "Adding extra group %q", name)
 			authInfo.UserInfo.Groups = append(authInfo.UserInfo.Groups, info.Group{Name: name})
+			existingGroups[name] = struct{}{}
+		}
+	}
+	if b.isOwner(authInfo.UserInfo.Name) {
+		for _, name := range b.cfg.ownerExtraGroups {
+			if _, exists := existingGroups[name]; !exists {
+				log.Debugf(context.Background(), "Adding owner extra group %q", name)
+				authInfo.UserInfo.Groups = append(authInfo.UserInfo.Groups, info.Group{Name: name})
+				existingGroups[name] = struct{}{}
+			}
 		}
 	}
 

--- a/authd-oidc-brokers/internal/broker/broker_test.go
+++ b/authd-oidc-brokers/internal/broker/broker_test.go
@@ -717,6 +717,29 @@ func TestIsAuthenticated(t *testing.T) {
 			ownerExtraGroups:         []string{"owner-group"},
 			wantGroups:               []info.Group{{Name: "remote-group"}, {Name: "owner-group"}},
 		},
+		"Extra_and_owner_extra_groups_configured_with_existing_extra_group_in_cached_user_info": {
+			firstMode: authmodes.Password,
+			token: &tokenOptions{groups: []info.Group{
+				{Name: "remote-group"},
+				{Name: "extra-group"},
+			}},
+			sessionOffline:   true,
+			extraGroups:      []string{"extra-group", "other-extra-group"},
+			ownerExtraGroups: []string{"owner-group"},
+			wantGroups:       []info.Group{{Name: "remote-group"}, {Name: "extra-group"}, {Name: "other-extra-group"}, {Name: "owner-group"}},
+		},
+		"Extra_and_owner_extra_groups_configured_but_already_in_cached_user_info": {
+			firstMode: authmodes.Password,
+			token: &tokenOptions{groups: []info.Group{
+				{Name: "remote-group"},
+				{Name: "extra-group"},
+				{Name: "owner-group"},
+			}},
+			sessionOffline:   true,
+			extraGroups:      []string{"extra-group"},
+			ownerExtraGroups: []string{"owner-group"},
+			wantGroups:       []info.Group{{Name: "remote-group"}, {Name: "extra-group"}, {Name: "owner-group"}},
+		},
 		"Owner_extra_groups_configured_but_user_does_not_become_owner": {
 			firstMode:                authmodes.Password,
 			token:                    &tokenOptions{},

--- a/authd-oidc-brokers/internal/broker/testdata/golden/TestIsAuthenticated/Extra_and_owner_extra_groups_configured_but_already_in_cached_user_info/data/provider_url/test-user@email.com/password
+++ b/authd-oidc-brokers/internal/broker/testdata/golden/TestIsAuthenticated/Extra_and_owner_extra_groups_configured_but_already_in_cached_user_info/data/provider_url/test-user@email.com/password
@@ -1,0 +1,1 @@
+Definitely a hashed password

--- a/authd-oidc-brokers/internal/broker/testdata/golden/TestIsAuthenticated/Extra_and_owner_extra_groups_configured_but_already_in_cached_user_info/data/provider_url/test-user@email.com/token.json
+++ b/authd-oidc-brokers/internal/broker/testdata/golden/TestIsAuthenticated/Extra_and_owner_extra_groups_configured_but_already_in_cached_user_info/data/provider_url/test-user@email.com/token.json
@@ -1,0 +1,1 @@
+Definitely a token

--- a/authd-oidc-brokers/internal/broker/testdata/golden/TestIsAuthenticated/Extra_and_owner_extra_groups_configured_but_already_in_cached_user_info/first_call
+++ b/authd-oidc-brokers/internal/broker/testdata/golden/TestIsAuthenticated/Extra_and_owner_extra_groups_configured_but_already_in_cached_user_info/first_call
@@ -1,0 +1,3 @@
+access: granted
+data: '{"userinfo":{"name":"test-user@email.com","uuid":"saved-user-id","dir":"/home/test-user@email.com","shell":"/usr/bin/bash","gecos":"test-user@email.com","groups":[{"name":"remote-group","ugid":""},{"name":"extra-group","ugid":""},{"name":"owner-group","ugid":""}]}}'
+err: <nil>

--- a/authd-oidc-brokers/internal/broker/testdata/golden/TestIsAuthenticated/Extra_and_owner_extra_groups_configured_with_existing_extra_group_in_cached_user_info/data/provider_url/test-user@email.com/password
+++ b/authd-oidc-brokers/internal/broker/testdata/golden/TestIsAuthenticated/Extra_and_owner_extra_groups_configured_with_existing_extra_group_in_cached_user_info/data/provider_url/test-user@email.com/password
@@ -1,0 +1,1 @@
+Definitely a hashed password

--- a/authd-oidc-brokers/internal/broker/testdata/golden/TestIsAuthenticated/Extra_and_owner_extra_groups_configured_with_existing_extra_group_in_cached_user_info/data/provider_url/test-user@email.com/token.json
+++ b/authd-oidc-brokers/internal/broker/testdata/golden/TestIsAuthenticated/Extra_and_owner_extra_groups_configured_with_existing_extra_group_in_cached_user_info/data/provider_url/test-user@email.com/token.json
@@ -1,0 +1,1 @@
+Definitely a token

--- a/authd-oidc-brokers/internal/broker/testdata/golden/TestIsAuthenticated/Extra_and_owner_extra_groups_configured_with_existing_extra_group_in_cached_user_info/first_call
+++ b/authd-oidc-brokers/internal/broker/testdata/golden/TestIsAuthenticated/Extra_and_owner_extra_groups_configured_with_existing_extra_group_in_cached_user_info/first_call
@@ -1,0 +1,3 @@
+access: granted
+data: '{"userinfo":{"name":"test-user@email.com","uuid":"saved-user-id","dir":"/home/test-user@email.com","shell":"/usr/bin/bash","gecos":"test-user@email.com","groups":[{"name":"remote-group","ugid":""},{"name":"extra-group","ugid":""},{"name":"other-extra-group","ugid":""},{"name":"owner-group","ugid":""}]}}'
+err: <nil>


### PR DESCRIPTION
Fixes #1495.

## What

`Broker.finishAuth` now deduplicates `b.cfg.extraGroups` and `b.cfg.ownerExtraGroups` against `authInfo.UserInfo.Groups` before appending them, so configured local groups can no longer be added more than once when the cached `authInfo` already contains them.

## Why

On the **online** auth path the calling code resets `authInfo.UserInfo.Groups` to a fresh provider response before `finishAuth` runs, so the unconditional `append` never produces duplicates. On the **offline** path that reset is skipped (no provider call possible), so `authInfo` is loaded from cache *with the previous extras already present* and the append silently doubles them.

The daemon (`authd`) then does a transactional `DELETE; INSERT VALUES (?, ?), (?, ?), …` against `users_to_local_groups` and the duplicate rows collide intra-transaction on the `(uid, group_name)` UNIQUE constraint. The user is rejected at GDM and (worse) ends up with no local groups recorded at all once the transaction rolls back.

See #1495 for the full root-cause writeup.

## Test

Manually verified on a single-user laptop with `owner_extra_groups = sudo, docker, dialout`:

1. Online sign-in: cached `Groups` slice contains `sudo`, `docker`, `dialout` exactly once. `id <user>` matches.
2. `nmcli networking off`, sign in again: succeeds. Cached slice unchanged. Daemon's `users_to_local_groups` rows unchanged.
3. Repeat offline sign-in 5×: still works, no duplicates ever introduced.

Without this patch, step 2 produces the `UNIQUE constraint failed: users_to_local_groups.uid, users_to_local_groups.group_name` error and step 3 never gets started. Patch has been running on my daily driver for ~24h with no regressions.

## Out of scope (suggested follow-up)

The daemon-side `handleUsersToLocalGroupsUpdate` would benefit from `INSERT … ON CONFLICT DO NOTHING` (or its own dedupe pass) so that a misbehaving broker can't take user provisioning down. Happy to file a separate issue for that if useful.
