### PR TITLE
e2e-tests: Improve broker_disabled test to also check GDM

### DIFF
--- a/e2e-tests/resources/utils.resource
+++ b/e2e-tests/resources/utils.resource
@@ -254,6 +254,11 @@ Force Password Change
     Match Text    passwd: password changed.    30
 
 
+Escape Back to GDM Login Screen
+    Hid.Keys Combo    Escape
+    Match Text    Not listed    120
+
+
 ### Setup ###
 
 Restore Snapshot

--- a/e2e-tests/tests/broker_disabled.robot
+++ b/e2e-tests/tests/broker_disabled.robot
@@ -21,6 +21,11 @@ Test that disabling broker prevents remote logins
     # Disable broker
     Disable Broker And Purge Config
 
+    # Check that remote user is redirected to local broker when trying to log in through GDM
+    Start Log In With Remote User Through GDM: QR Code    ${username}
+    Check That User Is Redirected To Local Broker
+    Escape Back to GDM Login Screen
+
     # Check that local user can still log in
     Log In
 


### PR DESCRIPTION
We used to only check whether the remote user was redirected to the local broker (if there is no remote broker available) only for CLI logins.

Added a check to also ensure that the behavior is the same when the user tries authenticating through GDM.

UDENG-9535