### PR TITLE
pam/integration-tests: Fix "Could not chdir to home directory" in SSH tests

### DIFF
--- a/e2e-tests/vm/ssh.sh
+++ b/e2e-tests/vm/ssh.sh
@@ -5,12 +5,16 @@ set -euo pipefail
 usage(){
     cat << EOF
 
-    Usage: $0 --release <release> [ssh options]
+    Usage: $0 --release <release> --user <user> [--] [ssh_options]
 
     SSH into the e2e-test VM for the specified Ubuntu release.
 
+    Options:
+      --release, -r <release>    The Ubuntu release to connect to (e.g., "noble", "resolute").
+      --user, -u <user>          The SSH user to connect as (default: "root").
+
     Example:
-      $0 --release questing
+      $0 --release resolute
 EOF
 }
 
@@ -24,6 +28,10 @@ while [[ $# -gt 0 ]]; do
             RELEASE="$2"
             shift 2
             ;;
+        -u|--user)
+            SSH_USER="$2"
+            shift 2
+            ;;
         --)
             shift
             break
@@ -34,12 +42,13 @@ while [[ $# -gt 0 ]]; do
     esac
 done
 
-
 if [ -z "${VM_NAME:-}" ] && [ -z "${RELEASE:-}" ]; then
     echo >&2 "Error: Missing required argument <release>"
     usage >&2
     exit 1
 fi
+
+SSH_USER=${SSH_USER:-"root"}
 
 VM_NAME=${VM_NAME:-"e2e-runner-${RELEASE}"}
 
@@ -51,4 +60,4 @@ exec ssh \
   -o UserKnownHostsFile=/dev/null \
   -o StrictHostKeyChecking=no \
   -o LogLevel=ERROR \
-  root@localhost "$@"
+  "${SSH_USER}@localhost" "$@"

--- a/internal/testlog/testlog.go
+++ b/internal/testlog/testlog.go
@@ -15,6 +15,8 @@ import (
 var (
 	isVerboseOnce sync.Once
 	isVerbose     bool
+	isQuietOnce   sync.Once
+	isQuiet       bool
 )
 
 type runWithTimingOptions struct {
@@ -201,6 +203,9 @@ func highRed(s string) string {
 //
 //nolint:thelper // we're not using t in any way that requires the helper annotation
 func testOutput(t *testing.T) io.Writer {
+	if Quiet() {
+		return io.Discard
+	}
 	if t != nil {
 		return &syncWriter{w: t.Output()}
 	}
@@ -224,6 +229,14 @@ func verbose() bool {
 		}
 	})
 	return isVerbose
+}
+
+// Quiet returns whether quiet mode is enabled, which is controlled by the AUTHD_TESTS_QUIET environment variable.
+func Quiet() bool {
+	isQuietOnce.Do(func() {
+		isQuiet = os.Getenv("AUTHD_TESTS_QUIET") != ""
+	})
+	return isQuiet
 }
 
 // syncWriter is a writer that synchronizes writes to its underlying writer.

--- a/internal/testutils/daemon.go
+++ b/internal/testutils/daemon.go
@@ -194,7 +194,10 @@ paths:
 
 		// For shared authd instances, we can't redirect the output to the test log,
 		// because the instance could still be running after the test finishes.
-		if opts.shared {
+		if testlog.Quiet() {
+			cmd.Stdout = nil
+			cmd.Stderr = nil
+		} else if opts.shared {
 			cmd.Stdout = os.Stdout
 			cmd.Stderr = os.Stderr
 		} else {
@@ -204,8 +207,13 @@ paths:
 
 		if opts.saveOutputAsTestArtifact {
 			authdOutput := &SyncBuffer{}
-			cmd.Stdout = io.MultiWriter(cmd.Stdout, authdOutput)
-			cmd.Stderr = io.MultiWriter(cmd.Stderr, authdOutput)
+			if testlog.Quiet() {
+				cmd.Stdout = authdOutput
+				cmd.Stderr = authdOutput
+			} else {
+				cmd.Stdout = io.MultiWriter(cmd.Stdout, authdOutput)
+				cmd.Stderr = io.MultiWriter(cmd.Stderr, authdOutput)
+			}
 			MaybeSaveBufferAsArtifactOnCleanup(t, authdOutput, "authd.log")
 		}
 

--- a/pam/integration-tests/ssh_test.go
+++ b/pam/integration-tests/ssh_test.go
@@ -328,7 +328,7 @@ func testSSHAuthenticate(t *testing.T, sharedSSHD bool) {
 			tapeVariables: map[string]string{
 				vhsCommandFinalAuthWaitVariable: fmt.Sprintf(
 					`Wait+Screen /Too many authentication failures/
-Wait@%dms`, sshDefaultFinalWaitTimeout),
+Wait@%dms`, sshDefaultFinalWaitTimeout.Milliseconds()),
 			},
 		},
 		"Deny_authentication_if_user_does_not_exist": {

--- a/pam/integration-tests/ssh_test.go
+++ b/pam/integration-tests/ssh_test.go
@@ -155,7 +155,8 @@ func testSSHAuthenticate(t *testing.T, sharedSSHD bool) {
 	var sharedSSHDPort, sharedSSHDUserHome, sharedAuthdSocket, sharedAuthdGroupOutput string
 	prepareSharedSSHDTests := func(subtest *testing.T) {
 		t.Logf("Preparing SSH tests with shared sshd, triggered by %q", subtest.Name())
-		sharedAuthdSocket, sharedAuthdGroupOutput = sharedAuthd(t)
+		sharedAuthdSocket, sharedAuthdGroupOutput = sharedAuthd(t,
+			testutils.WithHomeBaseDir(sshTestsHomeBase))
 		serviceFile := createSSHDServiceFile(t, execModule, execChild, pamMkHomeDirModule, sharedAuthdSocket)
 		sshdEnv = append(sshdEnv, nssEnv...)
 		sshdEnv = append(sshdEnv, fmt.Sprintf("AUTHD_NSS_SOCKET=%s", sharedAuthdSocket))
@@ -452,7 +453,8 @@ Wait@%dms`, sshDefaultFinalWaitTimeout.Milliseconds()),
 			} else if !sharedSSHD {
 				socketPath, groupOutput = sharedAuthd(t,
 					testutils.WithGroupFileOutput(sharedAuthdGroupOutput),
-					testutils.WithEnvironment(authdEnv...))
+					testutils.WithEnvironment(authdEnv...),
+					testutils.WithHomeBaseDir(sshTestsHomeBase))
 			}
 			if tc.socketPath != "" {
 				socketPath = tc.socketPath
@@ -684,7 +686,7 @@ func startSSHDForTest(t *testing.T, serviceFile, hostKey, user string, preloadLi
 		fmt.Sprintf("HOME=%s", sshTestsHomeBase),
 		fmt.Sprintf("LD_PRELOAD=%s", strings.Join(preloadLibraries, ":")),
 		fmt.Sprintf("AUTHD_TEST_SSH_USER=%s", user),
-		fmt.Sprintf("AUTHD_TEST_SSH_HOME=%s", userHome),
+		fmt.Sprintf("AUTHD_TEST_SSH_HOME_BASE=%s", sshTestsHomeBase),
 		fmt.Sprintf("AUTHD_TEST_SSH_PAM_SERVICE=%s", serviceFile),
 	}, env...))
 

--- a/pam/integration-tests/ssh_test.go
+++ b/pam/integration-tests/ssh_test.go
@@ -600,12 +600,27 @@ func sanitizedOutput(t *testing.T, td *tapeData) string {
 func createSSHDServiceFile(t *testing.T, module, execChild, mkHomeModule, socketPath string) string {
 	t.Helper()
 
+	pamLog := filepath.Join(t.TempDir(), "authd-pam.log")
+	err := os.WriteFile(pamLog, []byte{}, 0600)
+	require.NoError(t, err, "Setup: Could not create pam_authd log file")
+	testutils.MaybeSaveFilesAsArtifactsOnCleanup(t, pamLog)
+	t.Cleanup(func() {
+		out, err := os.ReadFile(pamLog)
+		if errors.Is(err, os.ErrNotExist) {
+			return
+		}
+		require.NoError(t, err, "Teardown: Impossible to read pam_authd logs")
+		if !testlog.Quiet() {
+			_, _ = fmt.Fprintf(os.Stderr, "pam_authd output for %s:\n%s\n", t.Name(), out)
+		}
+	})
+
 	moduleArgs := []string{
 		execChild,
 		"socket=" + socketPath,
 		fmt.Sprintf("connection_timeout=%d", defaultConnectionTimeout),
 		"debug=true",
-		"logfile=" + os.Stderr.Name(),
+		"logfile=" + pamLog,
 		"--exec-debug",
 	}
 
@@ -724,7 +739,11 @@ func startSSHD(t *testing.T, hostKey, forcedCommand string, env []string) string
 
 	// Write stdout/stderr both to our stdout/stderr and to the buffer
 	sshd.Stdout = io.MultiWriter(t.Output(), sshdOutput)
-	sshd.Stderr = io.MultiWriter(newFilteredStderrWriter(t.Output()), sshdOutput)
+	if testlog.Quiet() {
+		sshd.Stderr = sshdOutput
+	} else {
+		sshd.Stderr = io.MultiWriter(newFilteredStderrWriter(t.Output()), sshdOutput)
+	}
 
 	testlog.LogCommand(t, "Starting sshd", sshd)
 	start := time.Now()

--- a/pam/integration-tests/sshd_preloader/sshd_preloader.c
+++ b/pam/integration-tests/sshd_preloader/sshd_preloader.c
@@ -26,6 +26,7 @@ typedef struct {
   struct passwd parent;
 
   char *authd_name;
+  char *home_path;
 } MockPasswd;
 
 static MockPasswd passwd_entities[512];
@@ -40,20 +41,23 @@ __attribute__((destructor))
 void destructor (void)
 {
   for (size_t i = 0; i < SIZE_OF_ARRAY (passwd_entities); ++i)
-    free (passwd_entities[i].authd_name);
+    {
+      free (passwd_entities[i].authd_name);
+      free (passwd_entities[i].home_path);
+    }
 
   fprintf (stderr, "sshd_preloader[%d]: Library unloaded\n", getpid ());
 }
 
 static const char *
-get_home_path (void)
+get_home_base_path (void)
 {
-  const char *home_path = getenv ("AUTHD_TEST_SSH_HOME");
+  const char *base_path = getenv ("AUTHD_TEST_SSH_HOME_BASE");
 
-  if (home_path == NULL)
+  if (base_path == NULL)
     return "/not-existing-home";
 
-  return home_path;
+  return base_path;
 }
 
 static bool
@@ -117,6 +121,9 @@ getpwnam (const char *name)
   struct passwd *passwd_entity = NULL;
   static atomic_int last_entity_idx;
   int entity_idx;
+#ifdef AUTHD_TESTS_SSH_USE_AUTHD_NSS
+  struct passwd *nss_entity = NULL;
+#endif
 
   if (orig_getpwnam == NULL)
     {
@@ -135,6 +142,8 @@ getpwnam (const char *name)
 #ifdef AUTHD_TESTS_SSH_USE_AUTHD_NSS
   if ((passwd_entity = orig_getpwnam (name)))
     {
+      nss_entity = passwd_entity;
+
       fprintf (stderr, "sshd_preloader[%d]: Simulating to be the broker user %s (%d:%d)\n",
                getpid (), passwd_entity->pw_name, passwd_entity->pw_uid,
                passwd_entity->pw_gid);
@@ -175,6 +184,19 @@ getpwnam (const char *name)
       if (!passwd_entity->pw_name || strcmp (passwd_entity->pw_name, name) != 0)
         continue;
 
+#ifdef AUTHD_TESTS_SSH_USE_AUTHD_NSS
+      /* Update the cached entry with the latest NSS data so that fields
+       * like pw_dir reflect the broker-assigned home directory once the
+       * user has been authenticated and is known to authd.
+       */
+      if (nss_entity)
+        {
+          passwd_entity->pw_dir = nss_entity->pw_dir;
+          passwd_entity->pw_gecos = nss_entity->pw_gecos;
+          passwd_entity->pw_shell = nss_entity->pw_shell;
+        }
+#endif
+
       fprintf (stderr, "sshd_preloader[%d]: Recycling fake entity for user %s\n",
                getpid (), name);
       return passwd_entity;
@@ -193,10 +215,23 @@ getpwnam (const char *name)
 
   if (passwd_entity->pw_name == NULL)
     {
+      MockPasswd *mock_passwd = &passwd_entities[entity_idx];
+
       passwd_entity->pw_shell = AUTHD_TEST_SHELL;
       passwd_entity->pw_gecos = AUTHD_TEST_GECOS;
       passwd_entity->pw_name = (char *) name;
-      passwd_entity->pw_dir = (char *) get_home_path ();
+
+      /* Construct a per-user home path from the base dir + username,
+       * so each user gets their own home directory even in the shared
+       * sshd case where AUTHD_TEST_SSH_USER is the accept-all user.
+       */
+      free (mock_passwd->home_path);
+      if (asprintf (&mock_passwd->home_path, "%s/%s",
+                    get_home_base_path (), name) < 0)
+        mock_passwd->home_path = NULL;
+      passwd_entity->pw_dir = mock_passwd->home_path
+                                ? mock_passwd->home_path
+                                : (char *) get_home_base_path ();
 
       if (!is_lower_case (passwd_entity->pw_name))
         {
@@ -230,6 +265,57 @@ getpwnam (const char *name)
            passwd_entity->pw_gid);
 
   return passwd_entity;
+}
+
+/*
+ * Override getpwnam_r() so that pam_modutil_getpwnam() (which uses
+ * getpwnam_r internally) can also find our fake test users.
+ * Without this, pam_mkhomedir fails to look up the user and does not
+ * create the home directory, causing sshd to print
+ * "Could not chdir to home directory".
+ */
+int
+getpwnam_r (const char *name, struct passwd *pwd, char *buf, size_t buflen,
+            struct passwd **result)
+{
+  static int (*orig_getpwnam_r) (const char *, struct passwd *, char *,
+                                 size_t, struct passwd **) = NULL;
+
+  if (orig_getpwnam_r == NULL)
+    {
+      orig_getpwnam_r = dlsym (RTLD_NEXT, "getpwnam_r");
+      assert (orig_getpwnam_r);
+    }
+
+  if (!is_valid_test_user (name))
+    return orig_getpwnam_r (name, pwd, buf, buflen, result);
+
+#ifdef AUTHD_TESTS_SSH_USE_AUTHD_NSS
+  /* Try the real NSS lookup first (e.g. via authd NSS module). */
+  int ret = orig_getpwnam_r (name, pwd, buf, buflen, result);
+  if (ret != 0)
+    return ret;
+  assert (result);
+  if (*result != NULL)
+    {
+      /* Override uid/gid like getpwnam does. */
+      pwd->pw_uid = getuid ();
+      pwd->pw_gid = getgid ();
+      return 0;
+    }
+#endif
+
+  /* Fall back to our getpwnam() override which creates fake users. */
+  struct passwd *pw = getpwnam (name);
+  if (pw == NULL)
+    {
+      *result = NULL;
+      return 0;
+    }
+
+  *pwd = *pw;
+  *result = pwd;
+  return 0;
 }
 
 FILE *


### PR DESCRIPTION
When cargo is available in PATH, SSH integration tests produced spurious
"Could not chdir to home directory" errors in their output. This happened
because of a home directory path mismatch between the sshd preloader and
the broker:

1. The preloader set pw_dir to a flat path (AUTHD_TEST_SSH_HOME) that
was the same for all users.
2. The broker assigned per-user home directories under its configured
AUTHD_EXAMPLE_BROKER_HOME_BASE_DIR.
3. pam_mkhomedir, which resolved the test user through the test NSS
library, created the directory at the broker path, but sshd tried
to chdir to the preloader path — which did not exist.

The fix aligns both paths:

- The preloader now reads AUTHD_TEST_SSH_HOME_BASE and constructs
per-user paths as base/username, matching the broker's convention.
- All test authd instances receive WithHomeBaseDir(sshTestsHomeBase)
so the broker assigns homes under the same base directory.
- A getpwnam_r() override is added so pam_modutil_getpwnam() (used by
pam_mkhomedir) can find fake test users.
- Cached preloader entries are updated with NSS data on recycling, so
fields like pw_dir reflect the broker-assigned values after auth.

The issue manifests whenever cargo is in PATH. When cargo is available,
CanRunRustTests() succeeds and the test NSS library is built with the
integration_tests feature and injected into sshd via LD_PRELOAD. The
library's constructor calls __nss_configure_lookup("passwd", "files
authd"), overriding the NSS configuration at runtime regardless of what
/etc/nsswitch.conf contains. This causes orig_getpwnam() in the preloader
to resolve test users through authd (via AUTHD_NSS_SOCKET), which returns
the broker-assigned home path — diverging from the flat preloader path.

Without cargo in PATH, pam_mkhomedir cannot resolve the test user through
NSS and skips home directory creation entirely, so no path mismatch occurs.

Closes #1554
UDENG-10527