### PR TITLE
Make the Entra Password e2e-tests more robust

### DIFF
--- a/e2e-tests/resources/broker.resource
+++ b/e2e-tests/resources/broker.resource
@@ -445,12 +445,12 @@ Log In With Remote User Through CLI: Entra Password
 
     # With the device code flow disabled there is only one flow; the PAM module
     # auto-selects it and goes directly to the Entra ID password prompt.
-    Match Text    Enter your Entra ID password    30
+    Match Text    Enter your Entra ID password:    30    similarity=90
     Hid.Type String    %{E2E_PASSWORD}
     Hid.Keys Combo    Return
 
     # Wait for the MFA code prompt and enter a fresh TOTP code.
-    Match Text    Enter your MFA code    120
+    Match Text    Enter your MFA code:    120    similarity=88
     ${totp_code} =    TOTP.Generate Totp Code
     Hid.Type String    ${totp_code}
     Hid.Keys Combo    Return


### PR DESCRIPTION
We've seen it fail with:

    Rejected match for text 'Enter your Entra ID password' with similarity 90.56603773584906 and confidence 98.041: 'EnteryourEntraIDpassword:'

Setting the similarity to 90 should fix it.

UDENG-10970