### PR TITLE
pam/native: extract formatInfo function

### DIFF
--- a/pam/internal/adapter/nativemodel.go
+++ b/pam/internal/adapter/nativemodel.go
@@ -425,18 +425,25 @@ func (m nativeModel) sendInfo(infoMsg string) error {
 	return err
 }
 
+func (m nativeModel) formatInfo(title, message string) string {
+	if m.serviceName == polkitServiceName {
+		return message
+	}
+	if message == "" {
+		return fmt.Sprintf("== %s ==", title)
+	}
+	return fmt.Sprintf("== %s ==\n%s", title, message)
+}
+
 type choicePair struct {
 	id    string
 	label string
 }
 
 func (m nativeModel) promptForChoiceWithMessage(title string, message string, choices []choicePair, prompt string) (string, error) {
-	var msg string
-	if m.serviceName != polkitServiceName {
-		msg = fmt.Sprintf("== %s ==\n", title)
-	}
-	if message != "" {
-		msg += message + "\n"
+	msg := m.formatInfo(title, message)
+	if msg != "" {
+		msg += "\n"
 	}
 
 	for i, choice := range choices {
@@ -662,15 +669,7 @@ func (m nativeModel) handleFormChallenge(hasWait bool) tea.Cmd {
 	if goBackLabel := m.goBackActionLabel(); goBackLabel != "" {
 		instructions = fmt.Sprintf(instructions, nativeCancelKey, m.goBackActionLabel())
 	}
-	var info string
-	if m.serviceName != polkitServiceName {
-		info = fmt.Sprintf("== %s ==", authMode)
-		if instructions != "" {
-			info += "\n" + instructions
-		}
-	} else {
-		info = instructions
-	}
+	info := m.formatInfo(authMode, instructions)
 	if cmd := maybeSendPamError(m.sendInfo(info)); cmd != nil {
 		return cmd
 	}
@@ -832,15 +831,7 @@ func (m nativeModel) newPasswordChallenge(previousPassword *string) tea.Cmd {
 				nativeCancelKey, goBackLabel)
 		}
 		title := m.selectedAuthModeLabel("Password Update")
-		var info string
-		if m.serviceName != polkitServiceName {
-			info = fmt.Sprintf("== %s ==", title)
-			if instructions != "" {
-				info += "\n" + instructions
-			}
-		} else {
-			info = instructions
-		}
+		info := m.formatInfo(title, instructions)
 		if cmd := maybeSendPamError(m.sendInfo(info)); cmd != nil {
 			return cmd
 		}

--- a/pam/internal/adapter/nativemodel_test.go
+++ b/pam/internal/adapter/nativemodel_test.go
@@ -1,0 +1,47 @@
+package adapter
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestNativeModelFormatInfo(t *testing.T) {
+	t.Parallel()
+
+	tests := map[string]struct {
+		serviceName string
+		title       string
+		message     string
+		want        string
+	}{
+		"Regular_service_with_message": {
+			title:   "Authentication",
+			message: "Enter a password",
+			want:    "== Authentication ==\nEnter a password",
+		},
+		"Regular_service_without_message": {
+			title: "Authentication",
+			want:  "== Authentication ==",
+		},
+		"Polkit_service_with_message": {
+			serviceName: polkitServiceName,
+			title:       "Authentication",
+			message:     "Enter a password",
+			want:        "Enter a password",
+		},
+		"Polkit_service_without_message": {
+			serviceName: polkitServiceName,
+			title:       "Authentication",
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			m := nativeModel{serviceName: tc.serviceName}
+			require.Equal(t, tc.want, m.formatInfo(tc.title, tc.message))
+		})
+	}
+}


### PR DESCRIPTION
Extract a formatInfo function to avoid repeating the formatting logic.