### PR TITLE
snap/scripts/version: Consider "broker-" tags again

### DIFF
--- a/snap/scripts/version
+++ b/snap/scripts/version
@@ -18,14 +18,14 @@ set -eu
 # Finally, the version is appended with ".dirty" if there are uncommitted changes.
 
 get_version() {
-    snap_name=$(grep "^name:" snap/snapcraft.yaml | sed 's/^name:[[:space:]]*//;s/^authd-//')
+    broker=$(grep "^name:" snap/snapcraft.yaml | sed 's/^name:[[:space:]]*//;s/^authd-//')
 
-    # If the current commit is tagged with a "$snap_name-*" tag, where $snap_name is
+    # If the current commit is tagged with a "$broker-*" tag, where $broker is
     # the name from snapcraft.yaml, use that tag as the version after stripping the prefix.
     tags=$(git tag --points-at HEAD)
     for tag in ${tags}; do
-        if echo "${tag}" | grep -qE "^${snap_name}-"; then
-            version="${tag#"${snap_name}"-}"
+        if echo "${tag}" | grep -qE "^${broker}-"; then
+            version="${tag#"${broker}"-}"
             echo "${version}"
             return
         fi

--- a/snap/scripts/version
+++ b/snap/scripts/version
@@ -21,7 +21,8 @@ get_version() {
     broker=$(grep "^name:" snap/snapcraft.yaml | sed 's/^name:[[:space:]]*//;s/^authd-//')
 
     # If the current commit is tagged with a "$broker-*" tag, where $broker is
-    # the name from snapcraft.yaml, use that tag as the version after stripping the prefix.
+    # the name from snapcraft.yaml, use that tag as the version after stripping
+    # the prefix.
     tags=$(git tag --points-at HEAD)
     for tag in ${tags}; do
         if echo "${tag}" | grep -qE "^${broker}-"; then

--- a/snap/scripts/version
+++ b/snap/scripts/version
@@ -4,8 +4,8 @@ set -eu
 # This scripts prints the version of the snap based on the git tags and the
 # current branch. The version is determined as follows:
 #
-# The highest version tag which is prefixed with the snap name and is merged
-# into the current branch is used as the base version.
+# The highest version tag which is prefixed with the snap name or "broker-" and
+# is merged into the current branch is used as the base version.
 # If there is no such tag, "0.0.0" is used as the base version.
 #
 # If the current commit is tagged, that tag is used as the version as is.
@@ -31,12 +31,13 @@ get_version() {
         fi
     done
 
-    # Get the highest version tag which is prefixed with the snap name
-    tag=$(git -c "versionsort.suffix=-pre" tag --sort=-v:refname --merged="HEAD" | grep -E "^${snap_name}-" | head -n 1)
+    # Get the highest version tag which is prefixed with "broker-"
+    current_branch=$(git branch --show-current)
+    tag=$(git -c "versionsort.suffix=-pre" tag --sort=-v:refname --merged="${current_branch}" | grep -E '^broker-' | head -n 1)
     version="${tag}"
 
-    # Strip the snap name prefix from the version
-    version="${version#"${snap_name}"-}"
+    # Strip the "broker-" prefix (if any)
+    version="${version#broker-}"
 
     if [ -z "${version}" ]; then
         # No tag found, use "0.0.0"

--- a/snap/scripts/version
+++ b/snap/scripts/version
@@ -34,10 +34,7 @@ get_version() {
     # Get the highest version tag which is prefixed with "broker-"
     current_branch=$(git branch --show-current)
     tag=$(git -c "versionsort.suffix=-pre" tag --sort=-v:refname --merged="${current_branch}" | grep -E '^broker-' | head -n 1)
-    version="${tag}"
-
-    # Strip the "broker-" prefix (if any)
-    version="${version#broker-}"
+    version="${tag#broker-}"
 
     if [ -z "${version}" ]; then
         # No tag found, use "0.0.0"


### PR DESCRIPTION
Commit a50eab2 unintentionally ignored tags prefixed with "broker-". Consider those again.