### PR TITLE
e2e-tests: fix workflow cancellation not stopping the run-tests job

### DIFF
--- a/.github/workflows/e2e-tests-run.yaml
+++ b/.github/workflows/e2e-tests-run.yaml
@@ -64,7 +64,7 @@ jobs:
   run-tests:
     name: Run e2e-tests (${{ inputs.broker }})
     needs: build-broker-snap
-    if: always() && (needs.build-broker-snap.result == 'success' || needs.build-broker-snap.result == 'skipped')
+    if: ${{ !cancelled() && (needs.build-broker-snap.result == 'success' || needs.build-broker-snap.result == 'skipped') }}
     runs-on: ubuntu-latest
     permissions:
       # Needed by actions/checkout


### PR DESCRIPTION
The run-tests job had ` if: always()` which evaluates to true even when the workflow is cancelled, causing the job (and all its steps) to run regardless of cancellation. Replace with  ` !cancelled()` to preserve the intended logic (run if upstream succeeded or was skipped) while correctly honouring cancellation.

UDENG-10879