### PR TITLE
ci: Fix permissions of reusable workflows

### DIFF
--- a/.github/workflows/debian-build.yaml
+++ b/.github/workflows/debian-build.yaml
@@ -29,6 +29,11 @@ jobs:
   build-deb:
     name: Build Debian package (${{ inputs.files-hash }})
     runs-on: ubuntu-latest
+    permissions:
+      # Needed by actions/checkout
+      contents: read
+      # Needed to push OCI artifact to ghcr.io
+      packages: write
     outputs:
       pkg-name: ${{ steps.outputs.outputs.pkg-name }}
       pkg-version: ${{ steps.outputs.outputs.pkg-version }}

--- a/.github/workflows/debian.yaml
+++ b/.github/workflows/debian.yaml
@@ -107,6 +107,8 @@ jobs:
     needs:
       - compute-hash
       - get-modified-files
+    permissions:
+      contents: write
     strategy:
       matrix:
         ubuntu-version: [ 'noble', 'questing', 'devel' ]

--- a/.github/workflows/e2e-tests.yaml
+++ b/.github/workflows/e2e-tests.yaml
@@ -79,6 +79,10 @@ jobs:
 
   provision-and-run:
     needs: compute-hash
+    permissions:
+      contents: read
+      packages: write
+      statuses: write
     strategy:
       matrix:
         ubuntu-version: [ 'noble', 'resolute' ]


### PR DESCRIPTION
The jobs using reusable workflows suddenly started failing with errors like:

    Invalid workflow file: .github/workflows/e2e-tests.yaml#L80 The workflow is not valid. .github/workflows/e2e-tests.yaml (Line: 80, Col: 3): Error calling workflow 'canonical/authd/.github/workflows/e2e-tests-provision-and-run.yaml@bcc5e6d437bbdcdab9dd64c5c1f846aa5a1374b8'. The nested job 'provision-vm' is requesting 'packages: write', but is only allowed 'packages: read'.

Adding the permissions to the caller of the reusable workflow seems to fix it.

Closes #1528
