### PR TITLE
broker: Drop "local" from password prompt

### DIFF
--- a/authd-oidc-brokers/internal/broker/broker.go
+++ b/authd-oidc-brokers/internal/broker/broker.go
@@ -905,7 +905,7 @@ func (b *Broker) generateUILayout(session *session, authModeID string) (map[stri
 	case authmodes.Password:
 		uiLayout = map[string]string{
 			"type":  "form",
-			"label": "Enter your local password",
+			"label": "Enter your password",
 			"entry": "chars_password",
 		}
 

--- a/authd-oidc-brokers/internal/broker/testdata/golden/TestSelectAuthenticationMode/Successfully_select_password
+++ b/authd-oidc-brokers/internal/broker/testdata/golden/TestSelectAuthenticationMode/Successfully_select_password
@@ -1,3 +1,3 @@
 entry: chars_password
-label: Enter your local password
+label: Enter your password
 type: form

--- a/e2e-tests/resources/authd.resource
+++ b/e2e-tests/resources/authd.resource
@@ -36,7 +36,7 @@ Change Password
     Hid.Type String    passwd
     Hid.Keys Combo    Return
 
-    Match Text    Enter your local password:    15
+    Match Text    regex:Enter\\s*your\\s*(?:local\\s*)?password:    15
     Builtin.Sleep    2
     Hid.Type String    ${local_password}
     Hid.Keys Combo    Return
@@ -84,7 +84,7 @@ Check That Remote User Can Run Sudo Commands
     Hid.Type String    sudo touch sudo-test.txt
     Hid.Keys Combo    Return
     Builtin.Sleep    2
-    Match Text    Enter your local password:    15
+    Match Text    regex:Enter\\s*your\\s*(?:local\\s*)?password:    15
     Builtin.Sleep    2
     Hid.Type String    ${local_password}
     Hid.Keys Combo    Return

--- a/e2e-tests/resources/broker.resource
+++ b/e2e-tests/resources/broker.resource
@@ -101,7 +101,7 @@ Log In With Remote User Through CLI: Local Password
     Hid.Type String    ${username}
     Hid.Keys Combo    Return
     Builtin.Sleep    2
-    Match Text    Enter your local password:    120
+    Match Text    regex:Enter\\s*your\\s*(?:local\\s*)?password:    120
     Hid.Type String    ${local_password}
     Hid.Keys Combo    Return
     Builtin.Sleep    2
@@ -128,7 +128,7 @@ Check That Username Cannot Be Changed When Using su
 
 Try Navigating Back to User Selection
     # First screen is the autoselected local password mode
-    Match Text    Enter your local password:    120
+    Match Text    regex:Enter\\s*your\\s*(?:local\\s*)?password:    120
     Hid.Keys Combo    Escape
 
     # The previous screen should be the authentication mode selection
@@ -153,7 +153,7 @@ Log In With Remote User Through CLI: Local Password And Expect Failure
     Hid.Type String    ${username}
     Hid.Keys Combo    Return
     Builtin.Sleep    2
-    Match Text    Enter your local password:    120
+    Match Text    regex:Enter\\s*your\\s*(?:local\\s*)?password:    120
     Hid.Type String    ${local_password}
     Hid.Keys Combo    Return
     Check That Remote User Is Not Allowed To Log In
@@ -253,7 +253,7 @@ Log In With Remote User Through SSH: Local Password
     [Arguments]    ${username}    ${local_password}
     Hid.Type String    ssh ${username}@localhost
     Hid.Keys Combo    Return
-    Match Text    Enter your local password:    120
+    Match Text    regex:Enter\\s*your\\s*(?:local\\s*)?password:    120
     Hid.Type String    ${local_password}
     Hid.Keys Combo    Return
     Match Text    ${username}@ubuntu:~$    120


### PR DESCRIPTION
The broker currently labels the password field "Enter your local password". The extra word is unnecessary and the prompt is cleaner without it.

Use a regex in the e2e resources so the shared keyword still matches the old label on the stable broker and the new label on the edge broker, keeping the migration tests working across the upgrade.

UDENG-10823