### PR TITLE
e2e-tests: Set a larger Ptyxis font for reliable OCR

### DIFF
--- a/e2e-tests/vm/cloud-init-template-resolute.yaml
+++ b/e2e-tests/vm/cloud-init-template-resolute.yaml
@@ -69,6 +69,13 @@ write_files:
       [org/gnome/desktop/interface]
       text-scaling-factor=1.25
 
+      # Ptyxis defaults to a 10pt font, which is smaller than the 12pt
+      # gnome-terminal font used on Noble.
+      # Use a larger fixed font to improve OCR accuracy.
+      [org/gnome/Ptyxis]
+      use-system-font=false
+      font-name='Monospace 12'
+
   - path: /etc/ssh/sshd_config.d/root.conf
     content: |
       ${CI_ROOT_SSHD_CONFIG}

--- a/e2e-tests/vm/cloud-init-template-stonking.yaml
+++ b/e2e-tests/vm/cloud-init-template-stonking.yaml
@@ -69,6 +69,13 @@ write_files:
       [org/gnome/desktop/interface]
       text-scaling-factor=1.25
 
+      # Ptyxis defaults to a 10pt font, which is smaller than the 12pt
+      # gnome-terminal font used on Noble.
+      # Use a larger fixed font to improve OCR accuracy.
+      [org/gnome/Ptyxis]
+      use-system-font=false
+      font-name='Monospace 12'
+
   - path: /etc/ssh/sshd_config.d/root.conf
     content: |
       ${CI_ROOT_SSHD_CONFIG}


### PR DESCRIPTION
We're seeing bad OCR results on Resolute. Let's see if increasing the font size of the terminal helps.

On Noble, the default terminal is gnome-terminal with a 12pt font. Resolute and Stonking default to Ptyxis, which ships a 10pt font.

Pin Ptyxis to a 12pt monospace font so the effective size matches gnome-terminal on Noble.

Closes #1700
UDENG-10974