### PR TITLE
docs: conditional rendering

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -263,6 +263,29 @@ When you submit a PR, there are automated checks for typos and broken links.
 Please run the tests locally before submitting the PR to save yourself and your
 reviewers time.
 
+### Building stable and edge versions of the documentation
+
+authd publishes two versions of its documentation: stable-docs and edge-docs.
+By default, `make run` previews the stable version.
+
+To preview a specific version, set `READTHEDOCS_VERSION` before running `make run`:
+
+**Edge**:
+
+```shell
+READTHEDOCS_VERSION=edge-docs make run
+```
+
+**Stable**:
+
+```shell
+READTHEDOCS_VERSION=stable-docs make run
+```
+
+Some content is conditionally rendered depending on the version. This includes
+the version warning banner in the edge documentation and installation
+instructions that are specific to each version.
+
 ### Testing the documentation
 
 Automatic checks will be run on any PR relating to documentation to verify

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -29,6 +29,14 @@ author = "Canonical Ltd."
 
 version = os.environ.get('READTHEDOCS_VERSION', 'local')
 
+# Register the stable/edge build variant as a Sphinx tag so that
+# {only} directives can be used for conditional rendering
+
+if version == "edge-docs":
+    tags.add("edge")
+else:
+    tags.add("stable")
+
 # Sidebar documentation title; best kept reasonably short
 #
 # TODO: To include a version number, add it here (hardcoded or automated).

--- a/docs/explanation/security.md
+++ b/docs/explanation/security.md
@@ -138,8 +138,8 @@ Replace `@example.com` with the domain of your identity provider.
 
 When a new user logs in for the first time, or when a user is added to a new
 group in the identity provider (for providers that support group management, see
-[Group management](https://ubuntu.com/docs/authd/stable-docs/reference/group-management/)),
-authd automatically assigns a unique user ID (UID) and group ID (GID).
+[Group management](reference::group-management)), authd automatically assigns a
+unique user ID (UID) and group ID (GID).
 
 Before assigning a UID or GID, authd checks that there are no collisions with
 existing users or groups on the system. However, if a user or group is later

--- a/docs/howto/install-authd.md
+++ b/docs/howto/install-authd.md
@@ -13,13 +13,25 @@ This project consists of two components:
 
 authd is delivered as a Debian package for Ubuntu Desktop and Ubuntu Server.
 
-```{admonition} (Optional) Switching from stable to edge
+::::{only} stable
+:::{admonition} This guide is for the stable release of authd
 :class: important
-This guide describes how to install the stable version of authd and its brokers, which is recommended for production use. 
+It describes how to install the **stable** version of authd and its brokers, which is recommended for production use. 
 
-If you want to try the **edge** version, read our guide on [changing authd
+If you want to try the **edge** version, read the installation guide in authd's [edge documentation](https://ubuntu.com/docs/authd/edge-docs/howto/install-authd) or read the guide on [changing authd
 versions](ref::changing-versions).
-```
+:::
+::::
+
+::::{only} edge
+:::{admonition} This guide is for the edge release of authd
+:class: important
+It describes how to install the **edge** version of authd and its brokers, which is not recommended for production use. 
+
+If you want to try the **stable** version, read the installation guide in authd's [stable documentation](https://ubuntu.com/docs/authd/stable-docs/howto/install-authd) or read our guide on [changing authd
+versions](ref::changing-versions).
+:::
+::::
 
 ## System requirements
 
@@ -29,6 +41,7 @@ versions](ref::changing-versions).
 
 ## Install authd
 
+::::{only} stable
 On Ubuntu 26.04 LTS, `authd` is available directly from the Ubuntu archive.
 
 :::{admonition} Add PPA before installing on Ubuntu 24.04
@@ -39,6 +52,15 @@ On Ubuntu 24.04 LTS, `authd` must be installed from the [stable PPA](https://lau
 sudo add-apt-repository ppa:ubuntu-enterprise-desktop/authd
 ```
 :::
+::::
+
+::::{only} edge
+Before installing authd, add the [edge PPA](https://launchpad.net/~ubuntu-enterprise-desktop/+archive/ubuntu/authd-edge):
+
+```shell
+sudo add-apt-repository ppa:ubuntu-enterprise-desktop/authd-edge
+```
+::::
 
 Install authd and any additional Debian packages needed for your system of
 choice:
@@ -67,49 +89,74 @@ sudo apt install authd
 The brokers are provided as snap packages and are available from the Snap Store.
 Install the broker corresponding to the identity provider that you want to use:
 
-:::::{tab-set}
+::::::{tab-set}
 :sync-group: broker
 
-::::{tab-item} Google IAM
+:::::{tab-item} Google IAM
 :sync: google
 
 To install the Google IAM broker, run the following command:
 
+::::{only} stable
 ```shell
 sudo snap install authd-google
 ```
+::::
+
+::::{only} edge
+```shell
+sudo snap install authd-google --edge
+```
+::::
+
 At this stage, you have installed the main service and an identity broker to
 authenticate against Google IAM.
 
-::::
+:::::
 
-::::{tab-item} Microsoft Entra ID
+:::::{tab-item} Microsoft Entra ID
 :sync: msentraid
 
 To install the Microsoft Entra ID broker, run the following command:
 
+::::{only} stable
 ```shell
 sudo snap install authd-msentraid
 ```
+::::
+
+::::{only} edge
+```shell
+sudo snap install authd-msentraid --edge
+```
+::::
 
 At this stage, you have installed the main service and an identity broker to
 authenticate against Microsoft Entra ID.
 
-::::
+:::::
 
-::::{tab-item} Keycloak
+:::::{tab-item} Keycloak
 :sync: keycloak
 
 Keycloak can be used with the generic OIDC broker. Install the broker with the
 following command:
 
+::::{only} stable
 ```shell
 sudo snap install authd-oidc
 ```
+::::
+
+::::{only} edge
+```shell
+sudo snap install authd-oidc --edge
+```
+::::
 
 At this stage, you have installed the main service and an identity broker to
 authenticate against Keycloak or any other OIDC provider.
 
-::::
-
 :::::
+
+::::::


### PR DESCRIPTION
We build two versions of the docs: edge and stable.
In some limited cases, it may be beneficial to conditionally render content.

The obvious example is our installation guide, which currently defaults to instructions to install stable versions of authd and the brokers, even when a user is on the edge version of the docs.

This PR adds a configuration change so that tags (edge, stable) are created based on the version being built on Read the Docs. The `only` directive can then be used on individual pages to specify content that should only be rendered in specific versions.

The PR uses this functionality to conditionally render version-specific installation instructions.

Reviewers can check this by previewing the different versions locally:

```bash
# Edge version
READTHEDOCS_VERSION=edge-docs make run 
```

```bash
# Stable version (default)
READTHEDOCS_VERSION=stable-docs make run 
```

And then comparing the results at http://127.0.0.1:8000/howto/install-authd/

---

The PR also updates the contributing guide to reflect these changes and makes some minor modifications to wording in the installation guide to accomodate the changes.

---

Thanks to @nooreldeenmansour for proposing and testing this solution.

UDENG-10618