### PR TITLE
ci: add packages:write permission to debian workflow

### DIFF
--- a/.github/workflows/debian.yaml
+++ b/.github/workflows/debian.yaml
@@ -107,8 +107,12 @@ jobs:
     needs:
       - compute-hash
       - get-modified-files
+    # Permissions needed by nested debian-build-test-and-sync workflow:
+    # - contents: write: for pushing to packaging branches
+    # - packages: write: for pushing OCI artifacts to ghcr.io
     permissions:
       contents: write
+      packages: write
     strategy:
       matrix:
         ubuntu-version: [ 'noble', 'questing', 'devel' ]


### PR DESCRIPTION
The nested debian-build-test-and-sync workflow requires packages:write permission to push OCI artifacts to ghcr.io. This permission must be declared at the caller level to avoid validation errors.

Closes #1542
