### PR TITLE
Use relative symlinks for cache compatibility links

### DIFF
--- a/authd-oidc-brokers/internal/broker/broker.go
+++ b/authd-oidc-brokers/internal/broker/broker.go
@@ -243,9 +243,18 @@ func (b *Broker) cacheSymlinkTarget(linkPath string) (string, error) {
 }
 
 func (b *Broker) ensureCompatibilitySymlink(linkPath, target string) error {
+	// Use a relative symlink so that the link remains valid when the path prefix
+	// changes (e.g. a snap revision bump moves everything from .../316/... to
+	// .../317/... while the relative offset between the two sibling directories
+	// stays the same).
+	relTarget, err := filepath.Rel(filepath.Dir(linkPath), target)
+	if err != nil {
+		return fmt.Errorf("could not compute relative symlink target for %q → %q: %w", linkPath, target, err)
+	}
+
 	info, err := os.Lstat(linkPath)
 	if errors.Is(err, os.ErrNotExist) {
-		return os.Symlink(target, linkPath)
+		return os.Symlink(relTarget, linkPath)
 	}
 	if err != nil {
 		return err
@@ -260,7 +269,7 @@ func (b *Broker) ensureCompatibilitySymlink(linkPath, target string) error {
 		if rmErr := os.Remove(linkPath); rmErr != nil {
 			return fmt.Errorf("could not replace invalid cache compatibility symlink %q: %w", linkPath, rmErr)
 		}
-		return os.Symlink(target, linkPath)
+		return os.Symlink(relTarget, linkPath)
 	}
 	if filepath.Clean(existingTarget) != filepath.Clean(target) {
 		return fmt.Errorf("cache compatibility symlink already points to %q", existingTarget)

--- a/authd-oidc-brokers/internal/broker/broker.go
+++ b/authd-oidc-brokers/internal/broker/broker.go
@@ -275,7 +275,20 @@ func (b *Broker) ensureCompatibilitySymlink(linkPath, target string) error {
 		return fmt.Errorf("cache compatibility symlink already points to %q", existingTarget)
 	}
 
-	return nil
+	// The symlink resolves to the right target, but may be stored as an absolute
+	// path. Normalize it to a relative path so it survives a snap revision bump
+	// that moves the entire data directory prefix.
+	rawLink, err := os.Readlink(linkPath)
+	if err != nil {
+		return err
+	}
+	if rawLink == relTarget {
+		return nil
+	}
+	if rmErr := os.Remove(linkPath); rmErr != nil {
+		return fmt.Errorf("could not replace absolute cache compatibility symlink %q: %w", linkPath, rmErr)
+	}
+	return os.Symlink(relTarget, linkPath)
 }
 
 func consolidateKnownCacheFiles(sourceDir, targetDir string) error {

--- a/authd-oidc-brokers/internal/broker/broker_test.go
+++ b/authd-oidc-brokers/internal/broker/broker_test.go
@@ -280,6 +280,9 @@ func TestNewSessionWithProviderIDRepairsUsernameCompatibilityPath(t *testing.T) 
 	info, err := os.Lstat(usernameDir)
 	require.NoError(t, err, "The username compatibility path should exist")
 	require.NotZero(t, info.Mode()&os.ModeSymlink, "The username compatibility path should be a symlink")
+	rawLink, err := os.Readlink(usernameDir)
+	require.NoError(t, err, "os.Readlink on the compatibility symlink should not fail")
+	require.False(t, filepath.IsAbs(rawLink), "compatibility symlink should be stored as a relative path, got %q", rawLink)
 	target, err := filepath.EvalSymlinks(usernameDir)
 	require.NoError(t, err, "The username compatibility symlink should resolve")
 	require.Equal(t, providerIDDir, target, "The username compatibility symlink should target the provider ID cache dir")
@@ -2638,6 +2641,9 @@ func TestEnsureProviderIDCacheDir(t *testing.T) {
 				info, err := os.Lstat(usernameDir)
 				require.NoError(t, err, "The username path should exist")
 				require.NotZero(t, info.Mode()&os.ModeSymlink, "The username path should be a compatibility symlink")
+				rawLink, err := os.Readlink(usernameDir)
+				require.NoError(t, err, "os.Readlink on the compatibility symlink should not fail")
+				require.False(t, filepath.IsAbs(rawLink), "compatibility symlink should be stored as a relative path, got %q", rawLink)
 				target, err := filepath.EvalSymlinks(usernameDir)
 				require.NoError(t, err, "The compatibility symlink should resolve")
 				require.Equal(t, providerIDDir, target, "The compatibility symlink should point to the provider ID dir")
@@ -2654,6 +2660,50 @@ func TestEnsureProviderIDCacheDir(t *testing.T) {
 			}
 		})
 	}
+}
+
+// TestCompatibilitySymlinkSurvivesIssuerTreeMove verifies that the compatibility
+// symlink created by ensureCompatibilitySymlink is stored as a relative path and
+// therefore continues to resolve correctly after the entire issuer cache tree is
+// moved (e.g. during a snap revision bump that renames the data directory prefix).
+func TestCompatibilitySymlinkSurvivesIssuerTreeMove(t *testing.T) {
+	t.Parallel()
+
+	b := newBrokerForTests(t, &brokerForTestConfig{issuerURL: defaultIssuerURL})
+
+	const (
+		username   = "user@example.com"
+		providerID = "provider-id-123"
+	)
+
+	usernameDir, err := b.UserDataDir(username)
+	require.NoError(t, err, "Setup: deriving the username data dir should not fail")
+	providerIDDir, err := b.UserDataDir(providerID)
+	require.NoError(t, err, "Setup: deriving the provider ID data dir should not fail")
+
+	issuerDir := filepath.Dir(usernameDir)
+	require.NoError(t, os.MkdirAll(providerIDDir, 0700), "Setup: creating the provider ID dir")
+	require.NoError(t, os.WriteFile(filepath.Join(providerIDDir, "token.json"), []byte("cached-token"), 0600),
+		"Setup: writing the provider ID token file")
+
+	got := b.EnsureProviderIDCacheDir(username, usernameDir, providerID)
+	require.Equal(t, providerIDDir, got.UserDataDir, "Session should use the provider ID cache dir")
+
+	// The raw symlink value must be relative so it is not tied to the current path prefix.
+	rawLink, err := os.Readlink(usernameDir)
+	require.NoError(t, err, "os.Readlink on the compatibility symlink should not fail")
+	require.False(t, filepath.IsAbs(rawLink), "compatibility symlink should be stored as a relative path, got %q", rawLink)
+
+	// Simulate a snap revision bump by moving the entire issuer tree to a new prefix.
+	newIssuerDir := filepath.Join(t.TempDir(), "new-revision", filepath.Base(issuerDir))
+	require.NoError(t, os.MkdirAll(filepath.Dir(newIssuerDir), 0700), "Setup: creating parent of new issuer dir")
+	require.NoError(t, os.Rename(issuerDir, newIssuerDir), "Moving the issuer tree should not fail")
+
+	newUsernameDir := filepath.Join(newIssuerDir, username)
+	resolvedTarget, err := filepath.EvalSymlinks(newUsernameDir)
+	require.NoError(t, err, "compatibility symlink should still resolve after the issuer tree is moved")
+	require.Equal(t, filepath.Join(newIssuerDir, providerID), resolvedTarget,
+		"compatibility symlink should point to the provider ID dir in the new location")
 }
 
 func TestMain(m *testing.M) {


### PR DESCRIPTION
When a snap is updated the revision number embedded in the data-directory path changes (e.g. .../316/... → .../317/...).  The compatibility symlink created by the sub-ID migration was absolute, so after an update filepath.EvalSymlinks resolved it to the *old* revision path, which then failed the pathIsInside check and caused the symlink to be treated as dangling and removed.  With the symlink gone, an older authd that still resolves caches by username couldn't find the user's data directory and fell back to device-auth-only, breaking local-password login.

Fix ensureCompatibilitySymlink to compute a relative target with filepath.Rel.  Both the symlink and its target are siblings under the issuer cache directory, so the relative path is simply the base name of the target directory.  filepath.EvalSymlinks resolves relative symlinks relative to the directory that contains them, so the resolved path automatically tracks wherever the whole tree is moved.

Closes #1656 
UDENG-10887