### PR TITLE
e2e: replace flaky OCR desktop readiness check with systemd/logind probes

### DIFF
--- a/e2e-tests/resources/SSH.py
+++ b/e2e-tests/resources/SSH.py
@@ -58,14 +58,17 @@ class SSH:
 
     @keyword
     async def execute_as_current_user(self, command: str, timeout: int|None = 30) -> str:
-        # Get the user that is currently logged in by checking which user the
-        # gnome-shell process runs as
-        stdout = await self.execute("ps -C gnome-shell -o user=")
-        users = stdout.strip().split("\n")
-        if len(users) == 0:
-            raise RuntimeError("No user is currently logged in")
-        elif len(users) > 1:
-            raise RuntimeError(f"Multiple users are logged in: {users}")
-        user = users[0].strip()
+        # Use systemd-logind to find the active graphical session on seat0.
+        # Class=user excludes GDM greeter sessions, so the command fails (and
+        # the caller retries) until the real user session becomes active.
+        result = await self.execute(
+            "session=$(loginctl show-seat seat0 -p ActiveSession --value) && "
+            "class=$(loginctl show-session \"$session\" -p Class --value) && "
+            "[ \"$class\" = 'user' ] && "
+            "loginctl show-session \"$session\" -p Name --value"
+        )
+        user = result.strip()
+        if not user:
+            raise RuntimeError("No active user session on seat0")
         logger.info(f"Running command as user '{user}'")
         return await self.execute_as_user(user, command, timeout)

--- a/e2e-tests/resources/utils.resource
+++ b/e2e-tests/resources/utils.resource
@@ -85,33 +85,23 @@ Wait Until GDM Login Screen Ready
 
 Wait Until Desktop Ready
     Wait Until Keyword Succeeds    1 min    1 sec
-    ...    Try Desktop Ready
+    ...    Check Desktop Session Ready
     # Before 26.04, GNOME Shell sometimes starts with the Activities overview
     # opened, see https://bugs.launchpad.net/ubuntu/+source/gnome-shell/+bug/2145704.
-    # That causes the next steps to fail, so we need to ensure the overview is
-    # closed before proceeding.
-    ${matches}=    Find Text    Type to search
-    IF    ${matches}
-        Log    Activities Overview is open, closing it
-        Close Activities Overview
-    END
+    # That causes the next steps to fail, so we always dismiss it before
+    # proceeding. Escape is a no-op when the overview is already closed.
+    Close Activities Overview
 
 Close Activities Overview
-    WHILE    True
-        Hid.Keys Combo    Escape
-        BuiltIn.Sleep    1
-        ${matches}=    Find Text    Type to search
-        IF    not ${matches}
-            BREAK
-        END
-    END
+    Hid.Keys Combo    Escape
+    BuiltIn.Sleep    0.5
+    Hid.Keys Combo    Escape
 
 
-Try Desktop Ready
-    Hid.Move Pointer To Proportional    1    1
-    BuiltIn.Sleep    1
-    Hid.Move Pointer To Proportional    0    1
-    Match Text    Show Apps    2
+Check Desktop Session Ready
+    SSH.Execute As Current User
+    ...    systemctl --user is-active graphical-session.target
+    ...    timeout=5
 
 
 Open Terminal


### PR DESCRIPTION
Closes #1629 


Edit 1: It is no longer all red for resolute/devel, on this run: https://github.com/canonical/authd/actions/runs/28616921763/job/84862946343?pr=1664, but I'll force push a refinement and wait for the results

Edit 2: The [latest run ](https://github.com/canonical/authd/actions/runs/28621590656/job/84878333298?pr=1664) seems to be passing fine as well, the failed tests are flaky ones, might retry a few of them

For a comparison between the two approaches experimented with (run 1, and run 2), refer to [this diff](https://github.com/canonical/authd/compare/bd5848380ece3649f6b13a0a1b901449ac232a08..248f19fc6d465975b40aac1104ac0944b0e2bb6f)