### PR TITLE
e2e-tests: Use fuzzy match for Entra Password shell prompt

### DIFF
--- a/e2e-tests/resources/broker.resource
+++ b/e2e-tests/resources/broker.resource
@@ -465,7 +465,5 @@ Log In With Remote User Through CLI: Entra Password
     Hid.Type String    ${totp_code}
     Hid.Keys Combo    Return
 
-    # Wait for the authenticated shell prompt. Plain Match Text is fuzzy enough
-    # to false-positive on the preceding machinectl login line, so keep this in
-    # regex mode and require the remote-shell prefix after the username.
-    Match Text    regex:${username}@ubuntu:    120
+    # Wait for the authenticated shell prompt.
+    Match Text    ${username}@ubuntu:~$    120


### PR DESCRIPTION
OCR occasionally misreads characters (e.g. '1' as 'l'), causing the strict regex match to fail intermittently. Including '~$' in the match string gives enough context that the 92% similarity threshold should reliably distinguish the authenticated shell prompt from the preceding machinectl login line.

Closes #1705 
UDENG-10978