### PR TITLE
e2e-tests: Increase sshd LoginGraceTime to avoid auth timeouts

### DIFF
--- a/e2e-tests/vm/cloud-init-template-noble.yaml
+++ b/e2e-tests/vm/cloud-init-template-noble.yaml
@@ -80,6 +80,10 @@ write_files:
   - path: /etc/ssh/sshd_config.d/authd.conf
     content: |
       UsePAM yes
+      # The device authentication flow can take longer than the default
+      # LoginGraceTime of 2 minutes, which would cause sshd to abort the
+      # connection with "Timeout before authentication".
+      LoginGraceTime 300
       Match User *@*
           KbdInteractiveAuthentication yes
 

--- a/e2e-tests/vm/cloud-init-template-resolute.yaml
+++ b/e2e-tests/vm/cloud-init-template-resolute.yaml
@@ -74,6 +74,10 @@ write_files:
   - path: /etc/ssh/sshd_config.d/authd.conf
     content: |
       UsePAM yes
+      # The device authentication flow can take longer than the default
+      # LoginGraceTime of 2 minutes, which would cause sshd to abort the
+      # connection with "Timeout before authentication".
+      LoginGraceTime 300
       Match User *@*
           KbdInteractiveAuthentication yes
 

--- a/e2e-tests/vm/cloud-init-template-stonking.yaml
+++ b/e2e-tests/vm/cloud-init-template-stonking.yaml
@@ -74,6 +74,10 @@ write_files:
   - path: /etc/ssh/sshd_config.d/authd.conf
     content: |
       UsePAM yes
+      # The device authentication flow can take longer than the default
+      # LoginGraceTime of 2 minutes, which would cause sshd to abort the
+      # connection with "Timeout before authentication".
+      LoginGraceTime 300
       Match User *@*
           KbdInteractiveAuthentication yes
 


### PR DESCRIPTION
SSH logins in the e2e-tests sometimes failed with "Timeout before authentication". The device authentication flow can take more than two minutes, but sshd aborts the connection after the default LoginGraceTime of 120 seconds before authentication completes.

Raise LoginGraceTime to 300 seconds so slow device authentications have enough time to finish. The directive is global-only, so it must precede the Match block.

Closes #1650
UDENG-10873