### PR TITLE
ci: Force fresh VM image on scheduled e2e tests

### DIFF
--- a/.github/workflows/e2e-tests-provision-and-run.yaml
+++ b/.github/workflows/e2e-tests-provision-and-run.yaml
@@ -10,6 +10,11 @@ on:
       ubuntu-version:
         required: true
         type: string
+      force-fresh-image:
+        description: 'Force creation of a fresh VM image by ignoring cache'
+        type: boolean
+        required: false
+        default: false
     secrets:
       E2E_VM_SSH_PRIV_KEY:
         required: true
@@ -36,6 +41,7 @@ jobs:
 
       - name: Restore cached VM image (if available)
         id: restore-cache
+        if: ${{ !inputs.force-fresh-image }}
         uses: actions/cache/restore@v5
         with:
           path: ${{ env.ARTIFACTS_DIR }}/${{ env.VM_NAME_BASE }}-${{ inputs.ubuntu-version }}.qcow2
@@ -48,15 +54,15 @@ jobs:
           fail-on-cache-miss: false
 
       - uses: canonical/desktop-engineering/gh-actions/common/dpkg-install-speedup@main
-        if: steps.restore-cache.outputs.cache-hit != 'true'
+        if: steps.restore-cache.outputs.cache-hit != 'true' || inputs.force-fresh-image
 
       - name: Install APT dependencies for VM provisioning
-        if: steps.restore-cache.outputs.cache-hit != 'true'
+        if: steps.restore-cache.outputs.cache-hit != 'true' || inputs.force-fresh-image
         run: ./${{ env.E2E_TESTS_DIR }}/vm/install-provision-deps.sh
 
       - name: Set up SSH keys for the VM provisioning
         id: set-ssh-keys
-        if: steps.restore-cache.outputs.cache-hit != 'true'
+        if: steps.restore-cache.outputs.cache-hit != 'true' || inputs.force-fresh-image
         uses: ./.github/actions/e2e-tests/set-up-ssh-keys
         with:
           E2E_VM_SSH_PRIV_KEY: ${{ secrets.E2E_VM_SSH_PRIV_KEY }}
@@ -64,7 +70,7 @@ jobs:
 
       - name: Provision the VM
         id: provision-vm
-        if: steps.restore-cache.outputs.cache-hit != 'true'
+        if: steps.restore-cache.outputs.cache-hit != 'true' || inputs.force-fresh-image
         run: |
           set -eu
           export PATH="$(realpath "${{ env.E2E_TESTS_DIR }}/vm/helpers"):${PATH}"

--- a/.github/workflows/e2e-tests.yaml
+++ b/.github/workflows/e2e-tests.yaml
@@ -91,4 +91,5 @@ jobs:
     with:
       ubuntu-version: ${{ matrix.ubuntu-version }}
       files-hash: ${{ needs.compute-hash.outputs.files-hash }}
+      force-fresh-image: ${{ github.event_name == 'schedule' }}
     secrets: inherit


### PR DESCRIPTION
The Monday scheduled e2e test run should use a fresh VM image to capture any OS updates or system state changes. Previously it would reuse a cached image if available. Add a force-fresh-image flag that triggers on schedule events to skip the cache restore and always provision a new VM.

UDENG-10686