### PR TITLE
ci: Include broker-snap-channel in e2e-tests concurrency group

### DIFF
--- a/.github/workflows/e2e-tests.yaml
+++ b/.github/workflows/e2e-tests.yaml
@@ -64,7 +64,7 @@ on:
     - cron: '0 0 * * 1' # Runs every Monday at midnight
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ inputs.broker-snap-channel }}
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
Allows workflow runs with a broker-snap-channel to run in parallel with workflow runs without a broker-snap-channel.