### PR TITLE
GitHub issue template: Use issue types instead of labels

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,7 +1,7 @@
 name: Report an issue
 description: Create a bug report to fix an issue
 title: "Issue: "
-labels: ["bug"]
+type: bug
 body:
   - type: markdown
     attributes:

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,7 +1,7 @@
 name: Request a feature
 description: Suggest new functionality or improvements for this project
 title: "Feature: "
-labels: ["feature"]
+type: feature
 body:
   - type: markdown
     attributes:


### PR DESCRIPTION
GitHub introduced issue types in 2025. Since then, we have had two different ways to mark issues as bugs/features: The `bug` and `feature` labels and the issue types. Since we can't disable the issue types, let's use them instead of our labels.