### PR TITLE
ci: use authenticated requests for the generate action

### DIFF
--- a/.github/workflows/tics-run.yaml
+++ b/.github/workflows/tics-run.yaml
@@ -44,6 +44,7 @@ jobs:
             - uses: canonical/desktop-engineering/gh-actions/go/generate@main
               with:
                 tools-directory: ./tools
+                token: ${{ github.token }}
 
             - name: Fetch last successful QA runs ids
               env:


### PR DESCRIPTION
This workflow has been failing due to API rate limits for unauthenticated requests. See here: https://github.com/canonical/authd/actions/runs/26378106087/job/77642039856

Adding the token as an input should increase our limits and allow the action to work again.