### PR TITLE
pam/gdm: serialise concurrent PAM conversations

### DIFF
--- a/pam/internal/gdm/conversation.go
+++ b/pam/internal/gdm/conversation.go
@@ -5,13 +5,23 @@ import (
 	"errors"
 	"fmt"
 	"regexp"
+	"sync"
 	"sync/atomic"
 
 	"github.com/canonical/authd/log"
 	"github.com/msteinert/pam/v2"
 )
 
-var conversations atomic.Int32
+var (
+	// convMu serialises all PAM conversations. The GDM conversation
+	// callback (pam_conv.conv) is not goroutine-safe, so concurrent
+	// calls from the Bubble Tea event loop goroutines must be prevented.
+	// conversations is incremented before acquiring the lock so that
+	// ConversationInProgress correctly reflects pending callers.
+	convMu        sync.Mutex
+	conversations atomic.Int32
+)
+
 var secretRegex = regexp.MustCompile(`"secret"\s*:\s*"(?:[^"\\]|\\.)*"`)
 
 // ConversationInProgress checks if conversations are currently active.
@@ -20,8 +30,12 @@ func ConversationInProgress() bool {
 }
 
 func sendToGdm(pamMTx pam.ModuleTransaction, data []byte) ([]byte, error) {
+	// Count this call before acquiring the lock so that
+	// ConversationInProgress returns true while we are waiting.
 	conversations.Add(1)
 	defer conversations.Add(-1)
+	convMu.Lock()
+	defer convMu.Unlock()
 	binReq, err := NewBinaryJSONProtoRequest(data)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
The Bubble Tea event loop runs each tea.Cmd in its own goroutine, so handlers like emitEvent (brokersListReceived, userSelected, ...) and pollGdm can call gdm.SendData concurrently. Both funnel into sendToGdm, which invokes pamMTx.StartConv. The GDM conversation callback (pam_conv.conv) is not goroutine-safe, so concurrent calls can interleave the binary JSON request/response stream shared with the GNOME Shell authd extension. The existing conversations atomic.Int32 acknowledged that sendToGdm is reached from multiple goroutines but did nothing to prevent overlapping conversations.

This is a plausible cause of an observed failure where GDM never starts gnome-session and the login screen stays frozen: a corrupted conversation stream would leave the extension stuck.

Fix: add convMu, a package-level sync.Mutex, held by sendToGdm for the full send-plus-receive round trip so at most one PAM conversation is live at any instant. The conversations counter is still incremented before acquiring the lock, so ConversationInProgress keeps returning true while callers are waiting and shutdown continues to drain queued conversations.

Closes #1712
UDENG-10980