### PR TITLE
broker/msentraid: handle additional Entra token-expiry error codes

### DIFF
--- a/authd-oidc-brokers/internal/providers/msentraid/msentraid.go
+++ b/authd-oidc-brokers/internal/providers/msentraid/msentraid.go
@@ -979,7 +979,10 @@ func (p *Provider) IsTokenExpiredError(err *oauth2.RetrieveError) bool {
 	}
 
 	expiredPrefixes := []string{
+		"AADSTS50078:",  // MFA session expired due to sign-in frequency (Conditional Access)
+		"AADSTS50089:",  // refresh token expired or revoked by user or admin
 		"AADSTS50173:",  // grant revoked (password change/reset)
+		"AADSTS70008:",  // refresh token expired due to inactivity (legacy code for AADSTS700082)
 		"AADSTS70043:",  // refresh token expired due to sign-in frequency (Conditional Access)
 		"AADSTS700082:", // refresh token expired due to inactivity
 	}

--- a/authd-oidc-brokers/internal/providers/msentraid/msentraid_test.go
+++ b/authd-oidc-brokers/internal/providers/msentraid/msentraid_test.go
@@ -631,7 +631,10 @@ func TestIsTokenExpiredError(t *testing.T) {
 
 		wantExpired bool
 	}{
+		"AADSTS50078_mfa_session_expired":              {errorCode: "invalid_grant", errorDescription: "AADSTS50078: Presented multi-factor authentication has expired due to policies configured by your administrator.", wantExpired: true},
+		"AADSTS50089_flow_token_expired":               {errorCode: "invalid_grant", errorDescription: "AADSTS50089: Flow token has expired. User needs to reauthenticate.", wantExpired: true},
 		"AADSTS50173_token_expired":                    {errorCode: "invalid_grant", errorDescription: "AADSTS50173: The provided grant has expired", wantExpired: true},
+		"AADSTS70008_token_expired_due_to_inactivity":  {errorCode: "invalid_grant", errorDescription: "AADSTS70008: The refresh token has expired due to inactivity.", wantExpired: true},
 		"AADSTS70043_token_expired":                    {errorCode: "invalid_grant", errorDescription: "AADSTS70043: The refresh token has expired or is invalid", wantExpired: true},
 		"AADSTS700082_token_expired_due_to_inactivity": {errorCode: "invalid_grant", errorDescription: "AADSTS700082: The refresh token has expired due to inactivity.", wantExpired: true},
 


### PR DESCRIPTION
Added additional token expiry codes, here is the reference: https://learn.microsoft.com/en-us/entra/identity-platform/reference-error-codes

Closes #1680

