### PR TITLE
Fix e2e commit status not appearing on PR

### DIFF
--- a/.github/workflows/e2e-tests-run.yaml
+++ b/.github/workflows/e2e-tests-run.yaml
@@ -318,7 +318,7 @@ jobs:
             const response = await github.rest.repos.createCommitStatus({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              sha: context.sha,
+              sha: context.payload.pull_request?.head?.sha ?? context.sha,
               state: '${{ steps.run-tests.outputs.state }}',
               target_url: '${{ steps.prepare-pages.outputs.log-url }}',
               description: 'View logs',


### PR DESCRIPTION
For pull_request events, github.sha is a temporary merge commit that GitHub generates to test merging the feature branch into the base. This SHA is invalidated whenever the base branch advances: GitHub creates a new merge commit, leaving any status posted to the old SHA invisible on the PR — even though the API returns 201.

Use context.payload.pull_request?.head?.sha (the feature branch HEAD, which is stable across base-branch updates) for pull_request triggers, falling back to context.sha for push/schedule/workflow_dispatch events.