### PR TITLE
broker: fail on unknown config sections and keys

### DIFF
--- a/authd-oidc-brokers/cmd/authd-oidc/daemon/export_test.go
+++ b/authd-oidc-brokers/cmd/authd-oidc/daemon/export_test.go
@@ -70,14 +70,8 @@ func GenerateBrokerConfig(t *testing.T, p, providerURL string) {
 	require.NoError(t, err, "Setup: could not create parent broker configuration directory for tests")
 
 	brokerCfg := fmt.Sprintf(`
-[authd]
-name = %[1]s
-brand_icon = broker_icon.png
-dbus_name = com.ubuntu.authd.%[1]s
-dbus_object = /com/ubuntu/authd/%[1]s
-
 [oidc]
-issuer = %[2]s
+issuer = %s
 client_id = client_id
 
 [flows]
@@ -85,7 +79,7 @@ client_id = client_id
 # (enabled) would fail startup validation under the withmsentraid tag
 # because no client_secret or register_device is configured here.
 entra_password = false
-`, strings.ReplaceAll(t.Name(), "/", "_"), providerURL)
+`, providerURL)
 	err = os.WriteFile(p, []byte(brokerCfg), 0600)
 	require.NoError(t, err, "Setup: could not create broker configuration for tests")
 }

--- a/authd-oidc-brokers/internal/broker/config.go
+++ b/authd-oidc-brokers/internal/broker/config.go
@@ -283,23 +283,22 @@ func validatePlaceholders(path string, iniCfg *ini.File) error {
 }
 
 // validateConfigFile checks a parsed ini config for validity: parseable boolean
-// fields, and logs warnings for unknown sections/keys. It does not check for
+// fields, and returns errors for unknown sections/keys. It does not check for
 // template placeholders; call validatePlaceholders for that.
 func validateConfigFile(path string, iniCfg *ini.File) error {
-	// Log warnings for unknown sections and keys.
+	// Return errors for unknown sections and keys.
 	for _, section := range iniCfg.Sections() {
 		if section.Name() == ini.DefaultSection {
 			continue
 		}
 		sectionKeys, ok := knownConfigKeys[section.Name()]
 		if !ok {
-			log.Warningf(context.Background(), "unknown section %q in config file, ignoring", section.Name())
-			continue
+			return fmt.Errorf("unknown section %q in config file %q", section.Name(), path)
 		}
 
 		for _, key := range section.Keys() {
 			if _, ok := sectionKeys[key.Name()]; !ok {
-				log.Warningf(context.Background(), "unknown key %q in section %q in config file, ignoring", key.Name(), section.Name())
+				return fmt.Errorf("unknown key %q in section %q in config file %q", key.Name(), section.Name(), path)
 			}
 		}
 	}

--- a/authd-oidc-brokers/internal/broker/config.go
+++ b/authd-oidc-brokers/internal/broker/config.go
@@ -289,6 +289,9 @@ func validateConfigFile(path string, iniCfg *ini.File) error {
 	// Return errors for unknown sections and keys.
 	for _, section := range iniCfg.Sections() {
 		if section.Name() == ini.DefaultSection {
+			if len(section.Keys()) > 0 {
+				return fmt.Errorf("keys outside of any section in config file %q", path)
+			}
 			continue
 		}
 		sectionKeys, ok := knownConfigKeys[section.Name()]

--- a/authd-oidc-brokers/internal/broker/config_test.go
+++ b/authd-oidc-brokers/internal/broker/config_test.go
@@ -576,6 +576,16 @@ unknown_key = some_value
 `,
 			wantErr: `unknown key "unknown_key" in section "users" in config file`,
 		},
+		"Error_for_key_outside_any_section": {
+			config: `
+owner = someuser
+
+[oidc]
+issuer = https://issuer.url.com
+client_id = client_id
+`,
+			wantErr: `keys outside of any section in config file`,
+		},
 	}
 
 	for name, tc := range tests {

--- a/authd-oidc-brokers/internal/broker/config_test.go
+++ b/authd-oidc-brokers/internal/broker/config_test.go
@@ -1,7 +1,6 @@
 package broker
 
 import (
-	"context"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -13,7 +12,6 @@ import (
 
 	"github.com/canonical/authd/authd-oidc-brokers/internal/testutils"
 	"github.com/canonical/authd/internal/testutils/golden"
-	"github.com/canonical/authd/log"
 	"github.com/stretchr/testify/require"
 )
 
@@ -526,20 +524,20 @@ func TestRegisterOwnerRejectsInvalidChars(t *testing.T) {
 }
 
 func TestParseConfigUnknownSettings(t *testing.T) {
-	// This test is NOT parallel because it modifies the global log handler.
+	t.Parallel()
 	p := &testutils.MockProvider{}
 
 	tests := map[string]struct {
-		config      string
-		wantWarning string
+		config  string
+		wantErr string
 	}{
-		"No_warning_for_valid_config": {
+		"No_error_for_valid_config": {
 			config: configTypes["valid"],
 		},
-		"No_warning_for_valid_config_with_optional_values": {
+		"No_error_for_valid_config_with_optional_values": {
 			config: configTypes["valid+optional"],
 		},
-		"No_warning_for_valid_config_with_old_force_provider_authentication_key": {
+		"No_error_for_valid_config_with_old_force_provider_authentication_key": {
 			config: `
 [oidc]
 issuer = https://issuer.url.com
@@ -547,7 +545,7 @@ client_id = client_id
 force_provider_authentication = true
 `,
 		},
-		"Warn_about_unknown_section": {
+		"Error_for_unknown_section": {
 			config: `
 [oidc]
 issuer = https://issuer.url.com
@@ -556,18 +554,18 @@ client_id = client_id
 [unknown_section]
 some_key = some_value
 `,
-			wantWarning: `unknown section "unknown_section" in config file, ignoring`,
+			wantErr: `unknown section "unknown_section" in config file`,
 		},
-		"Warn_about_unknown_key_in_oidc_section": {
+		"Error_for_unknown_key_in_oidc_section": {
 			config: `
 [oidc]
 issuer = https://issuer.url.com
 client_id = client_id
 unknown_key = some_value
 `,
-			wantWarning: `unknown key "unknown_key" in section "oidc" in config file, ignoring`,
+			wantErr: `unknown key "unknown_key" in section "oidc" in config file`,
 		},
-		"Warn_about_unknown_key_in_users_section": {
+		"Error_for_unknown_key_in_users_section": {
 			config: `
 [oidc]
 issuer = https://issuer.url.com
@@ -576,38 +574,30 @@ client_id = client_id
 [users]
 unknown_key = some_value
 `,
-			wantWarning: `unknown key "unknown_key" in section "users" in config file, ignoring`,
+			wantErr: `unknown key "unknown_key" in section "users" in config file`,
 		},
 	}
 
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
-			var capturedWarnings []string
-			log.SetLevelHandler(log.WarnLevel, func(_ context.Context, _ log.Level, format string, args ...interface{}) {
-				capturedWarnings = append(capturedWarnings, fmt.Sprintf(format, args...))
-			})
-			t.Cleanup(func() {
-				log.SetLevelHandler(log.WarnLevel, nil)
-			})
+			t.Parallel()
 
 			confPath := filepath.Join(t.TempDir(), "broker.conf")
 			err := os.WriteFile(confPath, []byte(tc.config), 0600)
 			require.NoError(t, err, "Setup: Failed to write config file")
 
 			_, err = parseConfigFromPath(confPath, p)
-			require.NoError(t, err)
-
-			if tc.wantWarning == "" {
-				require.Empty(t, capturedWarnings, "No warnings should have been produced")
+			if tc.wantErr == "" {
+				require.NoError(t, err)
 			} else {
-				require.Contains(t, capturedWarnings, tc.wantWarning)
+				require.ErrorContains(t, err, tc.wantErr)
 			}
 		})
 	}
 }
 
 func TestBrokerConfFilesHaveNoUnknownSettings(t *testing.T) {
-	// This test is NOT parallel because it modifies the global log handler.
+	t.Parallel()
 	p := &testutils.MockProvider{}
 
 	confFiles := map[string]string{
@@ -618,6 +608,7 @@ func TestBrokerConfFilesHaveNoUnknownSettings(t *testing.T) {
 
 	for name, confFile := range confFiles {
 		t.Run(name, func(t *testing.T) {
+			t.Parallel()
 			content, err := os.ReadFile(confFile)
 			require.NoError(t, err, "Setup: Failed to read broker.conf")
 
@@ -630,22 +621,12 @@ func TestBrokerConfFilesHaveNoUnknownSettings(t *testing.T) {
 				"<ISSUER_ID>", "test-issuer-id",
 			).Replace(string(content))
 
-			var capturedWarnings []string
-			log.SetLevelHandler(log.WarnLevel, func(_ context.Context, _ log.Level, format string, args ...interface{}) {
-				capturedWarnings = append(capturedWarnings, fmt.Sprintf(format, args...))
-			})
-			t.Cleanup(func() {
-				log.SetLevelHandler(log.WarnLevel, nil)
-			})
-
 			confPath := filepath.Join(t.TempDir(), "broker.conf")
 			err = os.WriteFile(confPath, []byte(replaced), 0600)
 			require.NoError(t, err, "Setup: Failed to write config file")
 
 			_, err = parseConfigFromPath(confPath, p)
-			require.NoError(t, err)
-
-			require.Empty(t, capturedWarnings, "No unknown-setting warnings should be produced for the %s broker.conf", name)
+			require.NoError(t, err, "The %s broker.conf should not have unknown settings", name)
 		})
 	}
 }


### PR DESCRIPTION
An admin who accidentally puts a key like `owner` under `[oidc]` instead of `[users]` would only see a warning, assume the config is active, and unknowingly leave the machine open to any authenticated user.

Return an error instead of logging a warning when an unrecognized section or key is found in the broker configuration file, so the broker refuses to start and the misconfiguration is immediately visible.

Closes #1666
UDENG-10922
