### PR TITLE
ci: Allow using broker snaps from a Snap Store channel in e2e-tests

### DIFF
--- a/.github/workflows/debian-build.yaml
+++ b/.github/workflows/debian-build.yaml
@@ -206,7 +206,8 @@ jobs:
           (
             (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository) ||
             github.event_name == 'push' ||
-            github.event_name == 'release'
+            github.event_name == 'release' ||
+            github.event_name == 'workflow_dispatch'
           )
         run: |
           set -euo pipefail
@@ -240,7 +241,8 @@ jobs:
         if: >-
           (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository) ||
           github.event_name == 'push' ||
-          github.event_name == 'release'
+          github.event_name == 'release' ||
+          github.event_name == 'workflow_dispatch'
         run: |
           set -euo pipefail
           set -x

--- a/.github/workflows/debian-build.yaml
+++ b/.github/workflows/debian-build.yaml
@@ -207,6 +207,7 @@ jobs:
             (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository) ||
             github.event_name == 'push' ||
             github.event_name == 'release' ||
+            github.event_name == 'schedule' ||
             github.event_name == 'workflow_dispatch'
           )
         run: |
@@ -242,6 +243,7 @@ jobs:
           (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository) ||
           github.event_name == 'push' ||
           github.event_name == 'release' ||
+          github.event_name == 'schedule' ||
           github.event_name == 'workflow_dispatch'
         run: |
           set -euo pipefail

--- a/.github/workflows/e2e-tests-provision-and-run.yaml
+++ b/.github/workflows/e2e-tests-provision-and-run.yaml
@@ -15,6 +15,11 @@ on:
         type: boolean
         required: false
         default: false
+      broker-snap-channel:
+        description: 'If set, download the broker snap from this Snap Store channel instead of building it from source'
+        type: string
+        required: false
+        default: ''
     secrets:
       E2E_VM_SSH_PRIV_KEY:
         required: true
@@ -146,4 +151,5 @@ jobs:
     with:
       ubuntu-version: ${{ inputs.ubuntu-version }}
       broker: ${{ matrix.broker }}
+      broker-snap-channel: ${{ inputs.broker-snap-channel }}
     secrets: inherit

--- a/.github/workflows/e2e-tests-run.yaml
+++ b/.github/workflows/e2e-tests-run.yaml
@@ -9,6 +9,11 @@ on:
       broker:
         required: true
         type: string
+      broker-snap-channel:
+        description: 'If set, download the broker snap from this Snap Store channel instead of building it from source'
+        required: false
+        type: string
+        default: ''
     secrets:
       E2E_VM_SSH_PRIV_KEY:
         required: true
@@ -50,6 +55,7 @@ env:
 
 jobs:
   build-broker-snap:
+    if: inputs.broker-snap-channel == ''
     uses: ./.github/workflows/build-broker-snap.yaml
     with:
       broker: ${{ inputs.broker }}
@@ -58,6 +64,7 @@ jobs:
   run-tests:
     name: Run e2e-tests (${{ inputs.broker }})
     needs: build-broker-snap
+    if: always() && (needs.build-broker-snap.result == 'success' || needs.build-broker-snap.result == 'skipped')
     runs-on: ubuntu-latest
     permissions:
       # Needed by actions/checkout
@@ -73,8 +80,19 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Download the broker snap
-        id: download-broker-snap
+      - name: Download the broker snap from the Snap Store
+        id: download-broker-snap-from-store
+        if: inputs.broker-snap-channel != ''
+        run: |
+          set -euo pipefail
+          snap download "${{ inputs.broker }}" --channel "${{ inputs.broker-snap-channel }}"
+          mkdir -p "${{ env.ARTIFACTS_DIR }}"
+          mv ${{ inputs.broker }}_*.snap "${{ env.ARTIFACTS_DIR }}/${{ inputs.broker }}.snap"
+          echo "snap=${{ env.ARTIFACTS_DIR }}/${{ inputs.broker }}.snap" >> $GITHUB_OUTPUT
+
+      - name: Download the broker snap from the OCI registry
+        id: download-broker-snap-from-oci
+        if: inputs.broker-snap-channel == ''
         env:
           OCI_REPO: ghcr.io/${{ github.repository }}/${{ inputs.broker }}-snap
           OCI_TAG: ${{ github.sha }}
@@ -185,7 +203,7 @@ jobs:
           # Provision the VM
           ${{ env.E2E_TESTS_DIR }}/vm/provision-authd.sh \
             --authd-deb "${{ steps.download-authd-deb.outputs.deb }}" \
-            --broker-snap "${{ steps.download-broker-snap.outputs.snap }}"
+            --broker-snap "${{ steps.download-broker-snap-from-store.outputs.snap || steps.download-broker-snap-from-oci.outputs.snap }}"
 
       - name: Checkout YARF repo
         uses: actions/checkout@v6

--- a/.github/workflows/e2e-tests.yaml
+++ b/.github/workflows/e2e-tests.yaml
@@ -74,7 +74,8 @@ jobs:
        contains(github.event.pull_request.labels.*.name, 'e2e-tests')
       ) ||
       github.event_name == 'push' ||
-      github.event_name == 'release'
+      github.event_name == 'release' ||
+      github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     outputs:
       files-hash: ${{ steps.hash.outputs.hash }}

--- a/.github/workflows/e2e-tests.yaml
+++ b/.github/workflows/e2e-tests.yaml
@@ -54,6 +54,12 @@ on:
       - reopened
       - labeled
   workflow_dispatch:
+    inputs:
+      broker-snap-channel:
+        description: 'Download broker snaps from this Snap Store channel instead of building from source (e.g. "candidate")'
+        required: false
+        default: ''
+        type: string
   schedule:
     - cron: '0 0 * * 1' # Runs every Monday at midnight
 
@@ -102,4 +108,5 @@ jobs:
       ubuntu-version: ${{ matrix.ubuntu-version }}
       files-hash: ${{ needs.compute-hash.outputs.files-hash }}
       force-fresh-image: ${{ github.event_name == 'schedule' }}
+      broker-snap-channel: ${{ inputs.broker-snap-channel || '' }}
     secrets: inherit

--- a/.github/workflows/e2e-tests.yaml
+++ b/.github/workflows/e2e-tests.yaml
@@ -81,6 +81,7 @@ jobs:
       ) ||
       github.event_name == 'push' ||
       github.event_name == 'release' ||
+      github.event_name == 'schedule' ||
       github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     outputs:


### PR DESCRIPTION
When preparing a bugfix release, it's useful to be able to trigger an e2e-test run with the snap from the candidate channel.

This adds a `broker-snap-channel` workflow_dispatch input to e2e-tests.yaml. When set, the broker snap is downloaded from that Snap Store channel instead of being built from source.