### PR TITLE
e2e: Add tests for `home_base_dir` broker property

### DIFF
--- a/e2e-tests/resources/broker.resource
+++ b/e2e-tests/resources/broker.resource
@@ -183,7 +183,7 @@ Block Network Access To Identity Provider
 #     sed -i 's/#*${config_key} = .*/${config_key} = ${config_value}/g' ${BROKER_CFG}
 Change Broker Configuration
     [Arguments]    ${config_key}    ${config_value}
-    SSH.Execute    sudo sed -i 's/^#*${config_key} =.*/${config_key} = ${config_value}/g' ${BROKER_CFG}
+    SSH.Execute    sudo sed -i 's|^#*${config_key} =.*|${config_key} = ${config_value}|g' ${BROKER_CFG}
     SSH.Execute    sudo snap restart ${BROKER_SNAP_NAME}
 
 
@@ -337,13 +337,11 @@ Check If Owner Was Registered
 
 
 Check Home Directory
-    [Arguments]    ${username}
-    Hid.Type String    echo $HOME
-    Hid.Keys Combo    Return
-    Match Text    /home/${username}    120
-    Hid.Type String    stat -c %U:%G $HOME
-    Hid.Keys Combo    Return
-    Match Text    ${username}:${username}
+    [Arguments]    ${username}    ${base_dir}=/home
+    ${home_dir} =    SSH.Execute    getent passwd ${username} | cut -d: -f6
+    Should Start With    ${home_dir}    ${base_dir}/
+    ${ownership} =    SSH.Execute    sudo stat -c %U:%G ${home_dir}
+    Should Be Equal    ${ownership}    ${username}:${username}
 
 
 Check That Remote User Is Not Allowed To Log In

--- a/e2e-tests/tests/config_home_base_dir.robot
+++ b/e2e-tests/tests/config_home_base_dir.robot
@@ -1,0 +1,47 @@
+*** Settings ***
+Resource        resources/utils.resource
+Resource        resources/authd.resource
+Resource        resources/broker.resource
+
+Test Setup    utils.Test Setup    snapshot=%{BROKER}-installed
+Test Teardown   utils.Test Teardown
+
+
+*** Variables ***
+${username}    %{E2E_USER}
+${local_password}    qwer1234
+${first_home_base_dir}    /srv/authd-first-homes
+${second_home_base_dir}    /srv/authd-second-homes
+
+
+*** Test Cases ***
+Test login keeps existing home directory after changing home base dir
+    [Documentation]    Verify that a first login uses the configured home_base_dir and that changing the value later does not move an existing user home directory.
+
+    SSH.Execute    sudo mkdir -p ${first_home_base_dir} ${second_home_base_dir}
+    Change Broker Configuration    home_base_dir    ${first_home_base_dir}
+
+    # Log in with local user.
+    Log In
+
+    # First remote login should create the home directory under the configured base path.
+    Open Terminal
+    Log In With Remote User Through CLI: QR Code    ${username}    ${local_password}
+    Check If User Was Added Properly    ${username}
+    ${passwd_entry} =    SSH.Execute    getent passwd ${username}
+    Should Contain    ${passwd_entry}    ${first_home_base_dir}/
+    Should Contain    ${passwd_entry}    /bin/bash
+    Check Home Directory    ${username}    ${first_home_base_dir}
+    Log Out From Terminal Session
+    Close Focused Window
+
+    # Change the config after the user already exists.
+    Change Broker Configuration    home_base_dir    ${second_home_base_dir}
+
+    # Second login should still use the original home directory from the database.
+    Open Terminal
+    Log In With Remote User Through CLI: Local Password    ${username}    ${local_password}
+    ${passwd_entry} =    SSH.Execute    getent passwd ${username}
+    Should Contain    ${passwd_entry}    ${first_home_base_dir}/
+    Should Contain    ${passwd_entry}    /bin/bash
+    Check Home Directory    ${username}    ${first_home_base_dir}


### PR DESCRIPTION
Add two end-to-end tests for the `home_base_dir` broker property:
- First login with `home_base_dir` set as a specific value
- Second login with `home_base_dir` set as another different value

For the second login, the home directory doesn't change, as this property only affects first time logins

UDENG-9527
UDENG-9526
