### PR TITLE
robot.toml: enable robotcode SemanticModel analysis

### DIFF
--- a/robot.toml
+++ b/robot.toml
@@ -17,6 +17,9 @@ extend-python-path = [
     "e2e-tests/.yarf/yarf/rf_libraries/variables",
 ]
 
+[tool.robotcode-analyze]
+semantic-model = true
+
 [env]
 # These environment variables are used in our Robot Framework libraries to
 # determine which broker and release to test against. Setting them here allows


### PR DESCRIPTION
Enables richer static analysis in robotcode (VS Code / IntelliJ), including goto-definition for keyword names passed as arguments to run_keyword-style keywords.