### PR TITLE
pam: don't fail auth when UpdateBrokerForUser write fails

### DIFF
--- a/internal/services/pam/pam.go
+++ b/internal/services/pam/pam.go
@@ -462,8 +462,9 @@ func (s Service) IsAuthenticated(ctx context.Context, req *authd.IARequest) (res
 			return nil, err
 		}
 		if err = s.userManager.UpdateBrokerForUser(uInfo.Name, broker.ID); err != nil {
+			// A write failure (e.g. read-only filesystem) must not prevent a
+			// successfully authenticated user from logging in.
 			log.Errorf(ctx, "IsAuthenticated: Could not update broker for user %q in database: %v", uInfo.Name, err)
-			return nil, err
 		}
 	}
 

--- a/internal/services/pam/pam_test.go
+++ b/internal/services/pam/pam_test.go
@@ -403,6 +403,7 @@ func TestIsAuthenticated(t *testing.T) {
 	tests := map[string]struct {
 		sessionID  string
 		existingDB string
+		dbReadOnly bool
 
 		username        string
 		secondCall      bool
@@ -420,6 +421,12 @@ func TestIsAuthenticated(t *testing.T) {
 		"Update_local_groups":                                  {username: "success_with_local_groups@example.com", localGroupsFile: "valid.group"},
 		"Successfully_authenticate_user_with_uppercase":        {username: "SUCCESS@example.com"},
 		"Successfully_authenticate_with_groups_with_uppercase": {username: "success_with_uppercase_groups@example.com"},
+
+		// DB write failure: UpdateBrokerForUser fails (read-only filesystem) but auth still succeeds.
+		// UpdateUser is a no-op because the DB already has up-to-date user info; the first actual
+		// write attempt (UpdateBrokerForUser) fails when SQLite cannot create the rollback-journal
+		// file in a read-only directory.
+		"Successfully_authenticate_even_if_db_write_fails": {username: "success@example.com", existingDB: "cache-with-uptodate-user.db", dbReadOnly: true},
 
 		// service errors
 		"Error_when_sessionID_is_empty": {sessionID: "-"},
@@ -465,6 +472,16 @@ func TestIsAuthenticated(t *testing.T) {
 			m, err := users.NewManager(users.DefaultConfig, dbDir, managerOpts...)
 			require.NoError(t, err, "Setup: could not create user manager")
 			t.Cleanup(func() { _ = m.Stop() })
+
+			if tc.dbReadOnly {
+				// Make the directory read-only after the manager has opened its
+				// connection so that SQLite cannot create the rollback-journal
+				// file.  Reads still succeed because they are served from the
+				// already-open connection's page cache.
+				require.NoError(t, os.Chmod(dbDir, 0o500), "Setup: could not make database directory read-only") //nolint:gosec // test-only permission change
+				t.Cleanup(func() { _ = os.Chmod(dbDir, 0o700) })                                                 //nolint:gosec // test-only cleanup
+			}
+
 			client := newPamClient(t, m, globalBrokerManager)
 
 			switch tc.sessionID {

--- a/internal/services/pam/testdata/TestIsAuthenticated/cache-with-uptodate-user.db
+++ b/internal/services/pam/testdata/TestIsAuthenticated/cache-with-uptodate-user.db
@@ -1,0 +1,21 @@
+users:
+    - name: success@example.com
+      uid: 1111
+      gid: 1111
+      gecos: gecos for success@example.com
+      dir: /home/success@example.com
+      shell: /bin/sh/success@example.com
+      broker_id: "1902181170"
+      provider_id: providerid-success@example.com
+groups:
+    - name: success@example.com
+      gid: 1111
+      ugid: success@example.com
+    - name: group-success@example.com
+      gid: 22222
+      ugid: ugid-success@example.com
+users_to_groups:
+    - uid: 1111
+      gid: 1111
+    - uid: 1111
+      gid: 22222

--- a/internal/services/pam/testdata/golden/TestIsAuthenticated/Successfully_authenticate_even_if_db_write_fails/IsAuthenticated
+++ b/internal/services/pam/testdata/golden/TestIsAuthenticated/Successfully_authenticate_even_if_db_write_fails/IsAuthenticated
@@ -1,0 +1,4 @@
+FIRST CALL:
+	access: granted
+	msg: 
+	err: <nil>

--- a/internal/services/pam/testdata/golden/TestIsAuthenticated/Successfully_authenticate_even_if_db_write_fails/cache.db
+++ b/internal/services/pam/testdata/golden/TestIsAuthenticated/Successfully_authenticate_even_if_db_write_fails/cache.db
@@ -1,0 +1,22 @@
+users:
+    - name: success@example.com
+      uid: 1111
+      gid: 1111
+      gecos: gecos for success@example.com
+      dir: /home/success@example.com
+      shell: /bin/sh/success@example.com
+      broker_id: "1902181170"
+      provider_id: providerid-success@example.com
+groups:
+    - name: success@example.com
+      gid: 1111
+      ugid: success@example.com
+    - name: group-success@example.com
+      gid: 22222
+      ugid: ugid-success@example.com
+users_to_groups:
+    - uid: 1111
+      gid: 1111
+    - uid: 1111
+      gid: 22222
+schema_version: 3


### PR DESCRIPTION
On a read-only filesystem, SQLite cannot create the rollback-journal file in the database directory, so UpdateBrokerForUser returns an error. This was propagated back to the PAM client as an authentication failure, even though the user's credentials were valid.

On a second login for a user whose info hasn't changed, UpdateUser is a no-op (it detects no diff and skips the write), so the first actual write attempt is UpdateBrokerForUser. Making that failure non-fatal allows login to succeed when the broker preference can't be persisted.

Closes https://github.com/canonical/authd/issues/1693
UDENG-10975