### PR TITLE
broker: allow placeholder values in main config overridden by drop-ins

### DIFF
--- a/authd-oidc-brokers/internal/broker/config.go
+++ b/authd-oidc-brokers/internal/broker/config.go
@@ -263,8 +263,10 @@ func parseConfigFromPath(cfgPath string, p provider) (userConfig, error) {
 	return parseConfig(cfgFile, dropInFiles, p)
 }
 
-// validateConfigFile checks a parsed ini config for validity: template placeholders and parseable boolean fields.
-func validateConfigFile(path string, iniCfg *ini.File) error {
+// validatePlaceholders checks that no values in iniCfg still contain unedited
+// template placeholders (e.g. "<ISSUER_ID>"). path is used only for the error
+// message and should be the main config file path.
+func validatePlaceholders(path string, iniCfg *ini.File) error {
 	var placeholderErr error
 	for _, section := range iniCfg.Sections() {
 		for _, key := range section.Keys() {
@@ -277,7 +279,13 @@ func validateConfigFile(path string, iniCfg *ini.File) error {
 	if placeholderErr != nil {
 		return fmt.Errorf("config file %q has invalid values, did you edit the config file?\n%w", path, placeholderErr)
 	}
+	return nil
+}
 
+// validateConfigFile checks a parsed ini config for validity: parseable boolean
+// fields, and logs warnings for unknown sections/keys. It does not check for
+// template placeholders; call validatePlaceholders for that.
+func validateConfigFile(path string, iniCfg *ini.File) error {
 	// Log warnings for unknown sections and keys.
 	for _, section := range iniCfg.Sections() {
 		if section.Name() == ini.DefaultSection {
@@ -329,6 +337,9 @@ func parseConfig(cfg configFile, dropInCfgs []configFile, p provider) (userConfi
 		return userConfig{}, fmt.Errorf("error in config file %q: %w", cfg.path, err)
 	}
 
+	// Validate syntax of the main config, but defer the placeholder check until
+	// after all drop-ins are applied: drop-in files in broker.conf.d are allowed
+	// to override placeholder values from the main config.
 	if err := validateConfigFile(cfg.path, iniCfg); err != nil {
 		return userConfig{}, err
 	}
@@ -346,6 +357,11 @@ func parseConfig(cfg configFile, dropInCfgs []configFile, p provider) (userConfi
 		if err := iniCfg.Append(dropIn.content); err != nil {
 			return userConfig{}, fmt.Errorf("error in drop-in config file %q: %w", dropIn.path, err)
 		}
+	}
+
+	// Check that all placeholders from the main config were overridden by drop-ins.
+	if err := validatePlaceholders(cfg.path, iniCfg); err != nil {
+		return userConfig{}, err
 	}
 
 	oidc := iniCfg.Section(oidcSection)

--- a/authd-oidc-brokers/internal/broker/config_test.go
+++ b/authd-oidc-brokers/internal/broker/config_test.go
@@ -113,6 +113,12 @@ register_device = invalid
 
 	"invalid-ini": `=invalid`,
 
+	"override_template": `
+[oidc]
+issuer = https://issuer.url.com
+client_id = client_id
+`,
+
 	"overwrite_lower_precedence": `
 [oidc]
 issuer = https://lower-precedence-issuer.url.com
@@ -153,20 +159,25 @@ func TestParseConfig(t *testing.T) {
 			configType: "valid+flows_disabled",
 			dropInType: "flows",
 		},
+		"Successfully_parse_config_when_placeholders_are_overridden_by_drop_in": {
+			configType: "template",
+			dropInType: "override-template",
+		},
 
 		"Do_not_fail_if_values_contain_a_single_template_delimiter": {configType: "singles"},
 
-		"Error_if_all_flows_are_disabled":                        {configType: "valid+flows_disabled", wantErr: true},
-		"Error_if_file_does_not_exist":                           {configType: "inexistent", wantErr: true},
-		"Error_if_file_is_unreadable":                            {configType: "unreadable", wantErr: true},
-		"Error_if_file_is_not_updated":                           {configType: "template", wantErr: true},
-		"Error_if_main_config_has_invalid_syntax":                {configType: "invalid-ini", wantErr: true},
-		"Error_if_drop_in_directory_is_unreadable":               {dropInType: "unreadable-dir", wantErr: true},
-		"Error_if_drop_in_file_is_unreadable":                    {dropInType: "unreadable-file", wantErr: true},
-		"Error_if_config_contains_invalid_values":                {configType: "invalid_boolean_value", wantErr: true},
-		"Error_if_config_contains_invalid_register_device_value": {configType: "invalid_register_device_value", wantErr: true},
-		"Error_if_drop_in_file_is_invalid":                       {dropInType: "invalid-ini", wantErr: true, wantErrContainsDropInConfigPath: true},
-		"Error_if_drop_in_file_is_not_updated":                   {dropInType: "template", wantErr: true, wantErrContainsDropInConfigPath: true},
+		"Error_if_all_flows_are_disabled":                                                   {configType: "valid+flows_disabled", wantErr: true},
+		"Error_if_file_does_not_exist":                                                      {configType: "inexistent", wantErr: true},
+		"Error_if_file_is_unreadable":                                                       {configType: "unreadable", wantErr: true},
+		"Error_if_file_is_not_updated":                                                      {configType: "template", wantErr: true},
+		"Error_if_main_config_has_invalid_syntax":                                           {configType: "invalid-ini", wantErr: true},
+		"Error_if_drop_in_directory_is_unreadable":                                          {dropInType: "unreadable-dir", wantErr: true},
+		"Error_if_drop_in_file_is_unreadable":                                               {dropInType: "unreadable-file", wantErr: true},
+		"Error_if_config_contains_invalid_values":                                           {configType: "invalid_boolean_value", wantErr: true},
+		"Error_if_config_contains_invalid_register_device_value":                            {configType: "invalid_register_device_value", wantErr: true},
+		"Error_if_drop_in_file_is_invalid":                                                  {dropInType: "invalid-ini", wantErr: true, wantErrContainsDropInConfigPath: true},
+		"Error_if_drop_in_file_is_not_updated":                                              {dropInType: "template", wantErr: true},
+		"Successfully_parse_config_when_drop_in_placeholder_is_overridden_by_later_drop_in": {dropInType: "override-template-later"},
 	}
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
@@ -220,6 +231,15 @@ func TestParseConfig(t *testing.T) {
 				require.NoError(t, err, "Setup: Failed to write drop-in file")
 			case "template":
 				err = os.WriteFile(filepath.Join(dropInDir, "00-drop-in.conf"), []byte(configTypes["template"]), 0600)
+				require.NoError(t, err, "Setup: Failed to write drop-in file")
+			case "override-template":
+				err = os.WriteFile(filepath.Join(dropInDir, "00-drop-in.conf"), []byte(configTypes["override_template"]), 0600)
+				require.NoError(t, err, "Setup: Failed to write drop-in file")
+			case "override-template-later":
+				// 00-drop-in.conf has template placeholders; 01-drop-in.conf overrides them.
+				err = os.WriteFile(filepath.Join(dropInDir, "00-drop-in.conf"), []byte(configTypes["template"]), 0600)
+				require.NoError(t, err, "Setup: Failed to write drop-in file")
+				err = os.WriteFile(filepath.Join(dropInDir, "01-drop-in.conf"), []byte(configTypes["override_template"]), 0600)
 				require.NoError(t, err, "Setup: Failed to write drop-in file")
 			}
 

--- a/authd-oidc-brokers/internal/broker/testdata/golden/TestParseConfig/Successfully_parse_config_when_drop_in_placeholder_is_overridden_by_later_drop_in/config.txt
+++ b/authd-oidc-brokers/internal/broker/testdata/golden/TestParseConfig/Successfully_parse_config_when_drop_in_placeholder_is_overridden_by_later_drop_in/config.txt
@@ -1,0 +1,16 @@
+clientID=client_id
+clientSecret=
+issuerURL=https://issuer.url.com
+forceAccessCheckWithProvider=false
+registerDevice=false
+allowedUsers=map[]
+allUsersAllowed=false
+ownerAllowed=true
+firstUserBecomesOwner=true
+owner=
+homeBaseDir=
+allowedSSHSuffixes=[]
+extraGroups=[]
+ownerExtraGroups=[]
+extraScopes=[]
+flows={true true}

--- a/authd-oidc-brokers/internal/broker/testdata/golden/TestParseConfig/Successfully_parse_config_when_placeholders_are_overridden_by_drop_in/config.txt
+++ b/authd-oidc-brokers/internal/broker/testdata/golden/TestParseConfig/Successfully_parse_config_when_placeholders_are_overridden_by_drop_in/config.txt
@@ -1,0 +1,16 @@
+clientID=client_id
+clientSecret=
+issuerURL=https://issuer.url.com
+forceAccessCheckWithProvider=false
+registerDevice=false
+allowedUsers=map[]
+allUsersAllowed=false
+ownerAllowed=true
+firstUserBecomesOwner=true
+owner=
+homeBaseDir=
+allowedSSHSuffixes=[]
+extraGroups=[]
+ownerExtraGroups=[]
+extraScopes=[]
+flows={true true}


### PR DESCRIPTION
If broker.conf ships with template placeholders such as

    [oidc]
    issuer = <ISSUER_ID>
    client_id = <CLIENT_ID>

the broker should start successfully when a drop-in file in broker.conf.d supplies the real values. Since commit 6da52f67c ("Fix path to invalid config file") the placeholder check runs on the main config file before drop-in files are merged, so even a fully overriding drop-in cannot prevent the error.

Fix this by deferring the placeholder check until after all drop-in files have been applied to the merged ini config. Per-file syntax validation (boolean fields, unknown keys) is still done on each file individually.

Closes #1662
UDENG-10904