### PR TITLE
pam/adapter: Return ErrAuthinfoUnavail when broker listing fails

### DIFF
--- a/pam/integration-tests/testdata/golden/TestCLIAuthenticate/Deny_authentication_if_current_user_is_not_considered_as_root
+++ b/pam/integration-tests/testdata/golden/TestCLIAuthenticate/Deny_authentication_if_current_user_is_not_considered_as_root
@@ -2,8 +2,8 @@
 PAM Error Message: could not get current available brokers: permission denied: only root can perform this operation
 PAM Authenticate()
   User: "<unset>"
-  Result: error: PAM exit code: 4
-    System error
+  Result: error: PAM exit code: 9
+    Authentication service cannot retrieve authentication info
 PAM Info Message: acct=incomplete
 PAM AcctMgmt()
   User: "<unset>"
@@ -15,8 +15,8 @@ PAM AcctMgmt()
 PAM Error Message: could not get current available brokers: permission denied: only root can perform this operation
 PAM Authenticate()
   User: "<unset>"
-  Result: error: PAM exit code: 4
-    System error
+  Result: error: PAM exit code: 9
+    Authentication service cannot retrieve authentication info
 PAM Info Message: acct=incomplete
 PAM AcctMgmt()
   User: "<unset>"

--- a/pam/integration-tests/testdata/golden/TestCLIChangeAuthTok/Prevent_change_password_if_current_user_is_not_root_as_can_not_authenticate
+++ b/pam/integration-tests/testdata/golden/TestCLIChangeAuthTok/Prevent_change_password_if_current_user_is_not_root_as_can_not_authenticate
@@ -2,8 +2,8 @@
 PAM Error Message: could not get current available brokers: permission denied: only root can perform this operation
 PAM ChangeAuthTok()
   User: "<unset>"
-  Result: error: PAM exit code: 4
-    System error
+  Result: error: PAM exit code: 9
+    Authentication service cannot retrieve authentication info
 PAM Info Message: acct=incomplete
 PAM AcctMgmt()
   User: "<unset>"
@@ -15,8 +15,8 @@ PAM AcctMgmt()
 PAM Error Message: could not get current available brokers: permission denied: only root can perform this operation
 PAM ChangeAuthTok()
   User: "<unset>"
-  Result: error: PAM exit code: 4
-    System error
+  Result: error: PAM exit code: 9
+    Authentication service cannot retrieve authentication info
 PAM Info Message: acct=incomplete
 PAM AcctMgmt()
   User: "<unset>"

--- a/pam/integration-tests/testdata/golden/TestNativeAuthenticate/Deny_authentication_if_current_user_is_not_considered_as_root
+++ b/pam/integration-tests/testdata/golden/TestNativeAuthenticate/Deny_authentication_if_current_user_is_not_considered_as_root
@@ -2,8 +2,8 @@
 PAM Error Message: could not get current available brokers: permission denied: only root can perform this operation
 PAM Authenticate()
   User: "user-integration-native-deny-authentication-if-current-user-is-not-considered-as-root@example.com"
-  Result: error: PAM exit code: 4
-    System error
+  Result: error: PAM exit code: 9
+    Authentication service cannot retrieve authentication info
 acct=incomplete
 PAM AcctMgmt()
   User: "user-integration-native-deny-authentication-if-current-user-is-not-considered-as-root@example.com"
@@ -15,8 +15,8 @@ PAM AcctMgmt()
 PAM Error Message: could not get current available brokers: permission denied: only root can perform this operation
 PAM Authenticate()
   User: "user-integration-native-deny-authentication-if-current-user-is-not-considered-as-root@example.com"
-  Result: error: PAM exit code: 4
-    System error
+  Result: error: PAM exit code: 9
+    Authentication service cannot retrieve authentication info
 acct=incomplete
 PAM AcctMgmt()
   User: "user-integration-native-deny-authentication-if-current-user-is-not-considered-as-root@example.com"

--- a/pam/integration-tests/testdata/golden/TestNativeChangeAuthTok/Prevent_change_password_if_current_user_is_not_root_as_can_not_authenticate
+++ b/pam/integration-tests/testdata/golden/TestNativeChangeAuthTok/Prevent_change_password_if_current_user_is_not_root_as_can_not_authenticate
@@ -2,8 +2,8 @@
 PAM Error Message: could not get current available brokers: permission denied: only root can perform this operation
 PAM ChangeAuthTok()
   User: "<unset>"
-  Result: error: PAM exit code: 4
-    System error
+  Result: error: PAM exit code: 9
+    Authentication service cannot retrieve authentication info
 acct=incomplete
 PAM AcctMgmt()
   User: "<unset>"
@@ -15,8 +15,8 @@ PAM AcctMgmt()
 PAM Error Message: could not get current available brokers: permission denied: only root can perform this operation
 PAM ChangeAuthTok()
   User: "<unset>"
-  Result: error: PAM exit code: 4
-    System error
+  Result: error: PAM exit code: 9
+    Authentication service cannot retrieve authentication info
 acct=incomplete
 PAM AcctMgmt()
   User: "<unset>"

--- a/pam/internal/adapter/brokerselection.go
+++ b/pam/internal/adapter/brokerselection.go
@@ -160,7 +160,7 @@ func getAvailableBrokers(client authd.PAMClient) tea.Cmd {
 		brokersInfo, err := client.AvailableBrokers(context.TODO(), &authd.Empty{})
 		if err != nil {
 			return pamError{
-				status: pam.ErrSystem,
+				status: pam.ErrAuthinfoUnavail,
 				msg:    fmt.Sprintf("could not get current available brokers: %v", err),
 			}
 		}

--- a/pam/internal/adapter/gdmmodel_test.go
+++ b/pam/internal/adapter/gdmmodel_test.go
@@ -1704,7 +1704,7 @@ func TestGdmModel(t *testing.T) {
 				gdm.EventType_userSelected,
 			},
 			wantExitStatus: pamError{
-				status: pam.ErrSystem,
+				status: pam.ErrAuthinfoUnavail,
 				msg:    "could not get current available brokers: brokers loading failed",
 			},
 			wantNoBrokers: true,


### PR DESCRIPTION
getAvailableBrokers() was returning pam.ErrSystem when the gRPC call to AvailableBrokers failed. The correct PAM error code is ErrAuthinfoUnavail, which is already used in the adjacent case where the call succeeds but returns an empty list.

This caused the TestPamCLIRunStandalone test to fail when run on a system that has an authd instance running.

Closes #1526
UDENG-10219