### PR TITLE
pam/native: don't show stage headers in polkit dialog

### DIFF
--- a/pam/integration-tests/testdata/golden/TestNativeAuthenticate/Authenticate_user_successfully_with_password_only_supported_method_in_polkit
+++ b/pam/integration-tests/testdata/golden/TestNativeAuthenticate/Authenticate_user_successfully_with_password_only_supported_method_in_polkit
@@ -1,4 +1,3 @@
-== Password authentication ==
 Gimme your password:
 >
   PAM_AUTHTOK: "goodpass"

--- a/pam/integration-tests/testdata/golden/TestNativeAuthenticate/Authenticate_user_with_form_mode_with_button_in_polkit
+++ b/pam/integration-tests/testdata/golden/TestNativeAuthenticate/Authenticate_user_with_form_mode_with_button_in_polkit
@@ -1,8 +1,6 @@
-== Password authentication ==
 Enter 'r' to cancel the request and go back to select the authentication flow
 Gimme your password:
 >
-== Authentication method selection ==
   1. Password authentication
   2. Send URL to user-integration-native-authenticate-user-with-form-mode-with-button-in-polkit@example.com
   3. Use your fido device foo
@@ -12,19 +10,16 @@ Gimme your password:
   7. Authentication code
 Choose your authentication method:
 > 7
-== Authentication code ==
   1. Proceed with Authentication code
   2. Resend SMS (1 sent)
 Or enter 'r' to go back to select the authentication flow
 Choose action:
 > 2
-== Authentication code ==
   1. Proceed with Authentication code
   2. Resend SMS (2 sent)
 Or enter 'r' to go back to select the authentication flow
 Choose action:
 > 1
-== Authentication code ==
 Enter 'r' to cancel the request and go back to select the authentication flow
 Enter your one time credential:
 > temporary pass00

--- a/pam/integration-tests/testdata/golden/TestNativeChangeAuthTok/Change_password_successfully_and_authenticate_with_new_one_with_single_broker_and_password_only_supported_method
+++ b/pam/integration-tests/testdata/golden/TestNativeChangeAuthTok/Change_password_successfully_and_authenticate_with_new_one_with_single_broker_and_password_only_supported_method
@@ -1,7 +1,5 @@
-== Password authentication ==
 Gimme your password:
 >
-== Password reset ==
 Enter your new password:
 >
 Confirm Password:
@@ -12,7 +10,6 @@ PAM ChangeAuthTok()
   User: "user-auth-modes-password,mandatoryreset-integration-polkit-testnativechangeauthtok@example.com"
   Result: success
 
-== Password authentication ==
 Enter 'r' to cancel the request and go back to select the authentication flow
 Gimme your password:
 >

--- a/pam/internal/adapter/nativemodel.go
+++ b/pam/internal/adapter/nativemodel.go
@@ -417,11 +417,11 @@ func (m nativeModel) sendError(errorMsg string, args ...any) error {
 	return err
 }
 
-func (m nativeModel) sendInfo(infoMsg string, args ...any) error {
+func (m nativeModel) sendInfo(infoMsg string) error {
 	if infoMsg == "" {
 		return nil
 	}
-	_, err := m.pamMTx.StartStringConvf(pam.TextInfo, infoMsg, args...)
+	_, err := m.pamMTx.StartStringConvf(pam.TextInfo, infoMsg)
 	return err
 }
 
@@ -431,7 +431,10 @@ type choicePair struct {
 }
 
 func (m nativeModel) promptForChoiceWithMessage(title string, message string, choices []choicePair, prompt string) (string, error) {
-	msg := fmt.Sprintf("== %s ==\n", title)
+	var msg string
+	if m.serviceName != polkitServiceName {
+		msg = fmt.Sprintf("== %s ==\n", title)
+	}
 	if message != "" {
 		msg += message + "\n"
 	}
@@ -657,9 +660,18 @@ func (m nativeModel) handleFormChallenge(hasWait bool) tea.Cmd {
 	}
 
 	if goBackLabel := m.goBackActionLabel(); goBackLabel != "" {
-		instructions = "\n" + fmt.Sprintf(instructions, nativeCancelKey, m.goBackActionLabel())
+		instructions = fmt.Sprintf(instructions, nativeCancelKey, m.goBackActionLabel())
 	}
-	if cmd := maybeSendPamError(m.sendInfo("== %s ==%s", authMode, instructions)); cmd != nil {
+	var info string
+	if m.serviceName != polkitServiceName {
+		info = fmt.Sprintf("== %s ==", authMode)
+		if instructions != "" {
+			info += "\n" + instructions
+		}
+	} else {
+		info = instructions
+	}
+	if cmd := maybeSendPamError(m.sendInfo(info)); cmd != nil {
 		return cmd
 	}
 
@@ -816,11 +828,20 @@ func (m nativeModel) newPasswordChallenge(previousPassword *string) tea.Cmd {
 	if previousPassword == nil {
 		var instructions string
 		if goBackLabel := m.goBackActionLabel(); goBackLabel != "" {
-			instructions = fmt.Sprintf("\nEnter '%[1]s' to cancel the request and %[2]s",
+			instructions = fmt.Sprintf("Enter '%[1]s' to cancel the request and %[2]s",
 				nativeCancelKey, goBackLabel)
 		}
 		title := m.selectedAuthModeLabel("Password Update")
-		if cmd := maybeSendPamError(m.sendInfo("== %s ==%s", title, instructions)); cmd != nil {
+		var info string
+		if m.serviceName != polkitServiceName {
+			info = fmt.Sprintf("== %s ==", title)
+			if instructions != "" {
+				info += "\n" + instructions
+			}
+		} else {
+			info = instructions
+		}
+		if cmd := maybeSendPamError(m.sendInfo(info)); cmd != nil {
 			return cmd
 		}
 	}


### PR DESCRIPTION
The polkit dialog shows stage headers like '== Local Password Authentication ==' and '== Provider selection ==' as plain text, which looks out of place since the input placeholder already conveys the same context. Suppress these headers when the PAM service is polkit-1.

## Before
<img width="496" height="414" alt="image" src="https://github.com/user-attachments/assets/5ac1ff8a-19b9-4a03-aac8-01d7c29f2c4a" />


## After
<img width="501" height="419" alt="image" src="https://github.com/user-attachments/assets/7f1852dd-c2ca-48c7-a0f4-33237caa29eb" />


Closes: https://github.com/canonical/authd/issues/1665
UDENG-10921