### PR TITLE
e2e-tests: exclude msentraid-only tests via tag

### DIFF
--- a/e2e-tests/run-tests.sh
+++ b/e2e-tests/run-tests.sh
@@ -154,6 +154,9 @@ if [ -n "${RERUNFAILED:-}" ]; then
     echo "Rerunning failed tests from previous run in ${PREVIOUS_TEST_RUN_DIR}"
     ROBOT_ARGS+=(--rerunfailed "${PREVIOUS_TEST_RUN_DIR}/output.xml")
 fi
+if [[ "${BROKER}" != "authd-msentraid" ]]; then
+    ROBOT_ARGS+=(--exclude requires:msentraid)
+fi
 
 # Launch the domain if it's not already running, so that we can get its VNC port
 if ! virsh domstate "${VM_NAME}" | grep -q '^running'; then

--- a/e2e-tests/tests/device_registration.robot
+++ b/e2e-tests/tests/device_registration.robot
@@ -4,6 +4,7 @@ Resource        resources/authd.resource
 Resource        resources/broker.resource
 
 # Test Tags       robot:exit-on-failure
+Test Tags         requires:msentraid
 
 Test Setup    utils.Test Setup    snapshot=%{BROKER}-installed
 Test Teardown   utils.Test Teardown
@@ -22,9 +23,6 @@ Test device registration during device code flow
     ...    With 'register_device = true' the device-auth login flow is unchanged from the
     ...    user's perspective; the broker additionally registers the device and persists the
     ...    resulting registration data in the user's cached token.
-
-    Skip If    '%{BROKER}' != 'authd-msentraid'
-    ...    msg=Device registration is only supported by the msentraid broker.
 
     # Enable device registration before the first remote login, so the device is
     # registered as part of that login.

--- a/e2e-tests/tests/login_entra_password.robot
+++ b/e2e-tests/tests/login_entra_password.robot
@@ -4,6 +4,7 @@ Resource        resources/authd.resource
 Resource        resources/broker.resource
 
 # Test Tags       robot:exit-on-failure
+Test Tags         requires:msentraid
 
 Test Setup    Test Setup
 Test Teardown   utils.Test Teardown
@@ -11,10 +12,6 @@ Test Teardown   utils.Test Teardown
 
 *** Keywords ***
 Test Setup
-    # entra_password is an Entra ID-specific broker option; other brokers
-    # (e.g. google) don't offer it, so there is nothing to test there.
-    Skip If    '${BROKER_SNAP_NAME}' != 'authd-msentraid'
-    ...    entra_password is only supported by the msentraid broker
     utils.Test Setup    snapshot=%{BROKER}-installed
     # Enable the Entra ID password flow and disable device auth so only the
     # new password+MFA mode is offered, avoiding a provider-selection menu.

--- a/e2e-tests/tests/login_entra_password_client_secret.robot
+++ b/e2e-tests/tests/login_entra_password_client_secret.robot
@@ -4,6 +4,7 @@ Resource        resources/authd.resource
 Resource        resources/broker.resource
 
 # Test Tags       robot:exit-on-failure
+Test Tags         requires:msentraid
 
 Test Setup    Test Setup
 Test Teardown   utils.Test Teardown
@@ -11,10 +12,6 @@ Test Teardown   utils.Test Teardown
 
 *** Keywords ***
 Test Setup
-    # entra_password is an Entra ID-specific broker option; other brokers
-    # (e.g. google) don't offer it, so there is nothing to test there.
-    Skip If    '${BROKER_SNAP_NAME}' != 'authd-msentraid'
-    ...    entra_password is only supported by the msentraid broker
     utils.Test Setup    snapshot=%{BROKER}-installed
     # Inject the OIDC client secret into broker.conf at runtime. The base
     # snapshot ships with the secret commented out (so public-client flows are


### PR DESCRIPTION
Tests that only apply to the msentraid broker were guarded by inline `Skip If` checks, causing them to appear as SKIP in reports for other brokers.  We want to use SKIP for known flaky failures. To make the difference clear in the log file, we now exclude these tests before Robot Framework runs them.