### PR TITLE
pam/tests: Avoid snapshotting a half-rendered QR matrix

### DIFF
--- a/pam/integration-tests/cli_test.go
+++ b/pam/integration-tests/cli_test.go
@@ -867,6 +867,13 @@ func cliAuthenticateWithQRCode(t *testing.T, c *ptytest.Console, signalFn func(s
 	c.WaitFor(t, `6\. Use a QR code`)
 	c.Send(t, "6")
 	c.WaitFor(t, `Scan the qrcode or enter the code in the login page`)
+	// The QR view (label, QR matrix, URL, Code) is emitted as a single render,
+	// but in a TTY it exceeds the PTY read buffer and arrives in several reads.
+	// A WaitFor poll can therefore land between the chunk carrying the "Scan the
+	// qrcode" label (top of the view) and the one carrying "Code:" (bottom),
+	// snapshotting a half-drawn QR matrix. Discard that intermediate frame; the
+	// "Code:" frame below is a complete superset that captures the same screen.
+	c.DiscardLastSnapshot()
 	c.WaitFor(t, `Code:\s*1337`)
 	// The Regenerate button has a 500ms reselectionWaitTime guard to
 	// prevent accidental double-clicks right after mode selection.


### PR DESCRIPTION
TestCLIAuthenticate/Authenticate_user_with_qr_code_in_a_TTY intermittently captured an extra terminal frame: a QR screen with a partially-drawn matrix appeared between the auth-method-selection frame and the first complete QR frame, failing the golden comparison.

The QR view (label, QR matrix, URL, Code) is rendered as a single string, but in a TTY the large ToString() matrix exceeds the 4096-byte PTY read buffer and arrives over several reads. WaitFor polls the growing buffer every 50ms, so a poll for the "Scan the qrcode" label (top of the view) can match while later reads carrying "Code:" (bottom) are still pending, snapshotting a half-drawn matrix. Whether this intermediate frame coincides with a poll boundary is timing-dependent, hence the flake; the non-TTY variants use the smaller ToSmallString() matrix that fits in one read, so they never hit it.

Discard the intermediate "Scan the qrcode" frame and keep only the "Code:" frame, which is a cumulative-screen superset capturing the same fully-rendered view.