### PR TITLE
ci: Rename broker variant branch names

### DIFF
--- a/.github/workflows/update-broker-variant-branches.yaml
+++ b/.github/workflows/update-broker-variant-branches.yaml
@@ -24,17 +24,21 @@ jobs:
     name: Update snap branches
     strategy:
       matrix:
-        branch_name: ["google", "msentraid", "oidc"]
+        branch_name: ["google-edge", "msentraid-edge", "oidc-edge"]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
+      - name: Extract broker name
+        id: broker
+        run: echo "name=$(echo '${{ matrix.branch_name }}' | sed 's/-edge$//')" >> $GITHUB_OUTPUT
+
       - name: Prepare snapcraft.yaml
         # We can't symlink the snapcraft.yaml file here because it causes launchpad to fail with:
         # "The top level of snapcraft.yaml from ~ubuntu-enterprise-desktop/authd/+git/authd:oidc is not a mapping"
-        run: ./snap/scripts/prepare-variant --copy --broker ${{ matrix.branch_name }}
+        run: ./snap/scripts/prepare-variant --copy --broker ${{ steps.broker.outputs.name }}
 
       - name: Commit broker variant files
         run: |
@@ -43,7 +47,7 @@ jobs:
           git add --force .
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          git commit -m "Copy ${{ matrix.branch_name }} variant files"
+          git commit -m "Copy ${{ steps.broker.outputs.name }} variant files"
 
       - name: Push branch
         run: git push --force origin HEAD:${{ matrix.branch_name }}

--- a/snap/scripts/version
+++ b/snap/scripts/version
@@ -4,8 +4,8 @@ set -eu
 # This scripts prints the version of the snap based on the git tags and the
 # current branch. The version is determined as follows:
 #
-# The highest version tag which is prefixed with "broker-" and is merged into the
-# current branch is used as the base version.
+# The highest version tag which is prefixed with the snap name and is merged
+# into the current branch is used as the base version.
 # If there is no such tag, "0.0.0" is used as the base version.
 #
 # If the current commit is tagged, that tag is used as the version as is.
@@ -18,25 +18,25 @@ set -eu
 # Finally, the version is appended with ".dirty" if there are uncommitted changes.
 
 get_version() {
-    current_branch=$(git branch --show-current)
+    snap_name=$(grep "^name:" snap/snapcraft.yaml | sed 's/^name:[[:space:]]*//;s/^authd-//')
 
-    # If the current commit is tagged with a "$broker-*" tag, where $broker is
-    # the name of the current branch, use that tag as the version after stripping the prefix.
+    # If the current commit is tagged with a "$snap_name-*" tag, where $snap_name is
+    # the name from snapcraft.yaml, use that tag as the version after stripping the prefix.
     tags=$(git tag --points-at HEAD)
     for tag in ${tags}; do
-        if echo "${tag}" | grep -qE "^${current_branch}-"; then
-            version="${tag#"${current_branch}"-}"
+        if echo "${tag}" | grep -qE "^${snap_name}-"; then
+            version="${tag#"${snap_name}"-}"
             echo "${version}"
             return
         fi
     done
 
-    # Get the highest version tag which is prefixed with "broker-"
-    tag=$(git -c "versionsort.suffix=-pre" tag --sort=-v:refname --merged="${current_branch}" | grep -E '^broker-' | head -n 1)
+    # Get the highest version tag which is prefixed with the snap name
+    tag=$(git -c "versionsort.suffix=-pre" tag --sort=-v:refname --merged="HEAD" | grep -E "^${snap_name}-" | head -n 1)
     version="${tag}"
 
-    # Strip the "broker-" prefix
-    version="${version#broker-}"
+    # Strip the snap name prefix from the version
+    version="${version#"${snap_name}"-}"
 
     if [ -z "${version}" ]; then
         # No tag found, use "0.0.0"
@@ -54,6 +54,7 @@ get_version() {
     version="${version}+$(git rev-parse --short=7 HEAD)"
 
     # If the current branch is not "main", append the short sha of the last commit
+    current_branch=$(git branch --show-current)
     if [ "${current_branch}" = "main" ]; then
         # Current branch is "main", return the version as is.
         echo "${version}"


### PR DESCRIPTION
> [!note]
> This is based on https://github.com/canonical/authd/pull/1592

Rename the branches used to automatically publish the changes from main on the edge channel to use the "-edge" suffix.

The old branch names are now used to build snaps for the candidate channel during our release process.

UDENG-10711