### PR TITLE
authd-oidc-brokers: split Provider into core + optional interfaces

### DIFF
--- a/authd-oidc-brokers/internal/broker/broker.go
+++ b/authd-oidc-brokers/internal/broker/broker.go
@@ -26,7 +26,6 @@ import (
 	"github.com/canonical/authd/authd-oidc-brokers/internal/providers"
 	providerErrors "github.com/canonical/authd/authd-oidc-brokers/internal/providers/errors"
 	"github.com/canonical/authd/authd-oidc-brokers/internal/providers/info"
-	"github.com/canonical/authd/authd-oidc-brokers/internal/providers/msentraid/himmelblau"
 	"github.com/canonical/authd/authd-oidc-brokers/internal/token"
 	"github.com/canonical/authd/log"
 	"github.com/coreos/go-oidc/v3/oidc"
@@ -883,7 +882,7 @@ func (b *Broker) passwordAuth(ctx context.Context, session *session, secret stri
 
 	// Try to refresh the groups
 	groups, err := b.getGroups(ctx, session, authInfo)
-	if errors.Is(err, himmelblau.ErrDeviceDisabled) {
+	if errors.Is(err, providerErrors.ErrDeviceDisabled) {
 		// The device is disabled, deny login
 		log.Errorf(context.Background(), "Login failed: %s", err)
 
@@ -896,13 +895,13 @@ func (b *Broker) passwordAuth(ctx context.Context, session *session, secret stri
 
 		return AuthDenied, errorMessage{Message: fmt.Sprintf("This device is disabled in %s, please contact your administrator.", b.provider.DisplayName())}
 	}
-	if errors.Is(err, himmelblau.ErrInvalidRedirectURI) {
+	if errors.Is(err, providerErrors.ErrInvalidRedirectURI) {
 		// Deny login if the redirect URI is invalid, so that users and administrators are aware of the issue.
 		log.Errorf(context.Background(), "Login failed: %s", err)
 		return AuthDenied, errorMessageForDisplay(err, "Invalid redirect URI")
 	}
-	var tokenAcquisitionError himmelblau.TokenAcquisitionError
-	if errors.As(err, &tokenAcquisitionError) {
+	var retryWithDeviceAuthError *providerErrors.RetryWithDeviceAuthError
+	if errors.As(err, &retryWithDeviceAuthError) {
 		log.Errorf(context.Background(), "Token acquisition failed: %s. Try again using device authentication.", err)
 		// The token acquisition failed unexpectedly.
 		// One possible reason is that the device was deleted by an administrator in Entra ID.

--- a/authd-oidc-brokers/internal/broker/broker.go
+++ b/authd-oidc-brokers/internal/broker/broker.go
@@ -145,7 +145,7 @@ func New(cfg Config, apiVersion uint, args ...Option) (b *Broker, err error) {
 	}
 
 	clientID := cfg.clientID
-	if opts.provider.SupportsDeviceRegistration() && cfg.registerDevice {
+	if _, ok := providers.ProviderAs[providers.DeviceRegisterer](opts.provider); ok && cfg.registerDevice {
 		clientID = consts.MicrosoftBrokerAppID
 	}
 
@@ -245,7 +245,7 @@ func (b *Broker) NewSession(username, lang, mode string) (sessionID, encryptionK
 	}
 
 	scopes := append(consts.DefaultScopes, b.provider.AdditionalScopes()...)
-	if b.provider.SupportsDeviceRegistration() && b.cfg.registerDevice {
+	if _, ok := providers.ProviderAs[providers.DeviceRegisterer](b.provider); ok && b.cfg.registerDevice {
 		scopes = consts.MicrosoftBrokerAppScopes
 	}
 	// Append extra scopes from config
@@ -375,7 +375,8 @@ func (b *Broker) authModeIsAvailable(session session, authMode string) bool {
 			return false
 		}
 
-		if !b.provider.SupportsDeviceRegistration() {
+		dr, isDR := providers.ProviderAs[providers.DeviceRegisterer](b.provider)
+		if !isDR {
 			// If the provider does not support device registration,
 			// we can always use the token for local password authentication.
 			log.Debugf(context.Background(), "Provider does not support device registration, so local password authentication is available for user %q", session.username)
@@ -389,7 +390,7 @@ func (b *Broker) authModeIsAvailable(session session, authMode string) bool {
 			return true
 		}
 
-		isTokenForDeviceRegistration, err := b.provider.IsTokenForDeviceRegistration(authInfo.Token)
+		isTokenForDeviceRegistration, err := dr.IsTokenForDeviceRegistration(authInfo.Token)
 		if err != nil {
 			log.Warningf(context.Background(), "Could not check if token is for device registration, so local password authentication is not available: %v", err)
 			return false
@@ -710,12 +711,18 @@ func (b *Broker) deviceAuth(ctx context.Context, session *session) (string, isAu
 		return AuthDenied, unexpectedErrMsg("token response does not contain an ID token")
 	}
 
-	authInfo := token.NewAuthCachedInfo(t, rawIDToken, b.provider)
+	var extraFields map[string]interface{}
+	if mp, ok := providers.ProviderAs[providers.MetadataProvider](b.provider); ok {
+		extraFields = mp.GetExtraFields(t)
+	}
+	authInfo := token.NewAuthCachedInfo(t, rawIDToken, extraFields)
 
-	authInfo.ProviderMetadata, err = b.provider.GetMetadata(session.oidcServer)
-	if err != nil {
-		log.Errorf(context.Background(), "could not get provider metadata: %s", err)
-		return AuthDenied, unexpectedErrMsg("could not get provider metadata")
+	if mp, ok := providers.ProviderAs[providers.MetadataProvider](b.provider); ok {
+		authInfo.ProviderMetadata, err = mp.GetMetadata(session.oidcServer)
+		if err != nil {
+			log.Errorf(context.Background(), "could not get provider metadata: %s", err)
+			return AuthDenied, unexpectedErrMsg("could not get provider metadata")
+		}
 	}
 
 	authInfo.UserInfo, err = b.getUserInfo(ctx, session, t, rawIDToken, false)
@@ -729,7 +736,7 @@ func (b *Broker) deviceAuth(ctx context.Context, session *session) (string, isAu
 		return AuthDenied, errorMessage{Message: "Authentication failure: user not allowed in broker configuration"}
 	}
 
-	if b.provider.SupportsDeviceRegistration() && b.cfg.registerDevice {
+	if dr, ok := providers.ProviderAs[providers.DeviceRegisterer](b.provider); ok && b.cfg.registerDevice {
 		// Load existing device registration data if there is any, to avoid re-registering the device.
 		var deviceRegistrationData []byte
 		oldAuthInfo, err := token.LoadAuthInfo(session.tokenPath)
@@ -738,7 +745,7 @@ func (b *Broker) deviceAuth(ctx context.Context, session *session) (string, isAu
 		}
 
 		var cleanup func()
-		authInfo.DeviceRegistrationData, cleanup, err = b.provider.MaybeRegisterDevice(ctx, t,
+		authInfo.DeviceRegistrationData, cleanup, err = dr.MaybeRegisterDevice(ctx, t,
 			session.username,
 			b.cfg.issuerURL,
 			deviceRegistrationData,
@@ -828,7 +835,7 @@ func (b *Broker) passwordAuth(ctx context.Context, session *session, secret stri
 				session.nextAuthModes = []string{authmodes.Device, authmodes.DeviceQr}
 				return AuthNext, errorMessage{Message: "Refresh token expired, please authenticate again using device authentication."}
 			}
-			if b.provider.IsUserDisabledError(retrieveErr) {
+			if udc, ok := providers.ProviderAs[providers.UserDisabledChecker](b.provider); ok && udc.IsUserDisabledError(retrieveErr) {
 				log.Error(context.Background(), retrieveErr.Error())
 				log.Errorf(context.Background(), "Login denied: User %q is disabled in %s, please contact your administrator.", session.username, b.provider.DisplayName())
 
@@ -859,9 +866,9 @@ func (b *Broker) passwordAuth(ctx context.Context, session *session, secret stri
 	}
 
 	// If device registration is enabled, ensure that the device is registered.
-	if b.provider.SupportsDeviceRegistration() && !session.isOffline && b.cfg.registerDevice {
+	if dr, ok := providers.ProviderAs[providers.DeviceRegisterer](b.provider); ok && !session.isOffline && b.cfg.registerDevice {
 		var cleanup func()
-		authInfo.DeviceRegistrationData, cleanup, err = b.provider.MaybeRegisterDevice(ctx,
+		authInfo.DeviceRegistrationData, cleanup, err = dr.MaybeRegisterDevice(ctx,
 			authInfo.Token,
 			session.username,
 			b.cfg.issuerURL,
@@ -1160,7 +1167,11 @@ func (b *Broker) refreshToken(ctx context.Context, session *session, oldToken *t
 		rawIDToken = oldToken.RawIDToken
 	}
 
-	t := token.NewAuthCachedInfo(oauthToken, rawIDToken, b.provider)
+	var extraFields map[string]interface{}
+	if mp, ok := providers.ProviderAs[providers.MetadataProvider](b.provider); ok {
+		extraFields = mp.GetExtraFields(oauthToken)
+	}
+	t := token.NewAuthCachedInfo(oauthToken, rawIDToken, extraFields)
 	t.ProviderMetadata = oldToken.ProviderMetadata
 	t.DeviceRegistrationData = oldToken.DeviceRegistrationData
 
@@ -1229,7 +1240,12 @@ func (b *Broker) getGroups(ctx context.Context, session *session, t *token.AuthC
 		return nil, errors.New("session is in offline mode")
 	}
 
-	return b.provider.GetGroups(ctx,
+	gf, ok := providers.ProviderAs[providers.GroupFetcher](b.provider)
+	if !ok {
+		return nil, nil
+	}
+
+	return gf.GetGroups(ctx,
 		b.cfg.clientID,
 		b.cfg.issuerURL,
 		t.Token,

--- a/authd-oidc-brokers/internal/broker/broker_test.go
+++ b/authd-oidc-brokers/internal/broker/broker_test.go
@@ -2,7 +2,9 @@ package broker_test
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
+	"net/http"
 	"os"
 	"path/filepath"
 	"slices"
@@ -15,6 +17,7 @@ import (
 	"github.com/canonical/authd/authd-oidc-brokers/internal/broker/sessionmode"
 	"github.com/canonical/authd/authd-oidc-brokers/internal/consts"
 	"github.com/canonical/authd/authd-oidc-brokers/internal/password"
+	providerErrors "github.com/canonical/authd/authd-oidc-brokers/internal/providers/errors"
 	"github.com/canonical/authd/authd-oidc-brokers/internal/providers/info"
 	"github.com/canonical/authd/authd-oidc-brokers/internal/testutils"
 	"github.com/canonical/authd/internal/testutils/golden"
@@ -583,11 +586,17 @@ func TestIsAuthenticated(t *testing.T) {
 		providerSupportsDeviceRegistration bool
 		registerDevice                     bool
 		requireNameClaimOnInitialAuth      bool
+		providerSupportsMetadata           bool
+		metadataGetErr                     error
+		providerSupportsUserDisabledCheck  bool
+		userDisabledErrorCode              string
+		providerHasNoGroupFetcher          bool
 
 		firstMode                string
 		firstSecret              string
 		badFirstKey              bool
 		getGroupsFails           bool
+		getGroupsFunc            func() ([]info.Group, error)
 		useOldNameForSecretField bool
 		groupsReturnedByProvider []info.Group
 
@@ -918,6 +927,72 @@ func TestIsAuthenticated(t *testing.T) {
 				"/userinfo": testutils.UserInfoHandler(map[string]interface{}{}),
 			},
 		},
+
+		// MetadataProvider: the broker should call GetExtraFields and GetMetadata when the
+		// provider implements MetadataProvider.
+		"Successfully_authenticate_with_device_auth_when_provider_supports_metadata": {
+			firstSecret:              "-",
+			wantSecondCall:           true,
+			providerSupportsMetadata: true,
+		},
+		"Error_when_device_auth_metadata_provider_fails_to_get_metadata": {
+			firstSecret:              "-",
+			wantSecondCall:           true,
+			providerSupportsMetadata: true,
+			metadataGetErr:           errors.New("metadata unavailable"),
+		},
+		"Authenticating_with_password_when_provider_supports_metadata": {
+			firstMode:                authmodes.Password,
+			token:                    &tokenOptions{},
+			providerSupportsMetadata: true,
+		},
+
+		// NoGroupFetcher: when the provider does not implement GroupFetcher, getGroups
+		// returns nil and the user is authenticated without remote groups.
+		"Authenticating_with_password_when_provider_has_no_group_fetcher": {
+			firstMode:                 authmodes.Password,
+			token:                     &tokenOptions{},
+			providerHasNoGroupFetcher: true,
+			wantGroups:                []info.Group{},
+		},
+
+		// UserDisabledChecker: when a token refresh fails with a provider-specific
+		// "user disabled" error code, login is denied and the token is marked disabled.
+		"Error_when_user_is_disabled_according_to_user_disabled_checker": {
+			firstMode:                         authmodes.Password,
+			token:                             &tokenOptions{},
+			providerSupportsUserDisabledCheck: true,
+			userDisabledErrorCode:             "user_disabled",
+			customHandlers: map[string]testutils.EndpointHandler{
+				"/token": testutils.ErrorResponseHandler(http.StatusBadRequest,
+					`{"error":"user_disabled","error_description":"User account is disabled"}`),
+			},
+		},
+
+		// getGroups error cases: test that errors returned from the GroupFetcher are
+		// handled correctly.
+		"Error_when_getgroups_returns_device_disabled_error": {
+			firstMode: authmodes.Password,
+			token:     &tokenOptions{},
+			getGroupsFunc: func() ([]info.Group, error) {
+				return nil, providerErrors.ErrDeviceDisabled
+			},
+		},
+		"Error_when_getgroups_returns_invalid_redirect_uri_error": {
+			firstMode: authmodes.Password,
+			token:     &tokenOptions{},
+			getGroupsFunc: func() ([]info.Group, error) {
+				return nil, providerErrors.ErrInvalidRedirectURI
+			},
+		},
+		"Error_when_getgroups_returns_retry_with_device_auth_error": {
+			firstMode: authmodes.Password,
+			token:     &tokenOptions{},
+			getGroupsFunc: func() ([]info.Group, error) {
+				return nil, &providerErrors.RetryWithDeviceAuthError{Err: errors.New("token acquisition failed")}
+			},
+			wantNextAuthModes: []string{authmodes.Device, authmodes.DeviceQr},
+		},
 	}
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
@@ -951,6 +1026,11 @@ func TestIsAuthenticated(t *testing.T) {
 				supportsDeviceRegistration:    tc.providerSupportsDeviceRegistration,
 				requireNameClaimOnInitialAuth: tc.requireNameClaimOnInitialAuth,
 				registerDevice:                tc.registerDevice,
+				supportsMetadata:              tc.providerSupportsMetadata,
+				metadataGetErr:                tc.metadataGetErr,
+				supportsUserDisabledCheck:     tc.providerSupportsUserDisabledCheck,
+				userDisabledErrorCode:         tc.userDisabledErrorCode,
+				supportsFetchingGroups:        !tc.providerHasNoGroupFetcher,
 				tokenHandlerOptions:           tc.tokenHandlerOptions,
 			}
 			if tc.customHandlers == nil {
@@ -964,6 +1044,9 @@ func TestIsAuthenticated(t *testing.T) {
 				cfg.getGroupsFunc = func() ([]info.Group, error) {
 					return tc.groupsReturnedByProvider, nil
 				}
+			}
+			if tc.getGroupsFunc != nil {
+				cfg.getGroupsFunc = tc.getGroupsFunc
 			}
 			b := newBrokerForTests(t, cfg)
 

--- a/authd-oidc-brokers/internal/broker/helper_test.go
+++ b/authd-oidc-brokers/internal/broker/helper_test.go
@@ -41,6 +41,11 @@ type brokerForTestConfig struct {
 
 	getGroupsFails                bool
 	supportsDeviceRegistration    bool
+	supportsMetadata              bool
+	metadataGetErr                error
+	supportsUserDisabledCheck     bool
+	userDisabledErrorCode         string
+	supportsFetchingGroups        bool
 	requireNameClaimOnInitialAuth bool
 	firstCallDelay                int
 	secondCallDelay               int
@@ -49,6 +54,27 @@ type brokerForTestConfig struct {
 	listenAddress       string
 	tokenHandlerOptions *testutils.TokenHandlerOptions
 	customHandlers      map[string]testutils.EndpointHandler
+}
+
+func brokerProviderWithOptionalCapabilities(provider *testutils.MockProvider, cfg *brokerForTestConfig) providers.Provider {
+	capabilities := testutils.ProviderCapabilities{}
+	if cfg.supportsFetchingGroups {
+		capabilities.GroupFetcher = provider
+	}
+	if cfg.supportsDeviceRegistration {
+		capabilities.DeviceRegisterer = &testutils.MockDeviceRegistererProvider{MockProvider: provider}
+	}
+	if cfg.supportsMetadata {
+		capabilities.MetadataProvider = &testutils.MockMetadataProvider{MockProvider: provider, GetMetadataErr: cfg.metadataGetErr}
+	}
+	if cfg.supportsUserDisabledCheck {
+		capabilities.UserDisabledChecker = &testutils.MockUserDisabledCheckerProvider{
+			MockProvider:          provider,
+			UserDisabledErrorCode: cfg.userDisabledErrorCode,
+		}
+	}
+
+	return testutils.ComposeProvider(provider, capabilities)
 }
 
 // newBrokerForTests is a helper function to easily create a new broker for tests.
@@ -94,13 +120,14 @@ func newBrokerForTests(t *testing.T, cfg *brokerForTestConfig) (b *broker.Broker
 	}
 
 	provider := &testutils.MockProvider{
-		GetGroupsFails:                     cfg.getGroupsFails,
-		ProviderSupportsDeviceRegistration: cfg.supportsDeviceRegistration,
-		RequireNameClaimOnInitialAuth:      cfg.requireNameClaimOnInitialAuth,
-		FirstCallDelay:                     cfg.firstCallDelay,
-		SecondCallDelay:                    cfg.secondCallDelay,
-		GetGroupsFunc:                      cfg.getGroupsFunc,
+		GetGroupsFails:                cfg.getGroupsFails,
+		RequireNameClaimOnInitialAuth: cfg.requireNameClaimOnInitialAuth,
+		FirstCallDelay:                cfg.firstCallDelay,
+		SecondCallDelay:               cfg.secondCallDelay,
+		GetGroupsFunc:                 cfg.getGroupsFunc,
 	}
+
+	brokerProvider := brokerProviderWithOptionalCapabilities(provider, cfg)
 
 	if cfg.provider == nil {
 		cfg.SetProvider(provider)
@@ -131,7 +158,7 @@ func newBrokerForTests(t *testing.T, cfg *brokerForTestConfig) (b *broker.Broker
 		apiVersion = cfg.apiVersion
 	}
 
-	b, err := broker.New(cfg.Config, apiVersion, broker.WithCustomProvider(provider))
+	b, err := broker.New(cfg.Config, apiVersion, broker.WithCustomProvider(brokerProvider))
 	require.NoError(t, err, "Setup: New should not have returned an error")
 	return b
 }

--- a/authd-oidc-brokers/internal/broker/testdata/golden/TestIsAuthenticated/Authenticating_with_password_when_provider_has_no_group_fetcher/data/provider_url/test-user@email.com/password
+++ b/authd-oidc-brokers/internal/broker/testdata/golden/TestIsAuthenticated/Authenticating_with_password_when_provider_has_no_group_fetcher/data/provider_url/test-user@email.com/password
@@ -1,0 +1,1 @@
+Definitely a hashed password

--- a/authd-oidc-brokers/internal/broker/testdata/golden/TestIsAuthenticated/Authenticating_with_password_when_provider_has_no_group_fetcher/data/provider_url/test-user@email.com/token.json
+++ b/authd-oidc-brokers/internal/broker/testdata/golden/TestIsAuthenticated/Authenticating_with_password_when_provider_has_no_group_fetcher/data/provider_url/test-user@email.com/token.json
@@ -1,0 +1,1 @@
+Definitely a token

--- a/authd-oidc-brokers/internal/broker/testdata/golden/TestIsAuthenticated/Authenticating_with_password_when_provider_has_no_group_fetcher/first_call
+++ b/authd-oidc-brokers/internal/broker/testdata/golden/TestIsAuthenticated/Authenticating_with_password_when_provider_has_no_group_fetcher/first_call
@@ -1,0 +1,3 @@
+access: granted
+data: '{"userinfo":{"name":"test-user@email.com","uuid":"test-user-id","dir":"/home/test-user@email.com","shell":"/usr/bin/bash","gecos":"test-user","groups":null}}'
+err: <nil>

--- a/authd-oidc-brokers/internal/broker/testdata/golden/TestIsAuthenticated/Authenticating_with_password_when_provider_supports_metadata/data/provider_url/test-user@email.com/password
+++ b/authd-oidc-brokers/internal/broker/testdata/golden/TestIsAuthenticated/Authenticating_with_password_when_provider_supports_metadata/data/provider_url/test-user@email.com/password
@@ -1,0 +1,1 @@
+Definitely a hashed password

--- a/authd-oidc-brokers/internal/broker/testdata/golden/TestIsAuthenticated/Authenticating_with_password_when_provider_supports_metadata/data/provider_url/test-user@email.com/token.json
+++ b/authd-oidc-brokers/internal/broker/testdata/golden/TestIsAuthenticated/Authenticating_with_password_when_provider_supports_metadata/data/provider_url/test-user@email.com/token.json
@@ -1,0 +1,1 @@
+Definitely a token

--- a/authd-oidc-brokers/internal/broker/testdata/golden/TestIsAuthenticated/Authenticating_with_password_when_provider_supports_metadata/first_call
+++ b/authd-oidc-brokers/internal/broker/testdata/golden/TestIsAuthenticated/Authenticating_with_password_when_provider_supports_metadata/first_call
@@ -1,0 +1,3 @@
+access: granted
+data: '{"userinfo":{"name":"test-user@email.com","uuid":"test-user-id","dir":"/home/test-user@email.com","shell":"/usr/bin/bash","gecos":"test-user","groups":[{"name":"remote-test-group","ugid":"12345"},{"name":"local-test-group","ugid":""}]}}'
+err: <nil>

--- a/authd-oidc-brokers/internal/broker/testdata/golden/TestIsAuthenticated/Error_when_device_auth_metadata_provider_fails_to_get_metadata/first_call
+++ b/authd-oidc-brokers/internal/broker/testdata/golden/TestIsAuthenticated/Error_when_device_auth_metadata_provider_fails_to_get_metadata/first_call
@@ -1,0 +1,3 @@
+access: denied
+data: '{"message":"An unexpected error occurred: could not get provider metadata. Please report this error on https://github.com/canonical/authd/issues"}'
+err: <nil>

--- a/authd-oidc-brokers/internal/broker/testdata/golden/TestIsAuthenticated/Error_when_device_auth_metadata_provider_fails_to_get_metadata/second_call
+++ b/authd-oidc-brokers/internal/broker/testdata/golden/TestIsAuthenticated/Error_when_device_auth_metadata_provider_fails_to_get_metadata/second_call
@@ -1,0 +1,3 @@
+access: denied
+data: '{"message":"An unexpected error occurred: auth info is not set. Please report this error on https://github.com/canonical/authd/issues"}'
+err: <nil>

--- a/authd-oidc-brokers/internal/broker/testdata/golden/TestIsAuthenticated/Error_when_getgroups_returns_device_disabled_error/data/provider_url/test-user@email.com/password
+++ b/authd-oidc-brokers/internal/broker/testdata/golden/TestIsAuthenticated/Error_when_getgroups_returns_device_disabled_error/data/provider_url/test-user@email.com/password
@@ -1,0 +1,1 @@
+Definitely a hashed password

--- a/authd-oidc-brokers/internal/broker/testdata/golden/TestIsAuthenticated/Error_when_getgroups_returns_device_disabled_error/data/provider_url/test-user@email.com/token.json
+++ b/authd-oidc-brokers/internal/broker/testdata/golden/TestIsAuthenticated/Error_when_getgroups_returns_device_disabled_error/data/provider_url/test-user@email.com/token.json
@@ -1,0 +1,1 @@
+Definitely a token

--- a/authd-oidc-brokers/internal/broker/testdata/golden/TestIsAuthenticated/Error_when_getgroups_returns_device_disabled_error/first_call
+++ b/authd-oidc-brokers/internal/broker/testdata/golden/TestIsAuthenticated/Error_when_getgroups_returns_device_disabled_error/first_call
@@ -1,0 +1,3 @@
+access: denied
+data: '{"message":"This device is disabled in the identity provider, please contact your administrator."}'
+err: <nil>

--- a/authd-oidc-brokers/internal/broker/testdata/golden/TestIsAuthenticated/Error_when_getgroups_returns_invalid_redirect_uri_error/data/provider_url/test-user@email.com/password
+++ b/authd-oidc-brokers/internal/broker/testdata/golden/TestIsAuthenticated/Error_when_getgroups_returns_invalid_redirect_uri_error/data/provider_url/test-user@email.com/password
@@ -1,0 +1,1 @@
+Definitely a hashed password

--- a/authd-oidc-brokers/internal/broker/testdata/golden/TestIsAuthenticated/Error_when_getgroups_returns_invalid_redirect_uri_error/data/provider_url/test-user@email.com/token.json
+++ b/authd-oidc-brokers/internal/broker/testdata/golden/TestIsAuthenticated/Error_when_getgroups_returns_invalid_redirect_uri_error/data/provider_url/test-user@email.com/token.json
@@ -1,0 +1,1 @@
+Definitely a token

--- a/authd-oidc-brokers/internal/broker/testdata/golden/TestIsAuthenticated/Error_when_getgroups_returns_invalid_redirect_uri_error/first_call
+++ b/authd-oidc-brokers/internal/broker/testdata/golden/TestIsAuthenticated/Error_when_getgroups_returns_invalid_redirect_uri_error/first_call
@@ -1,0 +1,3 @@
+access: denied
+data: '{"message":"Invalid redirect URI"}'
+err: <nil>

--- a/authd-oidc-brokers/internal/broker/testdata/golden/TestIsAuthenticated/Error_when_getgroups_returns_retry_with_device_auth_error/data/provider_url/test-user@email.com/password
+++ b/authd-oidc-brokers/internal/broker/testdata/golden/TestIsAuthenticated/Error_when_getgroups_returns_retry_with_device_auth_error/data/provider_url/test-user@email.com/password
@@ -1,0 +1,1 @@
+Definitely a hashed password

--- a/authd-oidc-brokers/internal/broker/testdata/golden/TestIsAuthenticated/Error_when_getgroups_returns_retry_with_device_auth_error/data/provider_url/test-user@email.com/token.json
+++ b/authd-oidc-brokers/internal/broker/testdata/golden/TestIsAuthenticated/Error_when_getgroups_returns_retry_with_device_auth_error/data/provider_url/test-user@email.com/token.json
@@ -1,0 +1,1 @@
+Definitely a token

--- a/authd-oidc-brokers/internal/broker/testdata/golden/TestIsAuthenticated/Error_when_getgroups_returns_retry_with_device_auth_error/first_call
+++ b/authd-oidc-brokers/internal/broker/testdata/golden/TestIsAuthenticated/Error_when_getgroups_returns_retry_with_device_auth_error/first_call
@@ -1,0 +1,3 @@
+access: next
+data: '{"message":"Authentication failed due to a token issue. Please try again using device authentication."}'
+err: <nil>

--- a/authd-oidc-brokers/internal/broker/testdata/golden/TestIsAuthenticated/Error_when_user_is_disabled_according_to_user_disabled_checker/data/provider_url/test-user@email.com/password
+++ b/authd-oidc-brokers/internal/broker/testdata/golden/TestIsAuthenticated/Error_when_user_is_disabled_according_to_user_disabled_checker/data/provider_url/test-user@email.com/password
@@ -1,0 +1,1 @@
+Definitely a hashed password

--- a/authd-oidc-brokers/internal/broker/testdata/golden/TestIsAuthenticated/Error_when_user_is_disabled_according_to_user_disabled_checker/data/provider_url/test-user@email.com/token.json
+++ b/authd-oidc-brokers/internal/broker/testdata/golden/TestIsAuthenticated/Error_when_user_is_disabled_according_to_user_disabled_checker/data/provider_url/test-user@email.com/token.json
@@ -1,0 +1,1 @@
+Definitely a token

--- a/authd-oidc-brokers/internal/broker/testdata/golden/TestIsAuthenticated/Error_when_user_is_disabled_according_to_user_disabled_checker/first_call
+++ b/authd-oidc-brokers/internal/broker/testdata/golden/TestIsAuthenticated/Error_when_user_is_disabled_according_to_user_disabled_checker/first_call
@@ -1,0 +1,3 @@
+access: denied
+data: '{"message":"Your user account is disabled in the identity provider, please contact your administrator."}'
+err: <nil>

--- a/authd-oidc-brokers/internal/broker/testdata/golden/TestIsAuthenticated/Successfully_authenticate_with_device_auth_when_provider_supports_metadata/data/provider_url/test-user@email.com/password
+++ b/authd-oidc-brokers/internal/broker/testdata/golden/TestIsAuthenticated/Successfully_authenticate_with_device_auth_when_provider_supports_metadata/data/provider_url/test-user@email.com/password
@@ -1,0 +1,1 @@
+Definitely a hashed password

--- a/authd-oidc-brokers/internal/broker/testdata/golden/TestIsAuthenticated/Successfully_authenticate_with_device_auth_when_provider_supports_metadata/data/provider_url/test-user@email.com/token.json
+++ b/authd-oidc-brokers/internal/broker/testdata/golden/TestIsAuthenticated/Successfully_authenticate_with_device_auth_when_provider_supports_metadata/data/provider_url/test-user@email.com/token.json
@@ -1,0 +1,1 @@
+Definitely a token

--- a/authd-oidc-brokers/internal/broker/testdata/golden/TestIsAuthenticated/Successfully_authenticate_with_device_auth_when_provider_supports_metadata/first_call
+++ b/authd-oidc-brokers/internal/broker/testdata/golden/TestIsAuthenticated/Successfully_authenticate_with_device_auth_when_provider_supports_metadata/first_call
@@ -1,0 +1,3 @@
+access: next
+data: '{}'
+err: <nil>

--- a/authd-oidc-brokers/internal/broker/testdata/golden/TestIsAuthenticated/Successfully_authenticate_with_device_auth_when_provider_supports_metadata/second_call
+++ b/authd-oidc-brokers/internal/broker/testdata/golden/TestIsAuthenticated/Successfully_authenticate_with_device_auth_when_provider_supports_metadata/second_call
@@ -1,0 +1,3 @@
+access: granted
+data: '{"userinfo":{"name":"test-user@email.com","uuid":"test-user-id","dir":"/home/test-user@email.com","shell":"/usr/bin/bash","gecos":"test-user","groups":[{"name":"remote-test-group","ugid":"12345"},{"name":"local-test-group","ugid":""}]}}'
+err: <nil>

--- a/authd-oidc-brokers/internal/providers/errors/errors.go
+++ b/authd-oidc-brokers/internal/providers/errors/errors.go
@@ -5,6 +5,31 @@
 // provider packages in the future, so it's not worth the effort to fix this now.
 package errors
 
+import stderrors "errors"
+
+// ErrDeviceDisabled is returned when the device is disabled in the identity provider.
+var ErrDeviceDisabled = stderrors.New("device is disabled")
+
+// ErrInvalidRedirectURI is returned when the redirect URI of the client application is missing or invalid.
+var ErrInvalidRedirectURI = stderrors.New("invalid redirect URI")
+
+// RetryWithDeviceAuthError is returned when token acquisition fails and the user should retry
+// using device authentication (e.g. because the device was deleted by an administrator).
+type RetryWithDeviceAuthError struct {
+	Err error
+}
+
+func (e *RetryWithDeviceAuthError) Error() string {
+	if e.Err != nil {
+		return e.Err.Error()
+	}
+	return "token acquisition failed, retry with device authentication"
+}
+
+func (e *RetryWithDeviceAuthError) Unwrap() error {
+	return e.Err
+}
+
 // ForDisplayError is an error type for errors that are meant to be displayed to the user.
 type ForDisplayError struct {
 	Message string

--- a/authd-oidc-brokers/internal/providers/errors/errors_test.go
+++ b/authd-oidc-brokers/internal/providers/errors/errors_test.go
@@ -1,0 +1,54 @@
+package errors_test
+
+import (
+	"errors"
+	"testing"
+
+	providerErrors "github.com/canonical/authd/authd-oidc-brokers/internal/providers/errors"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRetryWithDeviceAuthError(t *testing.T) {
+	t.Parallel()
+
+	t.Run("Error_returns_wrapped_error_message_when_error_is_set", func(t *testing.T) {
+		t.Parallel()
+
+		inner := errors.New("inner error")
+		err := &providerErrors.RetryWithDeviceAuthError{Err: inner}
+		require.Equal(t, "inner error", err.Error())
+	})
+
+	t.Run("Error_returns_default_message_when_error_is_nil", func(t *testing.T) {
+		t.Parallel()
+
+		err := &providerErrors.RetryWithDeviceAuthError{}
+		require.Equal(t, "token acquisition failed, retry with device authentication", err.Error())
+	})
+
+	t.Run("Unwrap_returns_wrapped_error", func(t *testing.T) {
+		t.Parallel()
+
+		inner := errors.New("inner error")
+		err := &providerErrors.RetryWithDeviceAuthError{Err: inner}
+		require.Equal(t, inner, err.Unwrap())
+		require.ErrorIs(t, err, inner)
+	})
+
+	t.Run("Unwrap_returns_nil_when_no_wrapped_error", func(t *testing.T) {
+		t.Parallel()
+
+		err := &providerErrors.RetryWithDeviceAuthError{}
+		require.Nil(t, err.Unwrap())
+	})
+
+	t.Run("errors_As_matches_RetryWithDeviceAuthError", func(t *testing.T) {
+		t.Parallel()
+
+		inner := errors.New("cause")
+		original := &providerErrors.RetryWithDeviceAuthError{Err: inner}
+		var target *providerErrors.RetryWithDeviceAuthError
+		require.ErrorAs(t, original, &target)
+		require.Equal(t, original, target)
+	})
+}

--- a/authd-oidc-brokers/internal/providers/genericprovider/genericprovider.go
+++ b/authd-oidc-brokers/internal/providers/genericprovider/genericprovider.go
@@ -2,7 +2,6 @@
 package genericprovider
 
 import (
-	"context"
 	"errors"
 	"fmt"
 	"slices"
@@ -11,7 +10,6 @@ import (
 	"github.com/canonical/authd/authd-oidc-brokers/internal/broker/authmodes"
 	providerErrors "github.com/canonical/authd/authd-oidc-brokers/internal/providers/errors"
 	"github.com/canonical/authd/authd-oidc-brokers/internal/providers/info"
-	"github.com/coreos/go-oidc/v3/oidc"
 	"golang.org/x/oauth2"
 )
 
@@ -36,16 +34,6 @@ func (p GenericProvider) AdditionalScopes() []string {
 // AuthOptions is a no-op when no specific provider is in use.
 func (p GenericProvider) AuthOptions() []oauth2.AuthCodeOption {
 	return []oauth2.AuthCodeOption{}
-}
-
-// GetExtraFields returns the extra fields of the token which should be stored persistently.
-func (p GenericProvider) GetExtraFields(token *oauth2.Token) map[string]interface{} {
-	return nil
-}
-
-// GetMetadata is a no-op when no specific provider is in use.
-func (p GenericProvider) GetMetadata(provider *oidc.Provider) (map[string]interface{}, error) {
-	return nil, nil
 }
 
 // GetUserInfo returns user information from the claims of the provided Claimer.
@@ -95,11 +83,6 @@ func (p GenericProvider) GetUserInfo(claimer info.Claimer, _ bool) (info.User, e
 	), nil
 }
 
-// GetGroups is a no-op when no specific provider is in use.
-func (GenericProvider) GetGroups(ctx context.Context, clientID string, issuerURL string, token *oauth2.Token, providerMetadata map[string]interface{}, deviceRegistrationData []byte) ([]info.Group, error) {
-	return nil, nil
-}
-
 // NormalizeUsername parses a username into a normalized version.
 func (p GenericProvider) NormalizeUsername(username string) string {
 	return username
@@ -135,24 +118,4 @@ func (p GenericProvider) IsTokenExpiredError(err *oauth2.RetrieveError) bool {
 	return slices.ContainsFunc(expiredDescriptions, func(desc string) bool {
 		return strings.Contains(err.ErrorDescription, desc)
 	})
-}
-
-// IsUserDisabledError returns false, as the generic provider does not support disabling users.
-func (p GenericProvider) IsUserDisabledError(_ *oauth2.RetrieveError) bool {
-	return false
-}
-
-// SupportsDeviceRegistration returns false, as the generic provider does not support device registration.
-func (p GenericProvider) SupportsDeviceRegistration() bool {
-	return false
-}
-
-// IsTokenForDeviceRegistration returns false, as the generic provider does not support device registration.
-func (p GenericProvider) IsTokenForDeviceRegistration(_ *oauth2.Token) (bool, error) {
-	return false, nil
-}
-
-// MaybeRegisterDevice is a no-op when no specific provider is in use.
-func (p GenericProvider) MaybeRegisterDevice(_ context.Context, _ *oauth2.Token, _, _ string, _ []byte) ([]byte, func(), error) {
-	return nil, func() {}, nil
 }

--- a/authd-oidc-brokers/internal/providers/msentraid/msentraid.go
+++ b/authd-oidc-brokers/internal/providers/msentraid/msentraid.go
@@ -158,11 +158,15 @@ func (p *Provider) GetGroups(
 		tenantID := tenantID(issuerURL)
 		accessTokenStr, err = himmelblau.AcquireAccessTokenForGraphAPI(ctx, clientID, tenantID, token, data)
 		if errors.Is(err, himmelblau.ErrDeviceDisabled) {
-			return nil, err
+			return nil, fmt.Errorf("%w: %w", providerErrors.ErrDeviceDisabled, err)
 		}
 		if errors.Is(err, himmelblau.ErrInvalidRedirectURI) {
 			msg := "Token acquisition failed: The app is misconfigured in Microsoft Entra (the redirect URI is missing or invalid). Please contact your administrator."
-			return nil, &providerErrors.ForDisplayError{Message: msg, Err: err}
+			return nil, &providerErrors.ForDisplayError{Message: msg, Err: fmt.Errorf("%w: %w", providerErrors.ErrInvalidRedirectURI, err)}
+		}
+		var tokenAcquisitionError himmelblau.TokenAcquisitionError
+		if errors.As(err, &tokenAcquisitionError) {
+			return nil, &providerErrors.RetryWithDeviceAuthError{Err: fmt.Errorf("failed to acquire access token for Microsoft Graph API: %w", err)}
 		}
 		if err != nil {
 			return nil, fmt.Errorf("failed to acquire access token for Microsoft Graph API: %w", err)

--- a/authd-oidc-brokers/internal/providers/msentraid/msentraid.go
+++ b/authd-oidc-brokers/internal/providers/msentraid/msentraid.go
@@ -439,12 +439,6 @@ func (p *Provider) VerifyUsername(requestedUsername, authenticatedUsername strin
 	return nil
 }
 
-// SupportsDeviceRegistration checks if the provider supports device registration.
-func (p *Provider) SupportsDeviceRegistration() bool {
-	// The Microsoft Entra ID provider supports device registration.
-	return true
-}
-
 // IsTokenForDeviceRegistration checks if the token is for device registration.
 func (p *Provider) IsTokenForDeviceRegistration(token *oauth2.Token) (bool, error) {
 	accessToken, _, err := new(jwt.Parser).ParseUnverified(token.AccessToken, jwt.MapClaims{})

--- a/authd-oidc-brokers/internal/providers/providers.go
+++ b/authd-oidc-brokers/internal/providers/providers.go
@@ -9,16 +9,21 @@ import (
 	"golang.org/x/oauth2"
 )
 
-// Provider defines provider-specific methods to be used by the broker.
+// Provider defines the core provider-specific methods required by the broker.
+// Every provider implementation must satisfy this interface.
 type Provider interface {
 	AdditionalScopes() []string
 	AuthOptions() []oauth2.AuthCodeOption
 	DisplayName() string
-	GetExtraFields(token *oauth2.Token) map[string]interface{}
-	GetMetadata(provider *oidc.Provider) (map[string]interface{}, error)
-
 	GetUserInfo(claimer info.Claimer, isRefresh bool) (info.User, error)
+	IsTokenExpiredError(err *oauth2.RetrieveError) bool
+	NormalizeUsername(username string) string
+	SupportedOIDCAuthModes() []string
+	VerifyUsername(requestedUsername, authenticatedUsername string) error
+}
 
+// GroupFetcher is implemented by providers that can fetch group memberships from the identity provider.
+type GroupFetcher interface {
 	GetGroups(
 		ctx context.Context,
 		clientID string,
@@ -27,11 +32,17 @@ type Provider interface {
 		providerMetadata map[string]interface{},
 		deviceRegistrationData []byte,
 	) ([]info.Group, error)
+}
 
-	IsTokenExpiredError(err *oauth2.RetrieveError) bool
-	IsUserDisabledError(err *oauth2.RetrieveError) bool
+// MetadataProvider is implemented by providers that supply extra metadata or token fields.
+type MetadataProvider interface {
+	GetMetadata(provider *oidc.Provider) (map[string]interface{}, error)
+	GetExtraFields(token *oauth2.Token) map[string]interface{}
+}
+
+// DeviceRegisterer is implemented by providers that support device registration.
+type DeviceRegisterer interface {
 	IsTokenForDeviceRegistration(token *oauth2.Token) (bool, error)
-
 	MaybeRegisterDevice(
 		ctx context.Context,
 		token *oauth2.Token,
@@ -39,9 +50,36 @@ type Provider interface {
 		issuerURL string,
 		deviceRegistrationData []byte,
 	) ([]byte, func(), error)
+}
 
-	NormalizeUsername(username string) string
-	SupportedOIDCAuthModes() []string
-	VerifyUsername(requestedUsername, authenticatedUsername string) error
-	SupportsDeviceRegistration() bool
+// UserDisabledChecker is implemented by providers that can detect disabled users
+// from token refresh errors.
+type UserDisabledChecker interface {
+	IsUserDisabledError(err *oauth2.RetrieveError) bool
+}
+
+// Capability is an optional interface that allows a Provider to expose optional
+// interfaces dynamically, similar to errors.As. Composed or wrapped providers
+// should implement this to avoid combinatorial type-switch boilerplate.
+type Capability interface {
+	// ProviderAs sets *target to the capability of type T if available, and
+	// returns true. If the capability is not available, it returns false
+	// without modifying *target.
+	ProviderAs(target any) bool
+}
+
+// ProviderAs checks whether p exposes optional capability T. It first checks
+// if p implements Capability (for composed/wrapped providers), then falls back
+// to a direct interface assertion.
+func ProviderAs[T any](p Provider) (T, bool) {
+	if c, ok := p.(Capability); ok {
+		var t T
+		if c.ProviderAs(&t) {
+			return t, true
+		}
+		var zero T
+		return zero, false
+	}
+	t, ok := p.(T)
+	return t, ok
 }

--- a/authd-oidc-brokers/internal/testutils/provider.go
+++ b/authd-oidc-brokers/internal/testutils/provider.go
@@ -14,11 +14,13 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"net/http/httputil"
+	"reflect"
 	"strings"
 	"sync"
 	"time"
 
 	"github.com/canonical/authd/authd-oidc-brokers/internal/consts"
+	"github.com/canonical/authd/authd-oidc-brokers/internal/providers"
 	providerErrors "github.com/canonical/authd/authd-oidc-brokers/internal/providers/errors"
 	"github.com/canonical/authd/authd-oidc-brokers/internal/providers/genericprovider"
 	"github.com/canonical/authd/authd-oidc-brokers/internal/providers/info"
@@ -394,14 +396,13 @@ func ExpiryDeviceAuthHandler() EndpointHandler {
 // MockProvider is a mock that implements the Provider interface.
 type MockProvider struct {
 	genericprovider.GenericProvider
-	Scopes                             []string
-	Options                            []oauth2.AuthCodeOption
-	GetGroupsFunc                      func() ([]info.Group, error)
-	FirstCallDelay                     int
-	SecondCallDelay                    int
-	GetGroupsFails                     bool
-	ProviderSupportsDeviceRegistration bool
-	RequireNameClaimOnInitialAuth      bool
+	Scopes                        []string
+	Options                       []oauth2.AuthCodeOption
+	GetGroupsFunc                 func() ([]info.Group, error)
+	FirstCallDelay                int
+	SecondCallDelay               int
+	GetGroupsFails                bool
+	RequireNameClaimOnInitialAuth bool
 
 	numCalls     int
 	numCallsLock sync.Mutex
@@ -426,11 +427,6 @@ func (p *MockProvider) AuthOptions() []oauth2.AuthCodeOption {
 // NormalizeUsername parses a username into a normalized version.
 func (p *MockProvider) NormalizeUsername(username string) string {
 	return strings.ToLower(username)
-}
-
-// GetMetadata is a no-op when no specific provider is in use.
-func (p *MockProvider) GetMetadata(provider *oidc.Provider) (map[string]interface{}, error) {
-	return nil, nil
 }
 
 // GetUserInfo returns the user info parsed from the provided Claimer.
@@ -491,25 +487,6 @@ func (p *MockProvider) GetGroups(ctx context.Context, clientID string, issuerURL
 	return userGroups, nil
 }
 
-// IsTokenForDeviceRegistration checks if the token is for device registration.
-func (p *MockProvider) IsTokenForDeviceRegistration(token *oauth2.Token) (bool, error) {
-	if token == nil {
-		return false, errors.New("token is nil")
-	}
-
-	isForDeviceRegistration, ok := token.Extra(IsForDeviceRegistrationClaim).(bool)
-	if !ok {
-		return false, fmt.Errorf("token does not contain %q claim", IsForDeviceRegistrationClaim)
-	}
-
-	return isForDeviceRegistration, nil
-}
-
-// SupportsDeviceRegistration checks if the provider supports device registration.
-func (p *MockProvider) SupportsDeviceRegistration() bool {
-	return p.ProviderSupportsDeviceRegistration
-}
-
 type claims struct {
 	Email    string `json:"email"`
 	Sub      string `json:"sub"`
@@ -526,4 +503,115 @@ func (p *MockProvider) userClaims(idToken info.Claimer) (claims, error) {
 		return claims{}, fmt.Errorf("failed to get ID token claims: %v", err)
 	}
 	return userClaims, nil
+}
+
+// MockDeviceRegistererProvider wraps MockProvider and adds DeviceRegisterer support.
+// Use this when tests need the provider to implement the DeviceRegisterer interface.
+type MockDeviceRegistererProvider struct {
+	*MockProvider
+}
+
+// IsTokenForDeviceRegistration checks if the token is for device registration.
+func (p *MockDeviceRegistererProvider) IsTokenForDeviceRegistration(token *oauth2.Token) (bool, error) {
+	if token == nil {
+		return false, errors.New("token is nil")
+	}
+
+	isForDeviceRegistration, ok := token.Extra(IsForDeviceRegistrationClaim).(bool)
+	if !ok {
+		return false, fmt.Errorf("token does not contain %q claim", IsForDeviceRegistrationClaim)
+	}
+
+	return isForDeviceRegistration, nil
+}
+
+// MaybeRegisterDevice is a no-op for the mock device registrar.
+func (p *MockDeviceRegistererProvider) MaybeRegisterDevice(_ context.Context, _ *oauth2.Token, _, _ string, _ []byte) ([]byte, func(), error) {
+	return nil, func() {}, nil
+}
+
+// MockMetadataProvider wraps MockProvider and adds MetadataProvider support.
+// Use this when tests need the provider to implement the MetadataProvider interface.
+type MockMetadataProvider struct {
+	*MockProvider
+	GetMetadataErr error
+}
+
+// GetMetadata returns a fixed metadata map, or the configured error.
+func (p *MockMetadataProvider) GetMetadata(_ *oidc.Provider) (map[string]interface{}, error) {
+	if p.GetMetadataErr != nil {
+		return nil, p.GetMetadataErr
+	}
+	return map[string]interface{}{"test-metadata": "test-value"}, nil
+}
+
+// GetExtraFields returns a fixed extra-fields map for the given token.
+func (p *MockMetadataProvider) GetExtraFields(_ *oauth2.Token) map[string]interface{} {
+	return map[string]interface{}{"test-extra-field": "test-value"}
+}
+
+// MockUserDisabledCheckerProvider wraps MockProvider and adds UserDisabledChecker support.
+// Use this when tests need the provider to implement the UserDisabledChecker interface.
+type MockUserDisabledCheckerProvider struct {
+	*MockProvider
+	// UserDisabledErrorCode is the OAuth2 error code that signals a disabled user.
+	UserDisabledErrorCode string
+}
+
+// IsUserDisabledError returns true when the retrieve error code matches UserDisabledErrorCode.
+func (p *MockUserDisabledCheckerProvider) IsUserDisabledError(err *oauth2.RetrieveError) bool {
+	return err.ErrorCode == p.UserDisabledErrorCode
+}
+
+// ProviderCapabilities enumerates the optional provider interfaces to expose.
+type ProviderCapabilities struct {
+	GroupFetcher        providers.GroupFetcher
+	DeviceRegisterer    providers.DeviceRegisterer
+	MetadataProvider    providers.MetadataProvider
+	UserDisabledChecker providers.UserDisabledChecker
+}
+
+// ComposeProvider returns a provider exposing only the requested optional interfaces.
+func ComposeProvider(provider providers.Provider, capabilities ProviderCapabilities) providers.Provider {
+	caps := make(map[reflect.Type]any)
+	if capabilities.GroupFetcher != nil {
+		caps[reflect.TypeOf((*providers.GroupFetcher)(nil)).Elem()] = capabilities.GroupFetcher
+	}
+	if capabilities.DeviceRegisterer != nil {
+		caps[reflect.TypeOf((*providers.DeviceRegisterer)(nil)).Elem()] = capabilities.DeviceRegisterer
+	}
+	if capabilities.MetadataProvider != nil {
+		caps[reflect.TypeOf((*providers.MetadataProvider)(nil)).Elem()] = capabilities.MetadataProvider
+	}
+	if capabilities.UserDisabledChecker != nil {
+		caps[reflect.TypeOf((*providers.UserDisabledChecker)(nil)).Elem()] = capabilities.UserDisabledChecker
+	}
+	return &composedProvider{provider, caps}
+}
+
+type composedProvider struct {
+	providers.Provider
+	caps map[reflect.Type]any
+}
+
+func (c *composedProvider) ProviderAs(target any) bool {
+	tv := reflect.ValueOf(target)
+	if tv.Kind() != reflect.Pointer || tv.IsNil() {
+		return false
+	}
+	elem := tv.Elem()
+	if capability, ok := c.caps[elem.Type()]; ok {
+		elem.Set(reflect.ValueOf(capability))
+		return true
+	}
+	return false
+}
+
+// ErrorResponseHandler returns a handler that responds with the given HTTP status code and JSON body.
+func ErrorResponseHandler(statusCode int, body string) EndpointHandler {
+	return func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Add("Content-Type", "application/json")
+		w.WriteHeader(statusCode)
+		_, _ = w.Write([]byte(body))
+	}
 }

--- a/authd-oidc-brokers/internal/token/token.go
+++ b/authd-oidc-brokers/internal/token/token.go
@@ -7,7 +7,6 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/canonical/authd/authd-oidc-brokers/internal/providers"
 	"github.com/canonical/authd/authd-oidc-brokers/internal/providers/info"
 	"golang.org/x/oauth2"
 )
@@ -24,13 +23,13 @@ type AuthCachedInfo struct {
 	UserIsDisabled         bool
 }
 
-// NewAuthCachedInfo creates a new AuthCachedInfo. It sets the provided token and rawIDToken and the provider-specific
+// NewAuthCachedInfo creates a new AuthCachedInfo. It sets the provided token, rawIDToken, and
 // extra fields which should be stored persistently.
-func NewAuthCachedInfo(token *oauth2.Token, rawIDToken string, provider providers.Provider) *AuthCachedInfo {
+func NewAuthCachedInfo(token *oauth2.Token, rawIDToken string, extraFields map[string]interface{}) *AuthCachedInfo {
 	return &AuthCachedInfo{
 		Token:       token,
 		RawIDToken:  rawIDToken,
-		ExtraFields: provider.GetExtraFields(token),
+		ExtraFields: extraFields,
 	}
 }
 


### PR DESCRIPTION
Fixes #1549
UDENG-9739

## Motivation

See #1549

## Summary

Split the monolithic 16-method `providers.Provider` interface into a minimal core plus well-defined optional interfaces, and add shared error types to eliminate the broker's direct dependency on `msentraid/himmelblau`.

## Changes

### Commit 1: Shared error types
- Add `ErrDeviceDisabled`, `ErrInvalidRedirectURI`, `RetryWithDeviceAuthError` to `providers/errors`
- msentraid wraps himmelblau errors into these shared types in `GetGroups`
- Broker checks shared error types — removes the `msentraid/himmelblau` import from broker

### Commit 2: Split Provider interface

**Core `Provider` interface** (8 methods — required by all providers):
`AdditionalScopes`, `AuthOptions`, `DisplayName`, `GetUserInfo`, `IsTokenExpiredError`, `NormalizeUsername`, `SupportedOIDCAuthModes`, `VerifyUsername`

**Optional interfaces** (broker uses type assertions):
- `GroupFetcher` — `GetGroups`
- `MetadataProvider` — `GetMetadata`, `GetExtraFields`
- `DeviceRegistrar` — `IsTokenForDeviceRegistration`, `MaybeRegisterDevice`
- `UserDisabledChecker` — `IsUserDisabledError`

**Other changes:**
- Remove 7 no-op methods from `GenericProvider`
- Remove `SupportsDeviceRegistration()` — replaced by `DeviceRegistrar` type assertion
- `token.NewAuthCachedInfo` takes `extraFields map[string]interface{}` instead of `providers.Provider`
- `MockDeviceRegistrarProvider` wrapper lets tests control whether the mock satisfies `DeviceRegistrar`
