### PR TITLE
Bump Go toolchain version to 1.25.10

### DIFF
--- a/authd-oidc-brokers/go.mod
+++ b/authd-oidc-brokers/go.mod
@@ -2,7 +2,7 @@ module github.com/canonical/authd/authd-oidc-brokers
 
 go 1.25.0
 
-toolchain go1.25.9
+toolchain go1.25.10
 
 require (
 	github.com/Azure/azure-sdk-for-go/sdk/azcore v1.21.1

--- a/authd-oidc-brokers/tools/go.mod
+++ b/authd-oidc-brokers/tools/go.mod
@@ -2,7 +2,7 @@ module github.com/canonical/authd/authd-oidc-brokers/tools
 
 go 1.25.0
 
-toolchain go1.25.9
+toolchain go1.25.10
 
 require (
 	github.com/golangci/golangci-lint/v2 v2.12.1

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/canonical/authd
 
 go 1.25.0
 
-toolchain go1.25.9
+toolchain go1.25.10
 
 require (
 	github.com/charmbracelet/bubbles v0.20.0

--- a/tools/go.mod
+++ b/tools/go.mod
@@ -2,7 +2,7 @@ module github.com/canonical/authd/tools
 
 go 1.25.0
 
-toolchain go1.25.9
+toolchain go1.25.10
 
 require (
 	github.com/golang/protobuf v1.5.4


### PR DESCRIPTION
govulncheck reports the following vulnerabilities in go1.25.9:

```
Vulnerability #1: GO-2026-4982
    Bypass of meta content URL escaping causes XSS in html/template
  More info: https://pkg.go.dev/vuln/GO-2026-4982
  Standard library
    Found in: html/template@go1.25.9
    Fixed in: html/template@go1.25.10
    Example traces found:
Error:       #1: pam/integration-tests/ssh_test.go:715:30: integration.startSSHD calls httptest.NewServer, which eventually calls template.Template.Execute
Error:       #2: pam/integration-tests/ssh_test.go:715:30: integration.startSSHD calls httptest.NewServer, which eventually calls template.Template.ExecuteTemplate

Vulnerability #2: GO-2026-4980
    Escaper bypass leads to XSS in html/template
  More info: https://pkg.go.dev/vuln/GO-2026-4980
  Standard library
    Found in: html/template@go1.25.9
    Fixed in: html/template@go1.25.10
    Example traces found:
Error:       #1: pam/integration-tests/ssh_test.go:715:30: integration.startSSHD calls httptest.NewServer, which eventually calls template.Template.Execute
Error:       #2: pam/integration-tests/ssh_test.go:715:30: integration.startSSHD calls httptest.NewServer, which eventually calls template.Template.ExecuteTemplate

Vulnerability #3: GO-2026-4971
    Panic in Dial and LookupPort when handling NUL byte on Windows in net
  More info: https://pkg.go.dev/vuln/GO-2026-4971
  Standard library
    Found in: net@go1.25.9
    Fixed in: net@go1.25.10
    Example traces found:
Error:       #1: pam/internal/dbusmodule/transaction.go:51:24: dbusmodule.NewTransaction calls dbus.Dial, which eventually calls net.Dial
Error:       #2: pam/integration-tests/ssh_test.go:777:32: integration.startSSHD calls net.DialTimeout
Error:       #3: pam/integration-tests/vhs-helpers_test.go:417:26: integration.tapeData.SanitizedOutput calls sync.Once.Do, which eventually calls net.Dialer.DialContext
Error:       #4: internal/services/manager_test.go:89:24: services_test.TestAccessAuthorization calls net.Listen

Vulnerability #4: GO-2026-4918
    Infinite loop in HTTP/2 transport when given bad SETTINGS_MAX_FRAME_SIZE in
    net/http/internal/http2 in golang.org/x/net
  More info: https://pkg.go.dev/vuln/GO-2026-4918
  Module: golang.org/x/net
    Found in: golang.org/x/net@v0.51.0
    Fixed in: golang.org/x/net@v0.53.0

  Standard library
    Found in: net/http@go1.25.9
    Fixed in: net/http@go1.25.10
    Example traces found:
Error:       #1: pam/integration-tests/ssh_test.go:719:14: integration.startSSHD calls httptest.Server.Close, which calls http.Transport.CloseIdleConnections
```