### PR TITLE
Fix lxd-test-image-cache-refresh.yaml

### DIFF
--- a/.github/workflows/lxd-test-image-cache-refresh.yaml
+++ b/.github/workflows/lxd-test-image-cache-refresh.yaml
@@ -29,7 +29,9 @@ jobs:
           restore-lxd-image-cache: "false"
 
       - name: Warm version-specific LXD test container
-        run: go test -count=1 ./pam/integration-tests \ -run 'TestSSHAuthenticate/Exit_if_user_is_not_pre-checked_on_ssh_service_on_ubuntu_26\.04$'
+        run: |
+          go test -count=1 ./pam/integration-tests \
+            -run 'TestSSHAuthenticate/Exit_if_user_is_not_pre-checked_on_ssh_service_on_ubuntu_26\.04$'
 
       - name: Export LXD test image for cache
         id: export-lxd-test-image


### PR DESCRIPTION
The formatting with yamlfmt broke one command. Fix it by using a block scalar (`run: |`).