### PR TITLE
broker: Improve error message when initializing broker

### DIFF
--- a/authd-oidc-brokers/internal/dbusservice/dbusservice.go
+++ b/authd-oidc-brokers/internal/dbusservice/dbusservice.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/canonical/authd/authd-oidc-brokers/internal/broker"
 	"github.com/canonical/authd/authd-oidc-brokers/internal/consts"
+	"github.com/canonical/authd/log"
 	"github.com/godbus/dbus/v5"
 	"github.com/godbus/dbus/v5/introspect"
 )
@@ -93,10 +94,11 @@ func New(_ context.Context, brokerConfig broker.Config) (*Service, error) {
 
 	var introspectableBody string
 	for i, iface := range interfaceNames {
+		log.Debugf(context.Background(), "Initializing broker for interface %s", iface)
 		b, err := broker.New(brokerConfig, uint(i)+1) // There's no 0 version, so we start from 1.
 		if err != nil {
 			service.disconnect()
-			return nil, fmt.Errorf("error initializing broker for %q: %v", iface, err)
+			return nil, err
 		}
 
 		s := &Interface{


### PR DESCRIPTION
The "error initializing broker for ..." part doesn't help the user, so strip that. It's also unlikely to help us debug the error, but just in case, I added a debug log statement which tells us which interface is being initialized.

This simplifies the error message printed when the broker.conf was not edited from

    error initializing broker for "com.ubuntu.authd.Broker": config file "/var/snap/authd-msentraid/x23/broker.conf" has invalid values, did you edit the config file?
    unedited template placeholder found in section 'oidc', key 'issuer'
    unedited template placeholder found in section 'oidc', key 'client_id'

to

    config file "/var/snap/authd-msentraid/x24/broker.conf" has invalid values, did you edit the config file?
    unedited template placeholder found in section 'oidc', key 'issuer'
    unedited template placeholder found in section 'oidc', key 'client_id'

UDENG-10819