### PR TITLE
e2e-tests: verify local user password can be changed via CLI

### DIFF
--- a/e2e-tests/TESTING.md
+++ b/e2e-tests/TESTING.md
@@ -17,22 +17,33 @@ sudo ./e2e-tests/install-deps.sh
 
 ### 2. Configure
 
+#### Broker credentials
+
 For each broker you want to test, copy the corresponding template and fill in
-your credentials:
+your credentials (these files are gitignored):
+
+- For `authd-google`:
+  ```bash
+  cp e2e-tests/e2e-tests-google.env.template e2e-tests/e2e-tests-google.env
+  ```
+- For `authd-msentraid`:
+  ```bash
+  cp e2e-tests/e2e-tests-msentraid.env.template e2e-tests/e2e-tests-msentraid.env
+  ```
+
+#### VM provisioning config
+
+Copy `e2e-tests/vm/config.env.template` to `e2e-tests/vm/config.env` and set
+your SSH public key path (and optionally the default Ubuntu release and VM name
+prefix).
+
+If your SSH key is protected by a passphrase, add it to ssh-agent before
+provisioning. Note that ssh-agent entries do not persist across sessions, so
+you will need to run this again each time you start a new session:
 
 ```bash
-# For authd-google:
-cp e2e-tests/e2e-tests-google.env.template e2e-tests/e2e-tests-google.env
-
-# For authd-msentraid:
-cp e2e-tests/e2e-tests-msentraid.env.template e2e-tests/e2e-tests-msentraid.env
+ssh-add /path/to/key
 ```
-
-These files are gitignored.
-
-For VM provisioning, also copy `e2e-tests/vm/config.env.template` to
-`e2e-tests/vm/config.env` and set your SSH public key path (and optionally the
-default Ubuntu release and VM name prefix).
 
 ### 3. Provision the VM
 

--- a/e2e-tests/resources/utils.resource
+++ b/e2e-tests/resources/utils.resource
@@ -255,6 +255,37 @@ Try machinectl login Prompt
         ${tries} =    Evaluate    ${tries} - 1
     END
 
+Terminal Password Change
+    [arguments]    ${new_password}
+    Hid.Type String    passwd
+    Hid.Keys Combo    Return
+    Match Text    Current password:    5
+    Hid.Type String    ubuntu
+    Hid.Keys Combo    Return
+    Match Text    New password:    5
+    Hid.Type String    ${new_password}
+    Hid.Keys Combo    Return
+    Match Text    Retype new password:    5
+    Hid.Type String    ${new_password}
+    Hid.Keys Combo    Return
+    Match Text    passwd: password updated successfully    30
+    Clear Terminal
+
+Terminal Password Change Error
+    [arguments]    ${new_password}    ${expected_error}
+    Hid.Type String    passwd
+    Hid.Keys Combo    Return
+    Match Text    Current password:    5
+    Hid.Type String    ubuntu
+    Hid.Keys Combo    Return
+    Match Text    New password:    5
+    Hid.Type String    ${new_password}
+    Hid.Keys Combo    Return
+    Match Text    ${expected_error}
+    Hid.Keys Combo    Control_L    d
+    Match Text    password unchanged     10 
+    Match Text    ubuntu@ubuntu:~$    10
+    Clear Terminal
 
 Force Password Change
     Hid.Type String    passwd -e ubuntu

--- a/e2e-tests/tests/local_user_passwd_change_cli.robot
+++ b/e2e-tests/tests/local_user_passwd_change_cli.robot
@@ -1,0 +1,40 @@
+*** Settings ***
+Resource        resources/utils.resource
+Resource        resources/authd.resource
+
+Resource        resources/broker.resource
+
+# Test Tags       robot:exit-on-failure
+
+Test Setup    utils.Test Setup    snapshot=%{BROKER}-installed
+Test Teardown   utils.Test Teardown
+
+
+*** Variables ***
+${new_good_password}    2FuA2M3jfGl
+${new_password_too_short}    1234
+${new_password_too_simple}    12345678
+
+
+*** Test Cases ***
+Test changing local password of local user with passwd
+    [Documentation]    This test verifies that a local user can still change their local password with authd installed.
+    ...                It also verifies that the new password is not too short or too simple, and that the user can log in with the new password.
+
+    # Log in with local user
+    Log In
+    Open Terminal
+    
+    # Try to set a new password that is too short
+    Terminal Password Change Error    ${new_password_too_short}      The password is shorter than 8 characters
+    
+    # Try to set a new password that is too simple
+    Terminal Password Change Error    ${new_password_too_simple}     The password fails the dictionary check
+    
+    # Set a new password for the local user
+    Terminal Password Change     ${new_good_password}
+    Close Focused Window
+    Log Out
+
+    # Log in with new password
+    Log In With Password    ${new_good_password}


### PR DESCRIPTION
Adds test to check local user can change password via CLI.
New test checks too that system correctly rejects too short passwords (<8 chars) or passwords too simple or present in dictionary (i.e. 12345678)
Password previously used are allowed since test VMs are not configured to reject them

Updated TESTING.md to address previously not described issues and configuration steps

UDENG-9539
UDENG-9540