### PR TITLE
snap: Don't auto-restart the broker daemon

### DIFF
--- a/snap/variants/google/snapcraft.yaml
+++ b/snap/variants/google/snapcraft.yaml
@@ -34,7 +34,7 @@ apps:
       - dbus-authd
     plugs:
       - network
-    restart-condition: always
+    restart-condition: never
     activates-on: [dbus-authd]
     environment:
       SYSLOG_IDENTIFIER: authd-google

--- a/snap/variants/msentraid/snapcraft.yaml
+++ b/snap/variants/msentraid/snapcraft.yaml
@@ -34,7 +34,7 @@ apps:
       - dbus-authd
     plugs:
       - network
-    restart-condition: always
+    restart-condition: never
     activates-on: [dbus-authd]
     environment:
       SYSLOG_IDENTIFIER: authd-msentraid

--- a/snap/variants/oidc/snapcraft.yaml
+++ b/snap/variants/oidc/snapcraft.yaml
@@ -34,7 +34,7 @@ apps:
       - dbus-authd
     plugs:
       - network
-    restart-condition: always
+    restart-condition: never
     activates-on: [dbus-authd]
     environment:
       SYSLOG_IDENTIFIER: authd-oidc


### PR DESCRIPTION
The broker is D-Bus activated, so each login attempt re-triggers a start; automatic restart adds little for what are deterministic startup failures (bad config, missing library, name conflict). Worse, the restart loop trips systemd's start limiter, after which `systemctl status` only shows the rate-limiter's "Start request repeated too quickly" messages — scoped to an empty current invocation — hiding the broker's actual error. With no restart, a failed start leaves its real error visible in `systemctl status`, and the next D-Bus activation simply tries again.

Before:
```
sudo systemctl status snap.authd-msentraid.authd-msentraid.service
× snap.authd-msentraid.authd-msentraid.service - Service for snap application authd-msentraid.authd-msentraid
     Loaded: loaded (/etc/systemd/system/snap.authd-msentraid.authd-msentraid.service; static)
    Drop-In: /etc/systemd/system/snap.authd-msentraid.authd-msentraid.service.d
             └─override.conf
     Active: failed (Result: exit-code) since Thu 2026-06-25 12:00:57 CEST; 16min ago
   Duration: 81ms
 Invocation: c76badee563b4820ac451a6a8cd96bed
    Process: 126839 ExecStart=/usr/bin/snap run authd-msentraid -vv (code=exited, status=1/FAILURE)
   Main PID: 126839 (code=exited, status=1/FAILURE)
   Mem peak: 22.2M
        CPU: 138ms

Jun 25 12:00:57 ubuntu26-04 systemd[1]: snap.authd-msentraid.authd-msentraid.service: Scheduled restart job, restart counter is at 5.
Jun 25 12:00:57 ubuntu26-04 systemd[1]: snap.authd-msentraid.authd-msentraid.service: Start request repeated too quickly.
Jun 25 12:00:57 ubuntu26-04 systemd[1]: snap.authd-msentraid.authd-msentraid.service: Failed with result 'exit-code'.
Jun 25 12:00:57 ubuntu26-04 systemd[1]: Failed to start snap.authd-msentraid.authd-msentraid.service - Service for snap application authd-msentraid.authd-msentraid.
```

After:
```
sudo systemctl status snap.authd-msentraid.authd-msentraid.service
× snap.authd-msentraid.authd-msentraid.service - Service for snap application authd-msentraid.authd-msentraid
     Loaded: loaded (/etc/systemd/system/snap.authd-msentraid.authd-msentraid.service; static)
    Drop-In: /etc/systemd/system/snap.authd-msentraid.authd-msentraid.service.d
             └─override.conf
     Active: failed (Result: exit-code) since Thu 2026-06-25 12:43:48 CEST; 9s ago
   Duration: 81ms
 Invocation: e15f3334c39041a4b9eec723151f00b6
    Process: 128414 ExecStart=/usr/bin/snap run authd-msentraid -vv (code=exited, status=1/FAILURE)
   Main PID: 128414 (code=exited, status=1/FAILURE)
   Mem peak: 22.1M
        CPU: 123ms

Jun 25 12:43:48 ubuntu26-04 systemd[1]: Starting snap.authd-msentraid.authd-msentraid.service - Service for snap application authd-msentraid.authd-msentraid...
Jun 25 12:43:48 ubuntu26-04 authd-msentraid[128414]: Version: 0.0.0+ff80245.5108293
Jun 25 12:43:48 ubuntu26-04 authd-msentraid[128414]: Debug mode is enabled
Jun 25 12:43:48 ubuntu26-04 authd-msentraid[128414]: Initializing broker for interface com.ubuntu.authd.Broker
Jun 25 12:43:48 ubuntu26-04 authd-msentraid[128414]: config file "/var/snap/authd-msentraid/x32/broker.conf" has invalid values, did you edit the config file?
                                                     unedited template placeholder found in section 'oidc', key 'issuer'
                                                     unedited template placeholder found in section 'oidc', key 'client_id'
Jun 25 12:43:48 ubuntu26-04 systemd[1]: snap.authd-msentraid.authd-msentraid.service: Main process exited, code=exited, status=1/FAILURE
Jun 25 12:43:48 ubuntu26-04 systemd[1]: snap.authd-msentraid.authd-msentraid.service: Failed with result 'exit-code'.
Jun 25 12:43:48 ubuntu26-04 systemd[1]: Failed to start snap.authd-msentraid.authd-msentraid.service - Service for snap application authd-msentraid.authd-msentraid.
```

UDENG-10820