### PR TITLE
e2e-tests: only replay journal once the host is connected

### DIFF
--- a/e2e-tests/vm/cloud-init-template-noble.yaml
+++ b/e2e-tests/vm/cloud-init-template-noble.yaml
@@ -106,8 +106,12 @@ write_files:
       After=systemd-journald.service
       After=network.target
       Requires=network.target
-      # Disable rate limiting
-      StartLimitIntervalSec=0
+      # Stop respawning a few minutes after the host stops listening (i.e. once
+      # the tests have finished), to avoid burning CPU forever. The window is
+      # generous enough to survive the gaps between test suites, when the host
+      # listener is briefly down.
+      StartLimitIntervalSec=600
+      StartLimitBurst=300
 
       [Service]
       Type=simple

--- a/e2e-tests/vm/cloud-init-template-noble.yaml
+++ b/e2e-tests/vm/cloud-init-template-noble.yaml
@@ -111,7 +111,7 @@ write_files:
 
       [Service]
       Type=simple
-      ExecStart=/bin/bash -o pipefail -c 'journalctl -b --lines=all -o export -f | socat - ${SOCAT_ADDRESS}'
+      ExecStart=/usr/bin/socat ${SOCAT_ADDRESS} EXEC:'journalctl -b --lines=all -o export -f'
       OOMScoreAdjust=-1000
       Restart=always
       RestartSec=1

--- a/e2e-tests/vm/cloud-init-template-resolute.yaml
+++ b/e2e-tests/vm/cloud-init-template-resolute.yaml
@@ -85,8 +85,12 @@ write_files:
       After=systemd-journald.service
       After=network.target
       Requires=network.target
-      # Disable rate limiting
-      StartLimitIntervalSec=0
+      # Stop respawning a few minutes after the host stops listening (i.e. once
+      # the tests have finished), to avoid burning CPU forever. The window is
+      # generous enough to survive the gaps between test suites, when the host
+      # listener is briefly down.
+      StartLimitIntervalSec=600
+      StartLimitBurst=300
 
       [Service]
       Type=simple

--- a/e2e-tests/vm/cloud-init-template-resolute.yaml
+++ b/e2e-tests/vm/cloud-init-template-resolute.yaml
@@ -90,7 +90,7 @@ write_files:
 
       [Service]
       Type=simple
-      ExecStart=/bin/bash -o pipefail -c 'journalctl -b --lines=all -o export -f | socat - ${SOCAT_ADDRESS}'
+      ExecStart=/usr/bin/socat ${SOCAT_ADDRESS} EXEC:'journalctl -b --lines=all -o export -f'
       OOMScoreAdjust=-1000
       Restart=always
       RestartSec=1

--- a/e2e-tests/vm/cloud-init-template-stonking.yaml
+++ b/e2e-tests/vm/cloud-init-template-stonking.yaml
@@ -85,8 +85,12 @@ write_files:
       After=systemd-journald.service
       After=network.target
       Requires=network.target
-      # Disable rate limiting
-      StartLimitIntervalSec=0
+      # Stop respawning a few minutes after the host stops listening (i.e. once
+      # the tests have finished), to avoid burning CPU forever. The window is
+      # generous enough to survive the gaps between test suites, when the host
+      # listener is briefly down.
+      StartLimitIntervalSec=600
+      StartLimitBurst=300
 
       [Service]
       Type=simple

--- a/e2e-tests/vm/cloud-init-template-stonking.yaml
+++ b/e2e-tests/vm/cloud-init-template-stonking.yaml
@@ -90,7 +90,7 @@ write_files:
 
       [Service]
       Type=simple
-      ExecStart=/bin/bash -o pipefail -c 'journalctl -b --lines=all -o export -f | socat - ${SOCAT_ADDRESS}'
+      ExecStart=/usr/bin/socat ${SOCAT_ADDRESS} EXEC:'journalctl -b --lines=all -o export -f'
       OOMScoreAdjust=-1000
       Restart=always
       RestartSec=1


### PR DESCRIPTION
The journal-export service piped journalctl into socat, so the full boot journal was read and serialized on every start regardless of whether the host was listening. After tests finish the host stops listening, socat fails, and the 1s restart loop re-replays the whole (now large) journal every second, burning CPU.

Let socat establish the connection first and exec journalctl only on success, so the expensive replay happens only when there is somewhere to send it; a failed connect now exits cheaply.

UDENG-10845
