### PR TITLE
docs: update config for stable authd docs URL migration

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -27,6 +27,7 @@ import yaml
 project = "authd"
 author = "Canonical Ltd."
 
+version = f"{os.environ.get('READTHEDOCS_VERSION', 'local')}"
 
 # Sidebar documentation title; best kept reasonably short
 #
@@ -70,7 +71,7 @@ copyright = "%s CC-BY-SA, %s" % (datetime.date.today().year, author)
 # NOTE: The Open Graph Protocol (OGP) enhances page display in a social graph
 #       and is used by social media platforms; see https://ogp.me/
 
-ogp_site_url = "https://documentation.ubuntu.com/authd/stable-docs"
+ogp_site_url = f"https://ubuntu.com/docs/authd/{version}/"
 
 
 # Preview name of the documentation website
@@ -96,8 +97,6 @@ ogp_image = "https://assets.ubuntu.com/v1/cc828679-docs_illustration.svg"
 
 # Dictionary of values to pass into the Sphinx context for all pages:
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#confval-html_context
-
-version = os.getenv("READTHEDOCS_VERSION", "")
 
 html_context = {
     # Used for rendering version information and links in authd documentation
@@ -180,7 +179,7 @@ html_theme_options = {
 # TODO: If your documentation is hosted on https://docs.ubuntu.com/,
 #       uncomment and update as needed.
 
-slug = "authd"
+slug = "docs/authd"
 
 #######################
 # Sitemap configuration: https://sphinx-sitemap.readthedocs.io/
@@ -188,7 +187,7 @@ slug = "authd"
 
 # Use RTD canonical URL to ensure duplicate pages have a specific canonical URL
 
-html_baseurl = os.environ.get("READTHEDOCS_CANONICAL_URL", "/")
+html_baseurl = f"https://ubuntu.com/docs/authd/{version}/"
 
 # sphinx-sitemap uses html_baseurl to generate the full URL for each page:
 


### PR DESCRIPTION
This config change is necessary for the migration of the stable docs to a new URL at `ubuntu.com/docs/authd`.

We will also need to apply the config change to the edge-docs (latest) branch.

Both versions of the docs will be tested in staging then production before setting up redirects, etc.