### PR TITLE
pam/go-exec: drain GMainContext after stopping GDBusServer on cleanup

### DIFF
--- a/pam/go-exec/module.c
+++ b/pam/go-exec/module.c
@@ -352,6 +352,15 @@ on_exec_module_removed (pam_handle_t *pamh,
   if (server)
     g_dbus_server_stop (server);
 
+  /* Drain any callbacks queued by stopping the server (e.g., the pending
+   * GTask from g_socket_listener_accept_socket_async inside GDBusServer)
+   * so that GLib releases those objects before the main context is freed.
+   * Without this, they are reported as memory leaks by AddressSanitizer.
+   */
+  while (module_data->main_context &&
+         g_main_context_iteration (module_data->main_context, FALSE))
+    ;
+
   g_clear_object (&module_data->cancellable);
   g_clear_pointer (&module_data->main_context, g_main_context_unref);
   g_free (module_data);


### PR DESCRIPTION
When pam_authd exits, on_exec_module_removed stops the GDBusServer and then immediately frees the GMainContext. GDBusServer's socket listener uses g_socket_listener_accept_socket_async internally; stopping the server cancels that pending operation and queues a completion callback. But since nothing iterates the context afterwards, the GTask and GSource objects from the async accept are never freed and are reported as memory leaks by AddressSanitizer.

Iterate the main context until it drains after stopping the server so GLib can dispatch the cancellation callbacks and release those objects before the context is freed.

Closes #1686 
UDENG-10968