### PR TITLE
e2e-tests: Wait for GDM login screen to be fully loaded

### DIFF
--- a/e2e-tests/resources/broker.resource
+++ b/e2e-tests/resources/broker.resource
@@ -269,7 +269,7 @@ Log In With Remote User Through GDM: QR Code
 
 Start Log In With Remote User Through GDM: QR Code
     [Arguments]    ${username}
-    Match Text    Not listed    180
+    Wait Until GDM Login Screen Ready
     Move Pointer To Not listed
     Left Button Click
 
@@ -301,7 +301,7 @@ Continue Log In With Remote User Through GDM: Define Local Password
 
 Log In With Remote User Through GDM: Local Password
     [Arguments]    ${username}    ${local_password}
-    Match Text    Not listed    180
+    Wait Until GDM Login Screen Ready
     Move Pointer To Not listed
     Left Button Click
     # Enter the username

--- a/e2e-tests/resources/utils.resource
+++ b/e2e-tests/resources/utils.resource
@@ -29,7 +29,7 @@ Log In
 
 Log In With Password
     [Arguments]    ${password}
-    Match Text    Not listed    300
+    Wait Until GDM Login Screen Ready
     Wait Until User Selected
     Hid.Type String    ${password}
     Hid.Keys Combo    Return
@@ -38,7 +38,7 @@ Log In With Password
 
 Log In And Set Password
     [Arguments]    ${new_password}
-    Match Text    Not listed    300
+    Wait Until GDM Login Screen Ready
     Wait Until User Selected
     Hid.Type String    ubuntu
     Hid.Keys Combo    Return
@@ -72,6 +72,10 @@ Try Select User
 
 Log Out
     SSH.Execute    loginctl terminate-seat seat0
+
+
+Wait Until GDM Login Screen Ready
+    Match Text    Not listed    180
 
 
 Wait Until Desktop Ready

--- a/e2e-tests/resources/utils.resource
+++ b/e2e-tests/resources/utils.resource
@@ -76,6 +76,11 @@ Log Out
 
 Wait Until GDM Login Screen Ready
     Match Text    Not listed    180
+    # Sometimes the "Not listed" is shown for a brief moment before the other
+    # list items of the login screen are displayed, which resulted in the wrong
+    # list item being clicked in the next step. To avoid that, we sleep for
+    # 2 seconds to ensure the login screen is fully loaded before proceeding.
+    BuiltIn.Sleep    2
 
 
 Wait Until Desktop Ready


### PR DESCRIPTION
After "Not listed" appears, the other login items may still be loading, causing a click to land on the wrong item. Add a 2-second sleep after detecting the text to ensure the list is fully populated.

Closes #1644
UDENG-10847