### PR TITLE
e2e: select dependency PPA from PR descriptions

### DIFF
--- a/.github/workflows/e2e-tests-provision-and-run.yaml
+++ b/.github/workflows/e2e-tests-provision-and-run.yaml
@@ -20,6 +20,11 @@ on:
         type: string
         required: false
         default: ''
+      authd-ppa:
+        description: 'If set, use this PPA instead of authd-edge when installing the authd package and its dependencies'
+        type: string
+        required: false
+        default: ''
     secrets:
       E2E_VM_SSH_PRIV_KEY:
         required: true
@@ -152,4 +157,5 @@ jobs:
       ubuntu-version: ${{ inputs.ubuntu-version }}
       broker: ${{ matrix.broker }}
       broker-snap-channel: ${{ inputs.broker-snap-channel }}
+      authd-ppa: ${{ inputs.authd-ppa }}
     secrets: inherit

--- a/.github/workflows/e2e-tests-run.yaml
+++ b/.github/workflows/e2e-tests-run.yaml
@@ -14,6 +14,11 @@ on:
         required: false
         type: string
         default: ''
+      authd-ppa:
+        description: 'If set, use this PPA instead of authd-edge when installing the authd package and its dependencies'
+        required: false
+        type: string
+        default: ''
     secrets:
       E2E_VM_SSH_PRIV_KEY:
         required: true
@@ -199,6 +204,7 @@ jobs:
           # broker credentials from the environment)
           ${{ env.E2E_TESTS_DIR }}/vm/provision-authd.sh \
             --authd-deb "${{ steps.download-authd-deb.outputs.deb }}" \
+            ${{ inputs.authd-ppa && format('--authd-ppa {0}', inputs.authd-ppa) || '' }} \
             --broker-snap "${{ steps.download-broker-snap-from-store.outputs.snap || steps.download-broker-snap-from-oci.outputs.snap }}"
 
       - name: Checkout YARF repo

--- a/.github/workflows/e2e-tests.yaml
+++ b/.github/workflows/e2e-tests.yaml
@@ -53,6 +53,7 @@ on:
       - synchronize
       - reopened
       - labeled
+      - edited
   workflow_dispatch:
     inputs:
       broker-snap-channel:
@@ -110,4 +111,14 @@ jobs:
       files-hash: ${{ needs.compute-hash.outputs.files-hash }}
       force-fresh-image: ${{ github.event_name == 'schedule' }}
       broker-snap-channel: ${{ inputs.broker-snap-channel || '' }}
+      # PRs opt in by adding "e2e-ppa: authd-dev" to their description.
+      authd-ppa: >-
+        ${{
+          github.event_name == 'pull_request' &&
+          contains(
+            github.event.pull_request.body,
+            'e2e-ppa: authd-dev'
+          ) &&
+          'ubuntu-enterprise-desktop/authd-dev' || ''
+        }}
     secrets: inherit

--- a/e2e-tests/TESTING.md
+++ b/e2e-tests/TESTING.md
@@ -43,9 +43,14 @@ default Ubuntu release and VM name prefix).
 This sets up a libvirt VM with Ubuntu, installs authd and the broker, and
 creates the snapshots required by the tests. By default, authd is installed from
 the edge PPA and the broker from the edge channel snap. Use `--authd-deb` to
-install a locally built authd package, or `--broker-snap` to install a locally
+install a locally built authd package, `--authd-ppa <ppa>` to select a different
+PPA for authd and its dependencies, or `--broker-snap` to install a locally
 built broker snap. Run `./e2e-tests/vm/provision.sh --help` for all available
 options, including `--force` to reprovision.
+
+When running the tests in GitHub CI, add `e2e-ppa: authd-dev` to the pull request
+description to install the authd package and its dependencies from the
+`ubuntu-enterprise-desktop/authd-dev` PPA instead of `authd-edge`.
 
 ### 4. Set up YARF
 

--- a/e2e-tests/vm/provision-authd.sh
+++ b/e2e-tests/vm/provision-authd.sh
@@ -9,7 +9,7 @@ DATA_DIR="${XDG_DATA_HOME:-$HOME/.local/share}/authd-e2e-tests"
 
 usage(){
     cat << EOF
-Usage: $0 [--config-file <file>] [--release <release>] [--authd-deb <deb>] [--broker-snap <snap>]
+Usage: $0 [--config-file <file>] [--release <release>] [--authd-deb <deb>] [--authd-ppa <ppa>] [--broker-snap <snap>]
 
 Options:
    --config-file <file>  Path to the configuration file (default: config.env)
@@ -18,6 +18,8 @@ Options:
                         The existing snapshots will be deleted and recreated with the new installation.
    --broker <broker>    The broker to install ("authd-google", "authd-msentraid", ...)
    --authd-deb <deb>    Path to the authd deb file to install (default: install from the edge PPA)
+   --authd-ppa <ppa>    PPA to use instead of authd-edge when installing authd
+                        and its dependencies
    --broker-snap <snap> Path to the broker snap file to install (default: install from the edge channel)
   -h, --help             Show this help message and exit
 
@@ -45,6 +47,10 @@ while [[ $# -gt 0 ]]; do
             ;;
         --authd-deb)
             AUTHD_DEB="$2"
+            shift 2
+            ;;
+        --authd-ppa)
+            AUTHD_PPA="$2"
             shift 2
             ;;
         --broker-snap)
@@ -292,9 +298,9 @@ fi
 # Revert to the pre-authd setup snapshot before installing the version to test
 restore_snapshot_and_sync_time "$PRE_AUTHD_SNAPSHOT"
 
-# Add the edge PPA. We also need that when installing authd from a deb file,
-# because it depends on gnome-shell from the edge PPA.
-PPA="ubuntu-enterprise-desktop/authd-edge"
+# Add the PPA needed to resolve dependencies for the authd package under test.
+# authd-edge remains the default for local and normal CI runs.
+PPA="${AUTHD_PPA:-ubuntu-enterprise-desktop/authd-edge}"
 $SSH "add-apt-repository -y ppa:${PPA}"
 
 # Configure authd to be verbose. We do this before installing authd to avoid

--- a/e2e-tests/vm/provision.sh
+++ b/e2e-tests/vm/provision.sh
@@ -7,13 +7,14 @@ CONFIG_FILE="${SCRIPT_DIR}/config.env"
 
 usage(){
     cat << EOF
-Usage: $0 [--config-file <config file>] [--release <release>] [--broker <broker>] [--authd-deb <deb>] [--broker-snap <snap>] [--force]
+Usage: $0 [--config-file <config file>] [--release <release>] [--broker <broker>] [--authd-deb <deb>] [--authd-ppa <ppa>] [--broker-snap <snap>] [--force]
 
 Options:
   --config-file <config file>  Path to the configuration file (default: config.env)
   --release <release>          Ubuntu release to provision (e.g. noble, resolute); overrides config file
   --broker <broker>            The broker to install ("authd-google", "authd-msentraid", ...)
   --authd-deb <deb>            Path to the authd deb file to install (default: install from the edge PPA)
+  --authd-ppa <ppa>            PPA to use instead of authd-edge when installing authd and its dependencies
   --broker-snap <snap>         Path to the broker snap file to install (default: install from the edge channel)
   --force                      Force provisioning: remove existing VM and artifacts and create a fresh VM
   -h, --help                   Show this help message and exit
@@ -43,6 +44,10 @@ while [[ $# -gt 0 ]]; do
             ;;
         --authd-deb)
             AUTHD_DEB="$2"
+            shift 2
+            ;;
+        --authd-ppa)
+            AUTHD_PPA="$2"
             shift 2
             ;;
         --broker-snap)
@@ -78,5 +83,6 @@ set -x
   ${RELEASE_ARG:+--release "${RELEASE_ARG}"} \
   ${BROKER:+--broker "${BROKER}"} \
   ${AUTHD_DEB:+--authd-deb "${AUTHD_DEB}"} \
+  ${AUTHD_PPA:+--authd-ppa "${AUTHD_PPA}"} \
   ${BROKER_SNAP:+--broker-snap "${BROKER_SNAP}"} \
   ${FORCE:+--force}


### PR DESCRIPTION
Allow e2e test PRs to opt into the authd-dev PPA through their description. The selected PPA replaces authd-edge while APT resolves the dependencies of the authd package built from the PR. This allows us to depend on the gnome-shell version from the authd-dev PPA.

e2e-ppa: authd-dev