### PR TITLE
Fix SSH integration tests on Resolute

### DIFF
--- a/pam/integration-tests/ssh_test.go
+++ b/pam/integration-tests/ssh_test.go
@@ -382,7 +382,9 @@ Wait@%dms`, sshDefaultFinalWaitTimeout),
 		"Error_if_cannot_connect_to_authd": {
 			tape: "connection_error",
 			tapeVariables: map[string]string{
-				vhsCommandFinalAuthWaitVariable: `Wait /Password:/`,
+				vhsCommandFinalAuthWaitVariable: fmt.Sprintf(
+					`Wait+Screen /Password:|Disconnected from/
+Wait@%dms`, sshDefaultFinalWaitTimeout),
 			},
 			socketPath:          "/some-path/not-existent-socket",
 			wantNotLoggedInUser: true,
@@ -539,7 +541,13 @@ Wait@%dms`, sshDefaultFinalWaitTimeout),
 			output := sanitizedOutput(t, td)
 			golden.CheckOrUpdate(t, output)
 
-			userEnv := fmt.Sprintf("USER=%s", strings.ToLower(user))
+			// OpenSSH sets USER from authctxt->pw->pw_name which comes
+			// from the initial getpwnam() call. The sshd_preloader
+			// preserves the SSH login name case for pw_name, so USER
+			// matches the original case. authd uses lowercase
+			// internally but does not change PAM_USER for case-only
+			// differences (see userselection.go).
+			userEnv := fmt.Sprintf("USER=%s", user)
 			if tc.wantNotLoggedInUser {
 				if strings.Contains(output, userEnv) {
 					require.Fail(t, "Tape output should not contain the logged in user name",
@@ -663,7 +671,7 @@ func startSSHDForTest(t *testing.T, serviceFile, hostKey, user string, preloadLi
 		sshdConnectCommand += "&& /bin/sh"
 	}
 
-	userHome := filepath.Join(sshTestsHomeBase, user)
+	userHome := filepath.Join(sshTestsHomeBase, strings.ToLower(user))
 	sshdPort := startSSHD(t, hostKey, sshdConnectCommand, append([]string{
 		fmt.Sprintf("HOME=%s", sshTestsHomeBase),
 		fmt.Sprintf("LD_PRELOAD=%s", strings.Join(preloadLibraries, ":")),

--- a/pam/integration-tests/ssh_test.go
+++ b/pam/integration-tests/ssh_test.go
@@ -146,6 +146,12 @@ func testSSHAuthenticate(t *testing.T, sharedSSHD bool) {
 
 		testutils.MaybeSaveFilesAsArtifactsOnCleanup(t, sshdHostKeyPath+".pub")
 
+		err = os.MkdirAll(sshTestsHomeBase, 0700)
+		require.NoError(t, err, "Setup: failed to create home base directory")
+		t.Cleanup(func() {
+			_ = os.RemoveAll(sshTestsHomeBase)
+		})
+
 		if !t.Failed() {
 			t.Log("Prepared SSH tests")
 			sshTestsPrepared.Store(true)
@@ -155,7 +161,8 @@ func testSSHAuthenticate(t *testing.T, sharedSSHD bool) {
 	var sharedSSHDPort, sharedSSHDUserHome, sharedAuthdSocket, sharedAuthdGroupOutput string
 	prepareSharedSSHDTests := func(subtest *testing.T) {
 		t.Logf("Preparing SSH tests with shared sshd, triggered by %q", subtest.Name())
-		sharedAuthdSocket, sharedAuthdGroupOutput = sharedAuthd(t)
+		sharedAuthdSocket, sharedAuthdGroupOutput = sharedAuthd(t,
+			testutils.WithHomeBaseDir(sshTestsHomeBase))
 		serviceFile := createSSHDServiceFile(t, execModule, execChild, pamMkHomeDirModule, sharedAuthdSocket)
 		sshdEnv = append(sshdEnv, nssEnv...)
 		sshdEnv = append(sshdEnv, fmt.Sprintf("AUTHD_NSS_SOCKET=%s", sharedAuthdSocket))
@@ -434,15 +441,6 @@ Wait@%dms`, sshDefaultFinalWaitTimeout),
 				// location for us to test.
 				_, groupOutput = prepareGroupFiles(t)
 
-				// Since we are migrating users, we need to make sure that we can replicate
-				// the homedir they have in the database.
-				err := os.MkdirAll(sshTestsHomeBase, 0700)
-				require.NoError(t, err, "Setup: failed to create home directory")
-
-				t.Cleanup(func() {
-					_ = os.RemoveAll(sshTestsHomeBase)
-				})
-
 				socketPath = runAuthd(t,
 					testutils.WithCurrentUserAsRoot,
 					testutils.WithGroupFile(groupOutput),
@@ -452,7 +450,8 @@ Wait@%dms`, sshDefaultFinalWaitTimeout),
 			} else if !sharedSSHD {
 				socketPath, groupOutput = sharedAuthd(t,
 					testutils.WithGroupFileOutput(sharedAuthdGroupOutput),
-					testutils.WithEnvironment(authdEnv...))
+					testutils.WithEnvironment(authdEnv...),
+					testutils.WithHomeBaseDir(sshTestsHomeBase))
 			}
 			if tc.socketPath != "" {
 				socketPath = tc.socketPath
@@ -669,7 +668,7 @@ func startSSHDForTest(t *testing.T, serviceFile, hostKey, user string, preloadLi
 		fmt.Sprintf("HOME=%s", sshTestsHomeBase),
 		fmt.Sprintf("LD_PRELOAD=%s", strings.Join(preloadLibraries, ":")),
 		fmt.Sprintf("AUTHD_TEST_SSH_USER=%s", user),
-		fmt.Sprintf("AUTHD_TEST_SSH_HOME=%s", userHome),
+		fmt.Sprintf("AUTHD_TEST_SSH_HOME_BASE=%s", sshTestsHomeBase),
 		fmt.Sprintf("AUTHD_TEST_SSH_PAM_SERVICE=%s", serviceFile),
 	}, env...))
 

--- a/pam/integration-tests/sshd_preloader/sshd_preloader.c
+++ b/pam/integration-tests/sshd_preloader/sshd_preloader.c
@@ -10,9 +10,9 @@
 #include <sys/types.h>
 #include <dlfcn.h>
 #include <string.h>
-#include <ctype.h>
 #include <pwd.h>
 #include <limits.h>
+#include <ctype.h>
 #include <sys/types.h>
 
 #define AUTHD_TEST_SHELL "/bin/sh"
@@ -94,18 +94,6 @@ is_valid_test_user (const char *name)
   return is_supported_test_fake_user (name);
 }
 
-static bool
-is_lower_case (const char *str)
-{
-  for (size_t i = 0; str[i]; ++i)
-    {
-      if (isalpha (str[i]) && !islower (str[i]))
-        return false;
-    }
-
-  return true;
-}
-
 /*
  * This overrides allows us to manually handle the getpwnam() ensuring that
  * we reply a fake user only when an expected fake user is requested.
@@ -175,18 +163,29 @@ getpwnam (const char *name)
     {
       passwd_entity = &passwd_entities[i].parent;
 
-      if (!passwd_entity->pw_name || strcmp (passwd_entity->pw_name, name) != 0)
+      if (!passwd_entity->pw_name || strcasecmp (passwd_entity->pw_name, name) != 0)
         continue;
 
 #ifdef AUTHD_TESTS_SSH_USE_AUTHD_NSS
       /* If NSS now has updated data for this user (e.g. after auth registered
-       * them in authd), update pw_dir from NSS so we don't return a stale
-       * fake home path.
+       * them in authd), update pw_name and pw_dir from NSS so we don't return
+       * stale fake data. In particular, pw_name must reflect authd's canonical
+       * (lowercase) name so that sshd uses it for the session.
        */
       {
         struct passwd *nss_pw = orig_getpwnam (name);
-        if (nss_pw != NULL && nss_pw->pw_dir != NULL)
-          passwd_entity->pw_dir = nss_pw->pw_dir;
+        if (nss_pw != NULL)
+          {
+            if (nss_pw->pw_name != NULL)
+              {
+                MockPasswd *mock = &passwd_entities[i];
+                free (mock->authd_name);
+                mock->authd_name = strdup (nss_pw->pw_name);
+                passwd_entity->pw_name = mock->authd_name;
+              }
+            if (nss_pw->pw_dir != NULL)
+              passwd_entity->pw_dir = nss_pw->pw_dir;
+          }
       }
 #endif
 
@@ -206,45 +205,46 @@ getpwnam (const char *name)
   assert (passwd_entity->pw_name == NULL ||
           strcasecmp (passwd_entity->pw_name, name) == 0);
 
-  if (passwd_entity->pw_name == NULL)
-    {
-      MockPasswd *mock_passwd = &passwd_entities[entity_idx];
+  {
+    MockPasswd *mock_passwd = &passwd_entities[entity_idx];
 
-      passwd_entity->pw_shell = AUTHD_TEST_SHELL;
-      passwd_entity->pw_gecos = AUTHD_TEST_GECOS;
-      passwd_entity->pw_name = (char *) name;
+    if (passwd_entity->pw_name == NULL)
+      {
+        passwd_entity->pw_shell = AUTHD_TEST_SHELL;
+        passwd_entity->pw_gecos = AUTHD_TEST_GECOS;
+      }
 
-      /* Construct a per-user home path from the base dir + username,
-       * so each user gets their own home directory even in the shared
-       * sshd case where AUTHD_TEST_SSH_USER is the accept-all user.
-       */
-      free (mock_passwd->home_path);
-      if (asprintf (&mock_passwd->home_path, "%s/%s",
-                     get_home_base_path (), name) < 0)
-        mock_passwd->home_path = NULL;
-      passwd_entity->pw_dir = mock_passwd->home_path
-                                ? mock_passwd->home_path
-                                : (char *) get_home_base_path ();
+    /* Store pw_name preserving the original query case.
+     * OpenSSH 10.2+ validates that PAM_USER matches pw_name from
+     * getpwnam(), and PAM is initialized with the SSH login name
+     * (original case), so pw_name must match the queried name.
+     * The authd PAM module handles case normalization internally
+     * via Username() without changing PAM_USER.
+     */
+    free (mock_passwd->authd_name);
+    mock_passwd->authd_name = strdup (name);
+    passwd_entity->pw_name = mock_passwd->authd_name;
 
-      if (!is_lower_case (passwd_entity->pw_name))
-        {
-          /* authd uses lower-case user names */
-          MockPasswd *mock_passwd = (MockPasswd *) passwd_entity;
-          char *n = strdup (passwd_entity->pw_name);
-
-          for (size_t i = 0; n[i]; ++i)
-            n[i] = tolower (n[i]);
-
-          mock_passwd->authd_name = n;
-          passwd_entity->pw_name = mock_passwd->authd_name;
-
-          fprintf (stderr, "sshd_preloader[%d]: User %s converted to %s\n",
-                  getpid (), name, passwd_entity->pw_name);
-        }
-    }
-
-  /* authd uses lower-case user names */
-  assert (is_lower_case (passwd_entity->pw_name));
+    /* Construct a per-user home path from the base dir + a
+     * lowercase username, so each user gets their own home directory
+     * even in the shared sshd case where AUTHD_TEST_SSH_USER is the
+     * accept-all user. authd normalizes usernames to lowercase.
+     */
+    if (passwd_entity->pw_dir == NULL || mock_passwd->home_path != NULL)
+      {
+        char *lower_name = strdup (name);
+        for (char *p = lower_name; *p; p++)
+          *p = tolower ((unsigned char) *p);
+        free (mock_passwd->home_path);
+        if (asprintf (&mock_passwd->home_path, "%s/%s",
+                       get_home_base_path (), lower_name) < 0)
+          mock_passwd->home_path = NULL;
+        free (lower_name);
+        passwd_entity->pw_dir = mock_passwd->home_path
+                                  ? mock_passwd->home_path
+                                  : (char *) get_home_base_path ();
+      }
+  }
 
   /* We're simulating to be the same user running the test but with another
    * name, so that we won't touch the user settings, but it's still enough to

--- a/pam/integration-tests/sshd_preloader/sshd_preloader.c
+++ b/pam/integration-tests/sshd_preloader/sshd_preloader.c
@@ -26,6 +26,7 @@ typedef struct {
   struct passwd parent;
 
   char *authd_name;
+  char *home_path;
 } MockPasswd;
 
 static MockPasswd passwd_entities[512];
@@ -40,20 +41,23 @@ __attribute__((destructor))
 void destructor (void)
 {
   for (size_t i = 0; i < SIZE_OF_ARRAY (passwd_entities); ++i)
-    free (passwd_entities[i].authd_name);
+    {
+      free (passwd_entities[i].authd_name);
+      free (passwd_entities[i].home_path);
+    }
 
   fprintf (stderr, "sshd_preloader[%d]: Library unloaded\n", getpid ());
 }
 
 static const char *
-get_home_path (void)
+get_home_base_path (void)
 {
-  const char *home_path = getenv ("AUTHD_TEST_SSH_HOME");
+  const char *base_path = getenv ("AUTHD_TEST_SSH_HOME_BASE");
 
-  if (home_path == NULL)
+  if (base_path == NULL)
     return "/not-existing-home";
 
-  return home_path;
+  return base_path;
 }
 
 static bool
@@ -160,11 +164,10 @@ getpwnam (const char *name)
           abort();
         }
     }
-  else if (!is_supported_test_fake_user (name))
+  else
     {
-      fprintf (stderr, "sshd_preloader[%d]: User %s is not handled by authd brokers\n",
-               getpid (), name);
-      return NULL;
+      fprintf (stderr, "sshd_preloader[%d]: User %s is not yet handled by authd brokers,"
+               " creating a fake entry\n", getpid (), name);
     }
 #endif /* AUTHD_TESTS_SSH_USE_AUTHD_NSS */
 
@@ -174,6 +177,18 @@ getpwnam (const char *name)
 
       if (!passwd_entity->pw_name || strcmp (passwd_entity->pw_name, name) != 0)
         continue;
+
+#ifdef AUTHD_TESTS_SSH_USE_AUTHD_NSS
+      /* If NSS now has updated data for this user (e.g. after auth registered
+       * them in authd), update pw_dir from NSS so we don't return a stale
+       * fake home path.
+       */
+      {
+        struct passwd *nss_pw = orig_getpwnam (name);
+        if (nss_pw != NULL && nss_pw->pw_dir != NULL)
+          passwd_entity->pw_dir = nss_pw->pw_dir;
+      }
+#endif
 
       fprintf (stderr, "sshd_preloader[%d]: Recycling fake entity for user %s\n",
                getpid (), name);
@@ -193,10 +208,23 @@ getpwnam (const char *name)
 
   if (passwd_entity->pw_name == NULL)
     {
+      MockPasswd *mock_passwd = &passwd_entities[entity_idx];
+
       passwd_entity->pw_shell = AUTHD_TEST_SHELL;
       passwd_entity->pw_gecos = AUTHD_TEST_GECOS;
       passwd_entity->pw_name = (char *) name;
-      passwd_entity->pw_dir = (char *) get_home_path ();
+
+      /* Construct a per-user home path from the base dir + username,
+       * so each user gets their own home directory even in the shared
+       * sshd case where AUTHD_TEST_SSH_USER is the accept-all user.
+       */
+      free (mock_passwd->home_path);
+      if (asprintf (&mock_passwd->home_path, "%s/%s",
+                     get_home_base_path (), name) < 0)
+        mock_passwd->home_path = NULL;
+      passwd_entity->pw_dir = mock_passwd->home_path
+                                ? mock_passwd->home_path
+                                : (char *) get_home_base_path ();
 
       if (!is_lower_case (passwd_entity->pw_name))
         {
@@ -230,6 +258,54 @@ getpwnam (const char *name)
            passwd_entity->pw_gid);
 
   return passwd_entity;
+}
+
+/*
+ * This overrides getpwnam_r() so that pam_modutil_getpwnam() (which uses
+ * getpwnam_r internally) can also find our fake test users.
+ * Without this, pam_mkhomedir would fail to look up the user and would not
+ * create the home directory, causing sshd to print
+ * "Could not chdir to home directory".
+ */
+int
+getpwnam_r (const char *name, struct passwd *pwd, char *buf, size_t buflen,
+            struct passwd **result)
+{
+  static int (*orig_getpwnam_r) (const char *, struct passwd *, char *,
+                                 size_t, struct passwd **) = NULL;
+
+  if (orig_getpwnam_r == NULL)
+    {
+      orig_getpwnam_r = dlsym (RTLD_NEXT, "getpwnam_r");
+      assert (orig_getpwnam_r);
+    }
+
+  if (!is_valid_test_user (name))
+    return orig_getpwnam_r (name, pwd, buf, buflen, result);
+
+#ifdef AUTHD_TESTS_SSH_USE_AUTHD_NSS
+  /* Try the real NSS lookup first (e.g. via authd NSS module). */
+  int ret = orig_getpwnam_r (name, pwd, buf, buflen, result);
+  if (ret == 0 && *result != NULL)
+    {
+      /* Override uid/gid like getpwnam does. */
+      pwd->pw_uid = getuid ();
+      pwd->pw_gid = getgid ();
+      return 0;
+    }
+#endif
+
+  /* Fall back to our getpwnam override which creates fake users. */
+  struct passwd *pw = getpwnam (name);
+  if (pw == NULL)
+    {
+      *result = NULL;
+      return 0;
+    }
+
+  *pwd = *pw;
+  *result = pwd;
+  return 0;
 }
 
 FILE *

--- a/pam/integration-tests/testdata/golden/TestSSHAuthenticate/Authenticate_user_and_reset_password_with_case_insensitive_user_selection
+++ b/pam/integration-tests/testdata/golden/TestSSHAuthenticate/Authenticate_user_and_reset_password_with_case_insensitive_user_selection
@@ -74,11 +74,11 @@ Enter 'r' to cancel the request and go back to choose the provider
 >
 (USER-NEEDS-RESET-INTEGRATION-PRE-CHECK-CASE-INSENSITIVE-TESTSSHAUTHENTICATE@EXAMPLE.COM@localhost) Confirm Password:
 >
-PAM Authenticate() finished for user 'user-needs-reset-integration-pre-check-case-insensitive-testsshauthenticate@example.com'
-PAM AcctMgmt() finished for user 'user-needs-reset-integration-pre-check-case-insensitive-testsshauthenticate@example.com'
+PAM Authenticate() finished for user 'USER-NEEDS-RESET-INTEGRATION-PRE-CHECK-CASE-INSENSITIVE-TESTSSHAUTHENTICATE@EXAMPLE.COM'
+PAM AcctMgmt() finished for user 'USER-NEEDS-RESET-INTEGRATION-PRE-CHECK-CASE-INSENSITIVE-TESTSSHAUTHENTICATE@EXAMPLE.COM'
  SSHD: Connected to ssh via authd module! [TestSSHAuthenticate/Authenticate_user_and_reset_password_with_case_insensitive_user_selection]
   HOME=${AUTHD_TEST_HOME}
-  LOGNAME=user-needs-reset-integration-pre-check-case-insensitive-testsshauthenticate@example.com
+  LOGNAME=USER-NEEDS-RESET-INTEGRATION-PRE-CHECK-CASE-INSENSITIVE-TESTSSHAUTHENTICATE@EXAMPLE.COM
   PATH=${AUTHD_TEST_PATH}
   PWD=${AUTHD_TEST_PWD}
   SHELL=/bin/sh
@@ -86,7 +86,7 @@ PAM AcctMgmt() finished for user 'user-needs-reset-integration-pre-check-case-in
   SSH_CONNECTION=${AUTHD_TEST_SSH_CONNECTION}
   SSH_TTY=${AUTHD_TEST_SSH_TTY}
   TERM=xterm-256color
-  USER=user-needs-reset-integration-pre-check-case-insensitive-testsshauthenticate@example.com
+  USER=USER-NEEDS-RESET-INTEGRATION-PRE-CHECK-CASE-INSENSITIVE-TESTSSHAUTHENTICATE@EXAMPLE.COM
 Connection to localhost closed.
 >
 ────────────────────────────────────────────────────────────────────────────────
@@ -132,11 +132,11 @@ Enter 'r' to cancel the request and go back to select the authentication method
 Enter 'r' to cancel the request and go back to select the authentication method
 (user-needs-reset-integration-pre-check-Case-INSENSITIVE-testsshauthenticate@example.com@localhost) Gimme your password:
 >
-PAM Authenticate() finished for user 'user-needs-reset-integration-pre-check-case-insensitive-testsshauthenticate@example.com'
-PAM AcctMgmt() finished for user 'user-needs-reset-integration-pre-check-case-insensitive-testsshauthenticate@example.com'
+PAM Authenticate() finished for user 'user-needs-reset-integration-pre-check-Case-INSENSITIVE-testsshauthenticate@example.com'
+PAM AcctMgmt() finished for user 'user-needs-reset-integration-pre-check-Case-INSENSITIVE-testsshauthenticate@example.com'
  SSHD: Connected to ssh via authd module! [TestSSHAuthenticate/Authenticate_user_and_reset_password_with_case_insensitive_user_selection]
   HOME=${AUTHD_TEST_HOME}
-  LOGNAME=user-needs-reset-integration-pre-check-case-insensitive-testsshauthenticate@example.com
+  LOGNAME=user-needs-reset-integration-pre-check-Case-INSENSITIVE-testsshauthenticate@example.com
   PATH=${AUTHD_TEST_PATH}
   PWD=${AUTHD_TEST_PWD}
   SHELL=/bin/sh
@@ -144,7 +144,7 @@ PAM AcctMgmt() finished for user 'user-needs-reset-integration-pre-check-case-in
   SSH_CONNECTION=${AUTHD_TEST_SSH_CONNECTION}
   SSH_TTY=${AUTHD_TEST_SSH_TTY}
   TERM=xterm-256color
-  USER=user-needs-reset-integration-pre-check-case-insensitive-testsshauthenticate@example.com
+  USER=user-needs-reset-integration-pre-check-Case-INSENSITIVE-testsshauthenticate@example.com
 Connection to localhost closed.
 >
 ────────────────────────────────────────────────────────────────────────────────

--- a/pam/integration-tests/testdata/golden/TestSSHAuthenticate/Authenticate_user_successfully_if_already_registered_with_upper_case
+++ b/pam/integration-tests/testdata/golden/TestSSHAuthenticate/Authenticate_user_successfully_if_already_registered_with_upper_case
@@ -33,11 +33,11 @@ Enter 'r' to cancel the request and go back to select the authentication method
 Enter 'r' to cancel the request and go back to select the authentication method
 (USER-SSH2@example.com@localhost) Gimme your password:
 >
-PAM Authenticate() finished for user 'user-ssh2@example.com'
-PAM AcctMgmt() finished for user 'user-ssh2@example.com'
+PAM Authenticate() finished for user 'USER-SSH2@example.com'
+PAM AcctMgmt() finished for user 'USER-SSH2@example.com'
  SSHD: Connected to ssh via authd module! [TestSSHAuthenticate/Authenticate_user_successfully_if_already_registered_with_upper_case]
   HOME=${AUTHD_TEST_HOME}
-  LOGNAME=user-ssh2@example.com
+  LOGNAME=USER-SSH2@example.com
   PATH=${AUTHD_TEST_PATH}
   PWD=${AUTHD_TEST_PWD}
   SHELL=/bin/sh
@@ -45,7 +45,7 @@ PAM AcctMgmt() finished for user 'user-ssh2@example.com'
   SSH_CONNECTION=${AUTHD_TEST_SSH_CONNECTION}
   SSH_TTY=${AUTHD_TEST_SSH_TTY}
   TERM=xterm-256color
-  USER=user-ssh2@example.com
+  USER=USER-SSH2@example.com
 Connection to localhost closed.
 >
 ────────────────────────────────────────────────────────────────────────────────

--- a/pam/integration-tests/testdata/golden/TestSSHAuthenticate/Authenticate_user_successfully_with_upper_case
+++ b/pam/integration-tests/testdata/golden/TestSSHAuthenticate/Authenticate_user_successfully_with_upper_case
@@ -33,11 +33,11 @@ Enter 'r' to cancel the request and go back to select the authentication method
 Enter 'r' to cancel the request and go back to select the authentication method
 (USER-INTEGRATION-PRE-CHECK-UPPER-CASE-TESTSSHAUTHENTICATE@EXAMPLE.COM@localhost) Gimme your password:
 >
-PAM Authenticate() finished for user 'user-integration-pre-check-upper-case-testsshauthenticate@example.com'
-PAM AcctMgmt() finished for user 'user-integration-pre-check-upper-case-testsshauthenticate@example.com'
+PAM Authenticate() finished for user 'USER-INTEGRATION-PRE-CHECK-UPPER-CASE-TESTSSHAUTHENTICATE@EXAMPLE.COM'
+PAM AcctMgmt() finished for user 'USER-INTEGRATION-PRE-CHECK-UPPER-CASE-TESTSSHAUTHENTICATE@EXAMPLE.COM'
  SSHD: Connected to ssh via authd module! [TestSSHAuthenticate/Authenticate_user_successfully_with_upper_case]
   HOME=${AUTHD_TEST_HOME}
-  LOGNAME=user-integration-pre-check-upper-case-testsshauthenticate@example.com
+  LOGNAME=USER-INTEGRATION-PRE-CHECK-UPPER-CASE-TESTSSHAUTHENTICATE@EXAMPLE.COM
   PATH=${AUTHD_TEST_PATH}
   PWD=${AUTHD_TEST_PWD}
   SHELL=/bin/sh
@@ -45,7 +45,7 @@ PAM AcctMgmt() finished for user 'user-integration-pre-check-upper-case-testssha
   SSH_CONNECTION=${AUTHD_TEST_SSH_CONNECTION}
   SSH_TTY=${AUTHD_TEST_SSH_TTY}
   TERM=xterm-256color
-  USER=user-integration-pre-check-upper-case-testsshauthenticate@example.com
+  USER=USER-INTEGRATION-PRE-CHECK-UPPER-CASE-TESTSSHAUTHENTICATE@EXAMPLE.COM
 Connection to localhost closed.
 >
 ────────────────────────────────────────────────────────────────────────────────

--- a/pam/integration-tests/testdata/golden/TestSSHAuthenticate/Error_if_cannot_connect_to_authd
+++ b/pam/integration-tests/testdata/golden/TestSSHAuthenticate/Error_if_cannot_connect_to_authd
@@ -4,5 +4,8 @@
 could not connect to unix:///some-path/not-existent-socket: service took too long to respond. Disconnecting client
 PAM Authenticate() finished for user 'user-integration-pre-check-ssh-error-if-cannot-connect-to-authd@example.com'
 SSH PAM user 'user-integration-pre-check-ssh-error-if-cannot-connect-to-authd@example.com' using local broker
-(user-integration-pre-check-ssh-error-if-cannot-connect-to-authd@example.com@localhost) Password:
+could not get current available brokers: permission denied: only root can perform this operation
+Received disconnect from ${SSH_HOST} port ${SSH_PORT} Too many authentication failures
+Disconnected from ${SSH_HOST} port ${SSH_PORT}
+>
 ────────────────────────────────────────────────────────────────────────────────

--- a/pam/internal/adapter/userselection.go
+++ b/pam/internal/adapter/userselection.go
@@ -96,7 +96,13 @@ func (m userSelectionModel) Update(msg tea.Msg) (userSelectionModel, tea.Cmd) {
 					currentUser, selectedUser),
 			})
 		}
-		if selectedUser != currentUser {
+		// Only update PAM_USER when the user is genuinely different
+		// (not just a case variation). OpenSSH 10.2+ checks PAM_USER
+		// against pw_name from getpwnam() and rejects mismatches, so
+		// we must not change PAM_USER for case-only differences.
+		// The lowercase version is still used internally by authd
+		// via the Username() method.
+		if isDifferentUser {
 			err := m.pamMTx.SetItem(pam.User, selectedUser)
 			if cmd := maybeSendPamError(err); cmd != nil {
 				return m, cmd


### PR DESCRIPTION
This PR fixes two issues:

* The issue that "Could not chdir to home directory" is added to the golden files (which we only experience locally)
* Issues caused by PAM_USER validation added in OpenSSH 10.2. This doesn't affect CI because it's still running an older OpenSSH version.

See commit messages for details.

Closes #1511
Closes #1366
UDENG-10152