### PR TITLE
pam: Return PAM_IGNORE early when only the local broker is available

### DIFF
--- a/pam/internal/adapter/brokerselection.go
+++ b/pam/internal/adapter/brokerselection.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/canonical/authd/internal/brokers"
 	"github.com/canonical/authd/internal/proto/authd"
 	"github.com/canonical/authd/log"
 	"github.com/canonical/authd/pam/internal/proto"
@@ -165,8 +166,16 @@ func getAvailableBrokers(client authd.PAMClient) tea.Cmd {
 			}
 		}
 
+		bs := brokersInfo.BrokersInfos
+		// If only the local broker is available, this PAM module cannot authenticate.
+		// Return PAM_IGNORE early so the next PAM module (e.g. pam_unix) can take
+		// over instead.
+		if len(bs) == 1 && bs[0].GetId() == brokers.LocalBrokerName {
+			return pamError{status: pam.ErrIgnore}
+		}
+
 		return brokersListReceived{
-			brokers: brokersInfo.BrokersInfos,
+			brokers: bs,
 		}
 	}
 }

--- a/pam/internal/adapter/gdmmodel_test.go
+++ b/pam/internal/adapter/gdmmodel_test.go
@@ -14,6 +14,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/canonical/authd/internal/brokers"
 	"github.com/canonical/authd/internal/brokers/auth"
 	"github.com/canonical/authd/internal/brokers/layouts"
 	"github.com/canonical/authd/internal/proto/authd"
@@ -1817,6 +1818,24 @@ func TestGdmModel(t *testing.T) {
 			wantPAMReturnValue: pamError{
 				status: pam.ErrAuthinfoUnavail,
 				msg:    "No brokers available",
+			},
+		},
+		"Error_ignore_when_only_local_broker_is_available": {
+			clientOptions: append(slices.Clone(singleBrokerClientOptions),
+				pam_test.WithAvailableBrokers([]*authd.ABResponse_BrokerInfo{
+					{Id: brokers.LocalBrokerName},
+				}, nil),
+			),
+			wantGdmRequests: []gdm.RequestType{
+				gdm.RequestType_uiLayoutCapabilities,
+			},
+			wantNoGdmEvents: []gdm.EventType{
+				gdm.EventType_brokersReceived,
+				gdm.EventType_userSelected,
+			},
+			wantNoBrokers: true,
+			wantPAMReturnValue: pamError{
+				status: pam.ErrIgnore,
 			},
 		},
 		"Error_on_invalid_broker_selection": {


### PR DESCRIPTION
When authd has no brokers configured, the only available broker is the local one. The PAM module was walking through several unnecessary steps (user selection, broker auto-select, session start) before hitting the PAM_IGNORE that startBrokerSession emits for the local broker.

Bail out in getAvailableBrokers as soon as the single-local-broker case is detected. This avoids unnecessary RPC round-trips and makes the intent explicit at the earliest decision point.