### PR TITLE
ci: exclude conf/ changes from brokers QA trigger

### DIFF
--- a/.github/workflows/brokers-qa.yaml
+++ b/.github/workflows/brokers-qa.yaml
@@ -8,6 +8,7 @@ on:
     paths:
       - ".github/workflows/brokers-qa.yaml"
       - "authd-oidc-brokers/**"
+      - "!authd-oidc-brokers/conf/**"
       - "!authd-oidc-brokers/e2e-tests/**"
       - "!authd-oidc-brokers/po/**"
       - "!authd-oidc-brokers/.gitignore"
@@ -16,6 +17,7 @@ on:
     paths:
       - ".github/workflows/brokers-qa.yaml"
       - "authd-oidc-brokers/**"
+      - "!authd-oidc-brokers/conf/**"
       - "!authd-oidc-brokers/e2e-tests/**"
       - "!authd-oidc-brokers/po/**"
       - "!authd-oidc-brokers/.gitignore"


### PR DESCRIPTION
Changes to `authd-oidc-brokers/conf/` (broker configuration files) are documentation/configuration-only and should not trigger the full broker CI suite.