### PR TITLE
e2e-tests: use su for CLI local password authentication

### DIFF
--- a/e2e-tests/resources/broker.resource
+++ b/e2e-tests/resources/broker.resource
@@ -141,14 +141,11 @@ Log In With Remote User Through CLI: Local Password
     [Arguments]    ${username}    ${local_password}
     Hid.Type String    clear
     Hid.Keys Combo    Return
-    Try machinectl login Prompt
-    Hid.Type String    ${username}
+    Hid.Type String    su ${username}
     Hid.Keys Combo    Return
-    Builtin.Sleep    2
     Match Text    regex:Enter\\s*your\\s*(?:local\\s*)?password:    120
     Hid.Type String    ${local_password}
     Hid.Keys Combo    Return
-    Builtin.Sleep    2
     Wait For Shell Prompt After Login    ${username}@ubuntu:~$
 
 
@@ -193,19 +190,13 @@ Log In With Remote User Through CLI: Local Password And Expect Failure
     [Arguments]    ${username}    ${local_password}
     Hid.Type String    clear
     Hid.Keys Combo    Return
-    Try machinectl login Prompt
-    Hid.Type String    ${username}
+    Hid.Type String    su ${username}
     Hid.Keys Combo    Return
-    Builtin.Sleep    2
     Match Text    regex:Enter\\s*your\\s*(?:local\\s*)?password:    120
     Hid.Type String    ${local_password}
     Hid.Keys Combo    Return
     Check That Remote User Is Not Allowed To Log In
-    # Exit the machinectl session (three ^] within 1 s exits the session).
-    Hid.Keys Combo    Control_L    ]
-    Hid.Keys Combo    Control_L    ]
-    Hid.Keys Combo    Control_L    ]
-    # Wait until the shell prompt is back before the next login attempt.
+    # su exits automatically after authentication failure; wait for the shell prompt.
     Match Text    @ubuntu:~$    30
 
 

--- a/e2e-tests/resources/utils.resource
+++ b/e2e-tests/resources/utils.resource
@@ -169,6 +169,13 @@ Log Out From Terminal Session
     Hid.Keys Combo    Control_L    ]
 
 
+Log Out From su Session
+    Match Text    @ubuntu    120
+    Hid.Type String    exit
+    Hid.Keys Combo    Return
+    Match Text    @ubuntu:~$    30
+
+
 Log Out From SSH Session
     Hid.Type String    exit
     Hid.Keys Combo    Return

--- a/e2e-tests/tests/allowed_users.robot
+++ b/e2e-tests/tests/allowed_users.robot
@@ -48,7 +48,7 @@ Test allowed_users values with cached local password authentication
     Change allowed_users In Broker Configuration    OWNER
     Change Broker Configuration    owner    ${username}
     Log In With Remote User Through CLI: Local Password    ${username}    ${local_password}
-    Log Out From Terminal Session
+    Log Out From su Session
 
     # Scenario 2: OWNER + owner=different-user → failure
     # Using a non-empty wrong owner so the broker performs a deterministic
@@ -60,7 +60,7 @@ Test allowed_users values with cached local password authentication
     # Scenario 3: explicit username → success
     Change allowed_users In Broker Configuration    ${username}
     Log In With Remote User Through CLI: Local Password    ${username}    ${local_password}
-    Log Out From Terminal Session
+    Log Out From su Session
 
     # Scenario 4: non-allowed username → failure
     Change allowed_users In Broker Configuration    ${non_allowed_user}
@@ -69,6 +69,6 @@ Test allowed_users values with cached local password authentication
     # Scenario 5: ALL → success
     Change allowed_users In Broker Configuration    ALL
     Log In With Remote User Through CLI: Local Password    ${username}    ${local_password}
-    Log Out From Terminal Session
+    Log Out From su Session
 
     Close Focused Window

--- a/e2e-tests/tests/authd_disabled.robot
+++ b/e2e-tests/tests/authd_disabled.robot
@@ -30,6 +30,6 @@ Test that disabling authd prevents remote logins
     Close Terminal In Sudo Mode
 
     # Check that remote user cannot log in
-    Open Terminal In Sudo Mode
+    Open Terminal
     Try Log In With Remote User    ${username}
     Check That Log In Fails Because Authd Is Disabled

--- a/e2e-tests/tests/broker_disabled.robot
+++ b/e2e-tests/tests/broker_disabled.robot
@@ -35,6 +35,6 @@ Test that disabling broker prevents remote logins
     Close Terminal In Sudo Mode
 
     # Check that remote user cannot log in
-    Open Terminal In Sudo Mode
+    Open Terminal
     Try Log In With Remote User    ${username}
     Check That User Is Redirected To Local Broker

--- a/e2e-tests/tests/force_access_check_with_provider.robot
+++ b/e2e-tests/tests/force_access_check_with_provider.robot
@@ -28,7 +28,7 @@ Test second login succeeds with force_access_check_with_provider enabled
 
     Change Broker Configuration    force_access_check_with_provider    true
 
-    Open Terminal In Sudo Mode
+    Open Terminal
     Log In With Remote User Through CLI: Local Password    ${username}    ${local_password}
 
 
@@ -48,6 +48,6 @@ Test second login fails with force_access_check_with_provider enabled offline
     # Block outbound HTTPS to simulate the identity provider being unreachable.
     Block Network Access To Identity Provider
 
-    Open Terminal In Sudo Mode
+    Open Terminal
     Try Log In With Remote User    ${username}
     Check That Remote User Has No Available Authentication Modes

--- a/e2e-tests/tests/login.robot
+++ b/e2e-tests/tests/login.robot
@@ -32,10 +32,10 @@ Test login with CLI
     Close Focused Window
 
     # Log in with remote user with local password
-    Open Terminal In Sudo Mode
+    Open Terminal
     Log In With Remote User Through CLI: Local Password    ${username}    ${local_password}
-    Log Out From Terminal Session
-    Close Terminal In Sudo Mode
+    Log Out From su Session
+    Close Focused Window
 
     # Try to change username during su login, it should not be possible
     Open Terminal

--- a/e2e-tests/tests/migration_authd.robot
+++ b/e2e-tests/tests/migration_authd.robot
@@ -31,16 +31,16 @@ Test login after updating authd to edge version
     Close Focused Window
 
     # Log in with remote user with local password
-    Open Terminal In Sudo Mode
+    Open Terminal
     Log In With Remote User Through CLI: Local Password    ${username}    ${local_password}
-    Log Out From Terminal Session
-    Close Terminal In Sudo Mode
+    Log Out From su Session
+    Close Focused Window
 
     # Switch to the edge PPA for authd
     Enable Edge Repository For Authd
     Update Authd
 
     # Log in with remote user with local password after upgrading
-    Open Terminal In Sudo Mode
+    Open Terminal
     Log In With Remote User Through CLI: Local Password    ${username}    ${local_password}
     Check Home Directory    ${username}

--- a/e2e-tests/tests/migration_authd_broker.robot
+++ b/e2e-tests/tests/migration_authd_broker.robot
@@ -31,10 +31,10 @@ Test login after upgrading authd and broker to edge channel
     Close Focused Window
 
     # Log in with remote user with local password
-    Open Terminal In Sudo Mode
+    Open Terminal
     Log In With Remote User Through CLI: Local Password    ${username}    ${local_password}
-    Log Out From Terminal Session
-    Close Terminal In Sudo Mode
+    Log Out From su Session
+    Close Focused Window
 
     # Disable entra_password before upgrading: the edge broker refuses to start
     # if this flow is enabled without register_device or a client_secret, which
@@ -47,6 +47,6 @@ Test login after upgrading authd and broker to edge channel
     Update Authd
 
     # Log in with remote user with local password after upgrading
-    Open Terminal In Sudo Mode
+    Open Terminal
     Log In With Remote User Through CLI: Local Password    ${username}    ${local_password}
     Check Home Directory    ${username}

--- a/e2e-tests/tests/migration_broker.robot
+++ b/e2e-tests/tests/migration_broker.robot
@@ -31,10 +31,10 @@ Test login with broker on edge channel
     Close Focused Window
 
     # Log in with remote user with local password
-    Open Terminal In Sudo Mode
+    Open Terminal
     Log In With Remote User Through CLI: Local Password    ${username}    ${local_password}
-    Log Out From Terminal Session
-    Close Terminal In Sudo Mode
+    Log Out From su Session
+    Close Focused Window
 
     # Disable entra_password before upgrading: the edge broker refuses to start
     # if this flow is enabled without register_device or a client_secret, which
@@ -45,6 +45,6 @@ Test login with broker on edge channel
     Enable Edge Broker
 
     # Log in with remote user with local password after upgrading
-    Open Terminal In Sudo Mode
+    Open Terminal
     Log In With Remote User Through CLI: Local Password    ${username}    ${local_password}
     Check Home Directory    ${username}

--- a/e2e-tests/tests/mixed_case_username.robot
+++ b/e2e-tests/tests/mixed_case_username.robot
@@ -31,5 +31,5 @@ Test login with mixed case username
     Close Focused Window
 
     # Log in with remote user using mixed case username with local password
-    Open Terminal In Sudo Mode
+    Open Terminal
     Log In With Remote User Through CLI: Local Password    ${username}    ${local_password}

--- a/e2e-tests/tests/password_change.robot
+++ b/e2e-tests/tests/password_change.robot
@@ -33,9 +33,9 @@ Test changing local password of remote user
     Open Terminal
     Log In With Remote User Through CLI: Local Password    ${username}    ${local_password}
     Change Password    ${local_password}    ${new_password}
-    Log Out From Terminal Session
+    Log Out From su Session
     Close Focused Window
 
     # Log in with remote user with local password
-    Open Terminal In Sudo Mode
+    Open Terminal
     Log In With Remote User Through CLI: Local Password    ${username}    ${new_password}

--- a/e2e-tests/tests/read_only_fs.robot
+++ b/e2e-tests/tests/read_only_fs.robot
@@ -35,5 +35,5 @@ Test login with GDM
     Wait Until Keyword Succeeds    30s    1s    SSH.Execute    findmnt -n -o OPTIONS / | grep -qw ro
 
     # Log in with remote user with local password
-    Open Terminal In Sudo Mode
+    Open Terminal
     Log In With Remote User Through CLI: Local Password    ${username}    ${local_password}

--- a/e2e-tests/tests/regenerate_qrcode.robot
+++ b/e2e-tests/tests/regenerate_qrcode.robot
@@ -39,5 +39,5 @@ Test login with CLI and QR code regeneration
     Close Focused Window
 
     # Log in with remote user with local password
-    Open Terminal In Sudo Mode
+    Open Terminal
     Log In With Remote User Through CLI: Local Password    ${username}    ${local_password}


### PR DESCRIPTION
machinectl login is brittle: exiting with ^]^]^] can leave the container in a broken TTY state where the next machinectl login fails to spawn a getty (agetty: Failed at step STDIN spawning), causing the test to fail.

su goes through the same PAM/authd authentication stack but doesn't require a separate container TTY. It prompts for the user's local password, fails fast on denied access, and exits cleanly on its own — no special escape sequence needed to return to the host shell. It also works from a regular user shell, so Open Terminal In Sudo Mode is no longer needed for local password authentication.

Replace Try machinectl login Prompt + username entry with su ${username} in the local-password login keywords

Closes #1689
UDENG-10969