### PR TITLE
Improve PAM prompts

### DIFF
--- a/authd-oidc-brokers/internal/broker/authmodes/consts.go
+++ b/authd-oidc-brokers/internal/broker/authmodes/consts.go
@@ -34,7 +34,7 @@ var (
 		Device:        "Device code flow",
 		DeviceQr:      "Device code flow",
 		NewPassword:   "Define your local password",
-		EntraPassword: "Entra ID password",
+		EntraPassword: "Entra ID password + MFA",
 		EntraMFAWait:  "Waiting for MFA approval",
 		EntraMFACode:  "Enter your MFA code",
 	}

--- a/authd-oidc-brokers/internal/broker/authmodes/consts.go
+++ b/authd-oidc-brokers/internal/broker/authmodes/consts.go
@@ -30,7 +30,7 @@ var (
 	// Label is a map of auth mode IDs to their display labels.
 	//nolint:gosec // G101: These are auth mode display labels, not credentials.
 	Label = map[string]string{
-		Password:      "Local Password Authentication",
+		Password:      "Local password",
 		Device:        "Device code flow",
 		DeviceQr:      "Device code flow",
 		NewPassword:   "Define your local password",

--- a/authd-oidc-brokers/internal/broker/testdata/golden/TestGetAuthenticationModes/Get_only_password_if_device_should_be_registered_and_token_is_not_for_device_registration_but_provider_is_not_available
+++ b/authd-oidc-brokers/internal/broker/testdata/golden/TestGetAuthenticationModes/Get_only_password_if_device_should_be_registered_and_token_is_not_for_device_registration_but_provider_is_not_available
@@ -1,2 +1,2 @@
 - id: password
-  label: Local Password Authentication
+  label: Local password

--- a/authd-oidc-brokers/internal/broker/testdata/golden/TestGetAuthenticationModes/Get_only_password_if_device_should_not_be_registered_and_token_is_for_device_registration_but_provider_is_not_available
+++ b/authd-oidc-brokers/internal/broker/testdata/golden/TestGetAuthenticationModes/Get_only_password_if_device_should_not_be_registered_and_token_is_for_device_registration_but_provider_is_not_available
@@ -1,2 +1,2 @@
 - id: password
-  label: Local Password Authentication
+  label: Local password

--- a/authd-oidc-brokers/internal/broker/testdata/golden/TestGetAuthenticationModes/Get_only_password_if_token_exists_and_provider_does_not_support_device_auth_qr
+++ b/authd-oidc-brokers/internal/broker/testdata/golden/TestGetAuthenticationModes/Get_only_password_if_token_exists_and_provider_does_not_support_device_auth_qr
@@ -1,2 +1,2 @@
 - id: password
-  label: Local Password Authentication
+  label: Local password

--- a/authd-oidc-brokers/internal/broker/testdata/golden/TestGetAuthenticationModes/Get_only_password_if_token_exists_and_provider_is_not_available
+++ b/authd-oidc-brokers/internal/broker/testdata/golden/TestGetAuthenticationModes/Get_only_password_if_token_exists_and_provider_is_not_available
@@ -1,2 +1,2 @@
 - id: password
-  label: Local Password Authentication
+  label: Local password

--- a/authd-oidc-brokers/internal/broker/testdata/golden/TestGetAuthenticationModes/Get_only_password_if_token_exists_and_session_is_for_changing_password
+++ b/authd-oidc-brokers/internal/broker/testdata/golden/TestGetAuthenticationModes/Get_only_password_if_token_exists_and_session_is_for_changing_password
@@ -1,2 +1,2 @@
 - id: password
-  label: Local Password Authentication
+  label: Local password

--- a/authd-oidc-brokers/internal/broker/testdata/golden/TestGetAuthenticationModes/Get_only_password_if_token_exists_and_session_mode_is_the_old_passwd_value
+++ b/authd-oidc-brokers/internal/broker/testdata/golden/TestGetAuthenticationModes/Get_only_password_if_token_exists_and_session_mode_is_the_old_passwd_value
@@ -1,2 +1,2 @@
 - id: password
-  label: Local Password Authentication
+  label: Local password

--- a/authd-oidc-brokers/internal/broker/testdata/golden/TestGetAuthenticationModes/Get_password_and_device_auth_qr_if_device_should_be_registered_and_token_is_for_device_registration
+++ b/authd-oidc-brokers/internal/broker/testdata/golden/TestGetAuthenticationModes/Get_password_and_device_auth_qr_if_device_should_be_registered_and_token_is_for_device_registration
@@ -1,4 +1,4 @@
 - id: password
-  label: Local Password Authentication
+  label: Local password
 - id: device_auth_qr
   label: Device code flow

--- a/authd-oidc-brokers/internal/broker/testdata/golden/TestGetAuthenticationModes/Get_password_and_device_auth_qr_if_device_should_be_registered_and_token_is_not_for_device_registration_and_provider_does_not_support_it
+++ b/authd-oidc-brokers/internal/broker/testdata/golden/TestGetAuthenticationModes/Get_password_and_device_auth_qr_if_device_should_be_registered_and_token_is_not_for_device_registration_and_provider_does_not_support_it
@@ -1,4 +1,4 @@
 - id: password
-  label: Local Password Authentication
+  label: Local password
 - id: device_auth_qr
   label: Device code flow

--- a/authd-oidc-brokers/internal/broker/testdata/golden/TestGetAuthenticationModes/Get_password_and_device_auth_qr_if_device_should_not_be_registered_and_token_is_not_for_device_registration
+++ b/authd-oidc-brokers/internal/broker/testdata/golden/TestGetAuthenticationModes/Get_password_and_device_auth_qr_if_device_should_not_be_registered_and_token_is_not_for_device_registration
@@ -1,4 +1,4 @@
 - id: password
-  label: Local Password Authentication
+  label: Local password
 - id: device_auth_qr
   label: Device code flow

--- a/authd-oidc-brokers/internal/broker/testdata/golden/TestGetAuthenticationModes/Get_password_and_device_auth_qr_if_token_exists
+++ b/authd-oidc-brokers/internal/broker/testdata/golden/TestGetAuthenticationModes/Get_password_and_device_auth_qr_if_token_exists
@@ -1,4 +1,4 @@
 - id: password
-  label: Local Password Authentication
+  label: Local password
 - id: device_auth_qr
   label: Device code flow

--- a/authd-oidc-brokers/internal/broker/testdata/golden/TestGetAuthenticationModes/Get_password_and_device_auth_qr_if_token_is_not_for_device_registration_but_provider_does_not_support_it
+++ b/authd-oidc-brokers/internal/broker/testdata/golden/TestGetAuthenticationModes/Get_password_and_device_auth_qr_if_token_is_not_for_device_registration_but_provider_does_not_support_it
@@ -1,4 +1,4 @@
 - id: password
-  label: Local Password Authentication
+  label: Local password
 - id: device_auth_qr
   label: Device code flow

--- a/e2e-tests/resources/broker.resource
+++ b/e2e-tests/resources/broker.resource
@@ -176,7 +176,7 @@ Try Navigating Back to User Selection
     Hid.Keys Combo    Escape
 
     # The previous screen should be the authentication mode selection
-    Match Text    Select your authentication method    120
+    Match Text    Select the authentication flow    120
     Hid.Keys Combo    Escape
 
     # The previous screen should be the broker selection

--- a/e2e-tests/resources/broker.resource
+++ b/e2e-tests/resources/broker.resource
@@ -55,11 +55,11 @@ Start Log In With Remote User Through CLI: QR Code
     Hid.Type String    ${username}
     Hid.Keys Combo    Return
 
-    Match Text    Select your provider    15
+    Match Text    Select your provider:    15
 
 
 Select Provider
-    Match Text    Select your provider    15
+    Match Text    Select your provider:    15
     Match Text    2. ${PROVIDER_DISPLAY_NAME}
 
     Hid.Type String    2
@@ -176,17 +176,17 @@ Try Navigating Back to User Selection
     Hid.Keys Combo    Escape
 
     # The previous screen should be the authentication mode selection
-    Match Text    Select the authentication flow    120
+    Match Text    Select the authentication flow:    120
     Hid.Keys Combo    Escape
 
     # The previous screen should be the broker selection
-    Match Text    Select your provider    120
+    Match Text    Select your provider:    120
     Hid.Keys Combo    Escape
 
     # The previous screen is the username prompt, but it shouldn't be possible to get there
-    Match Text    Select your provider    120
+    Match Text    Select your provider:    120
     Hid.Keys Combo    Escape
-    Match Text    Select your provider    120
+    Match Text    Select your provider:    120
 
 
 Log In With Remote User Through CLI: Local Password And Expect Failure
@@ -453,7 +453,7 @@ Log In With Remote User Through CLI: Entra Password
     Hid.Type String    ${username}
     Hid.Keys Combo    Return
 
-    Match Text    Select your provider    15
+    Match Text    Select your provider:    15
     Match Text    2. ${PROVIDER_DISPLAY_NAME}
     Hid.Type String    2
 

--- a/pam/integration-tests/cli_test.go
+++ b/pam/integration-tests/cli_test.go
@@ -120,7 +120,7 @@ func TestCLIAuthenticate(t *testing.T) {
 
 				// Go to auth method selection first.
 				c.SendKey(t, ptytest.KeyEscape)
-				c.WaitFor(t, `Select the authentication flow`)
+				c.WaitFor(t, `Select the authentication flow:`)
 				c.WaitFor(t, `1\. Password authentication`)
 
 				// Select password auth.
@@ -132,7 +132,7 @@ func TestCLIAuthenticate(t *testing.T) {
 				c.WaitFor(t, `Plug your fido device and press with your thumb`)
 
 				c.SendKey(t, ptytest.KeyEscape)
-				c.WaitFor(t, `Select the authentication flow`)
+				c.WaitFor(t, `Select the authentication flow:`)
 				c.WaitFor(t, `1\. Use your fido device foo`)
 
 				c.SendKey(t, ptytest.KeyEnter) // Select first option
@@ -143,7 +143,7 @@ func TestCLIAuthenticate(t *testing.T) {
 				c.WaitFor(t, `Unlock your phone \+33`)
 
 				c.SendKey(t, ptytest.KeyEscape)
-				c.WaitFor(t, `Select the authentication flow`)
+				c.WaitFor(t, `Select the authentication flow:`)
 				c.WaitFor(t, `1\. Use your phone \+33`)
 
 				c.SendKey(t, ptytest.KeyEnter)
@@ -162,7 +162,7 @@ func TestCLIAuthenticate(t *testing.T) {
 				c.WaitFor(t, `Gimme your password`)
 
 				c.SendKey(t, ptytest.KeyEscape)
-				c.WaitFor(t, `Select the authentication flow`)
+				c.WaitFor(t, `Select the authentication flow:`)
 				c.WaitFor(t, `7\. Authentication code`)
 
 				c.Send(t, "7")
@@ -226,7 +226,7 @@ func TestCLIAuthenticate(t *testing.T) {
 				cliSelectBroker(t, c)
 				c.WaitFor(t, `Gimme your password`)
 				c.SendKey(t, ptytest.KeyEscape)
-				c.WaitFor(t, `Select the authentication flow`)
+				c.WaitFor(t, `Select the authentication flow:`)
 				c.WaitFor(t, `6\. Use a QR code`)
 				c.Send(t, "6")
 				c.WaitFor(t, `Scan the qrcode or enter the code in the login page`)
@@ -364,7 +364,7 @@ func TestCLIAuthenticate(t *testing.T) {
 
 				// Switch to auth mode selection.
 				c.SendKey(t, ptytest.KeyEscape)
-				c.WaitFor(t, `Select the authentication flow`)
+				c.WaitFor(t, `Select the authentication flow:`)
 				c.WaitFor(t, `2\. Send URL to`)
 
 				// Select "Send URL to" mode.
@@ -373,7 +373,7 @@ func TestCLIAuthenticate(t *testing.T) {
 
 				// Go back to auth mode selection.
 				c.SendKey(t, ptytest.KeyEscape)
-				c.WaitFor(t, `Select the authentication flow`)
+				c.WaitFor(t, `Select the authentication flow:`)
 				c.WaitFor(t, `3\. Use your fido device foo`)
 
 				// Select "Use your fido device" mode.
@@ -382,7 +382,7 @@ func TestCLIAuthenticate(t *testing.T) {
 
 				// Go back and select password auth.
 				c.SendKey(t, ptytest.KeyEscape)
-				c.WaitFor(t, `Select the authentication flow`)
+				c.WaitFor(t, `Select the authentication flow:`)
 				c.WaitFor(t, `1\. Password authentication`)
 
 				c.Send(t, "1")
@@ -406,7 +406,7 @@ func TestCLIAuthenticate(t *testing.T) {
 				c.SendKey(t, ptytest.KeyEnter)
 
 				// Capture initial provider-selection (shows user flow before going back).
-				c.WaitFor(t, `Select your provider`)
+				c.WaitFor(t, `Select your provider:`)
 
 				// Go back to username.
 				c.SendKey(t, ptytest.KeyEscape)
@@ -441,11 +441,11 @@ func TestCLIAuthenticate(t *testing.T) {
 
 				// Go back to auth method.
 				c.SendKey(t, ptytest.KeyEscape)
-				c.WaitFor(t, `Select the authentication flow`)
+				c.WaitFor(t, `Select the authentication flow:`)
 
 				// Go back to broker selection.
 				c.SendKey(t, ptytest.KeyEscape)
-				c.WaitFor(t, `Select your provider`)
+				c.WaitFor(t, `Select your provider:`)
 				c.WaitFor(t, `1\. local`)
 
 				// Select local broker.
@@ -481,7 +481,7 @@ func TestCLIAuthenticate(t *testing.T) {
 				c.WaitFor(t, `Gimme your password`)
 
 				c.SendKey(t, ptytest.KeyEscape)
-				c.WaitFor(t, `Select the authentication flow`)
+				c.WaitFor(t, `Select the authentication flow:`)
 				c.WaitFor(t, `7\. Authentication code`)
 
 				c.Send(t, "7")
@@ -541,10 +541,10 @@ func TestCLIAuthenticate(t *testing.T) {
 
 				// Go back to auth method, then provider.
 				c.SendKey(t, ptytest.KeyEscape)
-				c.WaitFor(t, `Select the authentication flow`)
+				c.WaitFor(t, `Select the authentication flow:`)
 
 				c.SendKey(t, ptytest.KeyEscape)
-				c.WaitFor(t, `Select your provider`)
+				c.WaitFor(t, `Select your provider:`)
 
 				// Verify we're still at provider selection by selecting broker.
 				// Don't use cliSelectBroker here because bubbletea won't re-render
@@ -627,7 +627,7 @@ func TestCLIAuthenticate(t *testing.T) {
 			expectedExitCode: 0,
 			test: func(t *testing.T, c *ptytest.Console) {
 				t.Helper()
-				c.WaitFor(t, `Select your provider`)
+				c.WaitFor(t, `Select your provider:`)
 				c.WaitFor(t, `1\. local`)
 				c.SendKey(t, ptytest.KeyEnter)
 				cliWaitForResult(t, c)
@@ -773,7 +773,7 @@ func cliEnterUsername(t *testing.T, c *ptytest.Console, username string) {
 func cliSelectBroker(t *testing.T, c *ptytest.Console) {
 	t.Helper()
 
-	c.WaitFor(t, `Select your provider`)
+	c.WaitFor(t, `Select your provider:`)
 	c.WaitFor(t, `2\. ExampleBroker`)
 	c.Send(t, "2")
 }
@@ -859,7 +859,7 @@ func cliAuthenticateWithQRCode(t *testing.T, c *ptytest.Console, signalFn func(s
 	cliSelectBroker(t, c)
 	c.WaitFor(t, `Gimme your password`)
 	c.SendKey(t, ptytest.KeyEscape)
-	c.WaitFor(t, `Select the authentication flow`)
+	c.WaitFor(t, `Select the authentication flow:`)
 	c.WaitFor(t, `6\. Use a QR code`)
 	c.Send(t, "6")
 	c.WaitFor(t, `Scan the qrcode or enter the code in the login page`)
@@ -973,21 +973,21 @@ func TestCLIChangeAuthTok(t *testing.T) {
 				cliSelectBroker(t, c)
 				c.WaitFor(t, `Gimme your password`)
 				c.SendKey(t, ptytest.KeyEscape)
-				c.WaitFor(t, `Select the authentication flow`)
+				c.WaitFor(t, `Select the authentication flow:`)
 				c.WaitFor(t, `1\. Password authentication`)
 				c.Send(t, "1")
 				c.WaitFor(t, `Gimme your password`)
 				cliSendPassword(t, c, "goodpass")
 				c.WaitFor(t, `Plug your fido device and press with your thumb`)
 				c.SendKey(t, ptytest.KeyEscape)
-				c.WaitFor(t, `Select the authentication flow`)
+				c.WaitFor(t, `Select the authentication flow:`)
 				c.WaitFor(t, `1\. Use your fido device foo`)
 				c.SendKey(t, ptytest.KeyEnter)
 				c.WaitFor(t, `Plug your fido device and press with your thumb`)
 				testutils.CreateBrokerCompletionSignal(t, socketPath, username)
 				c.WaitFor(t, `Unlock your phone \+33`)
 				c.SendKey(t, ptytest.KeyEscape)
-				c.WaitFor(t, `Select the authentication flow`)
+				c.WaitFor(t, `Select the authentication flow:`)
 				c.WaitFor(t, `1\. Use your phone \+33`)
 				c.SendKey(t, ptytest.KeyEnter)
 				c.WaitFor(t, `Unlock your phone \+33`)
@@ -1138,7 +1138,7 @@ func TestCLIChangeAuthTok(t *testing.T) {
 				t.Helper()
 				c := startCLIPAMRunner(t, clientPath, socketPath, pam_test.RunnerActionPasswd, cliEnv, clientOptions{})
 				cliEnterUsername(t, c, username)
-				c.WaitFor(t, `Select your provider`)
+				c.WaitFor(t, `Select your provider:`)
 				c.WaitFor(t, `1\. local`)
 				c.SendKey(t, ptytest.KeyEnter)
 				cliWaitForChangeAuthTokResult(t, c)

--- a/pam/integration-tests/cli_test.go
+++ b/pam/integration-tests/cli_test.go
@@ -120,7 +120,7 @@ func TestCLIAuthenticate(t *testing.T) {
 
 				// Go to auth method selection first.
 				c.SendKey(t, ptytest.KeyEscape)
-				c.WaitFor(t, `Select your authentication method`)
+				c.WaitFor(t, `Select the authentication flow`)
 				c.WaitFor(t, `1\. Password authentication`)
 
 				// Select password auth.
@@ -132,7 +132,7 @@ func TestCLIAuthenticate(t *testing.T) {
 				c.WaitFor(t, `Plug your fido device and press with your thumb`)
 
 				c.SendKey(t, ptytest.KeyEscape)
-				c.WaitFor(t, `Select your authentication method`)
+				c.WaitFor(t, `Select the authentication flow`)
 				c.WaitFor(t, `1\. Use your fido device foo`)
 
 				c.SendKey(t, ptytest.KeyEnter) // Select first option
@@ -143,7 +143,7 @@ func TestCLIAuthenticate(t *testing.T) {
 				c.WaitFor(t, `Unlock your phone \+33`)
 
 				c.SendKey(t, ptytest.KeyEscape)
-				c.WaitFor(t, `Select your authentication method`)
+				c.WaitFor(t, `Select the authentication flow`)
 				c.WaitFor(t, `1\. Use your phone \+33`)
 
 				c.SendKey(t, ptytest.KeyEnter)
@@ -162,7 +162,7 @@ func TestCLIAuthenticate(t *testing.T) {
 				c.WaitFor(t, `Gimme your password`)
 
 				c.SendKey(t, ptytest.KeyEscape)
-				c.WaitFor(t, `Select your authentication method`)
+				c.WaitFor(t, `Select the authentication flow`)
 				c.WaitFor(t, `7\. Authentication code`)
 
 				c.Send(t, "7")
@@ -226,7 +226,7 @@ func TestCLIAuthenticate(t *testing.T) {
 				cliSelectBroker(t, c)
 				c.WaitFor(t, `Gimme your password`)
 				c.SendKey(t, ptytest.KeyEscape)
-				c.WaitFor(t, `Select your authentication method`)
+				c.WaitFor(t, `Select the authentication flow`)
 				c.WaitFor(t, `6\. Use a QR code`)
 				c.Send(t, "6")
 				c.WaitFor(t, `Scan the qrcode or enter the code in the login page`)
@@ -364,7 +364,7 @@ func TestCLIAuthenticate(t *testing.T) {
 
 				// Switch to auth mode selection.
 				c.SendKey(t, ptytest.KeyEscape)
-				c.WaitFor(t, `Select your authentication method`)
+				c.WaitFor(t, `Select the authentication flow`)
 				c.WaitFor(t, `2\. Send URL to`)
 
 				// Select "Send URL to" mode.
@@ -373,7 +373,7 @@ func TestCLIAuthenticate(t *testing.T) {
 
 				// Go back to auth mode selection.
 				c.SendKey(t, ptytest.KeyEscape)
-				c.WaitFor(t, `Select your authentication method`)
+				c.WaitFor(t, `Select the authentication flow`)
 				c.WaitFor(t, `3\. Use your fido device foo`)
 
 				// Select "Use your fido device" mode.
@@ -382,7 +382,7 @@ func TestCLIAuthenticate(t *testing.T) {
 
 				// Go back and select password auth.
 				c.SendKey(t, ptytest.KeyEscape)
-				c.WaitFor(t, `Select your authentication method`)
+				c.WaitFor(t, `Select the authentication flow`)
 				c.WaitFor(t, `1\. Password authentication`)
 
 				c.Send(t, "1")
@@ -441,7 +441,7 @@ func TestCLIAuthenticate(t *testing.T) {
 
 				// Go back to auth method.
 				c.SendKey(t, ptytest.KeyEscape)
-				c.WaitFor(t, `Select your authentication method`)
+				c.WaitFor(t, `Select the authentication flow`)
 
 				// Go back to broker selection.
 				c.SendKey(t, ptytest.KeyEscape)
@@ -481,7 +481,7 @@ func TestCLIAuthenticate(t *testing.T) {
 				c.WaitFor(t, `Gimme your password`)
 
 				c.SendKey(t, ptytest.KeyEscape)
-				c.WaitFor(t, `Select your authentication method`)
+				c.WaitFor(t, `Select the authentication flow`)
 				c.WaitFor(t, `7\. Authentication code`)
 
 				c.Send(t, "7")
@@ -541,7 +541,7 @@ func TestCLIAuthenticate(t *testing.T) {
 
 				// Go back to auth method, then provider.
 				c.SendKey(t, ptytest.KeyEscape)
-				c.WaitFor(t, `Select your authentication method`)
+				c.WaitFor(t, `Select the authentication flow`)
 
 				c.SendKey(t, ptytest.KeyEscape)
 				c.WaitFor(t, `Select your provider`)
@@ -859,7 +859,7 @@ func cliAuthenticateWithQRCode(t *testing.T, c *ptytest.Console, signalFn func(s
 	cliSelectBroker(t, c)
 	c.WaitFor(t, `Gimme your password`)
 	c.SendKey(t, ptytest.KeyEscape)
-	c.WaitFor(t, `Select your authentication method`)
+	c.WaitFor(t, `Select the authentication flow`)
 	c.WaitFor(t, `6\. Use a QR code`)
 	c.Send(t, "6")
 	c.WaitFor(t, `Scan the qrcode or enter the code in the login page`)
@@ -973,21 +973,21 @@ func TestCLIChangeAuthTok(t *testing.T) {
 				cliSelectBroker(t, c)
 				c.WaitFor(t, `Gimme your password`)
 				c.SendKey(t, ptytest.KeyEscape)
-				c.WaitFor(t, `Select your authentication method`)
+				c.WaitFor(t, `Select the authentication flow`)
 				c.WaitFor(t, `1\. Password authentication`)
 				c.Send(t, "1")
 				c.WaitFor(t, `Gimme your password`)
 				cliSendPassword(t, c, "goodpass")
 				c.WaitFor(t, `Plug your fido device and press with your thumb`)
 				c.SendKey(t, ptytest.KeyEscape)
-				c.WaitFor(t, `Select your authentication method`)
+				c.WaitFor(t, `Select the authentication flow`)
 				c.WaitFor(t, `1\. Use your fido device foo`)
 				c.SendKey(t, ptytest.KeyEnter)
 				c.WaitFor(t, `Plug your fido device and press with your thumb`)
 				testutils.CreateBrokerCompletionSignal(t, socketPath, username)
 				c.WaitFor(t, `Unlock your phone \+33`)
 				c.SendKey(t, ptytest.KeyEscape)
-				c.WaitFor(t, `Select your authentication method`)
+				c.WaitFor(t, `Select the authentication flow`)
 				c.WaitFor(t, `1\. Use your phone \+33`)
 				c.SendKey(t, ptytest.KeyEnter)
 				c.WaitFor(t, `Unlock your phone \+33`)

--- a/pam/integration-tests/testdata/golden/TestCLIAuthenticate/Authenticate_user_and_add_it_to_local_group
+++ b/pam/integration-tests/testdata/golden/TestCLIAuthenticate/Authenticate_user_and_add_it_to_local_group
@@ -2,7 +2,7 @@ Username: user name
 ────────────────────────────────────────────────────────────────────────────────
 Username: user-local-groups-integration-auth-cli@example.com
 ────────────────────────────────────────────────────────────────────────────────
-  Select your provider
+  Select your provider:
 
 > 1. local
   2. ExampleBroker

--- a/pam/integration-tests/testdata/golden/TestCLIAuthenticate/Authenticate_user_and_add_it_to_local_group
+++ b/pam/integration-tests/testdata/golden/TestCLIAuthenticate/Authenticate_user_and_add_it_to_local_group
@@ -12,12 +12,12 @@ Username: user-local-groups-integration-auth-cli@example.com
 Gimme your password:
 >
 
-  Press escape key to go back to select the authentication method
+  Press escape key to go back to select the authentication flow
 ────────────────────────────────────────────────────────────────────────────────
 Gimme your password:
 > ********
 
-  Press escape key to go back to select the authentication method
+  Press escape key to go back to select the authentication flow
 ────────────────────────────────────────────────────────────────────────────────
   PAM_AUTHTOK: "goodpass"
 PAM Authenticate()

--- a/pam/integration-tests/testdata/golden/TestCLIAuthenticate/Authenticate_user_and_offer_password_reset
+++ b/pam/integration-tests/testdata/golden/TestCLIAuthenticate/Authenticate_user_and_offer_password_reset
@@ -12,18 +12,18 @@ Username: user-can-reset@example.com
 Gimme your password:
 >
 
-  Press escape key to go back to select the authentication method
+  Press escape key to go back to select the authentication flow
 ────────────────────────────────────────────────────────────────────────────────
 Gimme your password:
 > ********
 
-  Press escape key to go back to select the authentication method
+  Press escape key to go back to select the authentication flow
 ────────────────────────────────────────────────────────────────────────────────
 Gimme your password:
 > ********
 Password reset, 1 step(s) missing
 
-  Press escape key to go back to select the authentication method
+  Press escape key to go back to select the authentication flow
 ────────────────────────────────────────────────────────────────────────────────
 Enter your new password (3 days until mandatory)
 

--- a/pam/integration-tests/testdata/golden/TestCLIAuthenticate/Authenticate_user_and_offer_password_reset
+++ b/pam/integration-tests/testdata/golden/TestCLIAuthenticate/Authenticate_user_and_offer_password_reset
@@ -2,7 +2,7 @@ Username: user name
 ────────────────────────────────────────────────────────────────────────────────
 Username: user-can-reset@example.com
 ────────────────────────────────────────────────────────────────────────────────
-  Select your provider
+  Select your provider:
 
 > 1. local
   2. ExampleBroker

--- a/pam/integration-tests/testdata/golden/TestCLIAuthenticate/Authenticate_user_and_reset_password_while_enforcing_policy
+++ b/pam/integration-tests/testdata/golden/TestCLIAuthenticate/Authenticate_user_and_reset_password_while_enforcing_policy
@@ -12,18 +12,18 @@ Username: user-needs-reset-integration-mandatory@example.com
 Gimme your password:
 >
 
-  Press escape key to go back to select the authentication method
+  Press escape key to go back to select the authentication flow
 ────────────────────────────────────────────────────────────────────────────────
 Gimme your password:
 > ********
 
-  Press escape key to go back to select the authentication method
+  Press escape key to go back to select the authentication flow
 ────────────────────────────────────────────────────────────────────────────────
 Gimme your password:
 > ********
 Password reset, 1 step(s) missing
 
-  Press escape key to go back to select the authentication method
+  Press escape key to go back to select the authentication flow
 ────────────────────────────────────────────────────────────────────────────────
 Enter your new password
 

--- a/pam/integration-tests/testdata/golden/TestCLIAuthenticate/Authenticate_user_and_reset_password_while_enforcing_policy
+++ b/pam/integration-tests/testdata/golden/TestCLIAuthenticate/Authenticate_user_and_reset_password_while_enforcing_policy
@@ -2,7 +2,7 @@ Username: user name
 ────────────────────────────────────────────────────────────────────────────────
 Username: user-needs-reset-integration-mandatory@example.com
 ────────────────────────────────────────────────────────────────────────────────
-  Select your provider
+  Select your provider:
 
 > 1. local
   2. ExampleBroker

--- a/pam/integration-tests/testdata/golden/TestCLIAuthenticate/Authenticate_user_and_reset_password_with_case_insensitive_user_selection
+++ b/pam/integration-tests/testdata/golden/TestCLIAuthenticate/Authenticate_user_and_reset_password_with_case_insensitive_user_selection
@@ -13,18 +13,18 @@ Username: user-needs-reset-integration-case-insensitive-authenticate-user-and-re
 Gimme your password:
 >
 
-  Press escape key to go back to select the authentication method
+  Press escape key to go back to select the authentication flow
 ────────────────────────────────────────────────────────────────────────────────
 Gimme your password:
 > ********
 
-  Press escape key to go back to select the authentication method
+  Press escape key to go back to select the authentication flow
 ────────────────────────────────────────────────────────────────────────────────
 Gimme your password:
 > ********
 Password reset, 1 step(s) missing
 
-  Press escape key to go back to select the authentication method
+  Press escape key to go back to select the authentication flow
 ────────────────────────────────────────────────────────────────────────────────
 Enter your new password
 
@@ -72,12 +72,12 @@ Username: USER-NEEDS-RESET-INTEGRATION-CASE-INSENSITIVE-AUTHENTICATE-USER-AND-RE
 Gimme your password:
 >
 
-  Press escape key to go back to select the authentication method
+  Press escape key to go back to select the authentication flow
 ────────────────────────────────────────────────────────────────────────────────
 Gimme your password:
 > *********
 
-  Press escape key to go back to select the authentication method
+  Press escape key to go back to select the authentication flow
 ────────────────────────────────────────────────────────────────────────────────
   PAM_AUTHTOK: "authd2404"
 PAM Authenticate()
@@ -93,12 +93,12 @@ Username: user-needs-reset-integration-Case-INSENSITIVE-authenticate-user-and-re
 Gimme your password:
 >
 
-  Press escape key to go back to select the authentication method
+  Press escape key to go back to select the authentication flow
 ────────────────────────────────────────────────────────────────────────────────
 Gimme your password:
 > *********
 
-  Press escape key to go back to select the authentication method
+  Press escape key to go back to select the authentication flow
 ────────────────────────────────────────────────────────────────────────────────
   PAM_AUTHTOK: "authd2404"
 PAM Authenticate()

--- a/pam/integration-tests/testdata/golden/TestCLIAuthenticate/Authenticate_user_and_reset_password_with_case_insensitive_user_selection
+++ b/pam/integration-tests/testdata/golden/TestCLIAuthenticate/Authenticate_user_and_reset_password_with_case_insensitive_user_selection
@@ -3,7 +3,7 @@ Username: user name
 ────────────────────────────────────────────────────────────────────────────────
 Username: user-needs-reset-integration-case-insensitive-authenticate-user-and-reset-password-with-case-insensitive-user-selection@example.com
 ────────────────────────────────────────────────────────────────────────────────
-  Select your provider
+  Select your provider:
 
 > 1. local
   2. ExampleBroker

--- a/pam/integration-tests/testdata/golden/TestCLIAuthenticate/Authenticate_user_successfully
+++ b/pam/integration-tests/testdata/golden/TestCLIAuthenticate/Authenticate_user_successfully
@@ -12,12 +12,12 @@ Username: user-integration-simple-testcliauthenticate@example.com
 Gimme your password:
 >
 
-  Press escape key to go back to select the authentication method
+  Press escape key to go back to select the authentication flow
 ────────────────────────────────────────────────────────────────────────────────
 Gimme your password:
 > ********
 
-  Press escape key to go back to select the authentication method
+  Press escape key to go back to select the authentication flow
 ────────────────────────────────────────────────────────────────────────────────
   PAM_AUTHTOK: "goodpass"
 PAM Authenticate()

--- a/pam/integration-tests/testdata/golden/TestCLIAuthenticate/Authenticate_user_successfully
+++ b/pam/integration-tests/testdata/golden/TestCLIAuthenticate/Authenticate_user_successfully
@@ -2,7 +2,7 @@ Username: user name
 ────────────────────────────────────────────────────────────────────────────────
 Username: user-integration-simple-testcliauthenticate@example.com
 ────────────────────────────────────────────────────────────────────────────────
-  Select your provider
+  Select your provider:
 
 > 1. local
   2. ExampleBroker

--- a/pam/integration-tests/testdata/golden/TestCLIAuthenticate/Authenticate_user_successfully_after_trying_empty_user
+++ b/pam/integration-tests/testdata/golden/TestCLIAuthenticate/Authenticate_user_successfully_after_trying_empty_user
@@ -16,12 +16,12 @@ Username: user-integration-was-empty@example.com
 Gimme your password:
 >
 
-  Press escape key to go back to select the authentication method
+  Press escape key to go back to select the authentication flow
 ────────────────────────────────────────────────────────────────────────────────
 Gimme your password:
 > ********
 
-  Press escape key to go back to select the authentication method
+  Press escape key to go back to select the authentication flow
 ────────────────────────────────────────────────────────────────────────────────
   PAM_AUTHTOK: "goodpass"
 PAM Authenticate()

--- a/pam/integration-tests/testdata/golden/TestCLIAuthenticate/Authenticate_user_successfully_after_trying_empty_user
+++ b/pam/integration-tests/testdata/golden/TestCLIAuthenticate/Authenticate_user_successfully_after_trying_empty_user
@@ -6,7 +6,7 @@ Username: user name
 ────────────────────────────────────────────────────────────────────────────────
 Username: user-integration-was-empty@example.com
 ────────────────────────────────────────────────────────────────────────────────
-  Select your provider
+  Select your provider:
 
 > 1. local
   2. ExampleBroker

--- a/pam/integration-tests/testdata/golden/TestCLIAuthenticate/Authenticate_user_successfully_with_invalid_connection_timeout
+++ b/pam/integration-tests/testdata/golden/TestCLIAuthenticate/Authenticate_user_successfully_with_invalid_connection_timeout
@@ -12,12 +12,12 @@ Username: user-integration-invalid-timeout-testcliauthenticate@example.com
 Gimme your password:
 >
 
-  Press escape key to go back to select the authentication method
+  Press escape key to go back to select the authentication flow
 ────────────────────────────────────────────────────────────────────────────────
 Gimme your password:
 > ********
 
-  Press escape key to go back to select the authentication method
+  Press escape key to go back to select the authentication flow
 ────────────────────────────────────────────────────────────────────────────────
   PAM_AUTHTOK: "goodpass"
 PAM Authenticate()

--- a/pam/integration-tests/testdata/golden/TestCLIAuthenticate/Authenticate_user_successfully_with_invalid_connection_timeout
+++ b/pam/integration-tests/testdata/golden/TestCLIAuthenticate/Authenticate_user_successfully_with_invalid_connection_timeout
@@ -2,7 +2,7 @@ Username: user name
 ────────────────────────────────────────────────────────────────────────────────
 Username: user-integration-invalid-timeout-testcliauthenticate@example.com
 ────────────────────────────────────────────────────────────────────────────────
-  Select your provider
+  Select your provider:
 
 > 1. local
   2. ExampleBroker

--- a/pam/integration-tests/testdata/golden/TestCLIAuthenticate/Authenticate_user_successfully_with_password_only_supported_method
+++ b/pam/integration-tests/testdata/golden/TestCLIAuthenticate/Authenticate_user_successfully_with_password_only_supported_method
@@ -2,7 +2,7 @@ Username: user name
 ────────────────────────────────────────────────────────────────────────────────
 Username: user-auth-modes-password-integration-cli@example.com
 ────────────────────────────────────────────────────────────────────────────────
-  Select your provider
+  Select your provider:
 
 > 1. local
   2. ExampleBroker

--- a/pam/integration-tests/testdata/golden/TestCLIAuthenticate/Authenticate_user_successfully_with_preset_user
+++ b/pam/integration-tests/testdata/golden/TestCLIAuthenticate/Authenticate_user_successfully_with_preset_user
@@ -6,12 +6,12 @@
 Gimme your password:
 >
 
-  Press escape key to go back to select the authentication method
+  Press escape key to go back to select the authentication flow
 ────────────────────────────────────────────────────────────────────────────────
 Gimme your password:
 > ********
 
-  Press escape key to go back to select the authentication method
+  Press escape key to go back to select the authentication flow
 ────────────────────────────────────────────────────────────────────────────────
   PAM_AUTHTOK: "goodpass"
 PAM Authenticate()

--- a/pam/integration-tests/testdata/golden/TestCLIAuthenticate/Authenticate_user_successfully_with_preset_user
+++ b/pam/integration-tests/testdata/golden/TestCLIAuthenticate/Authenticate_user_successfully_with_preset_user
@@ -1,4 +1,4 @@
-  Select your provider
+  Select your provider:
 
 > 1. local
   2. ExampleBroker

--- a/pam/integration-tests/testdata/golden/TestCLIAuthenticate/Authenticate_user_successfully_with_upper_case
+++ b/pam/integration-tests/testdata/golden/TestCLIAuthenticate/Authenticate_user_successfully_with_upper_case
@@ -12,12 +12,12 @@ Username: user-integration-upper-case-testcliauthenticate@example.com
 Gimme your password:
 >
 
-  Press escape key to go back to select the authentication method
+  Press escape key to go back to select the authentication flow
 ────────────────────────────────────────────────────────────────────────────────
 Gimme your password:
 > ********
 
-  Press escape key to go back to select the authentication method
+  Press escape key to go back to select the authentication flow
 ────────────────────────────────────────────────────────────────────────────────
   PAM_AUTHTOK: "goodpass"
 PAM Authenticate()

--- a/pam/integration-tests/testdata/golden/TestCLIAuthenticate/Authenticate_user_successfully_with_upper_case
+++ b/pam/integration-tests/testdata/golden/TestCLIAuthenticate/Authenticate_user_successfully_with_upper_case
@@ -2,7 +2,7 @@ Username: user name
 ────────────────────────────────────────────────────────────────────────────────
 Username: user-integration-upper-case-testcliauthenticate@example.com
 ────────────────────────────────────────────────────────────────────────────────
-  Select your provider
+  Select your provider:
 
 > 1. local
   2. ExampleBroker

--- a/pam/integration-tests/testdata/golden/TestCLIAuthenticate/Authenticate_user_successfully_with_upper_case_preset_user
+++ b/pam/integration-tests/testdata/golden/TestCLIAuthenticate/Authenticate_user_successfully_with_upper_case_preset_user
@@ -6,12 +6,12 @@
 Gimme your password:
 >
 
-  Press escape key to go back to select the authentication method
+  Press escape key to go back to select the authentication flow
 ────────────────────────────────────────────────────────────────────────────────
 Gimme your password:
 > ********
 
-  Press escape key to go back to select the authentication method
+  Press escape key to go back to select the authentication flow
 ────────────────────────────────────────────────────────────────────────────────
   PAM_AUTHTOK: "goodpass"
 PAM Authenticate()

--- a/pam/integration-tests/testdata/golden/TestCLIAuthenticate/Authenticate_user_successfully_with_upper_case_preset_user
+++ b/pam/integration-tests/testdata/golden/TestCLIAuthenticate/Authenticate_user_successfully_with_upper_case_preset_user
@@ -1,4 +1,4 @@
-  Select your provider
+  Select your provider:
 
 > 1. local
   2. ExampleBroker

--- a/pam/integration-tests/testdata/golden/TestCLIAuthenticate/Authenticate_user_switching_auth_mode
+++ b/pam/integration-tests/testdata/golden/TestCLIAuthenticate/Authenticate_user_switching_auth_mode
@@ -12,9 +12,9 @@ Username: user-integration-switch-mode@example.com
 Gimme your password:
 >
 
-  Press escape key to go back to select the authentication method
+  Press escape key to go back to select the authentication flow
 ────────────────────────────────────────────────────────────────────────────────
-  Select your authentication method
+  Select the authentication flow
 
 > 1. Password authentication
   2. Send URL to user-integration-switch-mode@example.com
@@ -29,9 +29,9 @@ Gimme your password:
 Click on the link received at user-integration-switch-mode@example.com or enter the code:
 >
 
-  Press escape key to go back to select the authentication method
+  Press escape key to go back to select the authentication flow
 ────────────────────────────────────────────────────────────────────────────────
-  Select your authentication method
+  Select the authentication flow
 
   1. Password authentication
 > 2. Send URL to user-integration-switch-mode@example.com
@@ -45,9 +45,9 @@ Click on the link received at user-integration-switch-mode@example.com or enter 
 ────────────────────────────────────────────────────────────────────────────────
 Plug your fido device and press with your thumb
 
-  Press escape key to go back to select the authentication method
+  Press escape key to go back to select the authentication flow
 ────────────────────────────────────────────────────────────────────────────────
-  Select your authentication method
+  Select the authentication flow
 
   1. Password authentication
   2. Send URL to user-integration-switch-mode@example.com
@@ -62,12 +62,12 @@ Plug your fido device and press with your thumb
 Gimme your password:
 >
 
-  Press escape key to go back to select the authentication method
+  Press escape key to go back to select the authentication flow
 ────────────────────────────────────────────────────────────────────────────────
 Gimme your password:
 > ********
 
-  Press escape key to go back to select the authentication method
+  Press escape key to go back to select the authentication flow
 ────────────────────────────────────────────────────────────────────────────────
   PAM_AUTHTOK: "goodpass"
 PAM Authenticate()

--- a/pam/integration-tests/testdata/golden/TestCLIAuthenticate/Authenticate_user_switching_auth_mode
+++ b/pam/integration-tests/testdata/golden/TestCLIAuthenticate/Authenticate_user_switching_auth_mode
@@ -2,7 +2,7 @@ Username: user name
 ────────────────────────────────────────────────────────────────────────────────
 Username: user-integration-switch-mode@example.com
 ────────────────────────────────────────────────────────────────────────────────
-  Select your provider
+  Select your provider:
 
 > 1. local
   2. ExampleBroker
@@ -14,7 +14,7 @@ Gimme your password:
 
   Press escape key to go back to select the authentication flow
 ────────────────────────────────────────────────────────────────────────────────
-  Select the authentication flow
+  Select the authentication flow:
 
 > 1. Password authentication
   2. Send URL to user-integration-switch-mode@example.com
@@ -31,7 +31,7 @@ Click on the link received at user-integration-switch-mode@example.com or enter 
 
   Press escape key to go back to select the authentication flow
 ────────────────────────────────────────────────────────────────────────────────
-  Select the authentication flow
+  Select the authentication flow:
 
   1. Password authentication
 > 2. Send URL to user-integration-switch-mode@example.com
@@ -47,7 +47,7 @@ Plug your fido device and press with your thumb
 
   Press escape key to go back to select the authentication flow
 ────────────────────────────────────────────────────────────────────────────────
-  Select the authentication flow
+  Select the authentication flow:
 
   1. Password authentication
   2. Send URL to user-integration-switch-mode@example.com

--- a/pam/integration-tests/testdata/golden/TestCLIAuthenticate/Authenticate_user_switching_to_local_broker
+++ b/pam/integration-tests/testdata/golden/TestCLIAuthenticate/Authenticate_user_switching_to_local_broker
@@ -2,7 +2,7 @@ Username: user name
 ────────────────────────────────────────────────────────────────────────────────
 Username: user-integration-switch-broker@example.com
 ────────────────────────────────────────────────────────────────────────────────
-  Select your provider
+  Select your provider:
 
 > 1. local
   2. ExampleBroker
@@ -14,7 +14,7 @@ Gimme your password:
 
   Press escape key to go back to select the authentication flow
 ────────────────────────────────────────────────────────────────────────────────
-  Select the authentication flow
+  Select the authentication flow:
 
 > 1. Password authentication
   2. Send URL to user-integration-switch-broker@example.com
@@ -26,14 +26,14 @@ Gimme your password:
 
   Press escape key to go back to choose the provider
 ────────────────────────────────────────────────────────────────────────────────
-  Select your provider
+  Select your provider:
 
   1. local
 > 2. ExampleBroker
 
   Press escape key to go back to user selection
 ────────────────────────────────────────────────────────────────────────────────
-  Select your provider
+  Select your provider:
 
 > 1. local
   2. ExampleBroker

--- a/pam/integration-tests/testdata/golden/TestCLIAuthenticate/Authenticate_user_switching_to_local_broker
+++ b/pam/integration-tests/testdata/golden/TestCLIAuthenticate/Authenticate_user_switching_to_local_broker
@@ -12,9 +12,9 @@ Username: user-integration-switch-broker@example.com
 Gimme your password:
 >
 
-  Press escape key to go back to select the authentication method
+  Press escape key to go back to select the authentication flow
 ────────────────────────────────────────────────────────────────────────────────
-  Select your authentication method
+  Select the authentication flow
 
 > 1. Password authentication
   2. Send URL to user-integration-switch-broker@example.com

--- a/pam/integration-tests/testdata/golden/TestCLIAuthenticate/Authenticate_user_switching_username
+++ b/pam/integration-tests/testdata/golden/TestCLIAuthenticate/Authenticate_user_switching_username
@@ -2,7 +2,7 @@ Username: user name
 ────────────────────────────────────────────────────────────────────────────────
 Username: user-integration-switch-username@example.com
 ────────────────────────────────────────────────────────────────────────────────
-  Select your provider
+  Select your provider:
 
 > 1. local
   2. ExampleBroker
@@ -11,7 +11,7 @@ Username: user-integration-switch-username@example.com
 ────────────────────────────────────────────────────────────────────────────────
 Username: user-integration-username-switched@example.com
 ────────────────────────────────────────────────────────────────────────────────
-  Select your provider
+  Select your provider:
 
 > 1. local
   2. ExampleBroker

--- a/pam/integration-tests/testdata/golden/TestCLIAuthenticate/Authenticate_user_switching_username
+++ b/pam/integration-tests/testdata/golden/TestCLIAuthenticate/Authenticate_user_switching_username
@@ -21,12 +21,12 @@ Username: user-integration-username-switched@example.com
 Gimme your password:
 >
 
-  Press escape key to go back to select the authentication method
+  Press escape key to go back to select the authentication flow
 ────────────────────────────────────────────────────────────────────────────────
 Gimme your password:
 > ********
 
-  Press escape key to go back to select the authentication method
+  Press escape key to go back to select the authentication flow
 ────────────────────────────────────────────────────────────────────────────────
   PAM_AUTHTOK: "goodpass"
 PAM Authenticate()

--- a/pam/integration-tests/testdata/golden/TestCLIAuthenticate/Authenticate_user_with_form_mode_with_button
+++ b/pam/integration-tests/testdata/golden/TestCLIAuthenticate/Authenticate_user_with_form_mode_with_button
@@ -12,9 +12,9 @@ Username: user-integration-form-w-button@example.com
 Gimme your password:
 >
 
-  Press escape key to go back to select the authentication method
+  Press escape key to go back to select the authentication flow
 ────────────────────────────────────────────────────────────────────────────────
-  Select your authentication method
+  Select the authentication flow
 
 > 1. Password authentication
   2. Send URL to user-integration-form-w-button@example.com
@@ -31,21 +31,21 @@ Enter your one time credential:
 
   [ Resend SMS (1 sent) ]
 
-  Press escape key to go back to select the authentication method
+  Press escape key to go back to select the authentication flow
 ────────────────────────────────────────────────────────────────────────────────
 Enter your one time credential:
 >
 
   [ Resend SMS (2 sent) ]
 
-  Press escape key to go back to select the authentication method
+  Press escape key to go back to select the authentication flow
 ────────────────────────────────────────────────────────────────────────────────
 Enter your one time credential:
 > temporary pass00
 
   [ Resend SMS (2 sent) ]
 
-  Press escape key to go back to select the authentication method
+  Press escape key to go back to select the authentication flow
 ────────────────────────────────────────────────────────────────────────────────
   PAM_AUTHTOK: "temporary pass00"
 PAM Authenticate()

--- a/pam/integration-tests/testdata/golden/TestCLIAuthenticate/Authenticate_user_with_form_mode_with_button
+++ b/pam/integration-tests/testdata/golden/TestCLIAuthenticate/Authenticate_user_with_form_mode_with_button
@@ -2,7 +2,7 @@ Username: user name
 ────────────────────────────────────────────────────────────────────────────────
 Username: user-integration-form-w-button@example.com
 ────────────────────────────────────────────────────────────────────────────────
-  Select your provider
+  Select your provider:
 
 > 1. local
   2. ExampleBroker
@@ -14,7 +14,7 @@ Gimme your password:
 
   Press escape key to go back to select the authentication flow
 ────────────────────────────────────────────────────────────────────────────────
-  Select the authentication flow
+  Select the authentication flow:
 
 > 1. Password authentication
   2. Send URL to user-integration-form-w-button@example.com

--- a/pam/integration-tests/testdata/golden/TestCLIAuthenticate/Authenticate_user_with_mfa
+++ b/pam/integration-tests/testdata/golden/TestCLIAuthenticate/Authenticate_user_with_mfa
@@ -2,7 +2,7 @@ Username: user name
 ────────────────────────────────────────────────────────────────────────────────
 Username: user-mfa@example.com
 ────────────────────────────────────────────────────────────────────────────────
-  Select your provider
+  Select your provider:
 
 > 1. local
   2. ExampleBroker
@@ -14,7 +14,7 @@ Gimme your password:
 
   Press escape key to go back to select the authentication flow
 ────────────────────────────────────────────────────────────────────────────────
-  Select the authentication flow
+  Select the authentication flow:
 
 > 1. Password authentication
   2. Send URL to user-mfa@example.com
@@ -40,7 +40,7 @@ Plug your fido device and press with your thumb
 
   Press escape key to go back to select the authentication flow
 ────────────────────────────────────────────────────────────────────────────────
-  Select the authentication flow
+  Select the authentication flow:
 
 > 1. Use your fido device foo
   2. Use your phone +33...
@@ -56,7 +56,7 @@ Unlock your phone +33... or accept request on web interface
 
   Press escape key to go back to select the authentication flow
 ────────────────────────────────────────────────────────────────────────────────
-  Select the authentication flow
+  Select the authentication flow:
 
 > 1. Use your phone +33...
   2. Authentication code

--- a/pam/integration-tests/testdata/golden/TestCLIAuthenticate/Authenticate_user_with_mfa
+++ b/pam/integration-tests/testdata/golden/TestCLIAuthenticate/Authenticate_user_with_mfa
@@ -12,9 +12,9 @@ Username: user-mfa@example.com
 Gimme your password:
 >
 
-  Press escape key to go back to select the authentication method
+  Press escape key to go back to select the authentication flow
 ────────────────────────────────────────────────────────────────────────────────
-  Select your authentication method
+  Select the authentication flow
 
 > 1. Password authentication
   2. Send URL to user-mfa@example.com
@@ -29,18 +29,18 @@ Gimme your password:
 Gimme your password:
 >
 
-  Press escape key to go back to select the authentication method
+  Press escape key to go back to select the authentication flow
 ────────────────────────────────────────────────────────────────────────────────
 Gimme your password:
 > ********
 
-  Press escape key to go back to select the authentication method
+  Press escape key to go back to select the authentication flow
 ────────────────────────────────────────────────────────────────────────────────
 Plug your fido device and press with your thumb
 
-  Press escape key to go back to select the authentication method
+  Press escape key to go back to select the authentication flow
 ────────────────────────────────────────────────────────────────────────────────
-  Select your authentication method
+  Select the authentication flow
 
 > 1. Use your fido device foo
   2. Use your phone +33...
@@ -50,13 +50,13 @@ Plug your fido device and press with your thumb
 ────────────────────────────────────────────────────────────────────────────────
 Plug your fido device and press with your thumb
 
-  Press escape key to go back to select the authentication method
+  Press escape key to go back to select the authentication flow
 ────────────────────────────────────────────────────────────────────────────────
 Unlock your phone +33... or accept request on web interface
 
-  Press escape key to go back to select the authentication method
+  Press escape key to go back to select the authentication flow
 ────────────────────────────────────────────────────────────────────────────────
-  Select your authentication method
+  Select the authentication flow
 
 > 1. Use your phone +33...
   2. Authentication code
@@ -65,7 +65,7 @@ Unlock your phone +33... or accept request on web interface
 ────────────────────────────────────────────────────────────────────────────────
 Unlock your phone +33... or accept request on web interface
 
-  Press escape key to go back to select the authentication method
+  Press escape key to go back to select the authentication flow
 ────────────────────────────────────────────────────────────────────────────────
   PAM_AUTHTOK: "goodpass"
 PAM Authenticate()

--- a/pam/integration-tests/testdata/golden/TestCLIAuthenticate/Authenticate_user_with_mfa_and_reset_password_while_enforcing_policy
+++ b/pam/integration-tests/testdata/golden/TestCLIAuthenticate/Authenticate_user_with_mfa_and_reset_password_while_enforcing_policy
@@ -12,27 +12,27 @@ Username: user-mfa-with-reset@example.com
 Gimme your password:
 >
 
-  Press escape key to go back to select the authentication method
+  Press escape key to go back to select the authentication flow
 ────────────────────────────────────────────────────────────────────────────────
 Gimme your password:
 > ********
 
-  Press escape key to go back to select the authentication method
+  Press escape key to go back to select the authentication flow
 ────────────────────────────────────────────────────────────────────────────────
 Gimme your password:
 > ********
 Password reset, 2 step(s) missing
 
-  Press escape key to go back to select the authentication method
+  Press escape key to go back to select the authentication flow
 ────────────────────────────────────────────────────────────────────────────────
 Plug your fido device and press with your thumb
 
-  Press escape key to go back to select the authentication method
+  Press escape key to go back to select the authentication flow
 ────────────────────────────────────────────────────────────────────────────────
 Plug your fido device and press with your thumb
 Password reset, 1 step(s) missing
 
-  Press escape key to go back to select the authentication method
+  Press escape key to go back to select the authentication flow
 ────────────────────────────────────────────────────────────────────────────────
 Enter your new password (3 days until mandatory)
 

--- a/pam/integration-tests/testdata/golden/TestCLIAuthenticate/Authenticate_user_with_mfa_and_reset_password_while_enforcing_policy
+++ b/pam/integration-tests/testdata/golden/TestCLIAuthenticate/Authenticate_user_with_mfa_and_reset_password_while_enforcing_policy
@@ -2,7 +2,7 @@ Username: user name
 ────────────────────────────────────────────────────────────────────────────────
 Username: user-mfa-with-reset@example.com
 ────────────────────────────────────────────────────────────────────────────────
-  Select your provider
+  Select your provider:
 
 > 1. local
   2. ExampleBroker

--- a/pam/integration-tests/testdata/golden/TestCLIAuthenticate/Authenticate_user_with_qr_code
+++ b/pam/integration-tests/testdata/golden/TestCLIAuthenticate/Authenticate_user_with_qr_code
@@ -1,4 +1,4 @@
-  Select your provider
+  Select your provider:
 
 > 1. local
   2. ExampleBroker
@@ -8,7 +8,7 @@ Gimme your password:
 
   Press escape key to go back to select the authentication flow
 ────────────────────────────────────────────────────────────────────────────────
-  Select the authentication flow
+  Select the authentication flow:
 
 > 1. Password authentication
   2. Send URL to user-integration-qr-code@example.com

--- a/pam/integration-tests/testdata/golden/TestCLIAuthenticate/Authenticate_user_with_qr_code
+++ b/pam/integration-tests/testdata/golden/TestCLIAuthenticate/Authenticate_user_with_qr_code
@@ -6,9 +6,9 @@
 Gimme your password:
 >
 
-  Press escape key to go back to select the authentication method
+  Press escape key to go back to select the authentication flow
 ────────────────────────────────────────────────────────────────────────────────
-  Select your authentication method
+  Select the authentication flow
 
 > 1. Password authentication
   2. Send URL to user-integration-qr-code@example.com
@@ -45,7 +45,7 @@ Code: 1337
 
         [ Regenerate code ]
 
-  Press escape key to go back to select the authentication method
+  Press escape key to go back to select the authentication flow
 ────────────────────────────────────────────────────────────────────────────────
 Scan the qrcode or enter the code in the login page
 
@@ -72,7 +72,7 @@ Code: 1338
 
         [ Regenerate code ]
 
-  Press escape key to go back to select the authentication method
+  Press escape key to go back to select the authentication flow
 ────────────────────────────────────────────────────────────────────────────────
 Scan the qrcode or enter the code in the login page
 
@@ -101,7 +101,7 @@ Code: 1339
 
           [ Regenerate code ]
 
-  Press escape key to go back to select the authentication method
+  Press escape key to go back to select the authentication flow
 ────────────────────────────────────────────────────────────────────────────────
 Scan the qrcode or enter the code in the login page
 
@@ -128,7 +128,7 @@ Code: 1340
 
         [ Regenerate code ]
 
-  Press escape key to go back to select the authentication method
+  Press escape key to go back to select the authentication flow
 ────────────────────────────────────────────────────────────────────────────────
 Scan the qrcode or enter the code in the login page
 
@@ -155,7 +155,7 @@ Code: 1341
 
         [ Regenerate code ]
 
-  Press escape key to go back to select the authentication method
+  Press escape key to go back to select the authentication flow
 ────────────────────────────────────────────────────────────────────────────────
 PAM Authenticate()
   User: "user-integration-qr-code@example.com"

--- a/pam/integration-tests/testdata/golden/TestCLIAuthenticate/Authenticate_user_with_qr_code_after_many_regenerations
+++ b/pam/integration-tests/testdata/golden/TestCLIAuthenticate/Authenticate_user_with_qr_code_after_many_regenerations
@@ -2,7 +2,7 @@ Username: user name
 ────────────────────────────────────────────────────────────────────────────────
 Username: user-integration-qrcode-static-regenerate@example.com
 ────────────────────────────────────────────────────────────────────────────────
-  Select your provider
+  Select your provider:
 
 > 1. local
   2. ExampleBroker
@@ -14,7 +14,7 @@ Gimme your password:
 
   Press escape key to go back to select the authentication flow
 ────────────────────────────────────────────────────────────────────────────────
-  Select the authentication flow
+  Select the authentication flow:
 
 > 1. Password authentication
   2. Send URL to user-integration-qrcode-static-regenerate@example.com

--- a/pam/integration-tests/testdata/golden/TestCLIAuthenticate/Authenticate_user_with_qr_code_after_many_regenerations
+++ b/pam/integration-tests/testdata/golden/TestCLIAuthenticate/Authenticate_user_with_qr_code_after_many_regenerations
@@ -12,9 +12,9 @@ Username: user-integration-qrcode-static-regenerate@example.com
 Gimme your password:
 >
 
-  Press escape key to go back to select the authentication method
+  Press escape key to go back to select the authentication flow
 ────────────────────────────────────────────────────────────────────────────────
-  Select your authentication method
+  Select the authentication flow
 
 > 1. Password authentication
   2. Send URL to user-integration-qrcode-static-regenerate@example.com
@@ -51,7 +51,7 @@ Code: 1337
 
         [ Regenerate code ]
 
-  Press escape key to go back to select the authentication method
+  Press escape key to go back to select the authentication flow
 ────────────────────────────────────────────────────────────────────────────────
 PAM Authenticate()
   User: "user-integration-qrcode-static-regenerate@example.com"

--- a/pam/integration-tests/testdata/golden/TestCLIAuthenticate/Authenticate_user_with_qr_code_in_a_TTY
+++ b/pam/integration-tests/testdata/golden/TestCLIAuthenticate/Authenticate_user_with_qr_code_in_a_TTY
@@ -6,9 +6,9 @@
 Gimme your password:
 >
 
-  Press escape key to go back to select the authentication method
+  Press escape key to go back to select the authentication flow
 ────────────────────────────────────────────────────────────────────────────────
-  Select your authentication method
+  Select the authentication flow
 
 > 1. Password authentication
   2. Send URL to user-integration-qr-code-tty@example.com
@@ -61,7 +61,7 @@ Code: 1337
 
                         [ Regenerate code ]
 
-  Press escape key to go back to select the authentication method
+  Press escape key to go back to select the authentication flow
 ────────────────────────────────────────────────────────────────────────────────
 Scan the qrcode or enter the code in the login page
 
@@ -104,7 +104,7 @@ Code: 1338
 
                         [ Regenerate code ]
 
-  Press escape key to go back to select the authentication method
+  Press escape key to go back to select the authentication flow
 ────────────────────────────────────────────────────────────────────────────────
 Scan the qrcode or enter the code in the login page
 
@@ -151,7 +151,7 @@ Code: 1339
 
                             [ Regenerate code ]
 
-  Press escape key to go back to select the authentication method
+  Press escape key to go back to select the authentication flow
 ────────────────────────────────────────────────────────────────────────────────
 Scan the qrcode or enter the code in the login page
 
@@ -194,7 +194,7 @@ Code: 1340
 
                         [ Regenerate code ]
 
-  Press escape key to go back to select the authentication method
+  Press escape key to go back to select the authentication flow
 ────────────────────────────────────────────────────────────────────────────────
 Scan the qrcode or enter the code in the login page
 
@@ -237,7 +237,7 @@ Code: 1341
 
                         [ Regenerate code ]
 
-  Press escape key to go back to select the authentication method
+  Press escape key to go back to select the authentication flow
 ────────────────────────────────────────────────────────────────────────────────
 PAM Authenticate()
   User: "user-integration-qr-code-tty@example.com"

--- a/pam/integration-tests/testdata/golden/TestCLIAuthenticate/Authenticate_user_with_qr_code_in_a_TTY
+++ b/pam/integration-tests/testdata/golden/TestCLIAuthenticate/Authenticate_user_with_qr_code_in_a_TTY
@@ -1,4 +1,4 @@
-  Select your provider
+  Select your provider:
 
 > 1. local
   2. ExampleBroker
@@ -8,7 +8,7 @@ Gimme your password:
 
   Press escape key to go back to select the authentication flow
 ────────────────────────────────────────────────────────────────────────────────
-  Select the authentication flow
+  Select the authentication flow:
 
 > 1. Password authentication
   2. Send URL to user-integration-qr-code-tty@example.com

--- a/pam/integration-tests/testdata/golden/TestCLIAuthenticate/Authenticate_user_with_qr_code_in_a_TTY_session
+++ b/pam/integration-tests/testdata/golden/TestCLIAuthenticate/Authenticate_user_with_qr_code_in_a_TTY_session
@@ -6,9 +6,9 @@
 Gimme your password:
 >
 
-  Press escape key to go back to select the authentication method
+  Press escape key to go back to select the authentication flow
 ────────────────────────────────────────────────────────────────────────────────
-  Select your authentication method
+  Select the authentication flow
 
 > 1. Password authentication
   2. Send URL to user-integration-qr-code-tty-session@example.com
@@ -61,7 +61,7 @@ Code: 1337
 
                         [ Regenerate code ]
 
-  Press escape key to go back to select the authentication method
+  Press escape key to go back to select the authentication flow
 ────────────────────────────────────────────────────────────────────────────────
 Scan the qrcode or enter the code in the login page
 
@@ -104,7 +104,7 @@ Code: 1338
 
                         [ Regenerate code ]
 
-  Press escape key to go back to select the authentication method
+  Press escape key to go back to select the authentication flow
 ────────────────────────────────────────────────────────────────────────────────
 Scan the qrcode or enter the code in the login page
 
@@ -151,7 +151,7 @@ Code: 1339
 
                             [ Regenerate code ]
 
-  Press escape key to go back to select the authentication method
+  Press escape key to go back to select the authentication flow
 ────────────────────────────────────────────────────────────────────────────────
 Scan the qrcode or enter the code in the login page
 
@@ -194,7 +194,7 @@ Code: 1340
 
                         [ Regenerate code ]
 
-  Press escape key to go back to select the authentication method
+  Press escape key to go back to select the authentication flow
 ────────────────────────────────────────────────────────────────────────────────
 Scan the qrcode or enter the code in the login page
 
@@ -237,7 +237,7 @@ Code: 1341
 
                         [ Regenerate code ]
 
-  Press escape key to go back to select the authentication method
+  Press escape key to go back to select the authentication flow
 ────────────────────────────────────────────────────────────────────────────────
 PAM Authenticate()
   User: "user-integration-qr-code-tty-session@example.com"

--- a/pam/integration-tests/testdata/golden/TestCLIAuthenticate/Authenticate_user_with_qr_code_in_a_TTY_session
+++ b/pam/integration-tests/testdata/golden/TestCLIAuthenticate/Authenticate_user_with_qr_code_in_a_TTY_session
@@ -1,4 +1,4 @@
-  Select your provider
+  Select your provider:
 
 > 1. local
   2. ExampleBroker
@@ -8,7 +8,7 @@ Gimme your password:
 
   Press escape key to go back to select the authentication flow
 ────────────────────────────────────────────────────────────────────────────────
-  Select the authentication flow
+  Select the authentication flow:
 
 > 1. Password authentication
   2. Send URL to user-integration-qr-code-tty-session@example.com

--- a/pam/integration-tests/testdata/golden/TestCLIAuthenticate/Authenticate_user_with_qr_code_in_screen
+++ b/pam/integration-tests/testdata/golden/TestCLIAuthenticate/Authenticate_user_with_qr_code_in_screen
@@ -1,4 +1,4 @@
-  Select your provider
+  Select your provider:
 
 > 1. local
   2. ExampleBroker
@@ -8,7 +8,7 @@ Gimme your password:
 
   Press escape key to go back to select the authentication flow
 ────────────────────────────────────────────────────────────────────────────────
-  Select the authentication flow
+  Select the authentication flow:
 
 > 1. Password authentication
   2. Send URL to user-integration-qr-code-screen@example.com

--- a/pam/integration-tests/testdata/golden/TestCLIAuthenticate/Authenticate_user_with_qr_code_in_screen
+++ b/pam/integration-tests/testdata/golden/TestCLIAuthenticate/Authenticate_user_with_qr_code_in_screen
@@ -6,9 +6,9 @@
 Gimme your password:
 >
 
-  Press escape key to go back to select the authentication method
+  Press escape key to go back to select the authentication flow
 ────────────────────────────────────────────────────────────────────────────────
-  Select your authentication method
+  Select the authentication flow
 
 > 1. Password authentication
   2. Send URL to user-integration-qr-code-screen@example.com
@@ -61,7 +61,7 @@ Code: 1337
 
                         [ Regenerate code ]
 
-  Press escape key to go back to select the authentication method
+  Press escape key to go back to select the authentication flow
 ────────────────────────────────────────────────────────────────────────────────
 Scan the qrcode or enter the code in the login page
 
@@ -104,7 +104,7 @@ Code: 1338
 
                         [ Regenerate code ]
 
-  Press escape key to go back to select the authentication method
+  Press escape key to go back to select the authentication flow
 ────────────────────────────────────────────────────────────────────────────────
 Scan the qrcode or enter the code in the login page
 
@@ -151,7 +151,7 @@ Code: 1339
 
                             [ Regenerate code ]
 
-  Press escape key to go back to select the authentication method
+  Press escape key to go back to select the authentication flow
 ────────────────────────────────────────────────────────────────────────────────
 Scan the qrcode or enter the code in the login page
 
@@ -194,7 +194,7 @@ Code: 1340
 
                         [ Regenerate code ]
 
-  Press escape key to go back to select the authentication method
+  Press escape key to go back to select the authentication flow
 ────────────────────────────────────────────────────────────────────────────────
 Scan the qrcode or enter the code in the login page
 
@@ -237,7 +237,7 @@ Code: 1341
 
                         [ Regenerate code ]
 
-  Press escape key to go back to select the authentication method
+  Press escape key to go back to select the authentication flow
 ────────────────────────────────────────────────────────────────────────────────
 PAM Authenticate()
   User: "user-integration-qr-code-screen@example.com"

--- a/pam/integration-tests/testdata/golden/TestCLIAuthenticate/Authenticate_with_warnings_on_unsupported_arguments
+++ b/pam/integration-tests/testdata/golden/TestCLIAuthenticate/Authenticate_with_warnings_on_unsupported_arguments
@@ -12,12 +12,12 @@ Username: user2@example.com
 Gimme your password:
 >
 
-  Press escape key to go back to select the authentication method
+  Press escape key to go back to select the authentication flow
 ────────────────────────────────────────────────────────────────────────────────
 Gimme your password:
 > ********
 
-  Press escape key to go back to select the authentication method
+  Press escape key to go back to select the authentication flow
 ────────────────────────────────────────────────────────────────────────────────
   PAM_AUTHTOK: "goodpass"
 PAM Authenticate()

--- a/pam/integration-tests/testdata/golden/TestCLIAuthenticate/Authenticate_with_warnings_on_unsupported_arguments
+++ b/pam/integration-tests/testdata/golden/TestCLIAuthenticate/Authenticate_with_warnings_on_unsupported_arguments
@@ -2,7 +2,7 @@ Username: user name
 ────────────────────────────────────────────────────────────────────────────────
 Username: user2@example.com
 ────────────────────────────────────────────────────────────────────────────────
-  Select your provider
+  Select your provider:
 
 > 1. local
   2. ExampleBroker

--- a/pam/integration-tests/testdata/golden/TestCLIAuthenticate/Deny_authentication_if_max_attempts_reached
+++ b/pam/integration-tests/testdata/golden/TestCLIAuthenticate/Deny_authentication_if_max_attempts_reached
@@ -2,7 +2,7 @@ Username: user name
 ────────────────────────────────────────────────────────────────────────────────
 Username: user-integration-max-attempts@example.com
 ────────────────────────────────────────────────────────────────────────────────
-  Select your provider
+  Select your provider:
 
 > 1. local
   2. ExampleBroker

--- a/pam/integration-tests/testdata/golden/TestCLIAuthenticate/Deny_authentication_if_max_attempts_reached
+++ b/pam/integration-tests/testdata/golden/TestCLIAuthenticate/Deny_authentication_if_max_attempts_reached
@@ -12,31 +12,31 @@ Username: user-integration-max-attempts@example.com
 Gimme your password:
 >
 
-  Press escape key to go back to select the authentication method
+  Press escape key to go back to select the authentication flow
 ────────────────────────────────────────────────────────────────────────────────
 Gimme your password:
 >
 invalid password 'wrongpass1', should be 'goodpass'
 
-  Press escape key to go back to select the authentication method
+  Press escape key to go back to select the authentication flow
 ────────────────────────────────────────────────────────────────────────────────
 Gimme your password:
 >
 invalid password 'wrongpass2', should be 'goodpass'
 
-  Press escape key to go back to select the authentication method
+  Press escape key to go back to select the authentication flow
 ────────────────────────────────────────────────────────────────────────────────
 Gimme your password:
 >
 invalid password 'wrongpass3', should be 'goodpass'
 
-  Press escape key to go back to select the authentication method
+  Press escape key to go back to select the authentication flow
 ────────────────────────────────────────────────────────────────────────────────
 Gimme your password:
 >
 invalid password 'wrongpass4', should be 'goodpass'
 
-  Press escape key to go back to select the authentication method
+  Press escape key to go back to select the authentication flow
 ────────────────────────────────────────────────────────────────────────────────
 PAM Error Message: Maximum number of authentication attempts reached
 PAM Authenticate()

--- a/pam/integration-tests/testdata/golden/TestCLIAuthenticate/Deny_authentication_if_newpassword_does_not_match_required_criteria
+++ b/pam/integration-tests/testdata/golden/TestCLIAuthenticate/Deny_authentication_if_newpassword_does_not_match_required_criteria
@@ -12,18 +12,18 @@ Username: user-needs-reset@example.com
 Gimme your password:
 >
 
-  Press escape key to go back to select the authentication method
+  Press escape key to go back to select the authentication flow
 ────────────────────────────────────────────────────────────────────────────────
 Gimme your password:
 > ********
 
-  Press escape key to go back to select the authentication method
+  Press escape key to go back to select the authentication flow
 ────────────────────────────────────────────────────────────────────────────────
 Gimme your password:
 > ********
 Password reset, 1 step(s) missing
 
-  Press escape key to go back to select the authentication method
+  Press escape key to go back to select the authentication flow
 ────────────────────────────────────────────────────────────────────────────────
 Enter your new password
 

--- a/pam/integration-tests/testdata/golden/TestCLIAuthenticate/Deny_authentication_if_newpassword_does_not_match_required_criteria
+++ b/pam/integration-tests/testdata/golden/TestCLIAuthenticate/Deny_authentication_if_newpassword_does_not_match_required_criteria
@@ -2,7 +2,7 @@ Username: user name
 ────────────────────────────────────────────────────────────────────────────────
 Username: user-needs-reset@example.com
 ────────────────────────────────────────────────────────────────────────────────
-  Select your provider
+  Select your provider:
 
 > 1. local
   2. ExampleBroker

--- a/pam/integration-tests/testdata/golden/TestCLIAuthenticate/Deny_authentication_if_user_does_not_exist
+++ b/pam/integration-tests/testdata/golden/TestCLIAuthenticate/Deny_authentication_if_user_does_not_exist
@@ -2,14 +2,14 @@ Username: user name
 ────────────────────────────────────────────────────────────────────────────────
 Username: user-unexistent@example.com
 ────────────────────────────────────────────────────────────────────────────────
-  Select your provider
+  Select your provider:
 
 > 1. local
   2. ExampleBroker
 
   Press escape key to go back to user selection
 ────────────────────────────────────────────────────────────────────────────────
-  Select your provider
+  Select your provider:
 
   1. local
 > 2. ExampleBroker

--- a/pam/integration-tests/testdata/golden/TestCLIAuthenticate/Exit_authd_if_local_broker_is_selected
+++ b/pam/integration-tests/testdata/golden/TestCLIAuthenticate/Exit_authd_if_local_broker_is_selected
@@ -2,14 +2,14 @@ Username: user name
 ────────────────────────────────────────────────────────────────────────────────
 Username: user-local-broker
 ────────────────────────────────────────────────────────────────────────────────
-  Select your provider
+  Select your provider:
 
 > 1. local
   2. ExampleBroker
 
   Press escape key to go back to user selection
 ────────────────────────────────────────────────────────────────────────────────
-  Select your provider
+  Select your provider:
 
 > 1. local
   2. ExampleBroker

--- a/pam/integration-tests/testdata/golden/TestCLIAuthenticate/Exit_authd_if_user_presses_ctrl_d
+++ b/pam/integration-tests/testdata/golden/TestCLIAuthenticate/Exit_authd_if_user_presses_ctrl_d
@@ -12,7 +12,7 @@ Username: user-integration-ctrl-d@example.com
 Gimme your password:
 >
 
-  Press escape key to go back to select the authentication method
+  Press escape key to go back to select the authentication flow
 ────────────────────────────────────────────────────────────────────────────────
 Gimme your password:
 >

--- a/pam/integration-tests/testdata/golden/TestCLIAuthenticate/Exit_authd_if_user_presses_ctrl_d
+++ b/pam/integration-tests/testdata/golden/TestCLIAuthenticate/Exit_authd_if_user_presses_ctrl_d
@@ -2,7 +2,7 @@ Username: user name
 ────────────────────────────────────────────────────────────────────────────────
 Username: user-integration-ctrl-d@example.com
 ────────────────────────────────────────────────────────────────────────────────
-  Select your provider
+  Select your provider:
 
 > 1. local
   2. ExampleBroker

--- a/pam/integration-tests/testdata/golden/TestCLIAuthenticate/Exit_authd_if_user_sigints
+++ b/pam/integration-tests/testdata/golden/TestCLIAuthenticate/Exit_authd_if_user_sigints
@@ -12,7 +12,7 @@ Username: user-integration-sigint@example.com
 Gimme your password:
 >
 
-  Press escape key to go back to select the authentication method
+  Press escape key to go back to select the authentication flow
 ────────────────────────────────────────────────────────────────────────────────
 Gimme your password:
 >

--- a/pam/integration-tests/testdata/golden/TestCLIAuthenticate/Exit_authd_if_user_sigints
+++ b/pam/integration-tests/testdata/golden/TestCLIAuthenticate/Exit_authd_if_user_sigints
@@ -2,7 +2,7 @@ Username: user name
 ────────────────────────────────────────────────────────────────────────────────
 Username: user-integration-sigint@example.com
 ────────────────────────────────────────────────────────────────────────────────
-  Select your provider
+  Select your provider:
 
 > 1. local
   2. ExampleBroker

--- a/pam/integration-tests/testdata/golden/TestCLIAuthenticate/Prevent_user_from_switching_username
+++ b/pam/integration-tests/testdata/golden/TestCLIAuthenticate/Prevent_user_from_switching_username
@@ -6,9 +6,9 @@
 Gimme your password:
 >
 
-  Press escape key to go back to select the authentication method
+  Press escape key to go back to select the authentication flow
 ────────────────────────────────────────────────────────────────────────────────
-  Select your authentication method
+  Select the authentication flow
 
 > 1. Password authentication
   2. Send URL to user-integration-pam-preset@example.com
@@ -28,12 +28,12 @@ Gimme your password:
 Gimme your password:
 >
 
-  Press escape key to go back to select the authentication method
+  Press escape key to go back to select the authentication flow
 ────────────────────────────────────────────────────────────────────────────────
 Gimme your password:
 > ********
 
-  Press escape key to go back to select the authentication method
+  Press escape key to go back to select the authentication flow
 ────────────────────────────────────────────────────────────────────────────────
   PAM_AUTHTOK: "goodpass"
 PAM Authenticate()

--- a/pam/integration-tests/testdata/golden/TestCLIAuthenticate/Prevent_user_from_switching_username
+++ b/pam/integration-tests/testdata/golden/TestCLIAuthenticate/Prevent_user_from_switching_username
@@ -1,4 +1,4 @@
-  Select your provider
+  Select your provider:
 
 > 1. local
   2. ExampleBroker
@@ -8,7 +8,7 @@ Gimme your password:
 
   Press escape key to go back to select the authentication flow
 ────────────────────────────────────────────────────────────────────────────────
-  Select the authentication flow
+  Select the authentication flow:
 
 > 1. Password authentication
   2. Send URL to user-integration-pam-preset@example.com
@@ -20,7 +20,7 @@ Gimme your password:
 
   Press escape key to go back to choose the provider
 ────────────────────────────────────────────────────────────────────────────────
-  Select your provider
+  Select your provider:
 
   1. local
 > 2. ExampleBroker

--- a/pam/integration-tests/testdata/golden/TestCLIAuthenticate/Remember_last_successful_broker_and_mode
+++ b/pam/integration-tests/testdata/golden/TestCLIAuthenticate/Remember_last_successful_broker_and_mode
@@ -13,9 +13,9 @@ Username: user-integration-remember-mode@example.com
 Gimme your password:
 >
 
-  Press escape key to go back to select the authentication method
+  Press escape key to go back to select the authentication flow
 ────────────────────────────────────────────────────────────────────────────────
-  Select your authentication method
+  Select the authentication flow
 
 > 1. Password authentication
   2. Send URL to user-integration-remember-mode@example.com
@@ -32,14 +32,14 @@ Enter your one time credential:
 
   [ Resend SMS (1 sent) ]
 
-  Press escape key to go back to select the authentication method
+  Press escape key to go back to select the authentication flow
 ────────────────────────────────────────────────────────────────────────────────
 Enter your one time credential:
 > temporary pass0
 
   [ Resend SMS (1 sent) ]
 
-  Press escape key to go back to select the authentication method
+  Press escape key to go back to select the authentication flow
 ────────────────────────────────────────────────────────────────────────────────
   PAM_AUTHTOK: "temporary pass0"
 PAM Authenticate()
@@ -57,14 +57,14 @@ Enter your one time credential:
 
   [ Resend SMS (1 sent) ]
 
-  Press escape key to go back to select the authentication method
+  Press escape key to go back to select the authentication flow
 ────────────────────────────────────────────────────────────────────────────────
 Enter your one time credential:
 > temporary pass0
 
   [ Resend SMS (1 sent) ]
 
-  Press escape key to go back to select the authentication method
+  Press escape key to go back to select the authentication flow
 ────────────────────────────────────────────────────────────────────────────────
   PAM_AUTHTOK: "temporary pass0"
 PAM Authenticate()

--- a/pam/integration-tests/testdata/golden/TestCLIAuthenticate/Remember_last_successful_broker_and_mode
+++ b/pam/integration-tests/testdata/golden/TestCLIAuthenticate/Remember_last_successful_broker_and_mode
@@ -3,7 +3,7 @@ Username: user name
 ────────────────────────────────────────────────────────────────────────────────
 Username: user-integration-remember-mode@example.com
 ────────────────────────────────────────────────────────────────────────────────
-  Select your provider
+  Select your provider:
 
 > 1. local
   2. ExampleBroker
@@ -15,7 +15,7 @@ Gimme your password:
 
   Press escape key to go back to select the authentication flow
 ────────────────────────────────────────────────────────────────────────────────
-  Select the authentication flow
+  Select the authentication flow:
 
 > 1. Password authentication
   2. Send URL to user-integration-remember-mode@example.com

--- a/pam/integration-tests/testdata/golden/TestCLIChangeAuthTok/Change_passwd_after_MFA_auth
+++ b/pam/integration-tests/testdata/golden/TestCLIChangeAuthTok/Change_passwd_after_MFA_auth
@@ -2,7 +2,7 @@ Username: user name
 ────────────────────────────────────────────────────────────────────────────────
 Username: user-mfa-integration-cli-passwd@example.com
 ────────────────────────────────────────────────────────────────────────────────
-  Select your provider
+  Select your provider:
 
 > 1. local
   2. ExampleBroker
@@ -14,7 +14,7 @@ Gimme your password:
 
   Press escape key to go back to select the authentication flow
 ────────────────────────────────────────────────────────────────────────────────
-  Select the authentication flow
+  Select the authentication flow:
 
 > 1. Password authentication
   2. Send URL to user-mfa-integration-cli-passwd@example.com
@@ -40,7 +40,7 @@ Plug your fido device and press with your thumb
 
   Press escape key to go back to select the authentication flow
 ────────────────────────────────────────────────────────────────────────────────
-  Select the authentication flow
+  Select the authentication flow:
 
 > 1. Use your fido device foo
   2. Use your phone +33...
@@ -56,7 +56,7 @@ Unlock your phone +33... or accept request on web interface
 
   Press escape key to go back to select the authentication flow
 ────────────────────────────────────────────────────────────────────────────────
-  Select the authentication flow
+  Select the authentication flow:
 
 > 1. Use your phone +33...
   2. Authentication code

--- a/pam/integration-tests/testdata/golden/TestCLIChangeAuthTok/Change_passwd_after_MFA_auth
+++ b/pam/integration-tests/testdata/golden/TestCLIChangeAuthTok/Change_passwd_after_MFA_auth
@@ -12,9 +12,9 @@ Username: user-mfa-integration-cli-passwd@example.com
 Gimme your password:
 >
 
-  Press escape key to go back to select the authentication method
+  Press escape key to go back to select the authentication flow
 ────────────────────────────────────────────────────────────────────────────────
-  Select your authentication method
+  Select the authentication flow
 
 > 1. Password authentication
   2. Send URL to user-mfa-integration-cli-passwd@example.com
@@ -29,18 +29,18 @@ Gimme your password:
 Gimme your password:
 >
 
-  Press escape key to go back to select the authentication method
+  Press escape key to go back to select the authentication flow
 ────────────────────────────────────────────────────────────────────────────────
 Gimme your password:
 > ********
 
-  Press escape key to go back to select the authentication method
+  Press escape key to go back to select the authentication flow
 ────────────────────────────────────────────────────────────────────────────────
 Plug your fido device and press with your thumb
 
-  Press escape key to go back to select the authentication method
+  Press escape key to go back to select the authentication flow
 ────────────────────────────────────────────────────────────────────────────────
-  Select your authentication method
+  Select the authentication flow
 
 > 1. Use your fido device foo
   2. Use your phone +33...
@@ -50,13 +50,13 @@ Plug your fido device and press with your thumb
 ────────────────────────────────────────────────────────────────────────────────
 Plug your fido device and press with your thumb
 
-  Press escape key to go back to select the authentication method
+  Press escape key to go back to select the authentication flow
 ────────────────────────────────────────────────────────────────────────────────
 Unlock your phone +33... or accept request on web interface
 
-  Press escape key to go back to select the authentication method
+  Press escape key to go back to select the authentication flow
 ────────────────────────────────────────────────────────────────────────────────
-  Select your authentication method
+  Select the authentication flow
 
 > 1. Use your phone +33...
   2. Authentication code
@@ -65,7 +65,7 @@ Unlock your phone +33... or accept request on web interface
 ────────────────────────────────────────────────────────────────────────────────
 Unlock your phone +33... or accept request on web interface
 
-  Press escape key to go back to select the authentication method
+  Press escape key to go back to select the authentication flow
 ────────────────────────────────────────────────────────────────────────────────
 Enter your new password
 

--- a/pam/integration-tests/testdata/golden/TestCLIChangeAuthTok/Change_password_successfully_and_authenticate_with_new_one
+++ b/pam/integration-tests/testdata/golden/TestCLIChangeAuthTok/Change_password_successfully_and_authenticate_with_new_one
@@ -13,12 +13,12 @@ Username: user-integration-cli-passwd-change-password-successfully-and-authentic
 Gimme your password:
 >
 
-  Press escape key to go back to select the authentication method
+  Press escape key to go back to select the authentication flow
 ────────────────────────────────────────────────────────────────────────────────
 Gimme your password:
 > ********
 
-  Press escape key to go back to select the authentication method
+  Press escape key to go back to select the authentication flow
 ────────────────────────────────────────────────────────────────────────────────
 Enter your new password
 
@@ -67,12 +67,12 @@ Username: user-integration-cli-passwd-change-password-successfully-and-authentic
 Gimme your password:
 >
 
-  Press escape key to go back to select the authentication method
+  Press escape key to go back to select the authentication flow
 ────────────────────────────────────────────────────────────────────────────────
 Gimme your password:
 > *********
 
-  Press escape key to go back to select the authentication method
+  Press escape key to go back to select the authentication flow
 ────────────────────────────────────────────────────────────────────────────────
   PAM_AUTHTOK: "authd2404"
 PAM Authenticate()

--- a/pam/integration-tests/testdata/golden/TestCLIChangeAuthTok/Change_password_successfully_and_authenticate_with_new_one
+++ b/pam/integration-tests/testdata/golden/TestCLIChangeAuthTok/Change_password_successfully_and_authenticate_with_new_one
@@ -3,7 +3,7 @@ Username: user name
 ────────────────────────────────────────────────────────────────────────────────
 Username: user-integration-cli-passwd-change-password-successfully-and-authenticate-with-new-one@example.com
 ────────────────────────────────────────────────────────────────────────────────
-  Select your provider
+  Select your provider:
 
 > 1. local
   2. ExampleBroker

--- a/pam/integration-tests/testdata/golden/TestCLIChangeAuthTok/Change_password_successfully_and_authenticate_with_new_one_with_different_case
+++ b/pam/integration-tests/testdata/golden/TestCLIChangeAuthTok/Change_password_successfully_and_authenticate_with_new_one_with_different_case
@@ -13,12 +13,12 @@ Username: USER-INTEGRATION-CASE-INSENSITIVE-TESTCLICHANGEAUTHTOK@EXAMPLE.COM
 Gimme your password:
 >
 
-  Press escape key to go back to select the authentication method
+  Press escape key to go back to select the authentication flow
 ────────────────────────────────────────────────────────────────────────────────
 Gimme your password:
 > ********
 
-  Press escape key to go back to select the authentication method
+  Press escape key to go back to select the authentication flow
 ────────────────────────────────────────────────────────────────────────────────
 Enter your new password
 
@@ -67,12 +67,12 @@ Username: user-integration-case-insensitive-testclichangeauthtok@example.com
 Gimme your password:
 >
 
-  Press escape key to go back to select the authentication method
+  Press escape key to go back to select the authentication flow
 ────────────────────────────────────────────────────────────────────────────────
 Gimme your password:
 > *********
 
-  Press escape key to go back to select the authentication method
+  Press escape key to go back to select the authentication flow
 ────────────────────────────────────────────────────────────────────────────────
   PAM_AUTHTOK: "authd2404"
 PAM Authenticate()

--- a/pam/integration-tests/testdata/golden/TestCLIChangeAuthTok/Change_password_successfully_and_authenticate_with_new_one_with_different_case
+++ b/pam/integration-tests/testdata/golden/TestCLIChangeAuthTok/Change_password_successfully_and_authenticate_with_new_one_with_different_case
@@ -3,7 +3,7 @@ Username: user name
 ────────────────────────────────────────────────────────────────────────────────
 Username: USER-INTEGRATION-CASE-INSENSITIVE-TESTCLICHANGEAUTHTOK@EXAMPLE.COM
 ────────────────────────────────────────────────────────────────────────────────
-  Select your provider
+  Select your provider:
 
 > 1. local
   2. ExampleBroker

--- a/pam/integration-tests/testdata/golden/TestCLIChangeAuthTok/Exit_authd_if_local_broker_is_selected
+++ b/pam/integration-tests/testdata/golden/TestCLIChangeAuthTok/Exit_authd_if_local_broker_is_selected
@@ -2,14 +2,14 @@ Username: user name
 ────────────────────────────────────────────────────────────────────────────────
 Username: user-integration-cli-passwd-exit-authd-if-local-broker-is-selected@example.com
 ────────────────────────────────────────────────────────────────────────────────
-  Select your provider
+  Select your provider:
 
 > 1. local
   2. ExampleBroker
 
   Press escape key to go back to user selection
 ────────────────────────────────────────────────────────────────────────────────
-  Select your provider
+  Select your provider:
 
 > 1. local
   2. ExampleBroker

--- a/pam/integration-tests/testdata/golden/TestCLIChangeAuthTok/Exit_authd_if_user_presses_ctrl_d
+++ b/pam/integration-tests/testdata/golden/TestCLIChangeAuthTok/Exit_authd_if_user_presses_ctrl_d
@@ -12,7 +12,7 @@ Username: user-integration-cli-passwd-exit-authd-if-user-presses-ctrl-d@example.
 Gimme your password:
 >
 
-  Press escape key to go back to select the authentication method
+  Press escape key to go back to select the authentication flow
 ────────────────────────────────────────────────────────────────────────────────
 Gimme your password:
 >

--- a/pam/integration-tests/testdata/golden/TestCLIChangeAuthTok/Exit_authd_if_user_presses_ctrl_d
+++ b/pam/integration-tests/testdata/golden/TestCLIChangeAuthTok/Exit_authd_if_user_presses_ctrl_d
@@ -2,7 +2,7 @@ Username: user name
 ────────────────────────────────────────────────────────────────────────────────
 Username: user-integration-cli-passwd-exit-authd-if-user-presses-ctrl-d@example.com
 ────────────────────────────────────────────────────────────────────────────────
-  Select your provider
+  Select your provider:
 
 > 1. local
   2. ExampleBroker

--- a/pam/integration-tests/testdata/golden/TestCLIChangeAuthTok/Exit_authd_if_user_sigints
+++ b/pam/integration-tests/testdata/golden/TestCLIChangeAuthTok/Exit_authd_if_user_sigints
@@ -2,7 +2,7 @@ Username: user name
 ────────────────────────────────────────────────────────────────────────────────
 Username: user-integration-cli-passwd-exit-authd-if-user-sigints@example.com
 ────────────────────────────────────────────────────────────────────────────────
-  Select your provider
+  Select your provider:
 
 > 1. local
   2. ExampleBroker

--- a/pam/integration-tests/testdata/golden/TestCLIChangeAuthTok/Exit_authd_if_user_sigints
+++ b/pam/integration-tests/testdata/golden/TestCLIChangeAuthTok/Exit_authd_if_user_sigints
@@ -12,7 +12,7 @@ Username: user-integration-cli-passwd-exit-authd-if-user-sigints@example.com
 Gimme your password:
 >
 
-  Press escape key to go back to select the authentication method
+  Press escape key to go back to select the authentication flow
 ────────────────────────────────────────────────────────────────────────────────
 Gimme your password:
 >

--- a/pam/integration-tests/testdata/golden/TestCLIChangeAuthTok/Prevent_change_password_if_auth_fails
+++ b/pam/integration-tests/testdata/golden/TestCLIChangeAuthTok/Prevent_change_password_if_auth_fails
@@ -2,7 +2,7 @@ Username: user name
 ────────────────────────────────────────────────────────────────────────────────
 Username: user-integration-cli-passwd-prevent-change-password-if-auth-fails@example.com
 ────────────────────────────────────────────────────────────────────────────────
-  Select your provider
+  Select your provider:
 
 > 1. local
   2. ExampleBroker

--- a/pam/integration-tests/testdata/golden/TestCLIChangeAuthTok/Prevent_change_password_if_auth_fails
+++ b/pam/integration-tests/testdata/golden/TestCLIChangeAuthTok/Prevent_change_password_if_auth_fails
@@ -12,31 +12,31 @@ Username: user-integration-cli-passwd-prevent-change-password-if-auth-fails@exam
 Gimme your password:
 >
 
-  Press escape key to go back to select the authentication method
+  Press escape key to go back to select the authentication flow
 ────────────────────────────────────────────────────────────────────────────────
 Gimme your password:
 >
 invalid password 'wrongpass1', should be 'goodpass'
 
-  Press escape key to go back to select the authentication method
+  Press escape key to go back to select the authentication flow
 ────────────────────────────────────────────────────────────────────────────────
 Gimme your password:
 >
 invalid password 'wrongpass2', should be 'goodpass'
 
-  Press escape key to go back to select the authentication method
+  Press escape key to go back to select the authentication flow
 ────────────────────────────────────────────────────────────────────────────────
 Gimme your password:
 >
 invalid password 'wrongpass3', should be 'goodpass'
 
-  Press escape key to go back to select the authentication method
+  Press escape key to go back to select the authentication flow
 ────────────────────────────────────────────────────────────────────────────────
 Gimme your password:
 >
 invalid password 'wrongpass4', should be 'goodpass'
 
-  Press escape key to go back to select the authentication method
+  Press escape key to go back to select the authentication flow
 ────────────────────────────────────────────────────────────────────────────────
 PAM Error Message: Maximum number of authentication attempts reached
 PAM ChangeAuthTok()

--- a/pam/integration-tests/testdata/golden/TestCLIChangeAuthTok/Prevent_change_password_if_user_does_not_exist
+++ b/pam/integration-tests/testdata/golden/TestCLIChangeAuthTok/Prevent_change_password_if_user_does_not_exist
@@ -2,14 +2,14 @@ Username: user name
 ────────────────────────────────────────────────────────────────────────────────
 Username: user-unexistent@example.com
 ────────────────────────────────────────────────────────────────────────────────
-  Select your provider
+  Select your provider:
 
 > 1. local
   2. ExampleBroker
 
   Press escape key to go back to user selection
 ────────────────────────────────────────────────────────────────────────────────
-  Select your provider
+  Select your provider:
 
   1. local
 > 2. ExampleBroker

--- a/pam/integration-tests/testdata/golden/TestCLIChangeAuthTok/Retry_if_new_password_does_not_match_quality_criteria
+++ b/pam/integration-tests/testdata/golden/TestCLIChangeAuthTok/Retry_if_new_password_does_not_match_quality_criteria
@@ -2,7 +2,7 @@ Username: user name
 ────────────────────────────────────────────────────────────────────────────────
 Username: user-integration-cli-passwd-retry-if-new-password-does-not-match-quality-criteria@example.com
 ────────────────────────────────────────────────────────────────────────────────
-  Select your provider
+  Select your provider:
 
 > 1. local
   2. ExampleBroker

--- a/pam/integration-tests/testdata/golden/TestCLIChangeAuthTok/Retry_if_new_password_does_not_match_quality_criteria
+++ b/pam/integration-tests/testdata/golden/TestCLIChangeAuthTok/Retry_if_new_password_does_not_match_quality_criteria
@@ -12,12 +12,12 @@ Username: user-integration-cli-passwd-retry-if-new-password-does-not-match-quali
 Gimme your password:
 >
 
-  Press escape key to go back to select the authentication method
+  Press escape key to go back to select the authentication flow
 ────────────────────────────────────────────────────────────────────────────────
 Gimme your password:
 > ********
 
-  Press escape key to go back to select the authentication method
+  Press escape key to go back to select the authentication flow
 ────────────────────────────────────────────────────────────────────────────────
 Enter your new password
 

--- a/pam/integration-tests/testdata/golden/TestCLIChangeAuthTok/Retry_if_new_password_is_rejected_by_broker
+++ b/pam/integration-tests/testdata/golden/TestCLIChangeAuthTok/Retry_if_new_password_is_rejected_by_broker
@@ -12,12 +12,12 @@ Username: user-integration-cli-passwd-retry-if-new-password-is-rejected-by-broke
 Gimme your password:
 >
 
-  Press escape key to go back to select the authentication method
+  Press escape key to go back to select the authentication flow
 ────────────────────────────────────────────────────────────────────────────────
 Gimme your password:
 > ********
 
-  Press escape key to go back to select the authentication method
+  Press escape key to go back to select the authentication flow
 ────────────────────────────────────────────────────────────────────────────────
 Enter your new password
 
@@ -98,12 +98,12 @@ Username: user-integration-cli-passwd-retry-if-new-password-is-rejected-by-broke
 Gimme your password:
 >
 
-  Press escape key to go back to select the authentication method
+  Press escape key to go back to select the authentication flow
 ────────────────────────────────────────────────────────────────────────────────
 Gimme your password:
 > *********
 
-  Press escape key to go back to select the authentication method
+  Press escape key to go back to select the authentication flow
 ────────────────────────────────────────────────────────────────────────────────
 Enter your new password
 

--- a/pam/integration-tests/testdata/golden/TestCLIChangeAuthTok/Retry_if_new_password_is_rejected_by_broker
+++ b/pam/integration-tests/testdata/golden/TestCLIChangeAuthTok/Retry_if_new_password_is_rejected_by_broker
@@ -2,7 +2,7 @@ Username: user name
 ────────────────────────────────────────────────────────────────────────────────
 Username: user-integration-cli-passwd-retry-if-new-password-is-rejected-by-broker@example.com
 ────────────────────────────────────────────────────────────────────────────────
-  Select your provider
+  Select your provider:
 
 > 1. local
   2. ExampleBroker

--- a/pam/integration-tests/testdata/golden/TestCLIChangeAuthTok/Retry_if_new_password_is_same_of_previous
+++ b/pam/integration-tests/testdata/golden/TestCLIChangeAuthTok/Retry_if_new_password_is_same_of_previous
@@ -12,12 +12,12 @@ Username: user-integration-cli-passwd-retry-if-new-password-is-same-of-previous@
 Gimme your password:
 >
 
-  Press escape key to go back to select the authentication method
+  Press escape key to go back to select the authentication flow
 ────────────────────────────────────────────────────────────────────────────────
 Gimme your password:
 > ********
 
-  Press escape key to go back to select the authentication method
+  Press escape key to go back to select the authentication flow
 ────────────────────────────────────────────────────────────────────────────────
 Enter your new password
 

--- a/pam/integration-tests/testdata/golden/TestCLIChangeAuthTok/Retry_if_new_password_is_same_of_previous
+++ b/pam/integration-tests/testdata/golden/TestCLIChangeAuthTok/Retry_if_new_password_is_same_of_previous
@@ -2,7 +2,7 @@ Username: user name
 ────────────────────────────────────────────────────────────────────────────────
 Username: user-integration-cli-passwd-retry-if-new-password-is-same-of-previous@example.com
 ────────────────────────────────────────────────────────────────────────────────
-  Select your provider
+  Select your provider:
 
 > 1. local
   2. ExampleBroker

--- a/pam/integration-tests/testdata/golden/TestCLIChangeAuthTok/Retry_if_password_confirmation_is_not_the_same
+++ b/pam/integration-tests/testdata/golden/TestCLIChangeAuthTok/Retry_if_password_confirmation_is_not_the_same
@@ -2,7 +2,7 @@ Username: user name
 ────────────────────────────────────────────────────────────────────────────────
 Username: user-integration-cli-passwd-retry-if-password-confirmation-is-not-the-same@example.com
 ────────────────────────────────────────────────────────────────────────────────
-  Select your provider
+  Select your provider:
 
 > 1. local
   2. ExampleBroker

--- a/pam/integration-tests/testdata/golden/TestCLIChangeAuthTok/Retry_if_password_confirmation_is_not_the_same
+++ b/pam/integration-tests/testdata/golden/TestCLIChangeAuthTok/Retry_if_password_confirmation_is_not_the_same
@@ -12,12 +12,12 @@ Username: user-integration-cli-passwd-retry-if-password-confirmation-is-not-the-
 Gimme your password:
 >
 
-  Press escape key to go back to select the authentication method
+  Press escape key to go back to select the authentication flow
 ────────────────────────────────────────────────────────────────────────────────
 Gimme your password:
 > ********
 
-  Press escape key to go back to select the authentication method
+  Press escape key to go back to select the authentication flow
 ────────────────────────────────────────────────────────────────────────────────
 Enter your new password
 

--- a/pam/integration-tests/testdata/golden/TestNativeAuthenticate/Authenticate_user_and_accept_password_reset
+++ b/pam/integration-tests/testdata/golden/TestNativeAuthenticate/Authenticate_user_and_accept_password_reset
@@ -4,7 +4,7 @@
 Choose your provider:
 > 2
 == Password authentication ==
-Enter 'r' to cancel the request and go back to select the authentication method
+Enter 'r' to cancel the request and go back to select the authentication flow
 Gimme your password:
 >
 Password reset, 1 step(s) missing

--- a/pam/integration-tests/testdata/golden/TestNativeAuthenticate/Authenticate_user_and_add_it_to_local_group
+++ b/pam/integration-tests/testdata/golden/TestNativeAuthenticate/Authenticate_user_and_add_it_to_local_group
@@ -4,7 +4,7 @@
 Choose your provider:
 > 2
 == Password authentication ==
-Enter 'r' to cancel the request and go back to select the authentication method
+Enter 'r' to cancel the request and go back to select the authentication flow
 Gimme your password:
 >
   PAM_AUTHTOK: "goodpass"

--- a/pam/integration-tests/testdata/golden/TestNativeAuthenticate/Authenticate_user_and_offer_password_reset
+++ b/pam/integration-tests/testdata/golden/TestNativeAuthenticate/Authenticate_user_and_offer_password_reset
@@ -4,7 +4,7 @@
 Choose your provider:
 > 2
 == Password authentication ==
-Enter 'r' to cancel the request and go back to select the authentication method
+Enter 'r' to cancel the request and go back to select the authentication flow
 Gimme your password:
 >
 Password reset, 1 step(s) missing

--- a/pam/integration-tests/testdata/golden/TestNativeAuthenticate/Authenticate_user_and_reset_password_while_enforcing_policy
+++ b/pam/integration-tests/testdata/golden/TestNativeAuthenticate/Authenticate_user_and_reset_password_while_enforcing_policy
@@ -4,7 +4,7 @@
 Choose your provider:
 > 2
 == Password authentication ==
-Enter 'r' to cancel the request and go back to select the authentication method
+Enter 'r' to cancel the request and go back to select the authentication flow
 Gimme your password:
 >
 Password reset, 1 step(s) missing

--- a/pam/integration-tests/testdata/golden/TestNativeAuthenticate/Authenticate_user_and_reset_password_with_case_insensitive_user_selection
+++ b/pam/integration-tests/testdata/golden/TestNativeAuthenticate/Authenticate_user_and_reset_password_with_case_insensitive_user_selection
@@ -6,7 +6,7 @@ Or enter 'r' to go back to user selection
 Choose your provider:
 > 2
 == Password authentication ==
-Enter 'r' to cancel the request and go back to select the authentication method
+Enter 'r' to cancel the request and go back to select the authentication flow
 Gimme your password:
 >
 Password reset, 1 step(s) missing
@@ -23,7 +23,7 @@ PAM Authenticate()
 
 Username: USER-NEEDS-RESET-INTEGRATION-CASE-INSENSITIVE-NATIVE-TESTNATIVEAUTHENTICATE@EXAMPLE.COM
 == Password authentication ==
-Enter 'r' to cancel the request and go back to select the authentication method
+Enter 'r' to cancel the request and go back to select the authentication flow
 Gimme your password:
 >
   PAM_AUTHTOK: "authd2404"
@@ -33,7 +33,7 @@ PAM Authenticate()
 
 Username: user-needs-reset-integration-Case-INSENSITIVE-native-testnativeauthenticate@example.com
 == Password authentication ==
-Enter 'r' to cancel the request and go back to select the authentication method
+Enter 'r' to cancel the request and go back to select the authentication flow
 Gimme your password:
 >
   PAM_AUTHTOK: "authd2404"

--- a/pam/integration-tests/testdata/golden/TestNativeAuthenticate/Authenticate_user_on_ssh_service
+++ b/pam/integration-tests/testdata/golden/TestNativeAuthenticate/Authenticate_user_on_ssh_service
@@ -4,7 +4,7 @@
 Choose your provider:
 > 2
 == Password authentication ==
-Enter 'r' to cancel the request and go back to select the authentication method
+Enter 'r' to cancel the request and go back to select the authentication flow
 Gimme your password:
 >
   PAM_AUTHTOK: "goodpass"

--- a/pam/integration-tests/testdata/golden/TestNativeAuthenticate/Authenticate_user_on_ssh_service_with_custom_name_and_auth_info_env
+++ b/pam/integration-tests/testdata/golden/TestNativeAuthenticate/Authenticate_user_on_ssh_service_with_custom_name_and_auth_info_env
@@ -4,7 +4,7 @@
 Choose your provider:
 > 2
 == Password authentication ==
-Enter 'r' to cancel the request and go back to select the authentication method
+Enter 'r' to cancel the request and go back to select the authentication flow
 Gimme your password:
 >
   PAM_AUTHTOK: "goodpass"

--- a/pam/integration-tests/testdata/golden/TestNativeAuthenticate/Authenticate_user_on_ssh_service_with_custom_name_and_connection_env
+++ b/pam/integration-tests/testdata/golden/TestNativeAuthenticate/Authenticate_user_on_ssh_service_with_custom_name_and_connection_env
@@ -4,7 +4,7 @@
 Choose your provider:
 > 2
 == Password authentication ==
-Enter 'r' to cancel the request and go back to select the authentication method
+Enter 'r' to cancel the request and go back to select the authentication flow
 Gimme your password:
 >
   PAM_AUTHTOK: "goodpass"

--- a/pam/integration-tests/testdata/golden/TestNativeAuthenticate/Authenticate_user_successfully
+++ b/pam/integration-tests/testdata/golden/TestNativeAuthenticate/Authenticate_user_successfully
@@ -4,7 +4,7 @@
 Choose your provider:
 > 2
 == Password authentication ==
-Enter 'r' to cancel the request and go back to select the authentication method
+Enter 'r' to cancel the request and go back to select the authentication flow
 Gimme your password:
 >
   PAM_AUTHTOK: "goodpass"

--- a/pam/integration-tests/testdata/golden/TestNativeAuthenticate/Authenticate_user_successfully_using_upper_case_with_user_selection
+++ b/pam/integration-tests/testdata/golden/TestNativeAuthenticate/Authenticate_user_successfully_using_upper_case_with_user_selection
@@ -6,7 +6,7 @@ Or enter 'r' to go back to user selection
 Choose your provider:
 > 2
 == Password authentication ==
-Enter 'r' to cancel the request and go back to select the authentication method
+Enter 'r' to cancel the request and go back to select the authentication flow
 Gimme your password:
 >
   PAM_AUTHTOK: "goodpass"

--- a/pam/integration-tests/testdata/golden/TestNativeAuthenticate/Authenticate_user_successfully_with_invalid_connection_timeout
+++ b/pam/integration-tests/testdata/golden/TestNativeAuthenticate/Authenticate_user_successfully_with_invalid_connection_timeout
@@ -4,7 +4,7 @@
 Choose your provider:
 > 2
 == Password authentication ==
-Enter 'r' to cancel the request and go back to select the authentication method
+Enter 'r' to cancel the request and go back to select the authentication flow
 Gimme your password:
 >
   PAM_AUTHTOK: "goodpass"

--- a/pam/integration-tests/testdata/golden/TestNativeAuthenticate/Authenticate_user_successfully_with_upper_case
+++ b/pam/integration-tests/testdata/golden/TestNativeAuthenticate/Authenticate_user_successfully_with_upper_case
@@ -4,7 +4,7 @@
 Choose your provider:
 > 2
 == Password authentication ==
-Enter 'r' to cancel the request and go back to select the authentication method
+Enter 'r' to cancel the request and go back to select the authentication flow
 Gimme your password:
 >
   PAM_AUTHTOK: "goodpass"

--- a/pam/integration-tests/testdata/golden/TestNativeAuthenticate/Authenticate_user_successfully_with_user_selection
+++ b/pam/integration-tests/testdata/golden/TestNativeAuthenticate/Authenticate_user_successfully_with_user_selection
@@ -6,7 +6,7 @@ Or enter 'r' to go back to user selection
 Choose your provider:
 > 2
 == Password authentication ==
-Enter 'r' to cancel the request and go back to select the authentication method
+Enter 'r' to cancel the request and go back to select the authentication flow
 Gimme your password:
 >
   PAM_AUTHTOK: "goodpass"

--- a/pam/integration-tests/testdata/golden/TestNativeAuthenticate/Authenticate_user_switching_auth_mode
+++ b/pam/integration-tests/testdata/golden/TestNativeAuthenticate/Authenticate_user_switching_auth_mode
@@ -4,7 +4,7 @@
 Choose your provider:
 > 2
 == Password authentication ==
-Enter 'r' to cancel the request and go back to select the authentication method
+Enter 'r' to cancel the request and go back to select the authentication flow
 Gimme your password:
 >
 == Authentication method selection ==
@@ -20,7 +20,7 @@ Or enter 'r' to go back to choose the provider
 Choose your authentication method:
 > 2
 == Send URL to user-integration-switch-mode-native-testnativeauthenticate@example.com ==
-Leave the input field empty to wait for the alternative authentication method or enter 'r' to go back to select the authentication method
+Leave the input field empty to wait for the alternative authentication method or enter 'r' to go back to select the authentication flow
 Click on the link received at user-integration-switch-mode-native-testnativeauthenticate@example.com or enter the code:
 > r
 == Authentication method selection ==
@@ -36,7 +36,7 @@ Or enter 'r' to go back to choose the provider
 Choose your authentication method:
 > 3
 == Use your fido device foo ==
-Press Enter to wait for authentication or enter 'r' to go back to select the authentication method
+Press Enter to wait for authentication or enter 'r' to go back to select the authentication flow
 Plug your fido device and press with your thumb:
 > r
 == Authentication method selection ==
@@ -52,7 +52,7 @@ Or enter 'r' to go back to choose the provider
 Choose your authentication method:
 > 4
 == Use your phone +33... ==
-Press Enter to wait for authentication or enter 'r' to go back to select the authentication method
+Press Enter to wait for authentication or enter 'r' to go back to select the authentication flow
 Unlock your phone +33... or accept request on web interface:
 > r
 == Authentication method selection ==
@@ -68,7 +68,7 @@ Or enter 'r' to go back to choose the provider
 Choose your authentication method:
 > 5
 == Use your phone +1... ==
-Press Enter to wait for authentication or enter 'r' to go back to select the authentication method
+Press Enter to wait for authentication or enter 'r' to go back to select the authentication flow
 Unlock your phone +1... or accept request on web interface:
 > r
 == Authentication method selection ==
@@ -84,7 +84,7 @@ Or enter 'r' to go back to choose the provider
 Choose your authentication method:
 > 6
 == Pin code ==
-Enter 'r' to cancel the request and go back to select the authentication method
+Enter 'r' to cancel the request and go back to select the authentication flow
 Enter your pin code:
 > r
 == Authentication method selection ==
@@ -124,7 +124,7 @@ Code: 1337
 
   1. Wait for authentication result
   2. Regenerate code
-Or enter 'r' to go back to select the authentication method
+Or enter 'r' to go back to select the authentication flow
 Choose action:
 > r
 == Authentication method selection ==
@@ -142,7 +142,7 @@ Choose your authentication method:
 == Authentication code ==
   1. Proceed with Authentication code
   2. Resend SMS (1 sent)
-Or enter 'r' to go back to select the authentication method
+Or enter 'r' to go back to select the authentication flow
 Choose action:
 > r
 == Authentication method selection ==
@@ -174,7 +174,7 @@ Or enter 'r' to go back to choose the provider
 Choose your authentication method:
 > 6
 == Pin code ==
-Enter 'r' to cancel the request and go back to select the authentication method
+Enter 'r' to cancel the request and go back to select the authentication flow
 Enter your pin code:
 > 4242
   PAM_AUTHTOK: "4242"

--- a/pam/integration-tests/testdata/golden/TestNativeAuthenticate/Authenticate_user_switching_to_local_broker
+++ b/pam/integration-tests/testdata/golden/TestNativeAuthenticate/Authenticate_user_switching_to_local_broker
@@ -4,7 +4,7 @@
 Choose your provider:
 > 2
 == Password authentication ==
-Enter 'r' to cancel the request and go back to select the authentication method
+Enter 'r' to cancel the request and go back to select the authentication flow
 Gimme your password:
 >
 == Authentication method selection ==

--- a/pam/integration-tests/testdata/golden/TestNativeAuthenticate/Authenticate_user_switching_username
+++ b/pam/integration-tests/testdata/golden/TestNativeAuthenticate/Authenticate_user_switching_username
@@ -13,7 +13,7 @@ Or enter 'r' to go back to user selection
 Choose your provider:
 > 2
 == Password authentication ==
-Enter 'r' to cancel the request and go back to select the authentication method
+Enter 'r' to cancel the request and go back to select the authentication flow
 Gimme your password:
 >
   PAM_AUTHTOK: "goodpass"

--- a/pam/integration-tests/testdata/golden/TestNativeAuthenticate/Authenticate_user_with_form_mode_with_button
+++ b/pam/integration-tests/testdata/golden/TestNativeAuthenticate/Authenticate_user_with_form_mode_with_button
@@ -4,7 +4,7 @@
 Choose your provider:
 > 2
 == Password authentication ==
-Enter 'r' to cancel the request and go back to select the authentication method
+Enter 'r' to cancel the request and go back to select the authentication flow
 Gimme your password:
 >
 == Authentication method selection ==
@@ -22,17 +22,17 @@ Choose your authentication method:
 == Authentication code ==
   1. Proceed with Authentication code
   2. Resend SMS (1 sent)
-Or enter 'r' to go back to select the authentication method
+Or enter 'r' to go back to select the authentication flow
 Choose action:
 > 2
 == Authentication code ==
   1. Proceed with Authentication code
   2. Resend SMS (2 sent)
-Or enter 'r' to go back to select the authentication method
+Or enter 'r' to go back to select the authentication flow
 Choose action:
 > 1
 == Authentication code ==
-Enter 'r' to cancel the request and go back to select the authentication method
+Enter 'r' to cancel the request and go back to select the authentication flow
 Enter your one time credential:
 > temporary pass00
   PAM_AUTHTOK: "temporary pass00"

--- a/pam/integration-tests/testdata/golden/TestNativeAuthenticate/Authenticate_user_with_form_mode_with_button_in_polkit
+++ b/pam/integration-tests/testdata/golden/TestNativeAuthenticate/Authenticate_user_with_form_mode_with_button_in_polkit
@@ -1,5 +1,5 @@
 == Password authentication ==
-Enter 'r' to cancel the request and go back to select the authentication method
+Enter 'r' to cancel the request and go back to select the authentication flow
 Gimme your password:
 >
 == Authentication method selection ==
@@ -15,17 +15,17 @@ Choose your authentication method:
 == Authentication code ==
   1. Proceed with Authentication code
   2. Resend SMS (1 sent)
-Or enter 'r' to go back to select the authentication method
+Or enter 'r' to go back to select the authentication flow
 Choose action:
 > 2
 == Authentication code ==
   1. Proceed with Authentication code
   2. Resend SMS (2 sent)
-Or enter 'r' to go back to select the authentication method
+Or enter 'r' to go back to select the authentication flow
 Choose action:
 > 1
 == Authentication code ==
-Enter 'r' to cancel the request and go back to select the authentication method
+Enter 'r' to cancel the request and go back to select the authentication flow
 Enter your one time credential:
 > temporary pass00
   PAM_AUTHTOK: "temporary pass00"

--- a/pam/integration-tests/testdata/golden/TestNativeAuthenticate/Authenticate_user_with_form_mode_with_button_two_supported_methods
+++ b/pam/integration-tests/testdata/golden/TestNativeAuthenticate/Authenticate_user_with_form_mode_with_button_two_supported_methods
@@ -4,7 +4,7 @@
 Choose your provider:
 > 2
 == Password authentication ==
-Enter 'r' to cancel the request and go back to select the authentication method
+Enter 'r' to cancel the request and go back to select the authentication flow
 Gimme your password:
 >
 == Authentication method selection ==
@@ -16,17 +16,17 @@ Choose your authentication method:
 == Authentication code ==
   1. Proceed with Authentication code
   2. Resend SMS (1 sent)
-Or enter 'r' to go back to select the authentication method
+Or enter 'r' to go back to select the authentication flow
 Choose action:
 > 2
 == Authentication code ==
   1. Proceed with Authentication code
   2. Resend SMS (2 sent)
-Or enter 'r' to go back to select the authentication method
+Or enter 'r' to go back to select the authentication flow
 Choose action:
 > 1
 == Authentication code ==
-Enter 'r' to cancel the request and go back to select the authentication method
+Enter 'r' to cancel the request and go back to select the authentication flow
 Enter your one time credential:
 > temporary pass00
   PAM_AUTHTOK: "temporary pass00"

--- a/pam/integration-tests/testdata/golden/TestNativeAuthenticate/Authenticate_user_with_mfa
+++ b/pam/integration-tests/testdata/golden/TestNativeAuthenticate/Authenticate_user_with_mfa
@@ -4,7 +4,7 @@
 Choose your provider:
 > 2
 == Password authentication ==
-Enter 'r' to cancel the request and go back to select the authentication method
+Enter 'r' to cancel the request and go back to select the authentication flow
 Gimme your password:
 >
 == Authentication method selection ==
@@ -20,11 +20,11 @@ Or enter 'r' to go back to choose the provider
 Choose your authentication method:
 > 1
 == Password authentication ==
-Enter 'r' to cancel the request and go back to select the authentication method
+Enter 'r' to cancel the request and go back to select the authentication flow
 Gimme your password:
 >
 == Use your fido device foo ==
-Press Enter to wait for authentication or enter 'r' to go back to select the authentication method
+Press Enter to wait for authentication or enter 'r' to go back to select the authentication flow
 Plug your fido device and press with your thumb:
 > r
 == Authentication method selection ==
@@ -35,7 +35,7 @@ Or enter 'r' to go back to choose the provider
 Choose your authentication method:
 > 1
 == Use your fido device foo ==
-Press Enter to wait for authentication or enter 'r' to go back to select the authentication method
+Press Enter to wait for authentication or enter 'r' to go back to select the authentication flow
 Plug your fido device and press with your thumb:
 > r
 == Authentication method selection ==
@@ -46,11 +46,11 @@ Or enter 'r' to go back to choose the provider
 Choose your authentication method:
 > 2
 == Use your phone +33... ==
-Press Enter to wait for authentication or enter 'r' to go back to select the authentication method
+Press Enter to wait for authentication or enter 'r' to go back to select the authentication flow
 Unlock your phone +33... or accept request on web interface:
 >
 == Use your fido device foo ==
-Press Enter to wait for authentication or enter 'r' to go back to select the authentication method
+Press Enter to wait for authentication or enter 'r' to go back to select the authentication flow
 Plug your fido device and press with your thumb:
 >
   PAM_AUTHTOK: "goodpass"

--- a/pam/integration-tests/testdata/golden/TestNativeAuthenticate/Authenticate_user_with_mfa_and_reset_password_while_enforcing_policy
+++ b/pam/integration-tests/testdata/golden/TestNativeAuthenticate/Authenticate_user_with_mfa_and_reset_password_while_enforcing_policy
@@ -4,12 +4,12 @@
 Choose your provider:
 > 2
 == Password authentication ==
-Enter 'r' to cancel the request and go back to select the authentication method
+Enter 'r' to cancel the request and go back to select the authentication flow
 Gimme your password:
 >
 Password reset, 2 step(s) missing
 == Use your fido device foo ==
-Press Enter to wait for authentication or enter 'r' to go back to select the authentication method
+Press Enter to wait for authentication or enter 'r' to go back to select the authentication flow
 Plug your fido device and press with your thumb:
 >
 Password reset, 1 step(s) missing

--- a/pam/integration-tests/testdata/golden/TestNativeAuthenticate/Authenticate_user_with_mfa_and_reset_same_password
+++ b/pam/integration-tests/testdata/golden/TestNativeAuthenticate/Authenticate_user_with_mfa_and_reset_same_password
@@ -4,12 +4,12 @@
 Choose your provider:
 > 2
 == Password authentication ==
-Enter 'r' to cancel the request and go back to select the authentication method
+Enter 'r' to cancel the request and go back to select the authentication flow
 Gimme your password:
 >
 Password reset, 2 step(s) missing
 == Use your fido device foo ==
-Press Enter to wait for authentication or enter 'r' to go back to select the authentication method
+Press Enter to wait for authentication or enter 'r' to go back to select the authentication flow
 Plug your fido device and press with your thumb:
 >
 Password reset, 1 step(s) missing

--- a/pam/integration-tests/testdata/golden/TestNativeAuthenticate/Authenticate_user_with_qr_code
+++ b/pam/integration-tests/testdata/golden/TestNativeAuthenticate/Authenticate_user_with_qr_code
@@ -4,7 +4,7 @@
 Choose your provider:
 > 2
 == Password authentication ==
-Enter 'r' to cancel the request and go back to select the authentication method
+Enter 'r' to cancel the request and go back to select the authentication flow
 Gimme your password:
 >
 == Authentication method selection ==
@@ -44,7 +44,7 @@ Code: 1337
 
   1. Wait for authentication result
   2. Regenerate code
-Or enter 'r' to go back to select the authentication method
+Or enter 'r' to go back to select the authentication flow
 Choose action:
 > 2
 == Use a QR code ==
@@ -72,7 +72,7 @@ Code: 1338
 
   1. Wait for authentication result
   2. Regenerate code
-Or enter 'r' to go back to select the authentication method
+Or enter 'r' to go back to select the authentication flow
 Choose action:
 > 2
 == Use a QR code ==
@@ -102,7 +102,7 @@ Code: 1339
 
   1. Wait for authentication result
   2. Regenerate code
-Or enter 'r' to go back to select the authentication method
+Or enter 'r' to go back to select the authentication flow
 Choose action:
 > 2
 == Use a QR code ==
@@ -130,7 +130,7 @@ Code: 1340
 
   1. Wait for authentication result
   2. Regenerate code
-Or enter 'r' to go back to select the authentication method
+Or enter 'r' to go back to select the authentication flow
 Choose action:
 > 2
 == Use a QR code ==
@@ -158,7 +158,7 @@ Code: 1341
 
   1. Wait for authentication result
   2. Regenerate code
-Or enter 'r' to go back to select the authentication method
+Or enter 'r' to go back to select the authentication flow
 Choose action:
 > 1
 PAM Authenticate()

--- a/pam/integration-tests/testdata/golden/TestNativeAuthenticate/Authenticate_user_with_qr_code_in_a_TTY
+++ b/pam/integration-tests/testdata/golden/TestNativeAuthenticate/Authenticate_user_with_qr_code_in_a_TTY
@@ -4,7 +4,7 @@
 Choose your provider:
 > 2
 == Password authentication ==
-Enter 'r' to cancel the request and go back to select the authentication method
+Enter 'r' to cancel the request and go back to select the authentication flow
 Gimme your password:
 >
 == Authentication method selection ==
@@ -60,7 +60,7 @@ Code: 1337
 
   1. Wait for authentication result
   2. Regenerate code
-Or enter 'r' to go back to select the authentication method
+Or enter 'r' to go back to select the authentication flow
 Choose action:
 > 2
 == Use a QR code ==
@@ -104,7 +104,7 @@ Code: 1338
 
   1. Wait for authentication result
   2. Regenerate code
-Or enter 'r' to go back to select the authentication method
+Or enter 'r' to go back to select the authentication flow
 Choose action:
 > 2
 == Use a QR code ==
@@ -152,7 +152,7 @@ Code: 1339
 
   1. Wait for authentication result
   2. Regenerate code
-Or enter 'r' to go back to select the authentication method
+Or enter 'r' to go back to select the authentication flow
 Choose action:
 > 2
 == Use a QR code ==
@@ -196,7 +196,7 @@ Code: 1340
 
   1. Wait for authentication result
   2. Regenerate code
-Or enter 'r' to go back to select the authentication method
+Or enter 'r' to go back to select the authentication flow
 Choose action:
 > 2
 == Use a QR code ==
@@ -240,7 +240,7 @@ Code: 1341
 
   1. Wait for authentication result
   2. Regenerate code
-Or enter 'r' to go back to select the authentication method
+Or enter 'r' to go back to select the authentication flow
 Choose action:
 > 1
 PAM Authenticate()

--- a/pam/integration-tests/testdata/golden/TestNativeAuthenticate/Authenticate_user_with_qr_code_in_a_TTY_session
+++ b/pam/integration-tests/testdata/golden/TestNativeAuthenticate/Authenticate_user_with_qr_code_in_a_TTY_session
@@ -4,7 +4,7 @@
 Choose your provider:
 > 2
 == Password authentication ==
-Enter 'r' to cancel the request and go back to select the authentication method
+Enter 'r' to cancel the request and go back to select the authentication flow
 Gimme your password:
 >
 == Authentication method selection ==
@@ -60,7 +60,7 @@ Code: 1337
 
   1. Wait for authentication result
   2. Regenerate code
-Or enter 'r' to go back to select the authentication method
+Or enter 'r' to go back to select the authentication flow
 Choose action:
 > 2
 == Use a QR code ==
@@ -104,7 +104,7 @@ Code: 1338
 
   1. Wait for authentication result
   2. Regenerate code
-Or enter 'r' to go back to select the authentication method
+Or enter 'r' to go back to select the authentication flow
 Choose action:
 > 2
 == Use a QR code ==
@@ -152,7 +152,7 @@ Code: 1339
 
   1. Wait for authentication result
   2. Regenerate code
-Or enter 'r' to go back to select the authentication method
+Or enter 'r' to go back to select the authentication flow
 Choose action:
 > 2
 == Use a QR code ==
@@ -196,7 +196,7 @@ Code: 1340
 
   1. Wait for authentication result
   2. Regenerate code
-Or enter 'r' to go back to select the authentication method
+Or enter 'r' to go back to select the authentication flow
 Choose action:
 > 2
 == Use a QR code ==
@@ -240,7 +240,7 @@ Code: 1341
 
   1. Wait for authentication result
   2. Regenerate code
-Or enter 'r' to go back to select the authentication method
+Or enter 'r' to go back to select the authentication flow
 Choose action:
 > 1
 PAM Authenticate()

--- a/pam/integration-tests/testdata/golden/TestNativeAuthenticate/Authenticate_user_with_qr_code_in_screen
+++ b/pam/integration-tests/testdata/golden/TestNativeAuthenticate/Authenticate_user_with_qr_code_in_screen
@@ -4,7 +4,7 @@
 Choose your provider:
 > 2
 == Password authentication ==
-Enter 'r' to cancel the request and go back to select the authentication method
+Enter 'r' to cancel the request and go back to select the authentication flow
 Gimme your password:
 >
 == Authentication method selection ==
@@ -60,7 +60,7 @@ Code: 1337
 
   1. Wait for authentication result
   2. Regenerate code
-Or enter 'r' to go back to select the authentication method
+Or enter 'r' to go back to select the authentication flow
 Choose action:
 > 2
 == Use a QR code ==
@@ -104,7 +104,7 @@ Code: 1338
 
   1. Wait for authentication result
   2. Regenerate code
-Or enter 'r' to go back to select the authentication method
+Or enter 'r' to go back to select the authentication flow
 Choose action:
 > 2
 == Use a QR code ==
@@ -152,7 +152,7 @@ Code: 1339
 
   1. Wait for authentication result
   2. Regenerate code
-Or enter 'r' to go back to select the authentication method
+Or enter 'r' to go back to select the authentication flow
 Choose action:
 > 2
 == Use a QR code ==
@@ -196,7 +196,7 @@ Code: 1340
 
   1. Wait for authentication result
   2. Regenerate code
-Or enter 'r' to go back to select the authentication method
+Or enter 'r' to go back to select the authentication flow
 Choose action:
 > 2
 == Use a QR code ==
@@ -240,7 +240,7 @@ Code: 1341
 
   1. Wait for authentication result
   2. Regenerate code
-Or enter 'r' to go back to select the authentication method
+Or enter 'r' to go back to select the authentication flow
 Choose action:
 > 1
 PAM Authenticate()

--- a/pam/integration-tests/testdata/golden/TestNativeAuthenticate/Authenticate_user_with_qr_code_in_ssh
+++ b/pam/integration-tests/testdata/golden/TestNativeAuthenticate/Authenticate_user_with_qr_code_in_ssh
@@ -4,7 +4,7 @@
 Choose your provider:
 > 2
 == Password authentication ==
-Enter 'r' to cancel the request and go back to select the authentication method
+Enter 'r' to cancel the request and go back to select the authentication flow
 Gimme your password:
 >
 == Authentication method selection ==
@@ -27,7 +27,7 @@ Code: 1337
 
   1. Wait for authentication result
   2. Regenerate code
-Or enter 'r' to go back to select the authentication method
+Or enter 'r' to go back to select the authentication flow
 Choose action:
 > 2
 == Use a Login code ==
@@ -38,7 +38,7 @@ Code: 1338
 
   1. Wait for authentication result
   2. Regenerate code
-Or enter 'r' to go back to select the authentication method
+Or enter 'r' to go back to select the authentication flow
 Choose action:
 > 2
 == Use a Login code ==
@@ -49,7 +49,7 @@ Code: 1339
 
   1. Wait for authentication result
   2. Regenerate code
-Or enter 'r' to go back to select the authentication method
+Or enter 'r' to go back to select the authentication flow
 Choose action:
 > 2
 == Use a Login code ==
@@ -60,7 +60,7 @@ Code: 1340
 
   1. Wait for authentication result
   2. Regenerate code
-Or enter 'r' to go back to select the authentication method
+Or enter 'r' to go back to select the authentication flow
 Choose action:
 > 2
 == Use a Login code ==
@@ -71,7 +71,7 @@ Code: 1341
 
   1. Wait for authentication result
   2. Regenerate code
-Or enter 'r' to go back to select the authentication method
+Or enter 'r' to go back to select the authentication flow
 Choose action:
 > 1
 PAM Authenticate()

--- a/pam/integration-tests/testdata/golden/TestNativeAuthenticate/Authenticate_user_with_qr_code_without_code
+++ b/pam/integration-tests/testdata/golden/TestNativeAuthenticate/Authenticate_user_with_qr_code_without_code
@@ -4,7 +4,7 @@
 Choose your provider:
 > 2
 == Password authentication ==
-Enter 'r' to cancel the request and go back to select the authentication method
+Enter 'r' to cancel the request and go back to select the authentication flow
 Gimme your password:
 >
 == Authentication method selection ==
@@ -43,7 +43,7 @@ URL: https://ubuntu.com
 
   1. Wait for authentication result
   2. Regenerate code
-Or enter 'r' to go back to select the authentication method
+Or enter 'r' to go back to select the authentication flow
 Choose action:
 > 2
 == Use a QR code ==
@@ -70,7 +70,7 @@ URL: https://ubuntu.com
 
   1. Wait for authentication result
   2. Regenerate code
-Or enter 'r' to go back to select the authentication method
+Or enter 'r' to go back to select the authentication flow
 Choose action:
 > 2
 == Use a QR code ==
@@ -97,7 +97,7 @@ URL: https://ubuntu.com
 
   1. Wait for authentication result
   2. Regenerate code
-Or enter 'r' to go back to select the authentication method
+Or enter 'r' to go back to select the authentication flow
 Choose action:
 > 2
 == Use a QR code ==
@@ -124,7 +124,7 @@ URL: https://ubuntu.com
 
   1. Wait for authentication result
   2. Regenerate code
-Or enter 'r' to go back to select the authentication method
+Or enter 'r' to go back to select the authentication flow
 Choose action:
 > 2
 == Use a QR code ==
@@ -151,7 +151,7 @@ URL: https://ubuntu.com
 
   1. Wait for authentication result
   2. Regenerate code
-Or enter 'r' to go back to select the authentication method
+Or enter 'r' to go back to select the authentication flow
 Choose action:
 > 1
 PAM Authenticate()

--- a/pam/integration-tests/testdata/golden/TestNativeAuthenticate/Authenticate_with_warnings_on_unsupported_arguments
+++ b/pam/integration-tests/testdata/golden/TestNativeAuthenticate/Authenticate_with_warnings_on_unsupported_arguments
@@ -4,7 +4,7 @@
 Choose your provider:
 > 2
 == Password authentication ==
-Enter 'r' to cancel the request and go back to select the authentication method
+Enter 'r' to cancel the request and go back to select the authentication flow
 Gimme your password:
 >
   PAM_AUTHTOK: "goodpass"

--- a/pam/integration-tests/testdata/golden/TestNativeAuthenticate/Deny_authentication_if_max_attempts_reached
+++ b/pam/integration-tests/testdata/golden/TestNativeAuthenticate/Deny_authentication_if_max_attempts_reached
@@ -4,27 +4,27 @@
 Choose your provider:
 > 2
 == Password authentication ==
-Enter 'r' to cancel the request and go back to select the authentication method
+Enter 'r' to cancel the request and go back to select the authentication flow
 Gimme your password:
 >
 PAM Error Message: invalid password 'wrongpass', should be 'goodpass'
 == Password authentication ==
-Enter 'r' to cancel the request and go back to select the authentication method
+Enter 'r' to cancel the request and go back to select the authentication flow
 Gimme your password:
 >
 PAM Error Message: invalid password 'wrongpass', should be 'goodpass'
 == Password authentication ==
-Enter 'r' to cancel the request and go back to select the authentication method
+Enter 'r' to cancel the request and go back to select the authentication flow
 Gimme your password:
 >
 PAM Error Message: invalid password 'wrongpass', should be 'goodpass'
 == Password authentication ==
-Enter 'r' to cancel the request and go back to select the authentication method
+Enter 'r' to cancel the request and go back to select the authentication flow
 Gimme your password:
 >
 PAM Error Message: invalid password 'wrongpass', should be 'goodpass'
 == Password authentication ==
-Enter 'r' to cancel the request and go back to select the authentication method
+Enter 'r' to cancel the request and go back to select the authentication flow
 Gimme your password:
 >
 PAM Error Message: Maximum number of authentication attempts reached

--- a/pam/integration-tests/testdata/golden/TestNativeAuthenticate/Deny_authentication_if_newpassword_does_not_match_required_criteria
+++ b/pam/integration-tests/testdata/golden/TestNativeAuthenticate/Deny_authentication_if_newpassword_does_not_match_required_criteria
@@ -4,7 +4,7 @@
 Choose your provider:
 > 2
 == Password authentication ==
-Enter 'r' to cancel the request and go back to select the authentication method
+Enter 'r' to cancel the request and go back to select the authentication flow
 Gimme your password:
 >
 Password reset, 1 step(s) missing

--- a/pam/integration-tests/testdata/golden/TestNativeAuthenticate/Deny_authentication_if_user_does_not_exist_and_matches_cancel_key
+++ b/pam/integration-tests/testdata/golden/TestNativeAuthenticate/Deny_authentication_if_user_does_not_exist_and_matches_cancel_key
@@ -6,7 +6,7 @@ Or enter 'r' to go back to user selection
 Choose your provider:
 > 2
 == Password authentication ==
-Enter 'r' to cancel the request and go back to select the authentication method
+Enter 'r' to cancel the request and go back to select the authentication flow
 Gimme your password:
 >
 PAM Error Message: user not found

--- a/pam/integration-tests/testdata/golden/TestNativeAuthenticate/Exit_authd_if_user_sigints
+++ b/pam/integration-tests/testdata/golden/TestNativeAuthenticate/Exit_authd_if_user_sigints
@@ -4,6 +4,6 @@
 Choose your provider:
 > 2
 == Password authentication ==
-Enter 'r' to cancel the request and go back to select the authentication method
+Enter 'r' to cancel the request and go back to select the authentication flow
 Gimme your password:
 >

--- a/pam/integration-tests/testdata/golden/TestNativeAuthenticate/Prevent_preset_user_from_switching_username
+++ b/pam/integration-tests/testdata/golden/TestNativeAuthenticate/Prevent_preset_user_from_switching_username
@@ -7,7 +7,7 @@ PAM Error Message: Unsupported input
 Choose your provider:
 > 2
 == Password authentication ==
-Enter 'r' to cancel the request and go back to select the authentication method
+Enter 'r' to cancel the request and go back to select the authentication flow
 Gimme your password:
 >
 == Authentication method selection ==
@@ -34,7 +34,7 @@ PAM Error Message: Unsupported input
 Choose your provider:
 > 2
 == Password authentication ==
-Enter 'r' to cancel the request and go back to select the authentication method
+Enter 'r' to cancel the request and go back to select the authentication flow
 Gimme your password:
 >
   PAM_AUTHTOK: "goodpass"

--- a/pam/integration-tests/testdata/golden/TestNativeAuthenticate/Remember_last_successful_broker_and_mode
+++ b/pam/integration-tests/testdata/golden/TestNativeAuthenticate/Remember_last_successful_broker_and_mode
@@ -4,7 +4,7 @@
 Choose your provider:
 > 2
 == Password authentication ==
-Enter 'r' to cancel the request and go back to select the authentication method
+Enter 'r' to cancel the request and go back to select the authentication flow
 Gimme your password:
 >
 == Authentication method selection ==
@@ -22,11 +22,11 @@ Choose your authentication method:
 == Authentication code ==
   1. Proceed with Authentication code
   2. Resend SMS (1 sent)
-Or enter 'r' to go back to select the authentication method
+Or enter 'r' to go back to select the authentication flow
 Choose action:
 > 1
 == Authentication code ==
-Enter 'r' to cancel the request and go back to select the authentication method
+Enter 'r' to cancel the request and go back to select the authentication flow
 Enter your one time credential:
 > temporary pass0
   PAM_AUTHTOK: "temporary pass0"
@@ -37,11 +37,11 @@ PAM Authenticate()
 == Authentication code ==
   1. Proceed with Authentication code
   2. Resend SMS (1 sent)
-Or enter 'r' to go back to select the authentication method
+Or enter 'r' to go back to select the authentication flow
 Choose action:
 > 1
 == Authentication code ==
-Enter 'r' to cancel the request and go back to select the authentication method
+Enter 'r' to cancel the request and go back to select the authentication flow
 Enter your one time credential:
 > temporary pass0
   PAM_AUTHTOK: "temporary pass0"

--- a/pam/integration-tests/testdata/golden/TestNativeChangeAuthTok/Change_passwd_after_MFA_auth
+++ b/pam/integration-tests/testdata/golden/TestNativeChangeAuthTok/Change_passwd_after_MFA_auth
@@ -6,7 +6,7 @@ Or enter 'r' to go back to user selection
 Choose your provider:
 > 2
 == Password authentication ==
-Enter 'r' to cancel the request and go back to select the authentication method
+Enter 'r' to cancel the request and go back to select the authentication flow
 Gimme your password:
 >
 == Authentication method selection ==
@@ -22,11 +22,11 @@ Or enter 'r' to go back to choose the provider
 Choose your authentication method:
 > 1
 == Password authentication ==
-Enter 'r' to cancel the request and go back to select the authentication method
+Enter 'r' to cancel the request and go back to select the authentication flow
 Gimme your password:
 >
 == Use your fido device foo ==
-Press Enter to wait for authentication or enter 'r' to go back to select the authentication method
+Press Enter to wait for authentication or enter 'r' to go back to select the authentication flow
 Plug your fido device and press with your thumb:
 > r
 == Authentication method selection ==
@@ -37,11 +37,11 @@ Or enter 'r' to go back to choose the provider
 Choose your authentication method:
 > 1
 == Use your fido device foo ==
-Press Enter to wait for authentication or enter 'r' to go back to select the authentication method
+Press Enter to wait for authentication or enter 'r' to go back to select the authentication flow
 Plug your fido device and press with your thumb:
 >
 == Use your phone +33... ==
-Press Enter to wait for authentication or enter 'r' to go back to select the authentication method
+Press Enter to wait for authentication or enter 'r' to go back to select the authentication flow
 Unlock your phone +33... or accept request on web interface:
 > r
 == Authentication method selection ==
@@ -51,7 +51,7 @@ Or enter 'r' to go back to choose the provider
 Choose your authentication method:
 > 1
 == Use your phone +33... ==
-Press Enter to wait for authentication or enter 'r' to go back to select the authentication method
+Press Enter to wait for authentication or enter 'r' to go back to select the authentication flow
 Unlock your phone +33... or accept request on web interface:
 >
 == Password reset ==

--- a/pam/integration-tests/testdata/golden/TestNativeChangeAuthTok/Change_password_successfully_and_authenticate_with_new_one
+++ b/pam/integration-tests/testdata/golden/TestNativeChangeAuthTok/Change_password_successfully_and_authenticate_with_new_one
@@ -6,7 +6,7 @@ Or enter 'r' to go back to user selection
 Choose your provider:
 > 2
 == Password authentication ==
-Enter 'r' to cancel the request and go back to select the authentication method
+Enter 'r' to cancel the request and go back to select the authentication flow
 Gimme your password:
 >
 == Password reset ==
@@ -23,7 +23,7 @@ PAM ChangeAuthTok()
 
 Username: user-integration-simple-testnativechangeauthtok@example.com
 == Password authentication ==
-Enter 'r' to cancel the request and go back to select the authentication method
+Enter 'r' to cancel the request and go back to select the authentication flow
 Gimme your password:
 >
   PAM_AUTHTOK: "authd2404"

--- a/pam/integration-tests/testdata/golden/TestNativeChangeAuthTok/Change_password_successfully_and_authenticate_with_new_one_with_different_case
+++ b/pam/integration-tests/testdata/golden/TestNativeChangeAuthTok/Change_password_successfully_and_authenticate_with_new_one_with_different_case
@@ -6,7 +6,7 @@ Or enter 'r' to go back to user selection
 Choose your provider:
 > 2
 == Password authentication ==
-Enter 'r' to cancel the request and go back to select the authentication method
+Enter 'r' to cancel the request and go back to select the authentication flow
 Gimme your password:
 >
 == Password reset ==
@@ -23,7 +23,7 @@ PAM ChangeAuthTok()
 
 Username: user-integration-case-insensitive-testnativechangeauthtok@example.com
 == Password authentication ==
-Enter 'r' to cancel the request and go back to select the authentication method
+Enter 'r' to cancel the request and go back to select the authentication flow
 Gimme your password:
 >
   PAM_AUTHTOK: "authd2404"

--- a/pam/integration-tests/testdata/golden/TestNativeChangeAuthTok/Change_password_successfully_and_authenticate_with_new_one_with_single_broker_and_password_only_supported_method
+++ b/pam/integration-tests/testdata/golden/TestNativeChangeAuthTok/Change_password_successfully_and_authenticate_with_new_one_with_single_broker_and_password_only_supported_method
@@ -13,7 +13,7 @@ PAM ChangeAuthTok()
   Result: success
 
 == Password authentication ==
-Enter 'r' to cancel the request and go back to select the authentication method
+Enter 'r' to cancel the request and go back to select the authentication flow
 Gimme your password:
 >
   PAM_AUTHTOK: "authd2404"

--- a/pam/integration-tests/testdata/golden/TestNativeChangeAuthTok/Exit_authd_if_user_sigints
+++ b/pam/integration-tests/testdata/golden/TestNativeChangeAuthTok/Exit_authd_if_user_sigints
@@ -6,6 +6,6 @@ Or enter 'r' to go back to user selection
 Choose your provider:
 > 2
 == Password authentication ==
-Enter 'r' to cancel the request and go back to select the authentication method
+Enter 'r' to cancel the request and go back to select the authentication flow
 Gimme your password:
 >

--- a/pam/integration-tests/testdata/golden/TestNativeChangeAuthTok/Prevent_change_password_if_auth_fails
+++ b/pam/integration-tests/testdata/golden/TestNativeChangeAuthTok/Prevent_change_password_if_auth_fails
@@ -6,27 +6,27 @@ Or enter 'r' to go back to user selection
 Choose your provider:
 > 2
 == Password authentication ==
-Enter 'r' to cancel the request and go back to select the authentication method
+Enter 'r' to cancel the request and go back to select the authentication flow
 Gimme your password:
 >
 PAM Error Message: invalid password 'wrongpass', should be 'goodpass'
 == Password authentication ==
-Enter 'r' to cancel the request and go back to select the authentication method
+Enter 'r' to cancel the request and go back to select the authentication flow
 Gimme your password:
 >
 PAM Error Message: invalid password 'wrongpass', should be 'goodpass'
 == Password authentication ==
-Enter 'r' to cancel the request and go back to select the authentication method
+Enter 'r' to cancel the request and go back to select the authentication flow
 Gimme your password:
 >
 PAM Error Message: invalid password 'wrongpass', should be 'goodpass'
 == Password authentication ==
-Enter 'r' to cancel the request and go back to select the authentication method
+Enter 'r' to cancel the request and go back to select the authentication flow
 Gimme your password:
 >
 PAM Error Message: invalid password 'wrongpass', should be 'goodpass'
 == Password authentication ==
-Enter 'r' to cancel the request and go back to select the authentication method
+Enter 'r' to cancel the request and go back to select the authentication flow
 Gimme your password:
 >
 PAM Error Message: Maximum number of authentication attempts reached

--- a/pam/integration-tests/testdata/golden/TestNativeChangeAuthTok/Retry_if_new_password_does_not_match_quality_criteria
+++ b/pam/integration-tests/testdata/golden/TestNativeChangeAuthTok/Retry_if_new_password_does_not_match_quality_criteria
@@ -6,7 +6,7 @@ Or enter 'r' to go back to user selection
 Choose your provider:
 > 2
 == Password authentication ==
-Enter 'r' to cancel the request and go back to select the authentication method
+Enter 'r' to cancel the request and go back to select the authentication flow
 Gimme your password:
 >
 == Password reset ==

--- a/pam/integration-tests/testdata/golden/TestNativeChangeAuthTok/Retry_if_new_password_is_rejected_by_broker
+++ b/pam/integration-tests/testdata/golden/TestNativeChangeAuthTok/Retry_if_new_password_is_rejected_by_broker
@@ -6,7 +6,7 @@ Or enter 'r' to go back to user selection
 Choose your provider:
 > 2
 == Password authentication ==
-Enter 'r' to cancel the request and go back to select the authentication method
+Enter 'r' to cancel the request and go back to select the authentication flow
 Gimme your password:
 >
 == Password reset ==

--- a/pam/integration-tests/testdata/golden/TestNativeChangeAuthTok/Retry_if_new_password_is_same_of_previous
+++ b/pam/integration-tests/testdata/golden/TestNativeChangeAuthTok/Retry_if_new_password_is_same_of_previous
@@ -6,7 +6,7 @@ Or enter 'r' to go back to user selection
 Choose your provider:
 > 2
 == Password authentication ==
-Enter 'r' to cancel the request and go back to select the authentication method
+Enter 'r' to cancel the request and go back to select the authentication flow
 Gimme your password:
 >
 == Password reset ==

--- a/pam/integration-tests/testdata/golden/TestNativeChangeAuthTok/Retry_if_password_confirmation_is_not_the_same
+++ b/pam/integration-tests/testdata/golden/TestNativeChangeAuthTok/Retry_if_password_confirmation_is_not_the_same
@@ -6,7 +6,7 @@ Or enter 'r' to go back to user selection
 Choose your provider:
 > 2
 == Password authentication ==
-Enter 'r' to cancel the request and go back to select the authentication method
+Enter 'r' to cancel the request and go back to select the authentication flow
 Gimme your password:
 >
 == Password reset ==

--- a/pam/integration-tests/testdata/golden/TestSSHAuthenticate/Authenticate_user_and_accept_password_reset
+++ b/pam/integration-tests/testdata/golden/TestSSHAuthenticate/Authenticate_user_and_accept_password_reset
@@ -4,7 +4,7 @@
 (user-can-reset-integration-pre-check-ssh-authenticate-user-and-accept-password-reset@example.com@localhost) Choose your provider:
 > 2
 == Password authentication ==
-Enter 'r' to cancel the request and go back to select the authentication method
+Enter 'r' to cancel the request and go back to select the authentication flow
 (user-can-reset-integration-pre-check-ssh-authenticate-user-and-accept-password-reset@example.com@localhost) Gimme your password:
 >
 Password reset, 1 step(s) missing

--- a/pam/integration-tests/testdata/golden/TestSSHAuthenticate/Authenticate_user_and_accept_password_reset_with_shared_sshd
+++ b/pam/integration-tests/testdata/golden/TestSSHAuthenticate/Authenticate_user_and_accept_password_reset_with_shared_sshd
@@ -4,7 +4,7 @@
 (user-can-reset-integration-pre-check-ssh-authenticate-user-and-accept-password-reset-with-shared-sshd@example.com@localhost) Choose your provider:
 > 2
 == Password authentication ==
-Enter 'r' to cancel the request and go back to select the authentication method
+Enter 'r' to cancel the request and go back to select the authentication flow
 (user-can-reset-integration-pre-check-ssh-authenticate-user-and-accept-password-reset-with-shared-sshd@example.com@localhost) Gimme your password:
 >
 Password reset, 1 step(s) missing

--- a/pam/integration-tests/testdata/golden/TestSSHAuthenticate/Authenticate_user_and_add_it_to_local_group
+++ b/pam/integration-tests/testdata/golden/TestSSHAuthenticate/Authenticate_user_and_add_it_to_local_group
@@ -4,7 +4,7 @@
 (user-local-groups-integration-pre-check-ssh-authenticate-user-and-add-it-to-local-group@example.com@localhost) Choose your provider:
 > 2
 == Password authentication ==
-Enter 'r' to cancel the request and go back to select the authentication method
+Enter 'r' to cancel the request and go back to select the authentication flow
 (user-local-groups-integration-pre-check-ssh-authenticate-user-and-add-it-to-local-group@example.com@localhost) Gimme your password:
 >
 PAM Authenticate() finished for user 'user-local-groups-integration-pre-check-ssh-authenticate-user-and-add-it-to-local-group@example.com'

--- a/pam/integration-tests/testdata/golden/TestSSHAuthenticate/Authenticate_user_and_add_it_to_local_group_with_shared_sshd
+++ b/pam/integration-tests/testdata/golden/TestSSHAuthenticate/Authenticate_user_and_add_it_to_local_group_with_shared_sshd
@@ -4,7 +4,7 @@
 (user-local-groups-integration-pre-check-ssh-authenticate-user-and-add-it-to-local-group-with-shared-sshd@example.com@localhost) Choose your provider:
 > 2
 == Password authentication ==
-Enter 'r' to cancel the request and go back to select the authentication method
+Enter 'r' to cancel the request and go back to select the authentication flow
 (user-local-groups-integration-pre-check-ssh-authenticate-user-and-add-it-to-local-group-with-shared-sshd@example.com@localhost) Gimme your password:
 >
 PAM Authenticate() finished for user 'user-local-groups-integration-pre-check-ssh-authenticate-user-and-add-it-to-local-group-with-shared-sshd@example.com'

--- a/pam/integration-tests/testdata/golden/TestSSHAuthenticate/Authenticate_user_and_offer_password_reset
+++ b/pam/integration-tests/testdata/golden/TestSSHAuthenticate/Authenticate_user_and_offer_password_reset
@@ -4,7 +4,7 @@
 (user-can-reset-integration-pre-check-ssh-authenticate-user-and-offer-password-reset@example.com@localhost) Choose your provider:
 > 2
 == Password authentication ==
-Enter 'r' to cancel the request and go back to select the authentication method
+Enter 'r' to cancel the request and go back to select the authentication flow
 (user-can-reset-integration-pre-check-ssh-authenticate-user-and-offer-password-reset@example.com@localhost) Gimme your password:
 >
 Password reset, 1 step(s) missing

--- a/pam/integration-tests/testdata/golden/TestSSHAuthenticate/Authenticate_user_and_offer_password_reset_with_shared_sshd
+++ b/pam/integration-tests/testdata/golden/TestSSHAuthenticate/Authenticate_user_and_offer_password_reset_with_shared_sshd
@@ -4,7 +4,7 @@
 (user-can-reset-integration-pre-check-ssh-authenticate-user-and-offer-password-reset-with-shared-sshd@example.com@localhost) Choose your provider:
 > 2
 == Password authentication ==
-Enter 'r' to cancel the request and go back to select the authentication method
+Enter 'r' to cancel the request and go back to select the authentication flow
 (user-can-reset-integration-pre-check-ssh-authenticate-user-and-offer-password-reset-with-shared-sshd@example.com@localhost) Gimme your password:
 >
 Password reset, 1 step(s) missing

--- a/pam/integration-tests/testdata/golden/TestSSHAuthenticate/Authenticate_user_and_reset_password_then_allow_uppercase_re-login_on_ubuntu_24.04
+++ b/pam/integration-tests/testdata/golden/TestSSHAuthenticate/Authenticate_user_and_reset_password_then_allow_uppercase_re-login_on_ubuntu_24.04
@@ -4,7 +4,7 @@
 (user-needs-reset-integration-pre-check-case-insensitive-testsshauthenticate@example.com@localhost) Choose your provider:
 > 2
 == Password authentication ==
-Enter 'r' to cancel the request and go back to select the authentication method
+Enter 'r' to cancel the request and go back to select the authentication flow
 (user-needs-reset-integration-pre-check-case-insensitive-testsshauthenticate@example.com@localhost) Gimme your password:
 >
 Password reset, 1 step(s) missing
@@ -28,7 +28,7 @@ PAM Authenticate() finished for user 'user-needs-reset-integration-pre-check-cas
   USER=user-needs-reset-integration-pre-check-case-insensitive-testsshauthenticate@example.com
 Connection to localhost closed.
 == Password authentication ==
-Enter 'r' to cancel the request and go back to select the authentication method
+Enter 'r' to cancel the request and go back to select the authentication flow
 (USER-NEEDS-RESET-INTEGRATION-PRE-CHECK-CASE-INSENSITIVE-TESTSSHAUTHENTICATE@EXAMPLE.COM@localhost) Gimme your password:
 >
 PAM Authenticate() finished for user 'user-needs-reset-integration-pre-check-case-insensitive-testsshauthenticate@example.com'

--- a/pam/integration-tests/testdata/golden/TestSSHAuthenticate/Authenticate_user_and_reset_password_then_allow_uppercase_re-login_on_ubuntu_24.04_with_shared_sshd
+++ b/pam/integration-tests/testdata/golden/TestSSHAuthenticate/Authenticate_user_and_reset_password_then_allow_uppercase_re-login_on_ubuntu_24.04_with_shared_sshd
@@ -4,7 +4,7 @@
 (user-needs-reset-integration-pre-check-case-insensitive-testsshauthenticate@example.com@localhost) Choose your provider:
 > 2
 == Password authentication ==
-Enter 'r' to cancel the request and go back to select the authentication method
+Enter 'r' to cancel the request and go back to select the authentication flow
 (user-needs-reset-integration-pre-check-case-insensitive-testsshauthenticate@example.com@localhost) Gimme your password:
 >
 Password reset, 1 step(s) missing
@@ -28,7 +28,7 @@ PAM Authenticate() finished for user 'user-needs-reset-integration-pre-check-cas
   USER=user-needs-reset-integration-pre-check-case-insensitive-testsshauthenticate@example.com
 Connection to localhost closed.
 == Password authentication ==
-Enter 'r' to cancel the request and go back to select the authentication method
+Enter 'r' to cancel the request and go back to select the authentication flow
 (USER-NEEDS-RESET-INTEGRATION-PRE-CHECK-CASE-INSENSITIVE-TESTSSHAUTHENTICATE@EXAMPLE.COM@localhost) Gimme your password:
 >
 PAM Authenticate() finished for user 'user-needs-reset-integration-pre-check-case-insensitive-testsshauthenticate@example.com'

--- a/pam/integration-tests/testdata/golden/TestSSHAuthenticate/Authenticate_user_and_reset_password_then_deny_uppercase_re-login_on_ubuntu_26.04
+++ b/pam/integration-tests/testdata/golden/TestSSHAuthenticate/Authenticate_user_and_reset_password_then_deny_uppercase_re-login_on_ubuntu_26.04
@@ -4,7 +4,7 @@
 (user-needs-reset-integration-pre-check-case-insensitive-testsshauthenticate@example.com@localhost) Choose your provider:
 > 2
 == Password authentication ==
-Enter 'r' to cancel the request and go back to select the authentication method
+Enter 'r' to cancel the request and go back to select the authentication flow
 (user-needs-reset-integration-pre-check-case-insensitive-testsshauthenticate@example.com@localhost) Gimme your password:
 >
 Password reset, 1 step(s) missing

--- a/pam/integration-tests/testdata/golden/TestSSHAuthenticate/Authenticate_user_and_reset_password_then_deny_uppercase_re-login_on_ubuntu_26.04_with_shared_sshd
+++ b/pam/integration-tests/testdata/golden/TestSSHAuthenticate/Authenticate_user_and_reset_password_then_deny_uppercase_re-login_on_ubuntu_26.04_with_shared_sshd
@@ -4,7 +4,7 @@
 (user-needs-reset-integration-pre-check-case-insensitive-testsshauthenticate@example.com@localhost) Choose your provider:
 > 2
 == Password authentication ==
-Enter 'r' to cancel the request and go back to select the authentication method
+Enter 'r' to cancel the request and go back to select the authentication flow
 (user-needs-reset-integration-pre-check-case-insensitive-testsshauthenticate@example.com@localhost) Gimme your password:
 >
 Password reset, 1 step(s) missing

--- a/pam/integration-tests/testdata/golden/TestSSHAuthenticate/Authenticate_user_and_reset_password_while_enforcing_policy
+++ b/pam/integration-tests/testdata/golden/TestSSHAuthenticate/Authenticate_user_and_reset_password_while_enforcing_policy
@@ -4,7 +4,7 @@
 (user-needs-reset-integration-pre-check-ssh-authenticate-user-and-reset-password-while-enforcing-policy@example.com@localhost) Choose your provider:
 > 2
 == Password authentication ==
-Enter 'r' to cancel the request and go back to select the authentication method
+Enter 'r' to cancel the request and go back to select the authentication flow
 (user-needs-reset-integration-pre-check-ssh-authenticate-user-and-reset-password-while-enforcing-policy@example.com@localhost) Gimme your password:
 >
 Password reset, 1 step(s) missing

--- a/pam/integration-tests/testdata/golden/TestSSHAuthenticate/Authenticate_user_and_reset_password_while_enforcing_policy_with_shared_sshd
+++ b/pam/integration-tests/testdata/golden/TestSSHAuthenticate/Authenticate_user_and_reset_password_while_enforcing_policy_with_shared_sshd
@@ -4,7 +4,7 @@
 (user-needs-reset-integration-pre-check-ssh-authenticate-user-and-reset-password-while-enforcing-policy-with-shared-sshd@example.com@localhost) Choose your provider:
 > 2
 == Password authentication ==
-Enter 'r' to cancel the request and go back to select the authentication method
+Enter 'r' to cancel the request and go back to select the authentication flow
 (user-needs-reset-integration-pre-check-ssh-authenticate-user-and-reset-password-while-enforcing-policy-with-shared-sshd@example.com@localhost) Gimme your password:
 >
 Password reset, 1 step(s) missing

--- a/pam/integration-tests/testdata/golden/TestSSHAuthenticate/Authenticate_user_locks_and_unlocks_it
+++ b/pam/integration-tests/testdata/golden/TestSSHAuthenticate/Authenticate_user_locks_and_unlocks_it
@@ -4,7 +4,7 @@
 (user-integration-pre-check-ssh-authenticate-user-locks-and-unlocks-it@example.com@localhost) Choose your provider:
 > 2
 == Password authentication ==
-Enter 'r' to cancel the request and go back to select the authentication method
+Enter 'r' to cancel the request and go back to select the authentication flow
 (user-integration-pre-check-ssh-authenticate-user-locks-and-unlocks-it@example.com@localhost) Gimme your password:
 >
 PAM Authenticate() finished for user 'user-integration-pre-check-ssh-authenticate-user-locks-and-unlocks-it@example.com'
@@ -24,7 +24,7 @@ Connection to localhost closed.
 
 ────────────────────────────────────────────────────────────────────────────────
 == Password authentication ==
-Enter 'r' to cancel the request and go back to select the authentication method
+Enter 'r' to cancel the request and go back to select the authentication flow
 (user-integration-pre-check-ssh-authenticate-user-locks-and-unlocks-it@example.com@localhost) Gimme your password:
 >
 permission denied: user user-integration-pre-check-ssh-authenticate-user-locks-and-unlocks-it@example.com is locked
@@ -37,7 +37,7 @@ Disconnected from ${SSH_HOST} port ${SSH_PORT}
 
 ────────────────────────────────────────────────────────────────────────────────
 == Password authentication ==
-Enter 'r' to cancel the request and go back to select the authentication method
+Enter 'r' to cancel the request and go back to select the authentication flow
 (user-integration-pre-check-ssh-authenticate-user-locks-and-unlocks-it@example.com@localhost) Gimme your password:
 >
 PAM Authenticate() finished for user 'user-integration-pre-check-ssh-authenticate-user-locks-and-unlocks-it@example.com'

--- a/pam/integration-tests/testdata/golden/TestSSHAuthenticate/Authenticate_user_locks_and_unlocks_it_with_shared_sshd
+++ b/pam/integration-tests/testdata/golden/TestSSHAuthenticate/Authenticate_user_locks_and_unlocks_it_with_shared_sshd
@@ -4,7 +4,7 @@
 (user-integration-pre-check-ssh-authenticate-user-locks-and-unlocks-it-with-shared-sshd@example.com@localhost) Choose your provider:
 > 2
 == Password authentication ==
-Enter 'r' to cancel the request and go back to select the authentication method
+Enter 'r' to cancel the request and go back to select the authentication flow
 (user-integration-pre-check-ssh-authenticate-user-locks-and-unlocks-it-with-shared-sshd@example.com@localhost) Gimme your password:
 >
 PAM Authenticate() finished for user 'user-integration-pre-check-ssh-authenticate-user-locks-and-unlocks-it-with-shared-sshd@example.com'
@@ -24,7 +24,7 @@ Connection to localhost closed.
 
 ────────────────────────────────────────────────────────────────────────────────
 == Password authentication ==
-Enter 'r' to cancel the request and go back to select the authentication method
+Enter 'r' to cancel the request and go back to select the authentication flow
 (user-integration-pre-check-ssh-authenticate-user-locks-and-unlocks-it-with-shared-sshd@example.com@localhost) Gimme your password:
 >
 permission denied: user user-integration-pre-check-ssh-authenticate-user-locks-and-unlocks-it-with-shared-sshd@example.com is locked
@@ -37,7 +37,7 @@ Disconnected from ${SSH_HOST} port ${SSH_PORT}
 
 ────────────────────────────────────────────────────────────────────────────────
 == Password authentication ==
-Enter 'r' to cancel the request and go back to select the authentication method
+Enter 'r' to cancel the request and go back to select the authentication flow
 (user-integration-pre-check-ssh-authenticate-user-locks-and-unlocks-it-with-shared-sshd@example.com@localhost) Gimme your password:
 >
 PAM Authenticate() finished for user 'user-integration-pre-check-ssh-authenticate-user-locks-and-unlocks-it-with-shared-sshd@example.com'

--- a/pam/integration-tests/testdata/golden/TestSSHAuthenticate/Authenticate_user_successfully
+++ b/pam/integration-tests/testdata/golden/TestSSHAuthenticate/Authenticate_user_successfully
@@ -4,7 +4,7 @@
 (user-integration-pre-check-ssh-authenticate-user-successfully@example.com@localhost) Choose your provider:
 > 2
 == Password authentication ==
-Enter 'r' to cancel the request and go back to select the authentication method
+Enter 'r' to cancel the request and go back to select the authentication flow
 (user-integration-pre-check-ssh-authenticate-user-successfully@example.com@localhost) Gimme your password:
 >
 PAM Authenticate() finished for user 'user-integration-pre-check-ssh-authenticate-user-successfully@example.com'

--- a/pam/integration-tests/testdata/golden/TestSSHAuthenticate/Authenticate_user_successfully_and_enters_shell
+++ b/pam/integration-tests/testdata/golden/TestSSHAuthenticate/Authenticate_user_successfully_and_enters_shell
@@ -4,7 +4,7 @@
 (user-integration-pre-check-ssh-authenticate-user-successfully-and-enters-shell@example.com@localhost) Choose your provider:
 > 2
 == Password authentication ==
-Enter 'r' to cancel the request and go back to select the authentication method
+Enter 'r' to cancel the request and go back to select the authentication flow
 (user-integration-pre-check-ssh-authenticate-user-successfully-and-enters-shell@example.com@localhost) Gimme your password:
 >
 PAM Authenticate() finished for user 'user-integration-pre-check-ssh-authenticate-user-successfully-and-enters-shell@example.com'

--- a/pam/integration-tests/testdata/golden/TestSSHAuthenticate/Authenticate_user_successfully_and_enters_shell_with_shared_sshd
+++ b/pam/integration-tests/testdata/golden/TestSSHAuthenticate/Authenticate_user_successfully_and_enters_shell_with_shared_sshd
@@ -4,7 +4,7 @@
 (user-integration-pre-check-ssh-authenticate-user-successfully-and-enters-shell-with-shared-sshd@example.com@localhost) Choose your provider:
 > 2
 == Password authentication ==
-Enter 'r' to cancel the request and go back to select the authentication method
+Enter 'r' to cancel the request and go back to select the authentication flow
 (user-integration-pre-check-ssh-authenticate-user-successfully-and-enters-shell-with-shared-sshd@example.com@localhost) Gimme your password:
 >
 PAM Authenticate() finished for user 'user-integration-pre-check-ssh-authenticate-user-successfully-and-enters-shell-with-shared-sshd@example.com'

--- a/pam/integration-tests/testdata/golden/TestSSHAuthenticate/Authenticate_user_successfully_if_already_registered
+++ b/pam/integration-tests/testdata/golden/TestSSHAuthenticate/Authenticate_user_successfully_if_already_registered
@@ -4,7 +4,7 @@
 (user-ssh@example.com@localhost) Choose your provider:
 > 2
 == Password authentication ==
-Enter 'r' to cancel the request and go back to select the authentication method
+Enter 'r' to cancel the request and go back to select the authentication flow
 (user-ssh@example.com@localhost) Gimme your password:
 >
 PAM Authenticate() finished for user 'user-ssh@example.com'

--- a/pam/integration-tests/testdata/golden/TestSSHAuthenticate/Authenticate_user_successfully_if_already_registered_with_shared_sshd
+++ b/pam/integration-tests/testdata/golden/TestSSHAuthenticate/Authenticate_user_successfully_if_already_registered_with_shared_sshd
@@ -4,7 +4,7 @@
 (user-ssh@example.com@localhost) Choose your provider:
 > 2
 == Password authentication ==
-Enter 'r' to cancel the request and go back to select the authentication method
+Enter 'r' to cancel the request and go back to select the authentication flow
 (user-ssh@example.com@localhost) Gimme your password:
 >
 PAM Authenticate() finished for user 'user-ssh@example.com'

--- a/pam/integration-tests/testdata/golden/TestSSHAuthenticate/Authenticate_user_successfully_if_already_registered_with_upper_case_on_ubuntu_24.04
+++ b/pam/integration-tests/testdata/golden/TestSSHAuthenticate/Authenticate_user_successfully_if_already_registered_with_upper_case_on_ubuntu_24.04
@@ -4,7 +4,7 @@
 (USER-SSH2@example.com@localhost) Choose your provider:
 > 2
 == Password authentication ==
-Enter 'r' to cancel the request and go back to select the authentication method
+Enter 'r' to cancel the request and go back to select the authentication flow
 (USER-SSH2@example.com@localhost) Gimme your password:
 >
 PAM Authenticate() finished for user 'user-ssh2@example.com'

--- a/pam/integration-tests/testdata/golden/TestSSHAuthenticate/Authenticate_user_successfully_if_already_registered_with_upper_case_on_ubuntu_24.04_with_shared_sshd
+++ b/pam/integration-tests/testdata/golden/TestSSHAuthenticate/Authenticate_user_successfully_if_already_registered_with_upper_case_on_ubuntu_24.04_with_shared_sshd
@@ -4,7 +4,7 @@
 (USER-SSH2@example.com@localhost) Choose your provider:
 > 2
 == Password authentication ==
-Enter 'r' to cancel the request and go back to select the authentication method
+Enter 'r' to cancel the request and go back to select the authentication flow
 (USER-SSH2@example.com@localhost) Gimme your password:
 >
 PAM Authenticate() finished for user 'user-ssh2@example.com'

--- a/pam/integration-tests/testdata/golden/TestSSHAuthenticate/Authenticate_user_successfully_with_shared_sshd
+++ b/pam/integration-tests/testdata/golden/TestSSHAuthenticate/Authenticate_user_successfully_with_shared_sshd
@@ -4,7 +4,7 @@
 (user-integration-pre-check-ssh-authenticate-user-successfully-with-shared-sshd@example.com@localhost) Choose your provider:
 > 2
 == Password authentication ==
-Enter 'r' to cancel the request and go back to select the authentication method
+Enter 'r' to cancel the request and go back to select the authentication flow
 (user-integration-pre-check-ssh-authenticate-user-successfully-with-shared-sshd@example.com@localhost) Gimme your password:
 >
 PAM Authenticate() finished for user 'user-integration-pre-check-ssh-authenticate-user-successfully-with-shared-sshd@example.com'

--- a/pam/integration-tests/testdata/golden/TestSSHAuthenticate/Authenticate_user_successfully_with_upper_case_on_ubuntu_24.04
+++ b/pam/integration-tests/testdata/golden/TestSSHAuthenticate/Authenticate_user_successfully_with_upper_case_on_ubuntu_24.04
@@ -4,7 +4,7 @@
 (USER-INTEGRATION-PRE-CHECK-UPPER-CASE-TESTSSHAUTHENTICATE@EXAMPLE.COM@localhost) Choose your provider:
 > 2
 == Password authentication ==
-Enter 'r' to cancel the request and go back to select the authentication method
+Enter 'r' to cancel the request and go back to select the authentication flow
 (USER-INTEGRATION-PRE-CHECK-UPPER-CASE-TESTSSHAUTHENTICATE@EXAMPLE.COM@localhost) Gimme your password:
 >
 PAM Authenticate() finished for user 'user-integration-pre-check-upper-case-testsshauthenticate@example.com'

--- a/pam/integration-tests/testdata/golden/TestSSHAuthenticate/Authenticate_user_successfully_with_upper_case_on_ubuntu_24.04_with_shared_sshd
+++ b/pam/integration-tests/testdata/golden/TestSSHAuthenticate/Authenticate_user_successfully_with_upper_case_on_ubuntu_24.04_with_shared_sshd
@@ -4,7 +4,7 @@
 (USER-INTEGRATION-PRE-CHECK-UPPER-CASE-TESTSSHAUTHENTICATE@EXAMPLE.COM@localhost) Choose your provider:
 > 2
 == Password authentication ==
-Enter 'r' to cancel the request and go back to select the authentication method
+Enter 'r' to cancel the request and go back to select the authentication flow
 (USER-INTEGRATION-PRE-CHECK-UPPER-CASE-TESTSSHAUTHENTICATE@EXAMPLE.COM@localhost) Gimme your password:
 >
 PAM Authenticate() finished for user 'user-integration-pre-check-upper-case-testsshauthenticate@example.com'

--- a/pam/integration-tests/testdata/golden/TestSSHAuthenticate/Authenticate_user_switching_auth_mode
+++ b/pam/integration-tests/testdata/golden/TestSSHAuthenticate/Authenticate_user_switching_auth_mode
@@ -4,7 +4,7 @@
 (user-integration-pre-check-ssh-authenticate-user-switching-auth-mode@example.com@localhost) Choose your provider:
 > 2
 == Password authentication ==
-Enter 'r' to cancel the request and go back to select the authentication method
+Enter 'r' to cancel the request and go back to select the authentication flow
 (user-integration-pre-check-ssh-authenticate-user-switching-auth-mode@example.com@localhost) Gimme your password:
 >
 == Authentication method selection ==
@@ -20,7 +20,7 @@ Or enter 'r' to go back to choose the provider
 (user-integration-pre-check-ssh-authenticate-user-switching-auth-mode@example.com@localhost) Choose your authentication method:
 > 3
 == Send URL to user-integration-pre-check-ssh-authenticate-user-switching-auth-mode@example.com ==
-Leave the input field empty to wait for the alternative authentication method or enter 'r' to go back to select the authentication method
+Leave the input field empty to wait for the alternative authentication method or enter 'r' to go back to select the authentication flow
 (user-integration-pre-check-ssh-authenticate-user-switching-auth-mode@example.com@localhost) Click on the link received at user-integration-pre-check-ssh-authenticate-user-switching-auth-mode@example.com or enter the code:
 > r
 == Authentication method selection ==
@@ -36,7 +36,7 @@ Or enter 'r' to go back to choose the provider
 (user-integration-pre-check-ssh-authenticate-user-switching-auth-mode@example.com@localhost) Choose your authentication method:
 > 4
 == Use your fido device foo ==
-Press Enter to wait for authentication or enter 'r' to go back to select the authentication method
+Press Enter to wait for authentication or enter 'r' to go back to select the authentication flow
 (user-integration-pre-check-ssh-authenticate-user-switching-auth-mode@example.com@localhost) Plug your fido device and press with your thumb:
 > r
 == Authentication method selection ==
@@ -52,7 +52,7 @@ Or enter 'r' to go back to choose the provider
 (user-integration-pre-check-ssh-authenticate-user-switching-auth-mode@example.com@localhost) Choose your authentication method:
 > 5
 == Use your phone +33... ==
-Press Enter to wait for authentication or enter 'r' to go back to select the authentication method
+Press Enter to wait for authentication or enter 'r' to go back to select the authentication flow
 (user-integration-pre-check-ssh-authenticate-user-switching-auth-mode@example.com@localhost) Unlock your phone +33... or accept request on web interface:
 > r
 == Authentication method selection ==
@@ -68,7 +68,7 @@ Or enter 'r' to go back to choose the provider
 (user-integration-pre-check-ssh-authenticate-user-switching-auth-mode@example.com@localhost) Choose your authentication method:
 > 6
 == Use your phone +1... ==
-Press Enter to wait for authentication or enter 'r' to go back to select the authentication method
+Press Enter to wait for authentication or enter 'r' to go back to select the authentication flow
 (user-integration-pre-check-ssh-authenticate-user-switching-auth-mode@example.com@localhost) Unlock your phone +1... or accept request on web interface:
 > r
 == Authentication method selection ==
@@ -84,7 +84,7 @@ Or enter 'r' to go back to choose the provider
 (user-integration-pre-check-ssh-authenticate-user-switching-auth-mode@example.com@localhost) Choose your authentication method:
 > 7
 == Pin code ==
-Enter 'r' to cancel the request and go back to select the authentication method
+Enter 'r' to cancel the request and go back to select the authentication flow
 (user-integration-pre-check-ssh-authenticate-user-switching-auth-mode@example.com@localhost) Enter your pin code:
 > r
 == Authentication method selection ==
@@ -107,7 +107,7 @@ Code: 1337
 
   1. Wait for authentication result
   2. Regenerate code
-Or enter 'r' to go back to select the authentication method
+Or enter 'r' to go back to select the authentication flow
 (user-integration-pre-check-ssh-authenticate-user-switching-auth-mode@example.com@localhost) Choose action:
 > r
 == Authentication method selection ==
@@ -125,7 +125,7 @@ Or enter 'r' to go back to choose the provider
 == Authentication code ==
   1. Proceed with Authentication code
   2. Resend SMS (1 sent)
-Or enter 'r' to go back to select the authentication method
+Or enter 'r' to go back to select the authentication flow
 (user-integration-pre-check-ssh-authenticate-user-switching-auth-mode@example.com@localhost) Choose action:
 > r
 == Authentication method selection ==
@@ -157,7 +157,7 @@ Or enter 'r' to go back to choose the provider
 (user-integration-pre-check-ssh-authenticate-user-switching-auth-mode@example.com@localhost) Choose your authentication method:
 > 7
 == Pin code ==
-Enter 'r' to cancel the request and go back to select the authentication method
+Enter 'r' to cancel the request and go back to select the authentication flow
 (user-integration-pre-check-ssh-authenticate-user-switching-auth-mode@example.com@localhost) Enter your pin code:
 > 4242
 PAM Authenticate() finished for user 'user-integration-pre-check-ssh-authenticate-user-switching-auth-mode@example.com'

--- a/pam/integration-tests/testdata/golden/TestSSHAuthenticate/Authenticate_user_switching_auth_mode_with_shared_sshd
+++ b/pam/integration-tests/testdata/golden/TestSSHAuthenticate/Authenticate_user_switching_auth_mode_with_shared_sshd
@@ -4,7 +4,7 @@
 (user-integration-pre-check-ssh-authenticate-user-switching-auth-mode-with-shared-sshd@example.com@localhost) Choose your provider:
 > 2
 == Password authentication ==
-Enter 'r' to cancel the request and go back to select the authentication method
+Enter 'r' to cancel the request and go back to select the authentication flow
 (user-integration-pre-check-ssh-authenticate-user-switching-auth-mode-with-shared-sshd@example.com@localhost) Gimme your password:
 >
 == Authentication method selection ==
@@ -20,7 +20,7 @@ Or enter 'r' to go back to choose the provider
 (user-integration-pre-check-ssh-authenticate-user-switching-auth-mode-with-shared-sshd@example.com@localhost) Choose your authentication method:
 > 3
 == Send URL to user-integration-pre-check-ssh-authenticate-user-switching-auth-mode-with-shared-sshd@example.com ==
-Leave the input field empty to wait for the alternative authentication method or enter 'r' to go back to select the authentication method
+Leave the input field empty to wait for the alternative authentication method or enter 'r' to go back to select the authentication flow
 (user-integration-pre-check-ssh-authenticate-user-switching-auth-mode-with-shared-sshd@example.com@localhost) Click on the link received at user-integration-pre-check-ssh-authenticate-user-switching-auth-mode-with-shared-sshd@example.com or enter the code:
 > r
 == Authentication method selection ==
@@ -36,7 +36,7 @@ Or enter 'r' to go back to choose the provider
 (user-integration-pre-check-ssh-authenticate-user-switching-auth-mode-with-shared-sshd@example.com@localhost) Choose your authentication method:
 > 4
 == Use your fido device foo ==
-Press Enter to wait for authentication or enter 'r' to go back to select the authentication method
+Press Enter to wait for authentication or enter 'r' to go back to select the authentication flow
 (user-integration-pre-check-ssh-authenticate-user-switching-auth-mode-with-shared-sshd@example.com@localhost) Plug your fido device and press with your thumb:
 > r
 == Authentication method selection ==
@@ -52,7 +52,7 @@ Or enter 'r' to go back to choose the provider
 (user-integration-pre-check-ssh-authenticate-user-switching-auth-mode-with-shared-sshd@example.com@localhost) Choose your authentication method:
 > 5
 == Use your phone +33... ==
-Press Enter to wait for authentication or enter 'r' to go back to select the authentication method
+Press Enter to wait for authentication or enter 'r' to go back to select the authentication flow
 (user-integration-pre-check-ssh-authenticate-user-switching-auth-mode-with-shared-sshd@example.com@localhost) Unlock your phone +33... or accept request on web interface:
 > r
 == Authentication method selection ==
@@ -68,7 +68,7 @@ Or enter 'r' to go back to choose the provider
 (user-integration-pre-check-ssh-authenticate-user-switching-auth-mode-with-shared-sshd@example.com@localhost) Choose your authentication method:
 > 6
 == Use your phone +1... ==
-Press Enter to wait for authentication or enter 'r' to go back to select the authentication method
+Press Enter to wait for authentication or enter 'r' to go back to select the authentication flow
 (user-integration-pre-check-ssh-authenticate-user-switching-auth-mode-with-shared-sshd@example.com@localhost) Unlock your phone +1... or accept request on web interface:
 > r
 == Authentication method selection ==
@@ -84,7 +84,7 @@ Or enter 'r' to go back to choose the provider
 (user-integration-pre-check-ssh-authenticate-user-switching-auth-mode-with-shared-sshd@example.com@localhost) Choose your authentication method:
 > 7
 == Pin code ==
-Enter 'r' to cancel the request and go back to select the authentication method
+Enter 'r' to cancel the request and go back to select the authentication flow
 (user-integration-pre-check-ssh-authenticate-user-switching-auth-mode-with-shared-sshd@example.com@localhost) Enter your pin code:
 > r
 == Authentication method selection ==
@@ -107,7 +107,7 @@ Code: 1337
 
   1. Wait for authentication result
   2. Regenerate code
-Or enter 'r' to go back to select the authentication method
+Or enter 'r' to go back to select the authentication flow
 (user-integration-pre-check-ssh-authenticate-user-switching-auth-mode-with-shared-sshd@example.com@localhost) Choose action:
 > r
 == Authentication method selection ==
@@ -125,7 +125,7 @@ Or enter 'r' to go back to choose the provider
 == Authentication code ==
   1. Proceed with Authentication code
   2. Resend SMS (1 sent)
-Or enter 'r' to go back to select the authentication method
+Or enter 'r' to go back to select the authentication flow
 (user-integration-pre-check-ssh-authenticate-user-switching-auth-mode-with-shared-sshd@example.com@localhost) Choose action:
 > r
 == Authentication method selection ==
@@ -157,7 +157,7 @@ Or enter 'r' to go back to choose the provider
 (user-integration-pre-check-ssh-authenticate-user-switching-auth-mode-with-shared-sshd@example.com@localhost) Choose your authentication method:
 > 7
 == Pin code ==
-Enter 'r' to cancel the request and go back to select the authentication method
+Enter 'r' to cancel the request and go back to select the authentication flow
 (user-integration-pre-check-ssh-authenticate-user-switching-auth-mode-with-shared-sshd@example.com@localhost) Enter your pin code:
 > 4242
 PAM Authenticate() finished for user 'user-integration-pre-check-ssh-authenticate-user-switching-auth-mode-with-shared-sshd@example.com'

--- a/pam/integration-tests/testdata/golden/TestSSHAuthenticate/Authenticate_user_switching_to_local_broker
+++ b/pam/integration-tests/testdata/golden/TestSSHAuthenticate/Authenticate_user_switching_to_local_broker
@@ -4,7 +4,7 @@
 (user-integration-pre-check-ssh-authenticate-user-switching-to-local-broker@example.com@localhost) Choose your provider:
 > 2
 == Password authentication ==
-Enter 'r' to cancel the request and go back to select the authentication method
+Enter 'r' to cancel the request and go back to select the authentication flow
 (user-integration-pre-check-ssh-authenticate-user-switching-to-local-broker@example.com@localhost) Gimme your password:
 >
 == Authentication method selection ==

--- a/pam/integration-tests/testdata/golden/TestSSHAuthenticate/Authenticate_user_switching_to_local_broker_with_shared_sshd
+++ b/pam/integration-tests/testdata/golden/TestSSHAuthenticate/Authenticate_user_switching_to_local_broker_with_shared_sshd
@@ -4,7 +4,7 @@
 (user-integration-pre-check-ssh-authenticate-user-switching-to-local-broker-with-shared-sshd@example.com@localhost) Choose your provider:
 > 2
 == Password authentication ==
-Enter 'r' to cancel the request and go back to select the authentication method
+Enter 'r' to cancel the request and go back to select the authentication flow
 (user-integration-pre-check-ssh-authenticate-user-switching-to-local-broker-with-shared-sshd@example.com@localhost) Gimme your password:
 >
 == Authentication method selection ==

--- a/pam/integration-tests/testdata/golden/TestSSHAuthenticate/Authenticate_user_with_form_mode_with_button
+++ b/pam/integration-tests/testdata/golden/TestSSHAuthenticate/Authenticate_user_with_form_mode_with_button
@@ -4,7 +4,7 @@
 (user-integration-pre-check-ssh-authenticate-user-with-form-mode-with-button@example.com@localhost) Choose your provider:
 > 2
 == Password authentication ==
-Enter 'r' to cancel the request and go back to select the authentication method
+Enter 'r' to cancel the request and go back to select the authentication flow
 (user-integration-pre-check-ssh-authenticate-user-with-form-mode-with-button@example.com@localhost) Gimme your password:
 >
 == Authentication method selection ==
@@ -22,17 +22,17 @@ Or enter 'r' to go back to choose the provider
 == Authentication code ==
   1. Proceed with Authentication code
   2. Resend SMS (1 sent)
-Or enter 'r' to go back to select the authentication method
+Or enter 'r' to go back to select the authentication flow
 (user-integration-pre-check-ssh-authenticate-user-with-form-mode-with-button@example.com@localhost) Choose action:
 > 2
 == Authentication code ==
   1. Proceed with Authentication code
   2. Resend SMS (2 sent)
-Or enter 'r' to go back to select the authentication method
+Or enter 'r' to go back to select the authentication flow
 (user-integration-pre-check-ssh-authenticate-user-with-form-mode-with-button@example.com@localhost) Choose action:
 > 1
 == Authentication code ==
-Enter 'r' to cancel the request and go back to select the authentication method
+Enter 'r' to cancel the request and go back to select the authentication flow
 (user-integration-pre-check-ssh-authenticate-user-with-form-mode-with-button@example.com@localhost) Enter your one time credential:
 > temporary pass00
 PAM Authenticate() finished for user 'user-integration-pre-check-ssh-authenticate-user-with-form-mode-with-button@example.com'

--- a/pam/integration-tests/testdata/golden/TestSSHAuthenticate/Authenticate_user_with_form_mode_with_button_with_shared_sshd
+++ b/pam/integration-tests/testdata/golden/TestSSHAuthenticate/Authenticate_user_with_form_mode_with_button_with_shared_sshd
@@ -4,7 +4,7 @@
 (user-integration-pre-check-ssh-authenticate-user-with-form-mode-with-button-with-shared-sshd@example.com@localhost) Choose your provider:
 > 2
 == Password authentication ==
-Enter 'r' to cancel the request and go back to select the authentication method
+Enter 'r' to cancel the request and go back to select the authentication flow
 (user-integration-pre-check-ssh-authenticate-user-with-form-mode-with-button-with-shared-sshd@example.com@localhost) Gimme your password:
 >
 == Authentication method selection ==
@@ -22,17 +22,17 @@ Or enter 'r' to go back to choose the provider
 == Authentication code ==
   1. Proceed with Authentication code
   2. Resend SMS (1 sent)
-Or enter 'r' to go back to select the authentication method
+Or enter 'r' to go back to select the authentication flow
 (user-integration-pre-check-ssh-authenticate-user-with-form-mode-with-button-with-shared-sshd@example.com@localhost) Choose action:
 > 2
 == Authentication code ==
   1. Proceed with Authentication code
   2. Resend SMS (2 sent)
-Or enter 'r' to go back to select the authentication method
+Or enter 'r' to go back to select the authentication flow
 (user-integration-pre-check-ssh-authenticate-user-with-form-mode-with-button-with-shared-sshd@example.com@localhost) Choose action:
 > 1
 == Authentication code ==
-Enter 'r' to cancel the request and go back to select the authentication method
+Enter 'r' to cancel the request and go back to select the authentication flow
 (user-integration-pre-check-ssh-authenticate-user-with-form-mode-with-button-with-shared-sshd@example.com@localhost) Enter your one time credential:
 > temporary pass00
 PAM Authenticate() finished for user 'user-integration-pre-check-ssh-authenticate-user-with-form-mode-with-button-with-shared-sshd@example.com'

--- a/pam/integration-tests/testdata/golden/TestSSHAuthenticate/Authenticate_user_with_mfa
+++ b/pam/integration-tests/testdata/golden/TestSSHAuthenticate/Authenticate_user_with_mfa
@@ -4,7 +4,7 @@
 (user-mfa-integration-pre-check-ssh-authenticate-user-with-mfa@example.com@localhost) Choose your provider:
 > 2
 == Password authentication ==
-Enter 'r' to cancel the request and go back to select the authentication method
+Enter 'r' to cancel the request and go back to select the authentication flow
 (user-mfa-integration-pre-check-ssh-authenticate-user-with-mfa@example.com@localhost) Gimme your password:
 >
 == Authentication method selection ==
@@ -20,11 +20,11 @@ Or enter 'r' to go back to choose the provider
 (user-mfa-integration-pre-check-ssh-authenticate-user-with-mfa@example.com@localhost) Choose your authentication method:
 > 1
 == Password authentication ==
-Enter 'r' to cancel the request and go back to select the authentication method
+Enter 'r' to cancel the request and go back to select the authentication flow
 (user-mfa-integration-pre-check-ssh-authenticate-user-with-mfa@example.com@localhost) Gimme your password:
 >
 == Use your fido device foo ==
-Press Enter to wait for authentication or enter 'r' to go back to select the authentication method
+Press Enter to wait for authentication or enter 'r' to go back to select the authentication flow
 (user-mfa-integration-pre-check-ssh-authenticate-user-with-mfa@example.com@localhost) Plug your fido device and press with your thumb:
 > r
 == Authentication method selection ==
@@ -35,7 +35,7 @@ Or enter 'r' to go back to choose the provider
 (user-mfa-integration-pre-check-ssh-authenticate-user-with-mfa@example.com@localhost) Choose your authentication method:
 > 1
 == Use your fido device foo ==
-Press Enter to wait for authentication or enter 'r' to go back to select the authentication method
+Press Enter to wait for authentication or enter 'r' to go back to select the authentication flow
 (user-mfa-integration-pre-check-ssh-authenticate-user-with-mfa@example.com@localhost) Plug your fido device and press with your thumb:
 > r
 == Authentication method selection ==
@@ -46,11 +46,11 @@ Or enter 'r' to go back to choose the provider
 (user-mfa-integration-pre-check-ssh-authenticate-user-with-mfa@example.com@localhost) Choose your authentication method:
 > 2
 == Use your phone +33... ==
-Press Enter to wait for authentication or enter 'r' to go back to select the authentication method
+Press Enter to wait for authentication or enter 'r' to go back to select the authentication flow
 (user-mfa-integration-pre-check-ssh-authenticate-user-with-mfa@example.com@localhost) Unlock your phone +33... or accept request on web interface:
 >
 == Use your fido device foo ==
-Press Enter to wait for authentication or enter 'r' to go back to select the authentication method
+Press Enter to wait for authentication or enter 'r' to go back to select the authentication flow
 (user-mfa-integration-pre-check-ssh-authenticate-user-with-mfa@example.com@localhost) Plug your fido device and press with your thumb:
 >
 PAM Authenticate() finished for user 'user-mfa-integration-pre-check-ssh-authenticate-user-with-mfa@example.com'

--- a/pam/integration-tests/testdata/golden/TestSSHAuthenticate/Authenticate_user_with_mfa_and_reset_password_while_enforcing_policy
+++ b/pam/integration-tests/testdata/golden/TestSSHAuthenticate/Authenticate_user_with_mfa_and_reset_password_while_enforcing_policy
@@ -4,12 +4,12 @@
 (user-mfa-with-reset-integration-pre-check-ssh-authenticate-user-with-mfa-and-reset-password-while-enforcing-policy@example.com@localhost) Choose your provider:
 > 2
 == Password authentication ==
-Enter 'r' to cancel the request and go back to select the authentication method
+Enter 'r' to cancel the request and go back to select the authentication flow
 (user-mfa-with-reset-integration-pre-check-ssh-authenticate-user-with-mfa-and-reset-password-while-enforcing-policy@example.com@localhost) Gimme your password:
 >
 Password reset, 2 step(s) missing
 == Use your fido device foo ==
-Press Enter to wait for authentication or enter 'r' to go back to select the authentication method
+Press Enter to wait for authentication or enter 'r' to go back to select the authentication flow
 (user-mfa-with-reset-integration-pre-check-ssh-authenticate-user-with-mfa-and-reset-password-while-enforcing-policy@example.com@localhost) Plug your fido device and press with your thumb:
 >
 Password reset, 1 step(s) missing

--- a/pam/integration-tests/testdata/golden/TestSSHAuthenticate/Authenticate_user_with_mfa_and_reset_password_while_enforcing_policy_with_shared_sshd
+++ b/pam/integration-tests/testdata/golden/TestSSHAuthenticate/Authenticate_user_with_mfa_and_reset_password_while_enforcing_policy_with_shared_sshd
@@ -4,12 +4,12 @@
 (user-mfa-with-reset-integration-pre-check-ssh-authenticate-user-with-mfa-and-reset-password-while-enforcing-policy-with-shared-sshd@example.com@localhost) Choose your provider:
 > 2
 == Password authentication ==
-Enter 'r' to cancel the request and go back to select the authentication method
+Enter 'r' to cancel the request and go back to select the authentication flow
 (user-mfa-with-reset-integration-pre-check-ssh-authenticate-user-with-mfa-and-reset-password-while-enforcing-policy-with-shared-sshd@example.com@localhost) Gimme your password:
 >
 Password reset, 2 step(s) missing
 == Use your fido device foo ==
-Press Enter to wait for authentication or enter 'r' to go back to select the authentication method
+Press Enter to wait for authentication or enter 'r' to go back to select the authentication flow
 (user-mfa-with-reset-integration-pre-check-ssh-authenticate-user-with-mfa-and-reset-password-while-enforcing-policy-with-shared-sshd@example.com@localhost) Plug your fido device and press with your thumb:
 >
 Password reset, 1 step(s) missing

--- a/pam/integration-tests/testdata/golden/TestSSHAuthenticate/Authenticate_user_with_mfa_and_reset_same_password
+++ b/pam/integration-tests/testdata/golden/TestSSHAuthenticate/Authenticate_user_with_mfa_and_reset_same_password
@@ -4,12 +4,12 @@
 (user-mfa-with-reset-integration-pre-check-ssh-authenticate-user-with-mfa-and-reset-same-password@example.com@localhost) Choose your provider:
 > 2
 == Password authentication ==
-Enter 'r' to cancel the request and go back to select the authentication method
+Enter 'r' to cancel the request and go back to select the authentication flow
 (user-mfa-with-reset-integration-pre-check-ssh-authenticate-user-with-mfa-and-reset-same-password@example.com@localhost) Gimme your password:
 >
 Password reset, 2 step(s) missing
 == Use your fido device foo ==
-Press Enter to wait for authentication or enter 'r' to go back to select the authentication method
+Press Enter to wait for authentication or enter 'r' to go back to select the authentication flow
 (user-mfa-with-reset-integration-pre-check-ssh-authenticate-user-with-mfa-and-reset-same-password@example.com@localhost) Plug your fido device and press with your thumb:
 >
 Password reset, 1 step(s) missing

--- a/pam/integration-tests/testdata/golden/TestSSHAuthenticate/Authenticate_user_with_mfa_and_reset_same_password_with_shared_sshd
+++ b/pam/integration-tests/testdata/golden/TestSSHAuthenticate/Authenticate_user_with_mfa_and_reset_same_password_with_shared_sshd
@@ -4,12 +4,12 @@
 (user-mfa-with-reset-integration-pre-check-ssh-authenticate-user-with-mfa-and-reset-same-password-with-shared-sshd@example.com@localhost) Choose your provider:
 > 2
 == Password authentication ==
-Enter 'r' to cancel the request and go back to select the authentication method
+Enter 'r' to cancel the request and go back to select the authentication flow
 (user-mfa-with-reset-integration-pre-check-ssh-authenticate-user-with-mfa-and-reset-same-password-with-shared-sshd@example.com@localhost) Gimme your password:
 >
 Password reset, 2 step(s) missing
 == Use your fido device foo ==
-Press Enter to wait for authentication or enter 'r' to go back to select the authentication method
+Press Enter to wait for authentication or enter 'r' to go back to select the authentication flow
 (user-mfa-with-reset-integration-pre-check-ssh-authenticate-user-with-mfa-and-reset-same-password-with-shared-sshd@example.com@localhost) Plug your fido device and press with your thumb:
 >
 Password reset, 1 step(s) missing

--- a/pam/integration-tests/testdata/golden/TestSSHAuthenticate/Authenticate_user_with_mfa_with_shared_sshd
+++ b/pam/integration-tests/testdata/golden/TestSSHAuthenticate/Authenticate_user_with_mfa_with_shared_sshd
@@ -4,7 +4,7 @@
 (user-mfa-integration-pre-check-ssh-authenticate-user-with-mfa-with-shared-sshd@example.com@localhost) Choose your provider:
 > 2
 == Password authentication ==
-Enter 'r' to cancel the request and go back to select the authentication method
+Enter 'r' to cancel the request and go back to select the authentication flow
 (user-mfa-integration-pre-check-ssh-authenticate-user-with-mfa-with-shared-sshd@example.com@localhost) Gimme your password:
 >
 == Authentication method selection ==
@@ -20,11 +20,11 @@ Or enter 'r' to go back to choose the provider
 (user-mfa-integration-pre-check-ssh-authenticate-user-with-mfa-with-shared-sshd@example.com@localhost) Choose your authentication method:
 > 1
 == Password authentication ==
-Enter 'r' to cancel the request and go back to select the authentication method
+Enter 'r' to cancel the request and go back to select the authentication flow
 (user-mfa-integration-pre-check-ssh-authenticate-user-with-mfa-with-shared-sshd@example.com@localhost) Gimme your password:
 >
 == Use your fido device foo ==
-Press Enter to wait for authentication or enter 'r' to go back to select the authentication method
+Press Enter to wait for authentication or enter 'r' to go back to select the authentication flow
 (user-mfa-integration-pre-check-ssh-authenticate-user-with-mfa-with-shared-sshd@example.com@localhost) Plug your fido device and press with your thumb:
 > r
 == Authentication method selection ==
@@ -35,7 +35,7 @@ Or enter 'r' to go back to choose the provider
 (user-mfa-integration-pre-check-ssh-authenticate-user-with-mfa-with-shared-sshd@example.com@localhost) Choose your authentication method:
 > 1
 == Use your fido device foo ==
-Press Enter to wait for authentication or enter 'r' to go back to select the authentication method
+Press Enter to wait for authentication or enter 'r' to go back to select the authentication flow
 (user-mfa-integration-pre-check-ssh-authenticate-user-with-mfa-with-shared-sshd@example.com@localhost) Plug your fido device and press with your thumb:
 > r
 == Authentication method selection ==
@@ -46,11 +46,11 @@ Or enter 'r' to go back to choose the provider
 (user-mfa-integration-pre-check-ssh-authenticate-user-with-mfa-with-shared-sshd@example.com@localhost) Choose your authentication method:
 > 2
 == Use your phone +33... ==
-Press Enter to wait for authentication or enter 'r' to go back to select the authentication method
+Press Enter to wait for authentication or enter 'r' to go back to select the authentication flow
 (user-mfa-integration-pre-check-ssh-authenticate-user-with-mfa-with-shared-sshd@example.com@localhost) Unlock your phone +33... or accept request on web interface:
 >
 == Use your fido device foo ==
-Press Enter to wait for authentication or enter 'r' to go back to select the authentication method
+Press Enter to wait for authentication or enter 'r' to go back to select the authentication flow
 (user-mfa-integration-pre-check-ssh-authenticate-user-with-mfa-with-shared-sshd@example.com@localhost) Plug your fido device and press with your thumb:
 >
 PAM Authenticate() finished for user 'user-mfa-integration-pre-check-ssh-authenticate-user-with-mfa-with-shared-sshd@example.com'

--- a/pam/integration-tests/testdata/golden/TestSSHAuthenticate/Authenticate_user_with_qr_code
+++ b/pam/integration-tests/testdata/golden/TestSSHAuthenticate/Authenticate_user_with_qr_code
@@ -4,7 +4,7 @@
 (user-integration-pre-check-ssh-authenticate-user-with-qr-code@example.com@localhost) Choose your provider:
 > 2
 == Password authentication ==
-Enter 'r' to cancel the request and go back to select the authentication method
+Enter 'r' to cancel the request and go back to select the authentication flow
 (user-integration-pre-check-ssh-authenticate-user-with-qr-code@example.com@localhost) Gimme your password:
 >
 == Authentication method selection ==
@@ -27,7 +27,7 @@ Code: 1337
 
   1. Wait for authentication result
   2. Regenerate code
-Or enter 'r' to go back to select the authentication method
+Or enter 'r' to go back to select the authentication flow
 (user-integration-pre-check-ssh-authenticate-user-with-qr-code@example.com@localhost) Choose action:
 > 2
 == Use a Login code ==
@@ -38,7 +38,7 @@ Code: 1338
 
   1. Wait for authentication result
   2. Regenerate code
-Or enter 'r' to go back to select the authentication method
+Or enter 'r' to go back to select the authentication flow
 (user-integration-pre-check-ssh-authenticate-user-with-qr-code@example.com@localhost) Choose action:
 > 2
 == Use a Login code ==
@@ -49,7 +49,7 @@ Code: 1339
 
   1. Wait for authentication result
   2. Regenerate code
-Or enter 'r' to go back to select the authentication method
+Or enter 'r' to go back to select the authentication flow
 (user-integration-pre-check-ssh-authenticate-user-with-qr-code@example.com@localhost) Choose action:
 > 2
 == Use a Login code ==
@@ -60,7 +60,7 @@ Code: 1340
 
   1. Wait for authentication result
   2. Regenerate code
-Or enter 'r' to go back to select the authentication method
+Or enter 'r' to go back to select the authentication flow
 (user-integration-pre-check-ssh-authenticate-user-with-qr-code@example.com@localhost) Choose action:
 > 2
 == Use a Login code ==
@@ -71,7 +71,7 @@ Code: 1341
 
   1. Wait for authentication result
   2. Regenerate code
-Or enter 'r' to go back to select the authentication method
+Or enter 'r' to go back to select the authentication flow
 (user-integration-pre-check-ssh-authenticate-user-with-qr-code@example.com@localhost) Choose action:
 > 1
 PAM Authenticate() finished for user 'user-integration-pre-check-ssh-authenticate-user-with-qr-code@example.com'

--- a/pam/integration-tests/testdata/golden/TestSSHAuthenticate/Authenticate_user_with_qr_code_with_shared_sshd
+++ b/pam/integration-tests/testdata/golden/TestSSHAuthenticate/Authenticate_user_with_qr_code_with_shared_sshd
@@ -4,7 +4,7 @@
 (user-integration-pre-check-ssh-authenticate-user-with-qr-code-with-shared-sshd@example.com@localhost) Choose your provider:
 > 2
 == Password authentication ==
-Enter 'r' to cancel the request and go back to select the authentication method
+Enter 'r' to cancel the request and go back to select the authentication flow
 (user-integration-pre-check-ssh-authenticate-user-with-qr-code-with-shared-sshd@example.com@localhost) Gimme your password:
 >
 == Authentication method selection ==
@@ -27,7 +27,7 @@ Code: 1337
 
   1. Wait for authentication result
   2. Regenerate code
-Or enter 'r' to go back to select the authentication method
+Or enter 'r' to go back to select the authentication flow
 (user-integration-pre-check-ssh-authenticate-user-with-qr-code-with-shared-sshd@example.com@localhost) Choose action:
 > 2
 == Use a Login code ==
@@ -38,7 +38,7 @@ Code: 1338
 
   1. Wait for authentication result
   2. Regenerate code
-Or enter 'r' to go back to select the authentication method
+Or enter 'r' to go back to select the authentication flow
 (user-integration-pre-check-ssh-authenticate-user-with-qr-code-with-shared-sshd@example.com@localhost) Choose action:
 > 2
 == Use a Login code ==
@@ -49,7 +49,7 @@ Code: 1339
 
   1. Wait for authentication result
   2. Regenerate code
-Or enter 'r' to go back to select the authentication method
+Or enter 'r' to go back to select the authentication flow
 (user-integration-pre-check-ssh-authenticate-user-with-qr-code-with-shared-sshd@example.com@localhost) Choose action:
 > 2
 == Use a Login code ==
@@ -60,7 +60,7 @@ Code: 1340
 
   1. Wait for authentication result
   2. Regenerate code
-Or enter 'r' to go back to select the authentication method
+Or enter 'r' to go back to select the authentication flow
 (user-integration-pre-check-ssh-authenticate-user-with-qr-code-with-shared-sshd@example.com@localhost) Choose action:
 > 2
 == Use a Login code ==
@@ -71,7 +71,7 @@ Code: 1341
 
   1. Wait for authentication result
   2. Regenerate code
-Or enter 'r' to go back to select the authentication method
+Or enter 'r' to go back to select the authentication flow
 (user-integration-pre-check-ssh-authenticate-user-with-qr-code-with-shared-sshd@example.com@localhost) Choose action:
 > 1
 PAM Authenticate() finished for user 'user-integration-pre-check-ssh-authenticate-user-with-qr-code-with-shared-sshd@example.com'

--- a/pam/integration-tests/testdata/golden/TestSSHAuthenticate/Deny_authentication_if_max_attempts_reached
+++ b/pam/integration-tests/testdata/golden/TestSSHAuthenticate/Deny_authentication_if_max_attempts_reached
@@ -4,27 +4,27 @@
 (user-integration-pre-check-ssh-deny-authentication-if-max-attempts-reached@example.com@localhost) Choose your provider:
 > 2
 == Password authentication ==
-Enter 'r' to cancel the request and go back to select the authentication method
+Enter 'r' to cancel the request and go back to select the authentication flow
 (user-integration-pre-check-ssh-deny-authentication-if-max-attempts-reached@example.com@localhost) Gimme your password:
 >
 invalid password 'wrongpass', should be 'goodpass'
 == Password authentication ==
-Enter 'r' to cancel the request and go back to select the authentication method
+Enter 'r' to cancel the request and go back to select the authentication flow
 (user-integration-pre-check-ssh-deny-authentication-if-max-attempts-reached@example.com@localhost) Gimme your password:
 >
 invalid password 'wrongpass', should be 'goodpass'
 == Password authentication ==
-Enter 'r' to cancel the request and go back to select the authentication method
+Enter 'r' to cancel the request and go back to select the authentication flow
 (user-integration-pre-check-ssh-deny-authentication-if-max-attempts-reached@example.com@localhost) Gimme your password:
 >
 invalid password 'wrongpass', should be 'goodpass'
 == Password authentication ==
-Enter 'r' to cancel the request and go back to select the authentication method
+Enter 'r' to cancel the request and go back to select the authentication flow
 (user-integration-pre-check-ssh-deny-authentication-if-max-attempts-reached@example.com@localhost) Gimme your password:
 >
 invalid password 'wrongpass', should be 'goodpass'
 == Password authentication ==
-Enter 'r' to cancel the request and go back to select the authentication method
+Enter 'r' to cancel the request and go back to select the authentication flow
 (user-integration-pre-check-ssh-deny-authentication-if-max-attempts-reached@example.com@localhost) Gimme your password:
 >
 Maximum number of authentication attempts reached

--- a/pam/integration-tests/testdata/golden/TestSSHAuthenticate/Deny_authentication_if_max_attempts_reached_with_shared_sshd
+++ b/pam/integration-tests/testdata/golden/TestSSHAuthenticate/Deny_authentication_if_max_attempts_reached_with_shared_sshd
@@ -4,27 +4,27 @@
 (user-integration-pre-check-ssh-deny-authentication-if-max-attempts-reached-with-shared-sshd@example.com@localhost) Choose your provider:
 > 2
 == Password authentication ==
-Enter 'r' to cancel the request and go back to select the authentication method
+Enter 'r' to cancel the request and go back to select the authentication flow
 (user-integration-pre-check-ssh-deny-authentication-if-max-attempts-reached-with-shared-sshd@example.com@localhost) Gimme your password:
 >
 invalid password 'wrongpass', should be 'goodpass'
 == Password authentication ==
-Enter 'r' to cancel the request and go back to select the authentication method
+Enter 'r' to cancel the request and go back to select the authentication flow
 (user-integration-pre-check-ssh-deny-authentication-if-max-attempts-reached-with-shared-sshd@example.com@localhost) Gimme your password:
 >
 invalid password 'wrongpass', should be 'goodpass'
 == Password authentication ==
-Enter 'r' to cancel the request and go back to select the authentication method
+Enter 'r' to cancel the request and go back to select the authentication flow
 (user-integration-pre-check-ssh-deny-authentication-if-max-attempts-reached-with-shared-sshd@example.com@localhost) Gimme your password:
 >
 invalid password 'wrongpass', should be 'goodpass'
 == Password authentication ==
-Enter 'r' to cancel the request and go back to select the authentication method
+Enter 'r' to cancel the request and go back to select the authentication flow
 (user-integration-pre-check-ssh-deny-authentication-if-max-attempts-reached-with-shared-sshd@example.com@localhost) Gimme your password:
 >
 invalid password 'wrongpass', should be 'goodpass'
 == Password authentication ==
-Enter 'r' to cancel the request and go back to select the authentication method
+Enter 'r' to cancel the request and go back to select the authentication flow
 (user-integration-pre-check-ssh-deny-authentication-if-max-attempts-reached-with-shared-sshd@example.com@localhost) Gimme your password:
 >
 Maximum number of authentication attempts reached

--- a/pam/integration-tests/testdata/golden/TestSSHAuthenticate/Deny_authentication_if_newpassword_does_not_match_required_criteria
+++ b/pam/integration-tests/testdata/golden/TestSSHAuthenticate/Deny_authentication_if_newpassword_does_not_match_required_criteria
@@ -4,7 +4,7 @@
 (user-needs-reset-integration-pre-check-ssh-deny-authentication-if-newpassword-does-not-match-required-criteria@example.com@localhost) Choose your provider:
 > 2
 == Password authentication ==
-Enter 'r' to cancel the request and go back to select the authentication method
+Enter 'r' to cancel the request and go back to select the authentication flow
 (user-needs-reset-integration-pre-check-ssh-deny-authentication-if-newpassword-does-not-match-required-criteria@example.com@localhost) Gimme your password:
 >
 Password reset, 1 step(s) missing

--- a/pam/integration-tests/testdata/golden/TestSSHAuthenticate/Deny_authentication_if_newpassword_does_not_match_required_criteria_with_shared_sshd
+++ b/pam/integration-tests/testdata/golden/TestSSHAuthenticate/Deny_authentication_if_newpassword_does_not_match_required_criteria_with_shared_sshd
@@ -4,7 +4,7 @@
 (user-needs-reset-integration-pre-check-ssh-deny-authentication-if-newpassword-does-not-match-required-criteria-with-shared-sshd@example.com@localhost) Choose your provider:
 > 2
 == Password authentication ==
-Enter 'r' to cancel the request and go back to select the authentication method
+Enter 'r' to cancel the request and go back to select the authentication flow
 (user-needs-reset-integration-pre-check-ssh-deny-authentication-if-newpassword-does-not-match-required-criteria-with-shared-sshd@example.com@localhost) Gimme your password:
 >
 Password reset, 1 step(s) missing

--- a/pam/integration-tests/testdata/golden/TestSSHAuthenticate/Exit_authd_if_user_sigints
+++ b/pam/integration-tests/testdata/golden/TestSSHAuthenticate/Exit_authd_if_user_sigints
@@ -4,6 +4,6 @@
 (user-integration-pre-check-ssh-exit-authd-if-user-sigints@example.com@localhost) Choose your provider:
 > 2
 == Password authentication ==
-Enter 'r' to cancel the request and go back to select the authentication method
+Enter 'r' to cancel the request and go back to select the authentication flow
 (user-integration-pre-check-ssh-exit-authd-if-user-sigints@example.com@localhost) Gimme your password:
 >

--- a/pam/integration-tests/testdata/golden/TestSSHAuthenticate/Exit_authd_if_user_sigints_with_shared_sshd
+++ b/pam/integration-tests/testdata/golden/TestSSHAuthenticate/Exit_authd_if_user_sigints_with_shared_sshd
@@ -4,6 +4,6 @@
 (user-integration-pre-check-ssh-exit-authd-if-user-sigints-with-shared-sshd@example.com@localhost) Choose your provider:
 > 2
 == Password authentication ==
-Enter 'r' to cancel the request and go back to select the authentication method
+Enter 'r' to cancel the request and go back to select the authentication flow
 (user-integration-pre-check-ssh-exit-authd-if-user-sigints-with-shared-sshd@example.com@localhost) Gimme your password:
 >

--- a/pam/integration-tests/testdata/golden/TestSSHAuthenticate/Prevent_user_from_switching_username
+++ b/pam/integration-tests/testdata/golden/TestSSHAuthenticate/Prevent_user_from_switching_username
@@ -7,7 +7,7 @@ Unsupported input
 (user-integration-pre-check-ssh-prevent-user-from-switching-username@example.com@localhost) Choose your provider:
 > 2
 == Password authentication ==
-Enter 'r' to cancel the request and go back to select the authentication method
+Enter 'r' to cancel the request and go back to select the authentication flow
 (user-integration-pre-check-ssh-prevent-user-from-switching-username@example.com@localhost) Gimme your password:
 >
 == Authentication method selection ==
@@ -34,7 +34,7 @@ Unsupported input
 (user-integration-pre-check-ssh-prevent-user-from-switching-username@example.com@localhost) Choose your provider:
 > 2
 == Password authentication ==
-Enter 'r' to cancel the request and go back to select the authentication method
+Enter 'r' to cancel the request and go back to select the authentication flow
 (user-integration-pre-check-ssh-prevent-user-from-switching-username@example.com@localhost) Gimme your password:
 >
 PAM Authenticate() finished for user 'user-integration-pre-check-ssh-prevent-user-from-switching-username@example.com'

--- a/pam/integration-tests/testdata/golden/TestSSHAuthenticate/Prevent_user_from_switching_username_with_shared_sshd
+++ b/pam/integration-tests/testdata/golden/TestSSHAuthenticate/Prevent_user_from_switching_username_with_shared_sshd
@@ -7,7 +7,7 @@ Unsupported input
 (user-integration-pre-check-ssh-prevent-user-from-switching-username-with-shared-sshd@example.com@localhost) Choose your provider:
 > 2
 == Password authentication ==
-Enter 'r' to cancel the request and go back to select the authentication method
+Enter 'r' to cancel the request and go back to select the authentication flow
 (user-integration-pre-check-ssh-prevent-user-from-switching-username-with-shared-sshd@example.com@localhost) Gimme your password:
 >
 == Authentication method selection ==
@@ -34,7 +34,7 @@ Unsupported input
 (user-integration-pre-check-ssh-prevent-user-from-switching-username-with-shared-sshd@example.com@localhost) Choose your provider:
 > 2
 == Password authentication ==
-Enter 'r' to cancel the request and go back to select the authentication method
+Enter 'r' to cancel the request and go back to select the authentication flow
 (user-integration-pre-check-ssh-prevent-user-from-switching-username-with-shared-sshd@example.com@localhost) Gimme your password:
 >
 PAM Authenticate() finished for user 'user-integration-pre-check-ssh-prevent-user-from-switching-username-with-shared-sshd@example.com'

--- a/pam/integration-tests/testdata/golden/TestSSHAuthenticate/Remember_last_successful_broker_and_mode
+++ b/pam/integration-tests/testdata/golden/TestSSHAuthenticate/Remember_last_successful_broker_and_mode
@@ -4,7 +4,7 @@
 (user-integration-pre-check-ssh-remember-last-successful-broker-and-mode@example.com@localhost) Choose your provider:
 > 2
 == Password authentication ==
-Enter 'r' to cancel the request and go back to select the authentication method
+Enter 'r' to cancel the request and go back to select the authentication flow
 (user-integration-pre-check-ssh-remember-last-successful-broker-and-mode@example.com@localhost) Gimme your password:
 >
 == Authentication method selection ==
@@ -22,11 +22,11 @@ Or enter 'r' to go back to choose the provider
 == Authentication code ==
   1. Proceed with Authentication code
   2. Resend SMS (1 sent)
-Or enter 'r' to go back to select the authentication method
+Or enter 'r' to go back to select the authentication flow
 (user-integration-pre-check-ssh-remember-last-successful-broker-and-mode@example.com@localhost) Choose action:
 > 1
 == Authentication code ==
-Enter 'r' to cancel the request and go back to select the authentication method
+Enter 'r' to cancel the request and go back to select the authentication flow
 (user-integration-pre-check-ssh-remember-last-successful-broker-and-mode@example.com@localhost) Enter your one time credential:
 > temporary pass0
 PAM Authenticate() finished for user 'user-integration-pre-check-ssh-remember-last-successful-broker-and-mode@example.com'
@@ -45,11 +45,11 @@ Connection to localhost closed.
 == Authentication code ==
   1. Proceed with Authentication code
   2. Resend SMS (1 sent)
-Or enter 'r' to go back to select the authentication method
+Or enter 'r' to go back to select the authentication flow
 (user-integration-pre-check-ssh-remember-last-successful-broker-and-mode@example.com@localhost) Choose action:
 > 1
 == Authentication code ==
-Enter 'r' to cancel the request and go back to select the authentication method
+Enter 'r' to cancel the request and go back to select the authentication flow
 (user-integration-pre-check-ssh-remember-last-successful-broker-and-mode@example.com@localhost) Enter your one time credential:
 > temporary pass0
 PAM Authenticate() finished for user 'user-integration-pre-check-ssh-remember-last-successful-broker-and-mode@example.com'

--- a/pam/integration-tests/testdata/golden/TestSSHAuthenticate/Remember_last_successful_broker_and_mode_with_shared_sshd
+++ b/pam/integration-tests/testdata/golden/TestSSHAuthenticate/Remember_last_successful_broker_and_mode_with_shared_sshd
@@ -4,7 +4,7 @@
 (user-integration-pre-check-ssh-remember-last-successful-broker-and-mode-with-shared-sshd@example.com@localhost) Choose your provider:
 > 2
 == Password authentication ==
-Enter 'r' to cancel the request and go back to select the authentication method
+Enter 'r' to cancel the request and go back to select the authentication flow
 (user-integration-pre-check-ssh-remember-last-successful-broker-and-mode-with-shared-sshd@example.com@localhost) Gimme your password:
 >
 == Authentication method selection ==
@@ -22,11 +22,11 @@ Or enter 'r' to go back to choose the provider
 == Authentication code ==
   1. Proceed with Authentication code
   2. Resend SMS (1 sent)
-Or enter 'r' to go back to select the authentication method
+Or enter 'r' to go back to select the authentication flow
 (user-integration-pre-check-ssh-remember-last-successful-broker-and-mode-with-shared-sshd@example.com@localhost) Choose action:
 > 1
 == Authentication code ==
-Enter 'r' to cancel the request and go back to select the authentication method
+Enter 'r' to cancel the request and go back to select the authentication flow
 (user-integration-pre-check-ssh-remember-last-successful-broker-and-mode-with-shared-sshd@example.com@localhost) Enter your one time credential:
 > temporary pass0
 PAM Authenticate() finished for user 'user-integration-pre-check-ssh-remember-last-successful-broker-and-mode-with-shared-sshd@example.com'
@@ -45,11 +45,11 @@ Connection to localhost closed.
 == Authentication code ==
   1. Proceed with Authentication code
   2. Resend SMS (1 sent)
-Or enter 'r' to go back to select the authentication method
+Or enter 'r' to go back to select the authentication flow
 (user-integration-pre-check-ssh-remember-last-successful-broker-and-mode-with-shared-sshd@example.com@localhost) Choose action:
 > 1
 == Authentication code ==
-Enter 'r' to cancel the request and go back to select the authentication method
+Enter 'r' to cancel the request and go back to select the authentication flow
 (user-integration-pre-check-ssh-remember-last-successful-broker-and-mode-with-shared-sshd@example.com@localhost) Enter your one time credential:
 > temporary pass0
 PAM Authenticate() finished for user 'user-integration-pre-check-ssh-remember-last-successful-broker-and-mode-with-shared-sshd@example.com'

--- a/pam/internal/adapter/authmodeselection.go
+++ b/pam/internal/adapter/authmodeselection.go
@@ -52,7 +52,7 @@ func selectAuthMode(id string) tea.Cmd {
 // newAuthModeSelectionModel initializes an empty list with default options of authModeSelectionModel.
 func newAuthModeSelectionModel(clientType PamClientType) authModeSelectionModel {
 	return authModeSelectionModel{
-		List: NewList(clientType, "Select the authentication flow"),
+		List: NewList(clientType, "Select the authentication flow:"),
 	}
 }
 

--- a/pam/internal/adapter/authmodeselection.go
+++ b/pam/internal/adapter/authmodeselection.go
@@ -52,7 +52,7 @@ func selectAuthMode(id string) tea.Cmd {
 // newAuthModeSelectionModel initializes an empty list with default options of authModeSelectionModel.
 func newAuthModeSelectionModel(clientType PamClientType) authModeSelectionModel {
 	return authModeSelectionModel{
-		List: NewList(clientType, "Select your authentication method"),
+		List: NewList(clientType, "Select the authentication flow"),
 	}
 }
 

--- a/pam/internal/adapter/brokerselection.go
+++ b/pam/internal/adapter/brokerselection.go
@@ -46,7 +46,7 @@ func selectBroker(brokerID string) tea.Cmd {
 // newBrokerSelectionModel initializes an empty list with default options of brokerSelectionModel.
 func newBrokerSelectionModel(client authd.PAMClient, clientType PamClientType) brokerSelectionModel {
 	return brokerSelectionModel{
-		List:   NewList(clientType, "Select your provider"),
+		List:   NewList(clientType, "Select your provider:"),
 		client: client,
 	}
 }

--- a/pam/internal/adapter/utils.go
+++ b/pam/internal/adapter/utils.go
@@ -242,7 +242,7 @@ func safeMessageDebugWithPrefix(prefix string, msg tea.Msg, formatAndArgs ...any
 func goBackLabel(previousStage proto.Stage) string {
 	switch previousStage {
 	case proto.Stage_authModeSelection:
-		return "go back to select the authentication method"
+		return "go back to select the authentication flow"
 	case proto.Stage_brokerSelection:
 		return "go back to choose the provider"
 	case proto.Stage_challenge:


### PR DESCRIPTION
Improve the PAM prompts.

Old:

```
  Select your authentication method                                                                        
                                                                                                           
  1. Local Password Authentication                                                                         
> 2. Entra ID password                                                                        
  3. Device code flow      
```

New:
```
  Select the authentication flow:

    1. Local password
  > 2. Entra ID password + MFA
    3. Device code flow
```

See commit messages for details.

UDENG-10817