### PR TITLE
snap: install compatible prebuilt cargo-c

### DIFF
--- a/.github/workflows/brokers-qa.yaml
+++ b/.github/workflows/brokers-qa.yaml
@@ -39,6 +39,12 @@ jobs:
         with:
           submodules: recursive
 
+      - name: Cache cargo-c binary
+        uses: actions/cache@v4
+        with:
+          path: ~/.cargo/bin/cargo-cbuild
+          key: ${{ runner.os }}-cargo-c-${{ hashFiles('authd-oidc-brokers/tools/install-cargo-c') }}
+
       - name: Build libhimmelblau
         # The code sanity check fails if himmelblau.h does not exist, so we generate it first.
         run: go generate --tags withmsentraid ./internal/providers/msentraid/...
@@ -91,6 +97,12 @@ jobs:
           go install github.com/AlekSi/gocov-xml@latest
           go install github.com/adombeck/gocov/gocov@latest
           dotnet tool install -g dotnet-reportgenerator-globaltool
+
+      - name: Cache cargo-c binary
+        uses: actions/cache@v4
+        with:
+          path: ~/.cargo/bin/cargo-cbuild
+          key: ${{ runner.os }}-cargo-c-${{ hashFiles('authd-oidc-brokers/tools/install-cargo-c') }}
 
       - name: Build libhimmelblau
         run: go generate --tags withmsentraid ./internal/providers/msentraid/...

--- a/.github/workflows/update-cargo-c.yaml
+++ b/.github/workflows/update-cargo-c.yaml
@@ -1,0 +1,76 @@
+name: Update cargo-c
+
+on:
+  schedule:
+    # Every Thursday at 09:00 UTC.
+    - cron: '0 9 * * 4'
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+concurrency:
+  group: update-cargo-c
+
+jobs:
+  update-cargo-c:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Update to the latest cargo-c release
+        id: update
+        env:
+          GH_TOKEN: ${{ github.token }}
+          INSTALL_SCRIPT: authd-oidc-brokers/tools/install-cargo-c
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          release=$(gh api repos/lu-zero/cargo-c/releases/latest)
+          version=$(jq --raw-output '.tag_name | ltrimstr("v")' <<<"${release}")
+          aarch64_sha256=$(jq --raw-output '
+            .assets[]
+            | select(.name == "cargo-c-aarch64-unknown-linux-musl.tar.gz")
+            | .digest
+            | ltrimstr("sha256:")
+          ' <<<"${release}")
+          x86_64_sha256=$(jq --raw-output '
+            .assets[]
+            | select(.name == "cargo-c-x86_64-unknown-linux-musl.tar.gz")
+            | .digest
+            | ltrimstr("sha256:")
+          ' <<<"${release}")
+
+          if [[ -z "${version}" || "${version}" == "null" ||
+                -z "${aarch64_sha256}" || "${aarch64_sha256}" == "null" ||
+                -z "${x86_64_sha256}" || "${x86_64_sha256}" == "null" ]]; then
+            echo "Latest cargo-c release is missing a required Linux artifact" >&2
+            exit 1
+          fi
+
+          sed -i \
+            -e "s/^CARGO_C_VERSION=.*/CARGO_C_VERSION=${version}/" \
+            -e "s/^CARGO_C_AARCH64_SHA256=.*/CARGO_C_AARCH64_SHA256=${aarch64_sha256}/" \
+            -e "s/^CARGO_C_X86_64_SHA256=.*/CARGO_C_X86_64_SHA256=${x86_64_sha256}/" \
+            "${INSTALL_SCRIPT}"
+
+          if git diff --quiet -- "${INSTALL_SCRIPT}"; then
+            echo "No cargo-c update is needed"
+          else
+            echo "modified=true" >> "${GITHUB_OUTPUT}"
+            echo "version=${version}" >> "${GITHUB_OUTPUT}"
+          fi
+
+      - name: Create pull request
+        if: steps.update.outputs.modified == 'true'
+        uses: peter-evans/create-pull-request@v8
+        with:
+          branch: auto-update-cargo-c
+          delete-branch: true
+          commit-message: "deps(snap): update cargo-c to v${{ steps.update.outputs.version }}"
+          title: "deps(snap): update cargo-c to v${{ steps.update.outputs.version }}"
+          body: |
+            Updates cargo-c from its latest stable GitHub release.
+          labels: automated pr, e2e-tests

--- a/authd-oidc-brokers/internal/providers/msentraid/himmelblau/generate.sh
+++ b/authd-oidc-brokers/internal/providers/msentraid/himmelblau/generate.sh
@@ -13,7 +13,8 @@ if [ -z "${GIT_DIR}" ]; then
   exit 1
 fi
 
-cargo install --locked cargo-c cbindgen
+"${GIT_DIR}/authd-oidc-brokers/tools/install-cargo-c"
+cargo install --locked cbindgen
 
 cd "${GIT_DIR}/authd-oidc-brokers/third_party/libhimmelblau"
 

--- a/authd-oidc-brokers/tools/install-cargo-c
+++ b/authd-oidc-brokers/tools/install-cargo-c
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+CARGO_C_VERSION=0.10.24
+CARGO_C_AARCH64_SHA256=d1fac5dbecdc5f4c833e815d6d1717cdb762799e15ccfd122b08e5955a138394
+CARGO_C_X86_64_SHA256=503a6de066897b810051f2944e4157629c580d0e36219cddb39ad45116d0e8f5
+
+cargo_c_bin="${CARGO_HOME:-${HOME}/.cargo}/bin/cargo-cbuild"
+if [ -x "${cargo_c_bin}" ] \
+  && "${cargo_c_bin}" --version | grep -qF "cargo-c ${CARGO_C_VERSION}+"; then
+  echo "cargo-c ${CARGO_C_VERSION} is already installed, skipping download"
+  exit 0
+fi
+
+case "$(uname -m)" in
+  x86_64)
+    cargo_c_arch=x86_64-unknown-linux-musl
+    cargo_c_sha256="${CARGO_C_X86_64_SHA256}"
+    ;;
+  aarch64)
+    cargo_c_arch=aarch64-unknown-linux-musl
+    cargo_c_sha256="${CARGO_C_AARCH64_SHA256}"
+    ;;
+  *)
+    echo "Unsupported cargo-c build architecture: $(uname -m)" >&2
+    exit 1
+    ;;
+esac
+
+cargo_c_archive="cargo-c-${cargo_c_arch}.tar.gz"
+temp_dir=$(mktemp --directory)
+trap 'rm -rf "${temp_dir}"' EXIT
+
+curl --fail --location --silent --show-error --retry 3 \
+  --output "${temp_dir}/${cargo_c_archive}" \
+  "https://github.com/lu-zero/cargo-c/releases/download/v${CARGO_C_VERSION}/${cargo_c_archive}"
+echo "${cargo_c_sha256}  ${temp_dir}/${cargo_c_archive}" | sha256sum --check
+tar --extract --gzip --file "${temp_dir}/${cargo_c_archive}" \
+  --directory "${temp_dir}" cargo-cbuild
+install -Dm755 "${temp_dir}/cargo-cbuild" "${CARGO_HOME:-${HOME}/.cargo}/bin/cargo-cbuild"

--- a/snap/variants/msentraid/snapcraft.yaml
+++ b/snap/variants/msentraid/snapcraft.yaml
@@ -52,6 +52,7 @@ parts:
     # Force the rust plugin onto its rustup code path.
     rust-channel: stable
     build-packages:
+      - curl
       - libssl-dev
     build-environment:
       # Keep the compiled target/ outside the part's build tree so it survives
@@ -64,10 +65,9 @@ parts:
       snapcraftctl pull
       cp "$SNAPCRAFT_PROJECT_DIR/authd-oidc-brokers/rust-toolchain.toml" "$SNAPCRAFT_PART_SRC/"
     override-build: |
-      # cargo-c is only needed to provide 'cargo cbuild'. Skip reinstalling it
-      # when it is already on PATH (e.g. from a previous build in a reused build
-      # instance) to avoid a crates.io index update and rebuild every time.
-      command -v cargo-cbuild >/dev/null || cargo install --locked cargo-c
+      # Install cargo-c's prebuilt static binary so its build-time Rust MSRV
+      # does not constrain the Rust toolchain used for libhimmelblau.
+      "$SNAPCRAFT_PROJECT_DIR/authd-oidc-brokers/tools/install-cargo-c"
       cargo cbuild --release --lib --features=broker,changepassword,on_behalf_of,set_timeout
       echo "Installing libhimmelblau.so and himmelblau.h"
       TARGET_TRIPLE=$(rustc -vV | awk '/host:/ {print $2}')


### PR DESCRIPTION
Fresh broker Snap builds fail when cargo-c is compiled with Rust 1.94: new cargo-c releases require a newer compiler before libhimmelblau can build.

Install cargo-c's verified prebuilt release binary instead, decoupling its own build-time MSRV from the broker toolchain. The shared installer is used by both the Snap build and Himmelblau generator, and validates architecture- specific SHA-256 checksums.

Add a weekly workflow that opens a PR only for new stable cargo-c GitHub releases. It updates the pinned version and release-asset checksums so each upgrade is reviewed and validated by the normal PR checks.

Closes #1748 
UDENG-11052