### PR TITLE
e2e-tests: increase Show Apps match timeout in Try Desktop Ready

### DIFF
--- a/e2e-tests/resources/utils.resource
+++ b/e2e-tests/resources/utils.resource
@@ -111,7 +111,7 @@ Try Desktop Ready
     Hid.Move Pointer To Proportional    1    1
     BuiltIn.Sleep    1
     Hid.Move Pointer To Proportional    0    1
-    Match Text    Show Apps    2
+    Match Text    Show Apps    5
 
 
 Open Terminal


### PR DESCRIPTION
The dock animation after moving the pointer to the bottom-left corner can take longer than 2 seconds to settle, causing Match Text to capture screenshots before the launcher is visible even though it appears on the VM recording. Extending the timeout to 5 seconds gives the animation enough time to complete.

Closes #1629
UDENG-10891
