### PR TITLE
Bump Go toolchain version to 1.25.12

### DIFF
--- a/authd-oidc-brokers/go.mod
+++ b/authd-oidc-brokers/go.mod
@@ -2,7 +2,7 @@ module github.com/canonical/authd/authd-oidc-brokers
 
 go 1.25.0
 
-toolchain go1.25.11
+toolchain go1.25.12
 
 require (
 	github.com/Azure/azure-sdk-for-go/sdk/azcore v1.22.0

--- a/authd-oidc-brokers/tools/go.mod
+++ b/authd-oidc-brokers/tools/go.mod
@@ -2,7 +2,7 @@ module github.com/canonical/authd/authd-oidc-brokers/tools
 
 go 1.25.0
 
-toolchain go1.25.11
+toolchain go1.25.12
 
 require (
 	github.com/golangci/golangci-lint/v2 v2.12.2

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/canonical/authd
 
 go 1.25.0
 
-toolchain go1.25.11
+toolchain go1.25.12
 
 require (
 	github.com/charmbracelet/bubbles v0.20.0

--- a/tools/go.mod
+++ b/tools/go.mod
@@ -2,7 +2,7 @@ module github.com/canonical/authd/tools
 
 go 1.25.0
 
-toolchain go1.25.11
+toolchain go1.25.12
 
 require (
 	github.com/golang/protobuf v1.5.4


### PR DESCRIPTION
govulncheck reports the following vulnerabilities in go1.25.11:

```
Vulnerability #1: GO-2026-5856
    Invoking Encrypted Client Hello privacy leak in crypto/tls
  More info: https://pkg.go.dev/vuln/GO-2026-5856
  Standard library
    Found in: crypto/tls@go1.25.11
    Fixed in: crypto/tls@go1.25.12
    Example traces found:
Error:       #1: pam/integration-tests/ssh_test.go:741:30: integration.startSSHD calls httptest.NewServer, which eventually calls tls.Conn.HandshakeContext
Error:       #2: cmd/authd/daemon/daemon_test.go:248:18: daemon_test.TestAppCanSigHupWithoutExecute calls io.Copy, which eventually calls tls.Conn.Read
Error:       #3: internal/testutils/ptytest/ptytest.go:540:26: ptytest.Console.SendLine calls io.WriteString, which calls tls.Conn.Write

Vulnerability #2: GO-2026-4970
    Root escape via symlink plus trailing slash in os
  More info: https://pkg.go.dev/vuln/GO-2026-4970
  Standard library
    Found in: os@go1.25.11
    Fixed in: os@go1.25.12
    Example traces found:
Error:       #1: internal/fileutils/fileutils.go:170:19: fileutils.ChownRecursiveFrom calls fs.WalkDir, which eventually calls os.rootFS.Open
Error:       #2: internal/fileutils/fileutils.go:170:19: fileutils.ChownRecursiveFrom calls fs.WalkDir, which eventually calls os.rootFS.ReadDir
```