### PR TITLE
e2e-tests: Check for homedir creation for new remote users

### DIFF
--- a/e2e-tests/tests/login.robot
+++ b/e2e-tests/tests/login.robot
@@ -27,6 +27,7 @@ Test login with CLI
     Log In With Remote User Through CLI: QR Code    ${username}    ${local_password}
     # Check remote user is properly added to the system
     Check If User Was Added Properly    ${username}
+    Check Home Directory    ${username}
     Log Out From Terminal Session
     Close Focused Window
 

--- a/e2e-tests/tests/login_gdm.robot
+++ b/e2e-tests/tests/login_gdm.robot
@@ -26,6 +26,7 @@ Test login with GDM
     # Check remote user is properly added to the system
     Open Terminal
     Check If User Was Added Properly    ${username}
+    Check Home Directory    ${username}
     Close Focused Window
     Log Out
 


### PR DESCRIPTION
We were checking if the user was added properly, but we should also check if the home directory was created as it should be as well.