### PR TITLE
e2e-tests: Automatically set up YARF

### DIFF
--- a/e2e-tests/run-tests.sh
+++ b/e2e-tests/run-tests.sh
@@ -178,8 +178,13 @@ fi
 mkdir -p "${TEST_RUNS_DIR}"
 ln -sf --no-target-directory "${OUTPUT_DIR}" "${TEST_RUNS_DIR}/${BROKER}-latest"
 
-# Activate YARF environment
+# Set up YARF environment if not already set up
 YARF_DIR="${ROOT_DIR}/.yarf"
+if ! [ -f "${YARF_DIR}/.venv/bin/activate" ]; then
+    "${ROOT_DIR}/setup-yarf.sh"
+fi
+
+# Activate YARF environment
 if [ ! -d "${YARF_DIR}" ]; then
     echo >&2  "YARF directory not found at ${YARF_DIR}. Please run setup_yarf.sh first."
     exit 1


### PR DESCRIPTION
It's an unnecessary that setup-yarf.sh needs to be run manually. Run it automatically when we detect in run-tests.sh that YARF is not set up yet.