### PR TITLE
Add end-to-end tests for `force_access_check_with_provider`

### DIFF
--- a/e2e-tests/resources/broker.resource
+++ b/e2e-tests/resources/broker.resource
@@ -169,6 +169,14 @@ Remove Registered Owner
     SSH.Execute    sudo snap restart ${BROKER_SNAP_NAME}
 
 
+Block Network Access To Identity Provider
+    [Documentation]    Blocks outbound HTTPS traffic (IPv4 and IPv6) to simulate the identity
+    ...               provider being unreachable. The iptables rules are automatically reverted
+    ...               when the VM snapshot is restored at the start of the next test.
+    SSH.Execute    sudo iptables -I OUTPUT -p tcp --dport 443 -j REJECT
+    SSH.Execute    sudo ip6tables -I OUTPUT -p tcp --dport 443 -j REJECT
+
+
 # Uses sed to change the broker configuration.
 # It should match both commented and uncommented lines.
 # The full command looks like:

--- a/e2e-tests/tests/force_access_check_with_provider.robot
+++ b/e2e-tests/tests/force_access_check_with_provider.robot
@@ -1,0 +1,53 @@
+*** Settings ***
+Resource        resources/utils.resource
+Resource        resources/authd.resource
+Resource        resources/broker.resource
+
+# Test Tags       robot:exit-on-failure
+
+Test Setup    utils.Test Setup    snapshot=%{BROKER}-installed
+Test Teardown   utils.Test Teardown
+
+
+*** Variables ***
+${username}    %{E2E_USER}
+${local_password}    qwer1234
+
+
+*** Test Cases ***
+Test second login succeeds with force_access_check_with_provider enabled
+    [Documentation]    Verify that a registered user can log in with their local password
+    ...    when force_access_check_with_provider is enabled and the identity provider is reachable.
+
+    Log In
+
+    Open Terminal
+    Log In With Remote User Through CLI: QR Code    ${username}    ${local_password}
+    Log Out From Terminal Session
+    Close Focused Window
+
+    Change Broker Configuration    force_access_check_with_provider    true
+
+    Open Terminal In Sudo Mode
+    Log In With Remote User Through CLI: Local Password    ${username}    ${local_password}
+
+
+Test second login fails with force_access_check_with_provider enabled offline
+    [Documentation]    Verify that a registered user cannot log in when
+    ...    force_access_check_with_provider is enabled and the identity provider is unreachable.
+
+    Log In
+
+    Open Terminal
+    Log In With Remote User Through CLI: QR Code    ${username}    ${local_password}
+    Log Out From Terminal Session
+    Close Focused Window
+
+    Change Broker Configuration    force_access_check_with_provider    true
+
+    # Block outbound HTTPS to simulate the identity provider being unreachable.
+    Block Network Access To Identity Provider
+
+    Open Terminal In Sudo Mode
+    Try Log In With Remote User    ${username}
+    Check That Remote User Has No Available Authentication Modes


### PR DESCRIPTION
Adds two tests to verify the `force_access_check_with_provider` functionality:
- Allows login with local password when the identity provider is reachable.
- Denies login when the identity provider is unreachable.

Also adds a new keyword to block outbound HTTPS using `iptables` to simulate offline behavior

UDENG-9529
UDENG-9528