### PR TITLE
Fix SSH integration tests

### DIFF
--- a/internal/testutils/lxd.go
+++ b/internal/testutils/lxd.go
@@ -158,16 +158,8 @@ func RunTestInLXD(t *testing.T, ubuntuVersion string) bool {
 
 	// #nosec:G204 - we control the command arguments in tests
 	cmd := lxcCommand(args...)
-	cmd.Stdout = os.Stdout
-	cmd.Stderr = os.Stderr
-
-	testlog.LogCommand(t, fmt.Sprintf("Running %s in LXD (Ubuntu %s)", t.Name(), ubuntuVersion), cmd)
-	err = cmd.Run()
-	if err != nil {
-		testlog.LogEndSeparator(t, fmt.Sprintf("%s in LXD (Ubuntu %s) failed", t.Name(), ubuntuVersion))
-		require.Fail(t, "Running %s in LXD (Ubuntu %s) failed: %v", t.Name(), ubuntuVersion, err)
-	}
-	testlog.LogEndSeparatorf(t, "%s in LXD finished", t.Name())
+	err = testlog.RunWithTiming(t, fmt.Sprintf("Running %s in LXD (Ubuntu %s)", t.Name(), ubuntuVersion), cmd)
+	require.NoError(t, err)
 
 	return true
 }

--- a/internal/testutils/lxd.go
+++ b/internal/testutils/lxd.go
@@ -51,8 +51,8 @@ var (
 	hostUbuntuVersion     string // e.g. "24.04"
 	hostMachineSlugOnce   sync.Once
 	hostMachineSlug       string
-	hostGoModCacheOnce    sync.Once
-	hostGoModCache        string
+	hostGoPkgOnce         sync.Once
+	hostGoPkg             string
 	hostCargoCacheOnce    sync.Once
 	hostCargoRegistryPath string
 	hostCargoGitPath      string
@@ -496,62 +496,47 @@ func ensureBindMount(t *testing.T, containerName string) {
 	}
 }
 
-// ensureGoModCacheMount adds a bind mount for the host's Go module cache so
-// version-specific LXD test containers can reuse already-downloaded modules.
+// ensureGoModCacheMount adds a bind mount for the host's Go package directory
+// so version-specific LXD test containers can reuse already-downloaded modules
+// and cached checksums without re-downloading.
 func ensureGoModCacheMount(t *testing.T, containerName string) {
 	t.Helper()
 
-	hostCache := hostGoModCachePath(t)
-	if hostCache == "" {
-		return
-	}
-
-	const (
-		deviceName    = "go-mod-cache"
-		containerPath = "/home/ubuntu/go/pkg/mod"
-	)
-
-	// #nosec:G204 - we control the command arguments
-	cmd := lxcCommand("config", "device", "show", containerName)
-	out, err := cmd.Output()
-	if err != nil {
-		lxcRun(t, "config", "device", "add", containerName, deviceName,
-			"disk", "source="+hostCache, "path="+containerPath)
-		return
-	}
-
-	if !bytes.Contains(out, []byte(deviceName+":")) {
-		lxcRun(t, "config", "device", "add", containerName, deviceName,
-			"disk", "source="+hostCache, "path="+containerPath)
+	hostPkg := hostGoPkgPath(t)
+	if hostPkg != "" {
+		ensureLXDDeviceMount(t, containerName, "go-pkg-cache", hostPkg, "/home/ubuntu/go/pkg")
 	}
 }
 
-func hostGoModCachePath(t *testing.T) string {
+func hostGoPkgPath(t *testing.T) string {
 	t.Helper()
 
-	hostGoModCacheOnce.Do(func() {
+	hostGoPkgOnce.Do(func() {
 		// #nosec:G204 - controlled command to query local Go environment
-		cmd := exec.Command("go", "env", "GOMODCACHE")
+		cmd := exec.Command("go", "env", "GOPATH")
 		out, err := cmd.Output()
 		if err != nil {
 			return
 		}
 
-		hostGoModCache = strings.TrimSpace(string(out))
-		if hostGoModCache == "" {
+		gopath := strings.TrimSpace(string(out))
+		if gopath == "" {
 			return
 		}
 
-		if err := os.MkdirAll(hostGoModCache, 0o750); err != nil {
-			hostGoModCache = ""
+		pkgPath := filepath.Join(gopath, "pkg")
+		if err := os.MkdirAll(pkgPath, 0o750); err != nil {
+			return
 		}
+
+		hostGoPkg = pkgPath
 	})
 
-	if hostGoModCache == "" {
-		t.Log("Host Go module cache unavailable; running LXD tests without shared GOMODCACHE")
+	if hostGoPkg == "" {
+		t.Log("Host Go package directory unavailable; running LXD tests without shared Go cache")
 	}
 
-	return hostGoModCache
+	return hostGoPkg
 }
 
 // ensureCargoCacheMounts adds bind mounts for the host's Cargo download caches

--- a/internal/testutils/lxd.go
+++ b/internal/testutils/lxd.go
@@ -165,7 +165,7 @@ func RunTestInLXD(t *testing.T, ubuntuVersion string) bool {
 	err = cmd.Run()
 	if err != nil {
 		testlog.LogEndSeparator(t, fmt.Sprintf("%s in LXD (Ubuntu %s) failed", t.Name(), ubuntuVersion))
-		t.Fatalf("Running %s in LXD (Ubuntu %s) failed: %v", t.Name(), ubuntuVersion, err)
+		require.Fail(t, "Running %s in LXD (Ubuntu %s) failed: %v", t.Name(), ubuntuVersion, err)
 	}
 	testlog.LogEndSeparatorf(t, "%s in LXD finished", t.Name())
 

--- a/pam/integration-tests/sshd_preloader/sshd_preloader.c
+++ b/pam/integration-tests/sshd_preloader/sshd_preloader.c
@@ -32,6 +32,7 @@ typedef struct {
 } MockPasswd;
 
 static MockPasswd passwd_entities[512];
+static atomic_int passwd_entities_count;
 
 __attribute__((constructor))
 void constructor (void)
@@ -96,6 +97,17 @@ is_valid_test_user (const char *name)
   return is_supported_test_fake_user (name);
 }
 
+static uid_t
+get_effective_uid (void)
+{
+  static uid_t effective_uid = (uid_t) -1;
+
+  if (effective_uid == (uid_t) -1)
+    effective_uid = getuid () != 0 ? getuid () : 65534;
+
+  return effective_uid;
+}
+
 static bool
 is_lower_case (const char *str)
 {
@@ -122,7 +134,6 @@ getpwnam (const char *name)
   static struct passwd * (*orig_getpwnam) (const char *name) = NULL;
   struct passwd *passwd_entity = NULL;
   struct passwd *source_entity = NULL;
-  static atomic_int last_entity_idx;
   int entity_idx;
 #ifdef AUTHD_TESTS_SSH_USE_AUTHD_NSS
   struct passwd *nss_entity = NULL;
@@ -184,7 +195,7 @@ getpwnam (const char *name)
     }
 #endif /* AUTHD_TESTS_SSH_USE_AUTHD_NSS */
 
-  for (size_t i = atomic_load (&last_entity_idx); i != 0; --i)
+  for (size_t i = atomic_load (&passwd_entities_count); i != 0; --i)
     {
       struct passwd *cached_entity = &passwd_entities[i].parent;
 
@@ -211,7 +222,7 @@ getpwnam (const char *name)
       return passwd_entity;
     }
 
-  entity_idx = atomic_fetch_add_explicit (&last_entity_idx, 1,
+  entity_idx = atomic_fetch_add_explicit (&passwd_entities_count, 1,
                                           memory_order_relaxed);
   assert (entity_idx < SIZE_OF_ARRAY (passwd_entities));
 
@@ -277,10 +288,8 @@ getpwnam (const char *name)
    * (65534) as a safe non-root fallback. Auth-failure tests never actually
    * set up a user session, so the uid only needs to pass pre-auth checks.
    */
-  uid_t effective_uid = getuid () != 0 ? getuid () : 65534;
-  uid_t effective_gid = getgid () != 0 ? getgid () : 65534;
-  passwd_entity->pw_uid = effective_uid;
-  passwd_entity->pw_gid = effective_gid;
+  passwd_entity->pw_uid = get_effective_uid ();
+  passwd_entity->pw_gid = getgid () != 0 ? getgid () : 65534;
 
   fprintf (stderr, "sshd_preloader[%d]: Simulating to be fake user %s (%d:%d)\n",
            getpid (), passwd_entity->pw_name, passwd_entity->pw_uid,
@@ -325,7 +334,7 @@ getpwnam_r (const char *name, struct passwd *pwd, char *buf, size_t buflen,
        * OpenSSH's root-login special handling (PermitRootLogin checks, etc.).
        * Use nobody (65534) as a safe non-root fallback when running as root.
        */
-      pwd->pw_uid = getuid () != 0 ? getuid () : 65534;
+      pwd->pw_uid = get_effective_uid ();
       pwd->pw_gid = getgid () != 0 ? getgid () : 65534;
       return 0;
     }
@@ -341,6 +350,64 @@ getpwnam_r (const char *name, struct passwd *pwd, char *buf, size_t buflen,
 
   *pwd = *pw;
   *result = pwd;
+  return 0;
+}
+
+/*
+ * Override getpwuid() so that lookups by the fake UID (e.g. login_get_lastlog
+ * in OpenSSH 10.2+) resolve to the current test user rather than failing.
+ * Without this, sshd aborts the PTY allocation when it cannot find an account
+ * for uid=<effective_uid>, causing the session to close immediately after
+ * authentication.
+ */
+struct passwd *
+getpwuid (uid_t uid)
+{
+  static struct passwd pw;
+  struct passwd *result = NULL;
+  static char buf[4096];
+
+  if (getpwuid_r (uid, &pw, buf, sizeof (buf), &result) != 0)
+    return NULL;
+
+  return result;
+}
+
+/*
+ * Override getpwuid_r() for the same reason as getpwuid().
+ */
+int
+getpwuid_r (uid_t uid, struct passwd *pwd, char *buf, size_t buflen,
+            struct passwd **result)
+{
+  static int (*orig_getpwuid_r) (uid_t, struct passwd *, char *, size_t,
+                                 struct passwd **) = NULL;
+
+  if (orig_getpwuid_r == NULL)
+    {
+      orig_getpwuid_r = dlsym (RTLD_NEXT, "getpwuid_r");
+      assert (orig_getpwuid_r);
+    }
+
+  if (uid != get_effective_uid ())
+    return orig_getpwuid_r (uid, pwd, buf, buflen, result);
+
+  /* Return the first cached fake-user entry whose UID matches. */
+  for (size_t i = 0; i < (size_t) atomic_load (&passwd_entities_count); ++i)
+    {
+      struct passwd *cached = &passwd_entities[i].parent;
+
+      if (cached->pw_name && cached->pw_uid == uid)
+        {
+          fprintf (stderr, "sshd_preloader[%d]: getpwuid_r(%d) - returning cached entry for %s\n",
+                   getpid (), (int) uid, cached->pw_name);
+          *pwd = *cached;
+          *result = pwd;
+          return 0;
+        }
+    }
+
+  *result = NULL;
   return 0;
 }
 


### PR DESCRIPTION
Fix multiple issues I encountered when running the SSH integration tests locally:

* internal/testutils/lxd.go: Mount host sumdb cache in LXD containers

    The Go toolchain verifies module checksums against $GOPATH/pkg/sumdb,
    which was not bind-mounted into LXD containers. This caused toolchain
    downloads to fail with "no such file or directory" when the sum database
    cache was absent and network access was unavailable.
    
    Mount the host's sumdb alongside the existing mod cache mount so
    containers can verify checksums without network access.

* pam/integration-tests/sshd_preloader: fix SSH integration tests when current user not in /etc/passwd
    
    On hosts where the current user has no /etc/passwd entry (UID only known to
    a non-files NSS module), SSH integration tests failed in two ways:
    
    - On Ubuntu 24.04: test setup aborted with "No user exists for uid 1001" during
      ssh-keygen host key generation, before any connection was attempted.
    - On Ubuntu 26.04: the session was torn down immediately after PAM auth succeeded,
      with "Connection to localhost closed by remote host". OpenSSH 10.2's
      mm_answer_pty() calls login_get_lastlog() → getpwuid(effective_uid) during PTY
      setup and treats a failed lookup as fatal.
    
    In both cases the lookup went through the system NSS chain (passwd: files systemd
    authd). Since the user has no /etc/passwd entry, files and systemd both return
    nothing, and the lookup falls through to authd. The tests inject the test-built
    libnss_authd.so via LD_PRELOAD, so it is the test authd that is queried — but it
    also returns NotFound, because it only knows the test user by its own assigned UID
    (10000), not by the test runner's UID.
    
    The preloader already intercepts getpwnam() and returns fake user entries with
    pw_uid = effective_uid, but getpwuid() went unintercepted. Add getpwuid() and
    getpwuid_r() overrides that return the cached fake-user entry when the queried
    UID matches the effective test UID.

