### PR TITLE
ci: retry ASAN integration tests on ASAN-internal check failures

### DIFF
--- a/.github/workflows/qa.yaml
+++ b/.github/workflows/qa.yaml
@@ -412,12 +412,34 @@ jobs:
           echo "Running PAM integration tests"
           pushd ./pam/integration-tests
           go test -asan -gcflags=all="${GO_GC_FLAGS}" -c
-          go tool test2json -p pam/integrations-test ./integration-tests.test \
-            -test.v=test2json \
-            -test.failfast \
-            -test.timeout ${GO_TESTS_TIMEOUT} | \
-          gotestfmt --logfile "${AUTHD_TESTS_ARTIFACTS_PATH}/gotestfmt.pam-integration-tests-asan.log" || \
-          exit_code=$?
+
+          run_pam_integration_tests() {
+            local log_suffix="${1:-}"
+            go tool test2json -p pam/integrations-test ./integration-tests.test \
+              -test.v=test2json \
+              -test.failfast \
+              -test.timeout ${GO_TESTS_TIMEOUT} | \
+            gotestfmt --logfile "${AUTHD_TESTS_ARTIFACTS_PATH}/gotestfmt.pam-integration-tests-asan${log_suffix}.log"
+          }
+
+          if run_pam_integration_tests; then
+            :
+          else
+            exit_code=$?
+            # Retry once if all ASAN errors are ASAN-internal check failures (e.g.
+            # ThreadRegistry::StartThread invariant), not real memory bugs detected by
+            # ASAN. Real detections (heap-buffer-overflow, use-after-free, etc.) are
+            # never retried.
+            if grep -rl "AddressSanitizer:" "${AUTHD_TESTS_ARTIFACTS_PATH}"/asan.log* 2>/dev/null | grep -q . && \
+               ! grep -rh "AddressSanitizer:" "${AUTHD_TESTS_ARTIFACTS_PATH}"/asan.log* | grep -qv "CHECK failed"; then
+              echo "ASAN internal check failure detected — retrying once"
+              for f in "${AUTHD_TESTS_ARTIFACTS_PATH}"/asan.log*; do
+                [ -e "${f}" ] && mv "${f}" "${f}.prev"
+              done
+              exit_code=0
+              run_pam_integration_tests "-retry" || exit_code=$?
+            fi
+          fi
           popd
 
           # We don't need the xtrace output after this point


### PR DESCRIPTION
ASAN occasionally crashes with an internal invariant violation in its own ThreadRegistry ("CHECK failed: sanitizer_common.h:... ((i)) < ((size_))") when a CGo Go binary creates OS threads concurrently with fork+exec. This is an ASAN internal state-management glitch, not a memory bug in authd code, and it produces no actionable signal.

After a test failure, scan the collected asan.log* files. If every AddressSanitizer error line is a CHECK failure (ASAN's own assertion), rename those logs to *.prev and re-run the integration tests once. Real ASAN detections — heap-buffer-overflow, use-after-free, etc. — never trigger a retry; the job fails immediately as before.

Both the original and retry logs are preserved in the job artifacts and printed in the log preview.

Closes #1707
UDENG-10979