### PR TITLE
e2e-tests: Fix migration tests by disabling Entra password flow

### DIFF
--- a/e2e-tests/resources/broker.resource
+++ b/e2e-tests/resources/broker.resource
@@ -18,7 +18,7 @@ Variables           ./broker_vars.py
 
 *** Keywords ***
 Enable Edge Broker
-    SSH.Execute    sudo snap refresh ${BROKER_SNAP_NAME} --edge
+    SSH.Execute    snap refresh ${BROKER_SNAP_NAME} --edge
 
 
 Disable Entra Password Via Drop In
@@ -36,9 +36,9 @@ Disable Entra Password Via Drop In
 
 
 Disable Broker And Purge Config
-    SSH.Execute    sudo snap stop ${BROKER_SNAP_NAME}
-    SSH.Execute    sudo rm ${AUTHD_BROKER_CFG}
-    SSH.Execute    sudo systemctl restart authd.service
+    SSH.Execute    snap stop ${BROKER_SNAP_NAME}
+    SSH.Execute    rm ${AUTHD_BROKER_CFG}
+    SSH.Execute    systemctl restart authd.service
 
 
 Log In With Remote User Through CLI: QR Code
@@ -213,16 +213,16 @@ Remove Registered Owner
     [Documentation]    Removes the auto-registration drop-in that the broker creates when
     ...               the first user logs in, so that subsequent OWNER-based tests start
     ...               from a known-clean state.
-    SSH.Execute    sudo rm -f ${BROKER_CFG_DIR}/20-owner-autoregistration.conf
-    SSH.Execute    sudo snap restart ${BROKER_SNAP_NAME}
+    SSH.Execute    rm -f ${BROKER_CFG_DIR}/20-owner-autoregistration.conf
+    SSH.Execute    snap restart ${BROKER_SNAP_NAME}
 
 
 Block Network Access To Identity Provider
     [Documentation]    Blocks outbound HTTPS traffic (IPv4 and IPv6) to simulate the identity
     ...               provider being unreachable. The iptables rules are automatically reverted
     ...               when the VM snapshot is restored at the start of the next test.
-    SSH.Execute    sudo iptables -I OUTPUT -p tcp --dport 443 -j REJECT
-    SSH.Execute    sudo ip6tables -I OUTPUT -p tcp --dport 443 -j REJECT
+    SSH.Execute    iptables -I OUTPUT -p tcp --dport 443 -j REJECT
+    SSH.Execute    ip6tables -I OUTPUT -p tcp --dport 443 -j REJECT
 
 
 # Uses sed to change the broker configuration.
@@ -231,22 +231,22 @@ Block Network Access To Identity Provider
 #     sed -i 's/#*${config_key} = .*/${config_key} = ${config_value}/g' ${BROKER_CFG}
 Change Broker Configuration
     [Arguments]    ${config_key}    ${config_value}
-    SSH.Execute    sudo sed -i 's|^#*${config_key} =.*|${config_key} = ${config_value}|g' ${BROKER_CFG}
-    SSH.Execute    sudo snap restart ${BROKER_SNAP_NAME}
+    SSH.Execute    sed -i 's|^#*${config_key} =.*|${config_key} = ${config_value}|g' ${BROKER_CFG}
+    SSH.Execute    snap restart ${BROKER_SNAP_NAME}
 
 
 # Pretty much the same as the function above, but since YARF does not have support for
 # shifted characters yet, we need to do some workarounds.
 Change allowed_users In Broker Configuration
     [Arguments]    ${config_value}
-    SSH.Execute    sudo sed -i 's/^#*allowed_users =.*/allowed_users = ${config_value}/g' ${BROKER_CFG}
-    SSH.Execute    sudo snap restart ${BROKER_SNAP_NAME}
+    SSH.Execute    sed -i 's/^#*allowed_users =.*/allowed_users = ${config_value}/g' ${BROKER_CFG}
+    SSH.Execute    snap restart ${BROKER_SNAP_NAME}
 
 
 Comment Key In Broker Configuration
     [Arguments]    ${config_key}
-    SSH.Execute    sudo sed -i 's/^#*${config_key} =.*/#${config_key} = .*/g' ${BROKER_CFG}
-    SSH.Execute    sudo snap restart ${BROKER_SNAP_NAME}
+    SSH.Execute    sed -i 's/^#*${config_key} =.*/#${config_key} = .*/g' ${BROKER_CFG}
+    SSH.Execute    snap restart ${BROKER_SNAP_NAME}
 
 
 Log In With Remote User Through SSH: QR Code
@@ -369,13 +369,13 @@ Check User Information
 
 Check Configuration Value
     [Arguments]    ${config_key}    ${expected_value}
-    ${content} =    SSH.Execute    sudo grep ${config_key} ${BROKER_CFG}
+    ${content} =    SSH.Execute    grep ${config_key} ${BROKER_CFG}
     Should Contain    ${content}    ${expected_value}
 
 
 Check If Owner Was Registered
     [Arguments]    ${username}
-    ${content} =    SSH.Execute    sudo cat ${BROKER_CFG_DIR}/20-owner-autoregistration.conf
+    ${content} =    SSH.Execute    cat ${BROKER_CFG_DIR}/20-owner-autoregistration.conf
     Should Contain    ${content}    owner = ${username}
 
 
@@ -383,7 +383,7 @@ Check Home Directory
     [Arguments]    ${username}    ${base_dir}=/home
     ${home_dir} =    SSH.Execute    getent passwd ${username} | cut -d: -f6
     Should Start With    ${home_dir}    ${base_dir}/
-    ${ownership} =    SSH.Execute    sudo stat -c %U:%G ${home_dir}
+    ${ownership} =    SSH.Execute    stat -c %U:%G ${home_dir}
     Should Be Equal    ${ownership}    ${username}:${username}
 
 

--- a/e2e-tests/resources/broker.resource
+++ b/e2e-tests/resources/broker.resource
@@ -21,6 +21,20 @@ Enable Edge Broker
     SSH.Execute    sudo snap refresh ${BROKER_SNAP_NAME} --edge
 
 
+Disable Entra Password Via Drop In
+    [Documentation]    Writes a drop-in that sets entra_password = false.
+    ...
+    ...                More robust than Change Broker Configuration for this key,
+    ...                because stable snapshots provisioned before the [flows]
+    ...                section was added may not contain an entra_password line
+    ...                at all, causing a silent sed no-op.
+    # TODO(stable-release): Can be removed once the stable broker has been
+    #                       updated to include the [flows] section.
+    SSH.Execute    mkdir -p ${BROKER_CFG_DIR}
+    SSH.Execute    printf '[flows]\nentra_password = false\n' > ${BROKER_CFG_DIR}/99-disable-entra-password.conf
+    SSH.Execute    snap restart ${BROKER_SNAP_NAME}
+
+
 Disable Broker And Purge Config
     SSH.Execute    sudo snap stop ${BROKER_SNAP_NAME}
     SSH.Execute    sudo rm ${AUTHD_BROKER_CFG}

--- a/e2e-tests/tests/authctl_group_set_gid.robot
+++ b/e2e-tests/tests/authctl_group_set_gid.robot
@@ -38,7 +38,7 @@ Test authctl group set-gid
     Should Not Be Empty    ${home_dir}
     SSH.Execute As User    ${username}    touch ${home_dir}/test-file
 
-    ${output} =    SSH.Execute    sudo authctl group set-gid ${group_name} ${new_gid} 2>&1
+    ${output} =    SSH.Execute    authctl group set-gid ${group_name} ${new_gid} 2>&1
     Should Contain    ${output}    GID of group '${group_name}' set to ${new_gid}.
 
     ${actual_gid} =    SSH.Execute    getent group ${group_name} | cut -d: -f3
@@ -52,7 +52,7 @@ Test authctl group set-gid
 
     ${home_gid} =    SSH.Execute    stat -c %g ${home_dir}
     Should Be Equal As Strings    ${home_gid}    ${new_gid}
-    ${file_gid} =    SSH.Execute    sudo stat -c %g ${home_dir}/test-file
+    ${file_gid} =    SSH.Execute    stat -c %g ${home_dir}/test-file
     Should Be Equal As Strings    ${file_gid}    ${new_gid}
 
     # This test case tests a bug that was fixed in https://github.com/canonical/authd/pull/1422/

--- a/e2e-tests/tests/authctl_group_set_gid.robot
+++ b/e2e-tests/tests/authctl_group_set_gid.robot
@@ -36,7 +36,7 @@ Test authctl group set-gid
 
     ${home_dir} =    SSH.Execute    getent passwd ${username} | cut -d: -f6
     Should Not Be Empty    ${home_dir}
-    SSH.Execute    sudo -u ${username} touch ${home_dir}/test-file
+    SSH.Execute As User    ${username}    touch ${home_dir}/test-file
 
     ${output} =    SSH.Execute    sudo authctl group set-gid ${group_name} ${new_gid} 2>&1
     Should Contain    ${output}    GID of group '${group_name}' set to ${new_gid}.

--- a/e2e-tests/tests/authctl_user_set_uid.robot
+++ b/e2e-tests/tests/authctl_user_set_uid.robot
@@ -36,10 +36,10 @@ Test authctl user set-uid
     # rejects set-uid when any process runs under that UID) does not block the
     # operation.  Use loginctl to tear down the session gracefully, then poll
     # until all processes have exited rather than relying on a hard sleep.
-    SSH.Execute    sudo loginctl terminate-user ${username} || true
+    SSH.Execute    loginctl terminate-user ${username} || true
     Wait Until Keyword Succeeds    30s    1s    SSH.Execute    test -z "$(pgrep -u ${username})"
 
-    ${output} =    SSH.Execute    sudo authctl user set-uid ${username} ${new_uid} 2>&1
+    ${output} =    SSH.Execute    authctl user set-uid ${username} ${new_uid} 2>&1
     Should Contain    ${output}    UID of user '${username}' set to ${new_uid}.
 
     ${actual_uid} =    SSH.Execute    getent passwd ${username} | cut -d: -f3
@@ -53,7 +53,7 @@ Test authctl user set-uid
 
     ${home_uid} =    SSH.Execute    stat -c %u ${home_dir}
     Should Be Equal As Strings    ${home_uid}    ${new_uid}
-    ${file_uid} =    SSH.Execute    sudo stat -c %u ${home_dir}/test-file
+    ${file_uid} =    SSH.Execute    stat -c %u ${home_dir}/test-file
     Should Be Equal As Strings    ${file_uid}    ${new_uid}
 
     Open Terminal

--- a/e2e-tests/tests/authctl_user_set_uid.robot
+++ b/e2e-tests/tests/authctl_user_set_uid.robot
@@ -30,7 +30,7 @@ Test authctl user set-uid
 
     ${home_dir} =    SSH.Execute    getent passwd ${username} | cut -d: -f6
     Should Not Be Empty    ${home_dir}
-    SSH.Execute    sudo -u ${username} touch ${home_dir}/test-file
+    SSH.Execute As User    ${username}    touch ${home_dir}/test-file
 
     # Terminate the remote user's session so that proc.CheckUserBusy (which
     # rejects set-uid when any process runs under that UID) does not block the

--- a/e2e-tests/tests/config_home_base_dir.robot
+++ b/e2e-tests/tests/config_home_base_dir.robot
@@ -18,7 +18,7 @@ ${second_home_base_dir}    /srv/authd-second-homes
 Test login keeps existing home directory after changing home base dir
     [Documentation]    Verify that a first login uses the configured home_base_dir and that changing the value later does not move an existing user home directory.
 
-    SSH.Execute    sudo mkdir -p ${first_home_base_dir} ${second_home_base_dir}
+    SSH.Execute    mkdir -p ${first_home_base_dir} ${second_home_base_dir}
     Change Broker Configuration    home_base_dir    ${first_home_base_dir}
 
     # Log in with local user.

--- a/e2e-tests/tests/migration_authd_broker.robot
+++ b/e2e-tests/tests/migration_authd_broker.robot
@@ -36,6 +36,11 @@ Test login after upgrading authd and broker to edge channel
     Log Out From Terminal Session
     Close Terminal In Sudo Mode
 
+    # Disable entra_password before upgrading: the edge broker refuses to start
+    # if this flow is enabled without register_device or a client_secret, which
+    # are both not configured.
+    Disable Entra Password Via Drop In
+
     # Switch to the edge channel for the broker snap and the edge PPA for authd
     Enable Edge Repository For Authd
     Enable Edge Broker

--- a/e2e-tests/tests/migration_broker.robot
+++ b/e2e-tests/tests/migration_broker.robot
@@ -36,6 +36,11 @@ Test login with broker on edge channel
     Log Out From Terminal Session
     Close Terminal In Sudo Mode
 
+    # Disable entra_password before upgrading: the edge broker refuses to start
+    # if this flow is enabled without register_device or a client_secret, which
+    # are both not configured.
+    Disable Entra Password Via Drop In
+
     # Switch to edge channel for the broker snap
     Enable Edge Broker
 


### PR DESCRIPTION
The edge broker now validates at startup that if the entra_password flow is enabled, either register_device or a client_secret must be configured. The stable broker release's broker.conf does not contain an entra_password line, so the edge broker starts with entra_password=true by default, and then refuses to start after `snap refresh --edge`.

The migration tests don't use entra_password at all; they only test device-code and local-password logins. Disable entra_password before enabling the edge broker so the upgrade succeeds again.

Closes #1676 
UDENG-10961