### PR TITLE
Automatically set parent of gh-jira-synced tasks

### DIFF
--- a/.github/.jira_sync_config.yaml
+++ b/.github/.jira_sync_config.yaml
@@ -7,3 +7,4 @@ settings:
   status_mapping:
     opened: Untriaged
     closed: Done
+  epic_key: UDENG-9739


### PR DESCRIPTION
Tasks synced from GitHub issues are usually maintenance tasks, so add them to the "Maintenance - Enterprise" epic by default.

UDENG-10962