### PR TITLE
pam: reject broker mismatch early in SelectBroker

### DIFF
--- a/internal/services/pam/pam.go
+++ b/internal/services/pam/pam.go
@@ -156,13 +156,22 @@ func (s Service) SelectBroker(ctx context.Context, req *authd.SBRequest) (resp *
 		return nil, status.Error(codes.InvalidArgument, "invalid session mode")
 	}
 
-	// Look up the user's stable provider identifier from the database.
-	// If the user doesn't exist yet (first login), the lookup fails silently
-	// and an empty identifier is passed to the broker.
-	userProviderID, err := s.userManager.ProviderIDForUser(username, brokerID)
+	// Look up the user's stored broker and stable provider identifier. If the
+	// user is already bound to a different broker, reject early before opening
+	// a session that would inevitably fail after authentication completes.
+	storedBrokerID, userProviderID, err := s.userManager.BrokerAndProviderIDForUser(username)
 	if err != nil && !errors.Is(err, users.NoDataFoundError{}) {
-		log.Errorf(ctx, "SelectBroker: Could not look up provider ID for user %q and broker %q: %v", username, brokerID, err)
-		return nil, fmt.Errorf("could not look up provider ID for user %q: %w", username, err)
+		log.Errorf(ctx, "SelectBroker: Could not look up broker and provider ID for user %q: %v", username, err)
+		return nil, fmt.Errorf("could not look up broker for user %q: %w", username, err)
+	}
+	if storedBrokerID != "" && storedBrokerID != brokerID {
+		log.Errorf(ctx, "SelectBroker: User %q is bound to broker %q and cannot authenticate with broker %q", username, storedBrokerID, brokerID)
+		return nil, status.Errorf(codes.PermissionDenied, "user %q is already bound to broker %q and cannot authenticate with broker %q", username, storedBrokerID, brokerID)
+	}
+	// If the requested broker doesn't match the stored one, the provider ID
+	// from the stored broker is not applicable.
+	if storedBrokerID != brokerID {
+		userProviderID = ""
 	}
 
 	// Create a session and Memorize selected broker for it.

--- a/internal/services/pam/pam_test.go
+++ b/internal/services/pam/pam_test.go
@@ -203,14 +203,16 @@ func TestSelectBroker(t *testing.T) {
 		"Successfully_select_a_broker_and_creates_auth_session":   {username: "success@example.com", sessionMode: auth.SessionModeLogin},
 		"Successfully_select_a_broker_and_creates_passwd_session": {username: "success@example.com", sessionMode: auth.SessionModeChangePassword},
 
-		"Error_when_not_root":                             {username: "success@example.com", currentUserNotRoot: true, wantErr: true},
-		"Error_when_username_is_empty":                    {wantErr: true},
-		"Error_when_mode_is_empty":                        {sessionMode: "-", wantErr: true},
-		"Error_when_mode_does_not_exist":                  {sessionMode: "does not exist", wantErr: true},
-		"Error_when_brokerID_is_empty":                    {username: "empty broker@example.com", brokerID: "-", wantErr: true},
-		"Error_when_broker_does_not_exist":                {username: "no broker@example.com", brokerID: "does not exist", wantErr: true},
-		"Error_when_broker_does_not_provide_a_session_ID": {username: "ns_no_id@example.com", wantErr: true},
-		"Error_when_starting_the_session":                 {username: "ns_error@example.com", wantErr: true},
+		"Error_when_not_root":                                        {username: "success@example.com", currentUserNotRoot: true, wantErr: true},
+		"Error_when_username_is_empty":                               {wantErr: true},
+		"Error_when_mode_is_empty":                                   {sessionMode: "-", wantErr: true},
+		"Error_when_mode_does_not_exist":                             {sessionMode: "does not exist", wantErr: true},
+		"Error_when_brokerID_is_empty":                               {username: "empty broker@example.com", brokerID: "-", wantErr: true},
+		"Error_when_broker_does_not_exist":                           {username: "no broker@example.com", brokerID: "does not exist", wantErr: true},
+		"Error_when_broker_does_not_provide_a_session_ID":            {username: "ns_no_id@example.com", wantErr: true},
+		"Error_when_starting_the_session":                            {username: "ns_error@example.com", wantErr: true},
+		"Error_when_user_is_bound_to_a_different_broker":             {username: "bound@example.com", existingDB: "bound-to-other-broker.db", wantErr: true},
+		"Error_when_user_is_bound_to_non-local_broker_selects_local": {username: "bound@example.com", brokerID: brokers.LocalBrokerName, existingDB: "bound-to-other-broker.db", wantErr: true},
 	}
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {

--- a/internal/services/pam/testdata/TestSelectBroker/bound-to-other-broker.db
+++ b/internal/services/pam/testdata/TestSelectBroker/bound-to-other-broker.db
@@ -1,0 +1,29 @@
+users:
+    - name: testselectbroker/error_when_user_is_bound_to_a_different_broker_separator_bound@example.com
+      uid: 1111
+      gid: 11111
+      gecos: bound user
+      dir: /home/bound@example.com
+      shell: /bin/bash
+      broker_id: some-other-broker-id
+      provider_id: some-provider-id
+    - name: testselectbroker/error_when_user_is_bound_to_non-local_broker_selects_local_separator_bound@example.com
+      uid: 2222
+      gid: 22222
+      gecos: bound user
+      dir: /home/bound@example.com
+      shell: /bin/bash
+      broker_id: some-other-broker-id
+      provider_id: some-provider-id-2
+groups:
+    - name: testselectbroker/error_when_user_is_bound_to_a_different_broker_separator_bound@example.com
+      gid: 11111
+      ugid: testselectbroker/error_when_user_is_bound_to_a_different_broker_separator_bound@example.com
+    - name: testselectbroker/error_when_user_is_bound_to_non-local_broker_selects_local_separator_bound@example.com
+      gid: 22222
+      ugid: testselectbroker/error_when_user_is_bound_to_non-local_broker_selects_local_separator_bound@example.com
+users_to_groups:
+    - uid: 1111
+      gid: 11111
+    - uid: 2222
+      gid: 22222

--- a/internal/users/manager.go
+++ b/internal/users/manager.go
@@ -872,20 +872,6 @@ func (m *Manager) BrokerForUser(username string) (string, error) {
 	return u.BrokerID, nil
 }
 
-// ProviderIDForUser returns the stable provider identifier for the given user and broker.
-// Returns an empty string if the user has no matching identifier recorded (pre-migration, v2 broker, or another broker).
-func (m *Manager) ProviderIDForUser(username, brokerID string) (string, error) {
-	u, err := m.db.UserByName(username)
-	if err != nil {
-		return "", err
-	}
-	if brokerID != "" && u.BrokerID != "" && u.BrokerID != brokerID {
-		return "", nil
-	}
-
-	return u.ProviderID, nil
-}
-
 // BrokerAndProviderIDForUser returns the broker ID and the stable provider identifier recorded
 // for the user in a single database lookup. Both values are empty if not recorded (pre-migration
 // user, v2 broker, or local user).


### PR DESCRIPTION
A user bound to a broker could start a full authentication session with a different broker and only get rejected after completing it, when `UpdateUser` detected the conflict and returned:

    user "x" is already bound to broker "A" and cannot authenticate with broker "B"

The broker ID and provider ID are now looked up together via `BrokerAndProviderIDForUser` before the session is created. If the stored broker ID is non-empty and doesn't match the requested one, `SelectBroker` returns `PermissionDenied` immediately, sparing the user from an auth flow that was guaranteed to fail.

Fixes: https://github.com/canonical/authd/issues/1668