### PR TITLE
pam: fall back to native mode when TERM=dumb

### DIFF
--- a/pam/integration-tests/native_test.go
+++ b/pam/integration-tests/native_test.go
@@ -27,6 +27,10 @@ type nativePtySessionSpec struct {
 	username         string
 	extraArgs        []string
 	expectedExitCode int
+	// skipForceNative prevents force_native_client=true from being added to the
+	// PAM args, allowing the module to detect the client type from the environment
+	// (e.g. via TERM=dumb).
+	skipForceNative bool
 }
 
 type nativePtyTestContext struct {
@@ -45,7 +49,10 @@ func (r nativePtySessionRunner) start(t *testing.T, spec nativePtySessionSpec) *
 	cliEnv := append(r.cliEnv,
 		fmt.Sprintf("%s=1", pam_test.RunnerEnvSupportsConversation),
 	)
-	extraArgs := append([]string{"force_native_client=true"}, spec.extraArgs...)
+	extraArgs := spec.extraArgs
+	if !spec.skipForceNative {
+		extraArgs = append([]string{"force_native_client=true"}, extraArgs...)
+	}
 	c := startPAMRunner(t, r.clientPath, r.socketPath, spec.action, cliEnv, spec.clientOptions, extraArgs...)
 	if spec.username != "" && spec.clientOptions.PamUser == "" {
 		nativeEnterUsername(t, c, spec.username)
@@ -88,6 +95,7 @@ func TestNativeAuthenticate(t *testing.T) {
 		wantLocalGroups    bool
 		wantSeparateDaemon bool
 		skipRunnerCheck    bool
+		skipForceNative    bool
 		socketPath         string
 		extraArgs          []string
 		expectedUser       string
@@ -100,6 +108,15 @@ func TestNativeAuthenticate(t *testing.T) {
 		"Authenticate_user_successfully": {
 			test:         nativeSimpleAuth,
 			expectedUser: testUserName(t, "native"),
+		},
+		"Authenticate_user_successfully_with_dumb_terminal": {
+			// Verify that TERM=dumb causes the module to fall back to native mode
+			// even without force_native_client=true. This covers non-interactive
+			// consumers like Emacs TRAMP, scripted sudo, and Ansible.
+			clientOptions:   clientOptions{Term: "dumb"},
+			skipForceNative: true,
+			test:            nativeSimpleAuthNonInteractive,
+			expectedUser:    testUserName(t, "dumb-terminal"),
 		},
 		"Authenticate_user_successfully_with_upper_case": {
 			clientOptions: clientOptions{PamUser: strings.ToUpper(testUserName(t, "upper-case-native"))},
@@ -734,10 +751,11 @@ func TestNativeAuthenticate(t *testing.T) {
 					cliEnv:     cliEnv,
 				},
 				baseSpec: nativePtySessionSpec{
-					action:        pam_test.RunnerActionLogin,
-					clientOptions: clientOptions,
-					username:      username,
-					extraArgs:     tc.extraArgs,
+					action:          pam_test.RunnerActionLogin,
+					clientOptions:   clientOptions,
+					username:        username,
+					extraArgs:       tc.extraArgs,
+					skipForceNative: tc.skipForceNative,
 				},
 				authdCancel: authdCancel,
 			}
@@ -1039,7 +1057,7 @@ func nativeReloginAfterPasswordChange(t *testing.T, ctx *nativePtyTestContext) {
 // nativeSelectBroker waits for provider selection and selects ExampleBroker.
 func nativeSelectBroker(t *testing.T, c *ptytest.Console) {
 	t.Helper()
-	c.WaitFor(t, `(?s)== Provider selection ==.*2\. ExampleBroker.*Choose your provider:`)
+	c.WaitFor(t, `(?s)== Provider selection ==.*2\. ExampleBroker.*Choose your provider`)
 	sendEchoedLine(t, c, "2")
 }
 
@@ -1048,6 +1066,20 @@ func nativeSimpleAuth(t *testing.T, c *ptytest.Console) {
 	t.Helper()
 	nativeSelectBroker(t, c)
 	c.WaitFor(t, `Gimme your password:`)
+	c.SendLine(t, "goodpass")
+	nativeWaitForResult(t, c)
+}
+
+// nativeSimpleAuthNonInteractive performs basic native authentication for
+// non-interactive sessions (e.g. TERM=dumb), where prompts lack the ": \n> "
+// interactive suffix so sendEchoedLine cannot be used.  In non-interactive
+// mode promptForInput uses format "%s", so the broker label "Gimme your
+// password" is sent verbatim (no colon appended by the formatter).
+func nativeSimpleAuthNonInteractive(t *testing.T, c *ptytest.Console) {
+	t.Helper()
+	c.WaitFor(t, `(?s)== Provider selection ==.*2\. ExampleBroker.*Choose your provider`)
+	c.SendLine(t, "2")
+	c.WaitFor(t, `Gimme your password`)
 	c.SendLine(t, "goodpass")
 	nativeWaitForResult(t, c)
 }

--- a/pam/integration-tests/testdata/golden/TestNativeAuthenticate/Authenticate_user_successfully_with_dumb_terminal
+++ b/pam/integration-tests/testdata/golden/TestNativeAuthenticate/Authenticate_user_successfully_with_dumb_terminal
@@ -1,0 +1,11 @@
+== Provider selection ==
+  1. local
+  2. ExampleBroker
+Choose your provider2
+== Password authentication ==
+Enter 'r' to cancel the request and go back to select the authentication flow
+Gimme your password
+  PAM_AUTHTOK: "goodpass"
+PAM Authenticate()
+  User: "user-integration-native-authenticate-user-successfully-with-dumb-terminal@example.com"
+  Result: success

--- a/pam/internal/adapter/nativemodel.go
+++ b/pam/internal/adapter/nativemodel.go
@@ -85,7 +85,7 @@ func newNativeModel(mTx pam.ModuleTransaction, userServiceClient authd.UserServi
 		log.Errorf(context.TODO(), "failed to get the PAM service: %v", err)
 	}
 
-	m.interactive = isSSHSession(m.pamMTx) || IsTerminalTTY(m.pamMTx)
+	m.interactive = (isSSHSession(m.pamMTx) || IsTerminalTTY(m.pamMTx)) && !IsDumbTerminal()
 
 	return m
 }
@@ -778,7 +778,7 @@ func (m nativeModel) isQrcodeRenderingSupported() bool {
 		if isSSHSession(m.pamMTx) {
 			return false
 		}
-		return IsTerminalTTY(m.pamMTx)
+		return IsTerminalTTY(m.pamMTx) && !IsDumbTerminal()
 	}
 }
 

--- a/pam/internal/adapter/utils.go
+++ b/pam/internal/adapter/utils.go
@@ -127,6 +127,12 @@ func IsTerminalTTY(mTx pam.ModuleTransaction) bool {
 	return isTerminalTTYValue
 }
 
+// IsDumbTerminal returns whether the TERM environment variable is set to "dumb".
+// Dumb terminals do not support escape sequences and cannot render the TUI.
+func IsDumbTerminal() bool {
+	return os.Getenv("TERM") == "dumb"
+}
+
 func maybeSendPamError(err error) tea.Cmd {
 	if err == nil {
 		return nil

--- a/pam/internal/adapter/utils_test.go
+++ b/pam/internal/adapter/utils_test.go
@@ -314,6 +314,39 @@ func TestSafeMessageDebug(t *testing.T) {
 	}
 }
 
+func TestIsDumbTerminal(t *testing.T) {
+	// Cannot be parallel due to t.Setenv modifying the process environment.
+
+	tests := map[string]struct {
+		term string
+		want bool
+	}{
+		"Returns_true_when_TERM_is_dumb": {
+			term: "dumb",
+			want: true,
+		},
+		"Returns_false_when_TERM_is_xterm": {
+			term: "xterm",
+			want: false,
+		},
+		"Returns_false_when_TERM_is_xterm-256color": {
+			term: "xterm-256color",
+			want: false,
+		},
+		"Returns_false_when_TERM_is_empty": {
+			term: "",
+			want: false,
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Setenv("TERM", tc.term)
+			require.Equal(t, tc.want, IsDumbTerminal())
+		})
+	}
+}
+
 func TestFormatAlignedFields(t *testing.T) {
 	t.Parallel()
 

--- a/pam/pam.go
+++ b/pam/pam.go
@@ -310,7 +310,7 @@ func (h *pamModule) handleAuthRequest(mode authd.SessionMode, mTx pam.ModuleTran
 			return fmt.Errorf("%w: can't create tea options: %w", pam.ErrSystem, err)
 		}
 		teaOpts = append(teaOpts, modeOpts...)
-	} else if !forceNativeClient && adapter.IsTerminalTTY(mTx) {
+	} else if !forceNativeClient && adapter.IsTerminalTTY(mTx) && !adapter.IsDumbTerminal() {
 		pamClientType = adapter.InteractiveTerminal
 		tty, cleanup := adapter.GetPamTTY(mTx)
 		defer cleanup()


### PR DESCRIPTION
When TERM is set to "dumb", the terminal cannot render escape sequences or cursor positioning, making the interactive TUI unusable. Non-interactive consumers like Emacs TRAMP, scripted sudo, Ansible, and cron-driven privilege escalation set TERM=dumb and expect plain text PAM conversation prompts rather than a full-screen TUI.

Add IsDumbTerminal() to detect this condition and exclude dumb terminals from the InteractiveTerminal code path in the PAM module. The module falls back to Native mode, which uses standard PAM conversation for prompts.

Apply the same guard in nativeModel: skip interactive prompt formatting and QR code rendering on dumb terminals.

Closes https://github.com/canonical/authd/issues/1692
UDENG-10977