### PR TITLE
broker: Allow login when token cannot be stored

### DIFF
--- a/authd-oidc-brokers/internal/broker/broker.go
+++ b/authd-oidc-brokers/internal/broker/broker.go
@@ -1341,9 +1341,13 @@ func (b *Broker) finishAuth(session *session, authInfo *token.AuthCachedInfo) (s
 		b.ensureProviderIDCacheDir(session, authInfo.UserInfo.ProviderID)
 	}
 
-	if err := token.CacheAuthInfo(session.tokenPath, authInfo); err != nil {
+	err := token.CacheAuthInfo(session.tokenPath, authInfo)
+	if err != nil && b.cfg.forceAccessCheckWithProvider {
 		log.Errorf(context.Background(), "Failed to store token: %s", err)
 		return AuthDenied, unexpectedErrMsg("failed to store token")
+	}
+	if err != nil {
+		log.Errorf(context.Background(), "Failed to store token: %s. Continuing with login since provider access check is not forced.", err)
 	}
 
 	return AuthGranted, userInfoMessage{UserInfo: authInfo.UserInfo}

--- a/authd-oidc-brokers/internal/broker/broker_test.go
+++ b/authd-oidc-brokers/internal/broker/broker_test.go
@@ -1009,10 +1009,20 @@ func TestIsAuthenticated(t *testing.T) {
 			address: "127.0.0.1:31315",
 		},
 
-		"Error_when_authentication_data_is_invalid":         {invalidAuthData: true},
-		"Error_when_secret_can_not_be_decrypted":            {firstMode: authmodes.Password, badFirstKey: true},
-		"Error_when_provided_wrong_secret":                  {firstMode: authmodes.Password, token: &tokenOptions{}, firstSecret: "wrongpassword"},
-		"Error_when_can_not_cache_token":                    {firstSecret: "-", wantSecondCall: true, readOnlyDataDir: true},
+		"Error_when_authentication_data_is_invalid": {invalidAuthData: true},
+		"Error_when_secret_can_not_be_decrypted":    {firstMode: authmodes.Password, badFirstKey: true},
+		"Error_when_provided_wrong_secret":          {firstMode: authmodes.Password, token: &tokenOptions{}, firstSecret: "wrongpassword"},
+		"Authenticating_when_can_not_cache_token_without_forced_provider_access_check": {
+			firstMode:       authmodes.Password,
+			token:           &tokenOptions{},
+			readOnlyDataDir: true,
+		},
+		"Error_when_can_not_cache_token_with_forced_provider_access_check": {
+			firstMode:                    authmodes.Password,
+			token:                        &tokenOptions{},
+			forceAccessCheckWithProvider: true,
+			readOnlyDataDir:              true,
+		},
 		"Error_when_IsAuthenticated_is_ongoing_for_session": {dontWaitForFirstCall: true, wantSecondCall: true},
 
 		"Error_when_mode_is_password_and_token_does_not_exist": {firstMode: authmodes.Password},

--- a/authd-oidc-brokers/internal/broker/testdata/golden/TestIsAuthenticated/Authenticating_when_can_not_cache_token_without_forced_provider_access_check/data/provider_url/test-user@email.com/password
+++ b/authd-oidc-brokers/internal/broker/testdata/golden/TestIsAuthenticated/Authenticating_when_can_not_cache_token_without_forced_provider_access_check/data/provider_url/test-user@email.com/password
@@ -1,0 +1,1 @@
+Definitely a hashed password

--- a/authd-oidc-brokers/internal/broker/testdata/golden/TestIsAuthenticated/Authenticating_when_can_not_cache_token_without_forced_provider_access_check/data/provider_url/test-user@email.com/token.json
+++ b/authd-oidc-brokers/internal/broker/testdata/golden/TestIsAuthenticated/Authenticating_when_can_not_cache_token_without_forced_provider_access_check/data/provider_url/test-user@email.com/token.json
@@ -1,0 +1,1 @@
+Definitely a token

--- a/authd-oidc-brokers/internal/broker/testdata/golden/TestIsAuthenticated/Authenticating_when_can_not_cache_token_without_forced_provider_access_check/first_call
+++ b/authd-oidc-brokers/internal/broker/testdata/golden/TestIsAuthenticated/Authenticating_when_can_not_cache_token_without_forced_provider_access_check/first_call
@@ -1,0 +1,3 @@
+access: granted
+data: '{"userinfo":{"name":"test-user@email.com","uuid":"test-user-id","dir":"/home/test-user@email.com","shell":"/usr/bin/bash","gecos":"test-user","groups":[{"name":"remote-test-group","ugid":"12345"},{"name":"local-test-group","ugid":""}]}}'
+err: <nil>

--- a/authd-oidc-brokers/internal/broker/testdata/golden/TestIsAuthenticated/Error_when_can_not_cache_token/first_call
+++ b/authd-oidc-brokers/internal/broker/testdata/golden/TestIsAuthenticated/Error_when_can_not_cache_token/first_call
@@ -1,3 +1,0 @@
-access: next
-data: '{}'
-err: <nil>

--- a/authd-oidc-brokers/internal/broker/testdata/golden/TestIsAuthenticated/Error_when_can_not_cache_token/second_call
+++ b/authd-oidc-brokers/internal/broker/testdata/golden/TestIsAuthenticated/Error_when_can_not_cache_token/second_call
@@ -1,3 +1,0 @@
-access: denied
-data: '{"message":"An unexpected error occurred: failed to store password. Please report this error on https://github.com/canonical/authd/issues"}'
-err: <nil>

--- a/authd-oidc-brokers/internal/broker/testdata/golden/TestIsAuthenticated/Error_when_can_not_cache_token_with_forced_provider_access_check/data/provider_url/test-user@email.com/password
+++ b/authd-oidc-brokers/internal/broker/testdata/golden/TestIsAuthenticated/Error_when_can_not_cache_token_with_forced_provider_access_check/data/provider_url/test-user@email.com/password
@@ -1,0 +1,1 @@
+Definitely a hashed password

--- a/authd-oidc-brokers/internal/broker/testdata/golden/TestIsAuthenticated/Error_when_can_not_cache_token_with_forced_provider_access_check/data/provider_url/test-user@email.com/token.json
+++ b/authd-oidc-brokers/internal/broker/testdata/golden/TestIsAuthenticated/Error_when_can_not_cache_token_with_forced_provider_access_check/data/provider_url/test-user@email.com/token.json
@@ -1,0 +1,1 @@
+Definitely a token

--- a/authd-oidc-brokers/internal/broker/testdata/golden/TestIsAuthenticated/Error_when_can_not_cache_token_with_forced_provider_access_check/first_call
+++ b/authd-oidc-brokers/internal/broker/testdata/golden/TestIsAuthenticated/Error_when_can_not_cache_token_with_forced_provider_access_check/first_call
@@ -1,0 +1,3 @@
+access: denied
+data: '{"message":"An unexpected error occurred: failed to store token. Please report this error on https://github.com/canonical/authd/issues"}'
+err: <nil>

--- a/e2e-tests/resources/utils.resource
+++ b/e2e-tests/resources/utils.resource
@@ -30,7 +30,7 @@ Log In
 Log In With Password
     [Arguments]    ${password}
     Wait Until GDM Login Screen Ready
-    Wait Until User Selected
+    Select User
     Hid.Type String    ${password}
     Hid.Keys Combo    Return
     Wait Until Desktop Ready
@@ -39,7 +39,7 @@ Log In With Password
 Log In And Set Password
     [Arguments]    ${new_password}
     Wait Until GDM Login Screen Ready
-    Wait Until User Selected
+    Select User
     Hid.Type String    ubuntu
     Hid.Keys Combo    Return
 
@@ -60,7 +60,7 @@ Log In And Set Password
     Wait Until Desktop Ready
 
 
-Wait Until User Selected
+Select User
     Wait Until Keyword Succeeds    120 sec    1 sec
     ...    Try Select User
 

--- a/e2e-tests/tests/read_only_fs.robot
+++ b/e2e-tests/tests/read_only_fs.robot
@@ -1,0 +1,39 @@
+*** Settings ***
+Resource        resources/utils.resource
+Resource        resources/authd.resource
+
+Resource        resources/broker.resource
+
+# Test Tags       robot:exit-on-failure
+
+Test Setup    utils.Test Setup    snapshot=%{BROKER}-installed
+Test Teardown   utils.Test Teardown
+
+
+*** Variables ***
+${snapshot}    %{BROKER}-installed
+${username}    %{E2E_USER}
+${local_password}    qwer1234
+
+
+*** Test Cases ***
+Test login with GDM
+    [Documentation]    Test that a user can log in with a local password when the filesystem is read-only.
+
+    # Log in with local user
+    Log In
+
+    # Log in with remote user with device authentication
+    Open Terminal
+    Log In With Remote User Through CLI: QR Code    ${username}    ${local_password}
+    Log Out From Terminal Session
+    Close Focused Window
+
+    # Re-mount the filesystem read-only
+    SSH.Execute    echo u > /proc/sysrq-trigger
+    # Wait for the SysRq remount to take effect
+    Wait Until Keyword Succeeds    30s    1s    SSH.Execute    findmnt -n -o OPTIONS / | grep -qw ro
+
+    # Log in with remote user with local password
+    Open Terminal In Sudo Mode
+    Log In With Remote User Through CLI: Local Password    ${username}    ${local_password}

--- a/internal/users/export_test.go
+++ b/internal/users/export_test.go
@@ -19,7 +19,11 @@ func (m *Manager) GetOldUserInfoFromDB(name string) (oldUserInfo *types.UserInfo
 }
 
 func CompareNewUserInfoWithUserInfoFromDB(newUserInfo, dbUserInfo types.UserInfo) bool {
-	return compareNewUserInfoWithUserInfoFromDB(newUserInfo, dbUserInfo)
+	return len(diffNormalizedUserInfo(newUserInfo, dbUserInfo)) == 0
+}
+
+func DiffNewUserInfoWithUserInfoFromDB(newUserInfo, dbUserInfo types.UserInfo) []string {
+	return diffNormalizedUserInfo(newUserInfo, dbUserInfo)
 }
 
 func (m *Manager) UsersWithPrimaryGroup(gid uint32) ([]string, error) {

--- a/internal/users/manager.go
+++ b/internal/users/manager.go
@@ -10,6 +10,7 @@ import (
 	"os/user"
 	"slices"
 	"strconv"
+	"strings"
 	"sync"
 	"syscall"
 
@@ -174,7 +175,8 @@ func (m *Manager) UpdateUser(u types.UserInfo) (err error) {
 	userPrivateGroup := &u.Groups[0]
 
 	var oldUserInfo *types.UserInfo
-	checkEqualUserExists := func() (exists bool, err error) {
+	var pendingDiffs []string
+	checkUserNeedsUpdate := func() (needsUpdate bool, err error) {
 		// Check if the user already exists in the database.
 		oldUserInfo, err = m.getOldUserInfoFromDB(lookupName)
 		if err != nil {
@@ -186,7 +188,7 @@ func (m *Manager) UpdateUser(u types.UserInfo) (err error) {
 			if u.BrokerID != "" && u.ProviderID == "" {
 				return false, fmt.Errorf("broker %q did not provide a provider ID for new user %q; the broker may need to be updated to a version that identifies users by a stable provider ID", u.BrokerID, u.Name)
 			}
-			return false, nil
+			return true, nil
 		}
 		if oldUserInfo.BrokerID != "" && u.BrokerID != "" && oldUserInfo.BrokerID != u.BrokerID {
 			// The broker ID scopes the stored provider ID and must not change once set: a user
@@ -200,7 +202,7 @@ func (m *Manager) UpdateUser(u types.UserInfo) (err error) {
 		}
 		if oldUserInfo.BrokerID == "" && u.BrokerID != "" {
 			// First login after migration: persist broker ID in DB.
-			return false, nil
+			return true, nil
 		}
 		if oldUserInfo.ProviderID != "" && u.ProviderID == "" {
 			// Preserve already-recorded stable identity when brokers don't provide it (v2).
@@ -208,27 +210,27 @@ func (m *Manager) UpdateUser(u types.UserInfo) (err error) {
 		}
 		if oldUserInfo.ProviderID == "" && u.ProviderID != "" {
 			// First login after migration: persist provider ID in DB.
-			return false, nil
+			return true, nil
 		}
 		if lookupName != u.Name {
 			// Username changed (provider-ID matched rename): always trigger an update.
+			return true, nil
+		}
+		pendingDiffs = diffNormalizedUserInfo(u, *oldUserInfo)
+		if len(pendingDiffs) == 0 {
+			log.Debugf(context.TODO(), "User %q in database is up to date with current user info", u.Name)
 			return false, nil
 		}
-		if !compareNewUserInfoWithUserInfoFromDB(u, *oldUserInfo) {
-			log.Debugf(context.TODO(), "User %q is already in our database", u.Name)
-			return false, nil
-		}
-
-		log.Debugf(context.TODO(), "User %q in database already matches current", u.Name)
+		log.Debugf(context.TODO(), "User %q exists in database but needs update", u.Name)
 		return true, nil
 	}
 
 	// Do a first check before locking, so that if the user is already there and
 	// matches the DB entry, we can avoid any kind of locking (and so being
 	// blocked by other pre-auth users that may try to login meanwhile).
-	exists, err := checkEqualUserExists()
-	if exists || err != nil {
-		// The user already exists, so no update needed, or an error occurred.
+	needsUpdate, err := checkUserNeedsUpdate()
+	if !needsUpdate || err != nil {
+		// The user is up to date, or an error occurred.
 		return err
 	}
 
@@ -238,11 +240,15 @@ func (m *Manager) UpdateUser(u types.UserInfo) (err error) {
 	// Now that we're locked, check again if meanwhile some other request
 	// created the same user, if not we can do all the kinds of locking since
 	// we're sure that the user needs to be added or updated in the database.
-	if exists, err := checkEqualUserExists(); exists || err != nil {
+	if needsUpdate, err := checkUserNeedsUpdate(); !needsUpdate || err != nil {
 		return err
 	}
 
-	log.Debugf(context.TODO(), "User %q needs update", u.Name)
+	if oldUserInfo == nil {
+		log.Debugf(context.TODO(), "User %q needs update: new user", u.Name)
+	} else {
+		log.Debugf(context.TODO(), "User %q needs update: %s", u.Name, strings.Join(pendingDiffs, ", "))
+	}
 
 	lockedEntries, unlockEntries, err := localentries.WithUserDBLock()
 	if err != nil {
@@ -405,18 +411,18 @@ func (m *Manager) getOldUserInfoFromDB(name string) (oldUserInfo *types.UserInfo
 	return userInfoFromUserAndGroupRows(oldUser, oldGroups, oldLocalGroups), nil
 }
 
-func compareNewUserInfoWithUserInfoFromDB(newUserInfo, dbUserInfo types.UserInfo) bool {
-	if len(dbUserInfo.Groups) != len(newUserInfo.Groups) {
-		return false
-	}
-
-	// The new user UID may be set or un set, but despite that we're going to use
-	// the one we saved, so compare against it.
+// diffNormalizedUserInfo normalizes newUserInfo for comparison against dbUserInfo
+// (overriding UID and group GIDs to match existing DB values, since those are
+// assigned by authd and not by the broker) and returns the diff between the two.
+// An empty slice means the users are equal.
+func diffNormalizedUserInfo(newUserInfo, dbUserInfo types.UserInfo) []string {
+	// The new user UID may be set or unset, but we're going to use the one we
+	// saved, so normalize it before comparing.
 	newUserInfo.UID = dbUserInfo.UID
 
-	// We then need to normalize the new user groups in order to be able to
-	// compare the two users, in fact we may receive from the broker user entries
-	// with unset or different GIDs, so let's
+	// Normalize group GIDs: the broker may send different or absent GIDs, so
+	// match each new group to its existing DB counterpart (by UGID, falling
+	// back to name for legacy records where UGID was not stored).
 	for idx, g := range newUserInfo.Groups {
 		oldGroupIdx := slices.IndexFunc(dbUserInfo.Groups, func(dg types.GroupInfo) bool {
 			if dg.UGID == "" {
@@ -432,7 +438,7 @@ func compareNewUserInfoWithUserInfoFromDB(newUserInfo, dbUserInfo types.UserInfo
 		newUserInfo.Groups[idx].GID = dbUserInfo.Groups[oldGroupIdx].GID
 	}
 
-	return dbUserInfo.Equals(newUserInfo)
+	return dbUserInfo.Diff(newUserInfo)
 }
 
 // SetUserIDResp is the response type of SetUserID.

--- a/internal/users/manager_test.go
+++ b/internal/users/manager_test.go
@@ -1654,6 +1654,41 @@ func TestCompareNewUserInfoWithDB(t *testing.T) {
 	}
 }
 
+func TestDiffNewUserInfoWithDBNormalizesMatchingGroupsWhenGroupCountsDiffer(t *testing.T) {
+	t.Parallel()
+
+	userPrivateGroupGID := uint32(11111)
+	existingGroupGID := uint32(22222)
+
+	dbUserInfo := types.UserInfo{
+		Name:  "user1@example.com",
+		UID:   1111,
+		Gecos: "User1 gecos",
+		Dir:   "/home/user1@example.com",
+		Shell: "/bin/bash",
+		Groups: []types.GroupInfo{
+			{Name: "user1@example.com", UGID: "user1@example.com", GID: &userPrivateGroupGID},
+			{Name: "group1@example.com", UGID: "12345678", GID: &existingGroupGID},
+		},
+	}
+
+	newUserInfo := types.UserInfo{
+		Name:  "user1@example.com",
+		Gecos: "User1 gecos",
+		Dir:   "/home/user1@example.com",
+		Shell: "/bin/bash",
+		Groups: []types.GroupInfo{
+			{Name: "user1@example.com", UGID: "user1@example.com"},
+			{Name: "group1@example.com", UGID: "12345678"},
+			{Name: "group2@example.com", UGID: "87654321"},
+		},
+	}
+
+	got := users.DiffNewUserInfoWithUserInfoFromDB(newUserInfo, dbUserInfo)
+
+	require.Equal(t, []string{`group "group2@example.com" added`}, got)
+}
+
 func TestRegisterUserPreAuthWhenLocked(t *testing.T) {
 	// This cannot be parallel
 

--- a/internal/users/types/userinfo.go
+++ b/internal/users/types/userinfo.go
@@ -1,15 +1,52 @@
 package types
 
-import "github.com/canonical/authd/internal/sliceutils"
+import (
+	"fmt"
+
+	"github.com/canonical/authd/internal/sliceutils"
+)
+
+// Diff returns a human-readable description of the fields that differ between
+// u (the "before" state) and other (the "after" state). The returned slice is
+// empty when the two users are equal. Callers that only need a boolean result
+// should use Equals.
+func (u UserInfo) Diff(other UserInfo) []string {
+	var diffs []string
+	if u.Name != other.Name {
+		diffs = append(diffs, fmt.Sprintf("name (%q → %q)", u.Name, other.Name))
+	}
+	if u.UID != other.UID {
+		diffs = append(diffs, fmt.Sprintf("uid (%d → %d)", u.UID, other.UID))
+	}
+	if u.Gecos != other.Gecos {
+		diffs = append(diffs, fmt.Sprintf("gecos (%q → %q)", u.Gecos, other.Gecos))
+	}
+	if u.Dir != other.Dir {
+		diffs = append(diffs, fmt.Sprintf("dir (%q → %q)", u.Dir, other.Dir))
+	}
+	if u.Shell != other.Shell {
+		diffs = append(diffs, fmt.Sprintf("shell (%q → %q)", u.Shell, other.Shell))
+	}
+	for _, g := range sliceutils.DifferenceFunc(other.Groups, u.Groups, GroupInfo.Equals) {
+		diffs = append(diffs, fmt.Sprintf("group %q added", g.Name))
+	}
+	for _, g := range sliceutils.DifferenceFunc(u.Groups, other.Groups, GroupInfo.Equals) {
+		diffs = append(diffs, fmt.Sprintf("group %q removed", g.Name))
+	}
+	return diffs
+}
 
 // Equals checks that two users are equal.
 func (u UserInfo) Equals(other UserInfo) bool {
-	return u.Name == other.Name &&
-		u.UID == other.UID &&
-		u.Gecos == other.Gecos &&
-		u.Dir == other.Dir &&
-		u.Shell == other.Shell &&
-		u.BrokerID == other.BrokerID &&
-		u.ProviderID == other.ProviderID &&
-		sliceutils.EqualContentFunc(u.Groups, other.Groups, GroupInfo.Equals)
+	if u.Name != other.Name ||
+		u.UID != other.UID ||
+		u.Gecos != other.Gecos ||
+		u.Dir != other.Dir ||
+		u.Shell != other.Shell ||
+		u.BrokerID != other.BrokerID ||
+		u.ProviderID != other.ProviderID {
+		return false
+	}
+
+	return sliceutils.EqualContentFunc(u.Groups, other.Groups, GroupInfo.Equals)
 }


### PR DESCRIPTION
Logging in as an authd user was impossible when the token failed to be stored, for example when the filesystem was mounted read-only due to disk errors. Existing users should still be able to log in.

This commit allows login with a local password in that case unless force_access_check_with_provider is set.

Note that only logging in via device authentication still fails, because the local password cannot be stored. That should be fine, I don't think we have to support new users logging in in that case.

Closes #1182
UDENG-10203