### PR TITLE
e2e-tests: Add yarf as a git submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,6 @@
 [submodule "authd-oidc-brokers/third_party/libhimmelblau"]
 	path = authd-oidc-brokers/third_party/libhimmelblau
 	url = https://gitlab.com/samba-team/libhimmelblau.git
+[submodule "e2e-tests/.yarf"]
+	path = e2e-tests/.yarf
+	url = https://github.com/adombeck/yarf

--- a/e2e-tests/.gitignore
+++ b/e2e-tests/.gitignore
@@ -1,3 +1,2 @@
 /vm/config.sh
-/.yarf
 

--- a/e2e-tests/setup-yarf.sh
+++ b/e2e-tests/setup-yarf.sh
@@ -2,20 +2,11 @@
 set -euo pipefail
 set -x
 
-YARF_REPO_URL="https://github.com/adombeck/yarf"
-
 SCRIPT_DIR=$(dirname "$(readlink -f "$0")")
 YARF_DIR="${SCRIPT_DIR}/.yarf"
 
-# Clone the YARF repository if it doesn't exist
-if [ ! -d "$YARF_DIR" ]; then
-    echo "Cloning YARF repository into $YARF_DIR..."
-    git clone --depth=1 "$YARF_REPO_URL" "$YARF_DIR"
-else
-    echo "YARF repository already exists at $YARF_DIR, pulling latest changes..."
-    cd "$YARF_DIR"
-    git pull
-fi
+# Ensure that the YARF submodule is initialized
+git -C "${SCRIPT_DIR}/.." submodule update --init --depth=1 e2e-tests/.yarf
 
 # Install uv snap if not already installed
 if ! command -v uv &> /dev/null; then


### PR DESCRIPTION
Replace the clone/pull logic in setup-yarf.sh with a submodule at e2e-tests/.yarf. This lets different authd branches pin different yarf commits, making it possible to test yarf changes on a branch before merging them.

UDENG-10860