### PR TITLE
Install cargo-c with `--locked`

### DIFF
--- a/authd-oidc-brokers/internal/providers/msentraid/himmelblau/generate.sh
+++ b/authd-oidc-brokers/internal/providers/msentraid/himmelblau/generate.sh
@@ -13,7 +13,7 @@ if [ -z "${GIT_DIR}" ]; then
   exit 1
 fi
 
-cargo install cargo-c cbindgen
+cargo install --locked cargo-c cbindgen
 
 cd "${GIT_DIR}/authd-oidc-brokers/third_party/libhimmelblau"
 

--- a/snap/variants/msentraid/snapcraft.yaml
+++ b/snap/variants/msentraid/snapcraft.yaml
@@ -67,7 +67,7 @@ parts:
       # cargo-c is only needed to provide 'cargo cbuild'. Skip reinstalling it
       # when it is already on PATH (e.g. from a previous build in a reused build
       # instance) to avoid a crates.io index update and rebuild every time.
-      command -v cargo-cbuild >/dev/null || cargo install cargo-c
+      command -v cargo-cbuild >/dev/null || cargo install --locked cargo-c
       cargo cbuild --release --lib --features=broker,changepassword,on_behalf_of,set_timeout
       echo "Installing libhimmelblau.so and himmelblau.h"
       TARGET_TRIPLE=$(rustc -vV | awk '/host:/ {print $2}')


### PR DESCRIPTION
The `Build libhimmelblau` step started failing with:

    rustc 1.94.0 is not supported by the following package:
      cargo-credential-libsecret@0.5.8 requires rustc 1.95

`cargo install cargo-c` resolves transitive dependencies to their latest compatible versions, so a freshly published dependency that bumped its MSRV above the CI toolchain's rustc breaks installation even though our own code is unchanged. Passing --locked makes cargo honor the crates' own lockfiles, pinning dependencies to versions that build with the current toolchain. This matches how debian-build.yaml and auto-updates.yaml already install cargo binaries.

Closes #1730 
UDENG-10998
