### PR TITLE
e2e-tests: add device registration test for msentraid

### DIFF
--- a/e2e-tests/resources/broker.resource
+++ b/e2e-tests/resources/broker.resource
@@ -373,3 +373,36 @@ Check If User Was Added Properly
 Check User Groups
     [Arguments]    ${username}    ${remote_group}
     Match Text    ${username} sudo ${remote_group}    120
+
+
+Enable Device Registration
+    [Documentation]    Turns on automatic device registration in the broker config.
+    ...               The 'register_device' key lives in the '[msentraid]' section and is
+    ...               only meaningful for the msentraid broker.
+    Change Broker Configuration    register_device    true
+
+
+Check That Device Was Registered
+    [Documentation]    Verifies that device registration data was persisted for the user.
+    ...
+    ...               On successful registration the broker stores the device registration
+    ...               data in the user's cached token at
+    ...               <SNAP_DATA>/<issuer>/<username>/token.json. The data is held in the
+    ...               'DeviceRegistrationData' field, which is null when the device is not
+    ...               registered and a (base64-encoded) string once it is. We assert over
+    ...               SSH because the on-disk state is the authoritative outcome and is not
+    ...               observable on screen.
+    [Arguments]    ${username}
+    # The issuer (tenant-specific) is part of the path, so glob across issuer dirs.
+    # 'current' is a symlink to the snap revision, so '-L' is needed to descend
+    # into it.
+    ${token_path} =    SSH.Execute
+    ...    sudo find -L /var/snap/${BROKER_SNAP_NAME}/current -path '*/${username}/token.json'
+    Should Not Be Empty    ${token_path}
+    ...    msg=No token.json found for ${username}; device auth did not cache a token.
+    # DeviceRegistrationData is null when the device is not registered and a
+    # (base64-encoded) string once it is.
+    ${registered} =    SSH.Execute
+    ...    sudo jq -r '.DeviceRegistrationData != null and .DeviceRegistrationData != ""' '${token_path}'
+    Should Be Equal    ${registered}    true
+    ...    msg=token.json has no DeviceRegistrationData; the device was not registered.

--- a/e2e-tests/tests/device_registration.robot
+++ b/e2e-tests/tests/device_registration.robot
@@ -1,0 +1,41 @@
+*** Settings ***
+Resource        resources/utils.resource
+Resource        resources/authd.resource
+Resource        resources/broker.resource
+
+# Test Tags       robot:exit-on-failure
+
+Test Setup    utils.Test Setup    snapshot=%{BROKER}-installed
+Test Teardown   utils.Test Teardown
+
+
+*** Variables ***
+${username}    %{E2E_USER}
+${local_password}    qwer1234
+
+
+*** Test Cases ***
+Test device registration during device authentication
+    [Documentation]    Verify that enabling 'register_device' causes the machine to be
+    ...    registered as a device in Microsoft Entra ID during device authentication.
+    ...
+    ...    With 'register_device = true' the device-auth login flow is unchanged from the
+    ...    user's perspective; the broker additionally registers the device and persists the
+    ...    resulting registration data in the user's cached token.
+
+    Skip If    '%{BROKER}' != 'authd-msentraid'
+    ...    msg=Device registration is only supported by the msentraid broker.
+
+    # Enable device registration before the first remote login, so the device is
+    # registered as part of that login.
+    Enable Device Registration
+
+    Log In
+
+    Open Terminal
+    Log In With Remote User Through CLI: QR Code    ${username}    ${local_password}
+
+    Check That Device Was Registered    ${username}
+
+    Log Out From Terminal Session
+    Close Focused Window


### PR DESCRIPTION
Add an e2e test that enables 'register_device' and verifies the machine is registered as a device in Microsoft Entra ID during device authentication.

UDENG-10738