### PR TITLE
e2e-tests/r2-worker: Add log.html shortcut to directory listings

### DIFF
--- a/e2e-tests/r2-worker/src/index.js
+++ b/e2e-tests/r2-worker/src/index.js
@@ -1,3 +1,33 @@
+// List a directory, following pagination so entries don't disappear.
+async function listDir(bucket, prefix) {
+  const objects = [];
+  const delimitedPrefixes = [];
+  let cursor;
+
+  do {
+    const listing = await bucket.list({ prefix, delimiter: "/", cursor });
+    objects.push(...listing.objects);
+    delimitedPrefixes.push(...listing.delimitedPrefixes);
+    cursor = listing.truncated ? listing.cursor : undefined;
+  } while (cursor);
+
+  return { objects, uniquePrefixes: [...new Set(delimitedPrefixes)] };
+}
+
+// A directory collapses (redirects straight through) when it holds nothing
+// but a single subdirectory, so there's no real choice to make.
+function collapsesTo({ objects, uniquePrefixes }) {
+  return !objects.length && uniquePrefixes.length === 1 ? uniquePrefixes[0] : null;
+}
+
+// Immediate parent of a directory prefix; "" for a top-level dir, null at root.
+function parentOf(prefix) {
+  if (!prefix) return null;
+  const trimmed = prefix.replace(/\/$/, "");
+  const idx = trimmed.lastIndexOf("/");
+  return idx === -1 ? "" : trimmed.slice(0, idx + 1);
+}
+
 export default {
   async fetch(request, env) {
     const url = new URL(request.url);
@@ -14,37 +44,27 @@ export default {
       }
     }
 
-    // List the directory, following pagination so entries don't disappear.
     const prefix = path ? path.replace(/\/?$/, "/") : "";
-    const objects = [];
-    const delimitedPrefixes = [];
-    let cursor;
+    const { objects, uniquePrefixes } = await listDir(env.BUCKET, prefix);
 
-    do {
-      const listing = await env.BUCKET.list({ prefix, delimiter: "/", cursor });
-      objects.push(...listing.objects);
-      delimitedPrefixes.push(...listing.delimitedPrefixes);
-      cursor = listing.truncated ? listing.cursor : undefined;
-    } while (cursor);
-
-    if (!objects.length && !delimitedPrefixes.length) {
+    if (!objects.length && !uniquePrefixes.length) {
       return new Response("Not found", { status: 404 });
     }
 
-    // When a directory holds nothing but a single subdirectory, there's no
-    // real choice to make, so redirect straight into it instead of showing a
-    // dead-end listing.
-    const uniquePrefixes = [...new Set(delimitedPrefixes)];
-    if (wantsDirectory && !objects.length && uniquePrefixes.length === 1) {
-      return Response.redirect(new URL(`/${uniquePrefixes[0]}`, url), 302);
+    // Redirect straight through collapsing directories instead of showing a
+    // dead-end listing with a single entry.
+    const collapseTarget = collapsesTo({ objects, uniquePrefixes });
+    if (wantsDirectory && collapseTarget) {
+      return Response.redirect(new URL(`/${collapseTarget}`, url), 302);
     }
 
-    // Calculate parent path for '..' link
-    let parent = null;
-    if (prefix) {
-      const trimmed = prefix.replace(/\/$/, "");
-      const idx = trimmed.lastIndexOf("/");
-      parent = idx === -1 ? "" : trimmed.slice(0, idx + 1);
+    // Compute the '..' target, walking up past ancestors that would only
+    // redirect back down here, so '..' lands somewhere with a real choice.
+    let parent = parentOf(prefix);
+    while (parent) {
+      const grandparent = parentOf(parent);
+      if (collapsesTo(await listDir(env.BUCKET, parent)) === null) break;
+      parent = grandparent;
     }
 
     // Show a 'log' shortcut only on directories that actually contain a

--- a/e2e-tests/r2-worker/src/index.js
+++ b/e2e-tests/r2-worker/src/index.js
@@ -39,12 +39,20 @@ export default {
       parent = idx === -1 ? "" : trimmed.slice(0, idx + 1);
     }
 
+    // Show a 'log' shortcut only on directories that actually contain a
+    // log.html, so it doesn't appear on intermediate dirs where it 404s.
+    const sortedPrefixes = [...new Set(delimitedPrefixes)].sort();
+    const hasLog = await Promise.all(
+      sortedPrefixes.map(p => env.BUCKET.head(`${p}log.html`).then(o => o !== null))
+    );
+
     const rows = [
       // Add '..' row if not at root
       ...(parent !== null ? [`<li><a href="/${parent}">..</a></li>`] : []),
-      ...[...new Set(delimitedPrefixes)].sort().map(p => {
+      ...sortedPrefixes.map((p, i) => {
         const name = p.replace(prefix, "");
-        return `<li><a href="/${p}">${name}</a></li>`;
+        const log = hasLog[i] ? ` [<a href="/${p}log.html">log</a>]` : "";
+        return `<li><a href="/${p}">${name}</a>${log}</li>`;
       }),
       ...objects.map(o => {
         const name = o.key.replace(prefix, "");

--- a/e2e-tests/r2-worker/src/index.js
+++ b/e2e-tests/r2-worker/src/index.js
@@ -31,6 +31,14 @@ export default {
       return new Response("Not found", { status: 404 });
     }
 
+    // When a directory holds nothing but a single subdirectory, there's no
+    // real choice to make, so redirect straight into it instead of showing a
+    // dead-end listing.
+    const uniquePrefixes = [...new Set(delimitedPrefixes)];
+    if (wantsDirectory && !objects.length && uniquePrefixes.length === 1) {
+      return Response.redirect(new URL(`/${uniquePrefixes[0]}`, url), 302);
+    }
+
     // Calculate parent path for '..' link
     let parent = null;
     if (prefix) {
@@ -41,7 +49,7 @@ export default {
 
     // Show a 'log' shortcut only on directories that actually contain a
     // log.html, so it doesn't appear on intermediate dirs where it 404s.
-    const sortedPrefixes = [...new Set(delimitedPrefixes)].sort();
+    const sortedPrefixes = [...uniquePrefixes].sort();
     const hasLog = await Promise.all(
       sortedPrefixes.map(p => env.BUCKET.head(`${p}log.html`).then(o => o !== null))
     );


### PR DESCRIPTION
Reaching a run's log from the bucket index meant clicking into each result directory before finding log.html. Surface a shortcut link directly on subdirectory rows so the log is one click away.

Only render the shortcut on directories that actually contain a log.html: intermediate dirs (e.g. run-*/) have no log of their own, so an unconditional link there 404s.
